### PR TITLE
Add Linux build targets

### DIFF
--- a/EmptyEpsilon.cbp
+++ b/EmptyEpsilon.cbp
@@ -46,6 +46,44 @@
 					<Add library="glu32" />
 				</Linker>
 			</Target>
+			<Target title="Linux Debug">
+				<Option output=".bin/Debug/EmptyEpsilon" prefix_auto="1" extension_auto="1" />
+				<Option object_output=".obj/Debug/" />
+				<Option type="1" />
+				<Option compiler="gcc" />
+				<Compiler>
+					<Add option="-g" />
+					<Add option="-DDEBUG" />
+				</Compiler>
+				<Linker>
+					<Add library="sfml-window-d" />
+					<Add library="sfml-audio-d" />
+					<Add library="sfml-graphics-d" />
+					<Add library="sfml-system-d" />
+					<Add library="sfml-network-d" />
+					<Add library="GL" />
+					<Add library="GLU" />
+				</Linker>
+			</Target>
+			<Target title="Linux Release">
+				<Option output=".bin/Release/EmptyEpsilon" prefix_auto="1" extension_auto="1" />
+				<Option object_output=".obj/Release/" />
+				<Option type="0" />
+				<Option compiler="gcc" />
+				<Compiler>
+					<Add option="-O2" />
+				</Compiler>
+				<Linker>
+					<Add option="-s" />
+					<Add library="sfml-audio" />
+					<Add library="sfml-graphics" />
+					<Add library="sfml-system" />
+					<Add library="sfml-window" />
+					<Add library="sfml-network" />
+					<Add library="GL" />
+					<Add library="GLU" />
+				</Linker>
+			</Target>
 		</Build>
 		<Compiler>
 			<Add option="-Wall" />


### PR DESCRIPTION
This will add debug and release targets that have the correct libraries to build on Linux in codeblocks. This way people won't have to hack up your files to build ;)
