### PR TITLE
Add a hint for how to enable http script access

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -56,9 +56,12 @@ int main(int argc, char** argv)
             string line = string(buffer).strip();
             if (line.find("=") > -1)
             {
-                string key = line.substr(0, line.find("="));
-                string value = line.substr(line.find("=") + 1);
-                startup_parameters[key] = value;
+                if(line.find("#") != 0) {
+                    string key = line.substr(0, line.find("="));
+                    string value = line.substr(line.find("=") + 1);
+                    startup_parameters[key] = value;
+                }
+
             }
         }
         fclose(f);
@@ -193,6 +196,8 @@ int main(int argc, char** argv)
         startup_parameters["fsaa"] = windowManager->getFSAA();
         startup_parameters["fullscreen"] = windowManager->isFullscreen() ? 1 : 0;
         startup_parameters["music_volume"] = soundManager.getMusicVolume();
+        fprintf(f, "# Empty Epsilon Settings\n# This file will be overwritten by EE.\n\n");
+        fprintf(f, "# Include the following line to enable an experimental http server:\n# httpserver=8080\n\n");
         for(std::map<string, string>::iterator i = startup_parameters.begin(); i != startup_parameters.end(); i++)
         {
             fprintf(f, "%s=%s\n", i->first.c_str(), i->second.c_str());


### PR DESCRIPTION
Also, ignore settings that start with a #, which is the convention for .ini files.