### PR TITLE
added weapon damage modifiers

### DIFF
--- a/src/shipTemplate.cpp
+++ b/src/shipTemplate.cpp
@@ -22,6 +22,7 @@ REGISTER_SCRIPT_CLASS(ShipTemplate)
     REGISTER_SCRIPT_CLASS_FUNCTION(ShipTemplate, setJumpDrive);
     REGISTER_SCRIPT_CLASS_FUNCTION(ShipTemplate, setCloaking);
     REGISTER_SCRIPT_CLASS_FUNCTION(ShipTemplate, setWeaponStorage);
+    REGISTER_SCRIPT_CLASS_FUNCTION(ShipTemplate, setWeaponDamageModifier);
     REGISTER_SCRIPT_CLASS_FUNCTION(ShipTemplate, addRoom);
     REGISTER_SCRIPT_CLASS_FUNCTION(ShipTemplate, addRoomSystem);
     REGISTER_SCRIPT_CLASS_FUNCTION(ShipTemplate, addDoor);

--- a/src/shipTemplate.h
+++ b/src/shipTemplate.h
@@ -85,6 +85,7 @@ public:
     float impulse_acceleration;
     bool has_jump_drive, has_cloaking;
     int weapon_storage[MW_Count];
+    float weapon_damage_modifier[MW_Count] = {1.0}; // Damage of tube-launched weapons
 
     std::vector<ShipRoomTemplate> rooms;
     std::vector<ShipDoorTemplate> doors;
@@ -105,7 +106,8 @@ public:
     void setWarpSpeed(float warp) { warp_speed = warp; }
     void setJumpDrive(bool enabled) { has_jump_drive = enabled; }
     void setCloaking(bool enabled) { has_cloaking = enabled; }
-    void setWeaponStorage(EMissileWeapons weapon, int amount) { if (weapon != MW_None) weapon_storage[weapon] = amount; }
+    void setWeaponStorage(EMissileWeapons weapon, int amount)  { if (weapon != MW_None) weapon_storage[weapon] = amount; }
+    void setWeaponDamageModifier( EMissileWeapons weapon, float damage){ if (weapon != MW_None) weapon_damage_modifier[weapon] = damage; }
     void addRoom(sf::Vector2i position, sf::Vector2i size) { rooms.push_back(ShipRoomTemplate(position, size, SYS_None)); }
     void addRoomSystem(sf::Vector2i position, sf::Vector2i size, ESystem system) { rooms.push_back(ShipRoomTemplate(position, size, system)); }
     void addDoor(sf::Vector2i position, bool horizontal) { doors.push_back(ShipDoorTemplate(position, horizontal)); }

--- a/src/spaceObjects/EMPMissile.cpp
+++ b/src/spaceObjects/EMPMissile.cpp
@@ -1,6 +1,7 @@
 #include "EMPMissile.h"
 #include "particleEffect.h"
 #include "electricExplosionEffect.h"
+#include "spaceship.h"
 
 REGISTER_MULTIPLAYER_CLASS(EMPMissile, "EMPMissile");
 EMPMissile::EMPMissile()
@@ -10,8 +11,18 @@ EMPMissile::EMPMissile()
 
 void EMPMissile::hitObject(P<SpaceObject> object)
 {
+    float damageAtEdge_modified = damageAtEdge;
+    float damageAtCenter_modified = damageAtCenter;
+    
     DamageInfo info(owner, DT_EMP, getPosition());
-    SpaceObject::damageArea(getPosition(), blastRange, damageAtEdge, damageAtCenter, info, getRadius());
+    
+    if (P<SpaceShip>(owner))
+    {
+        damageAtEdge_modified *=   (P<SpaceShip>(owner))->weapon_damage_modifier[MW_EMP];
+        damageAtCenter_modified *= (P<SpaceShip>(owner))->weapon_damage_modifier[MW_EMP];
+    }
+    
+    SpaceObject::damageArea(getPosition(), blastRange, damageAtEdge_modified, damageAtCenter_modified, info, getRadius());
 
     P<ElectricExplosionEffect> e = new ElectricExplosionEffect();
     e->setSize(blastRange);

--- a/src/spaceObjects/homingMissile.cpp
+++ b/src/spaceObjects/homingMissile.cpp
@@ -1,6 +1,7 @@
 #include "homingMissile.h"
 #include "particleEffect.h"
 #include "explosionEffect.h"
+#include "spaceship.h"
 
 REGISTER_MULTIPLAYER_CLASS(HomingMissile, "HomingMissile");
 HomingMissile::HomingMissile()
@@ -10,8 +11,15 @@ HomingMissile::HomingMissile()
 
 void HomingMissile::hitObject(P<SpaceObject> object)
 {
+    float weapon_damage = damage;
     DamageInfo info(owner, DT_Kinetic, getPosition());
-    object->takeDamage(35, info);
+    
+    if (P<SpaceShip>(owner))
+        weapon_damage *= (P<SpaceShip>(owner))->weapon_damage_modifier[MW_Homing];
+        
+    LOG(DEBUG) << "Doing damage: " << weapon_damage;
+    
+    object->takeDamage(weapon_damage, info);
     P<ExplosionEffect> e = new ExplosionEffect();
     e->setSize(30);
     e->setPosition(getPosition());

--- a/src/spaceObjects/homingMissile.h
+++ b/src/spaceObjects/homingMissile.h
@@ -5,6 +5,7 @@
 
 class HomingMissile : public MissileWeapon
 {
+    constexpr static float damage = 35;
 public:
     HomingMissile();
     

--- a/src/spaceObjects/nuke.cpp
+++ b/src/spaceObjects/nuke.cpp
@@ -1,6 +1,7 @@
 #include "nuke.h"
 #include "particleEffect.h"
 #include "explosionEffect.h"
+#include "spaceship.h"
 
 REGISTER_MULTIPLAYER_CLASS(Nuke, "Nuke");
 Nuke::Nuke()
@@ -10,8 +11,18 @@ Nuke::Nuke()
 
 void Nuke::hitObject(P<SpaceObject> object)
 {
+    float damageAtEdge_modified = damageAtEdge;
+    float damageAtCenter_modified = damageAtCenter;
+    
     DamageInfo info(owner, DT_Kinetic, getPosition());
-    SpaceObject::damageArea(getPosition(), blastRange, damageAtEdge, damageAtCenter, info, getRadius());
+    
+    if (P<SpaceShip>(owner))
+    {
+        damageAtEdge_modified *=   (P<SpaceShip>(owner))->weapon_damage_modifier[MW_Nuke];
+        damageAtCenter_modified *= (P<SpaceShip>(owner))->weapon_damage_modifier[MW_Nuke];
+    }
+    
+    SpaceObject::damageArea(getPosition(), blastRange, damageAtEdge_modified, damageAtCenter_modified, info, getRadius());
 
     P<ExplosionEffect> e = new ExplosionEffect();
     e->setSize(blastRange);

--- a/src/spaceObjects/spaceship.cpp
+++ b/src/spaceObjects/spaceship.cpp
@@ -221,6 +221,11 @@ void SpaceShip::setShipTemplate(string template_name)
         beam_weapons[n].cycleTime = ship_template->beams[n].cycle_time;
         beam_weapons[n].damage = ship_template->beams[n].damage;
     }
+    
+    for (int n=0; n < MW_Count; n++)
+    {
+        weapon_damage_modifier[n] = ship_template->weapon_damage_modifier[n];
+    }
     weapon_tubes = ship_template->weapon_tubes;
     hull_strength = hull_max = ship_template->hull;
     front_shield = ship_template->front_shields;

--- a/src/spaceObjects/spaceship.h
+++ b/src/spaceObjects/spaceship.h
@@ -167,6 +167,11 @@ public:
     int beam_frequency;
     ESystem beam_system_target;
     BeamWeapon beam_weapons[max_beam_weapons];
+    
+    /*!
+     * [output] Damage of tube-launched weapons
+     */
+    float weapon_damage_modifier[MW_Count] = {1.0};
 
     float hull_strength, hull_max;
     bool shields_active;


### PR DESCRIPTION
I've added damage modifiers to all missile-weapons.
You can now use the templates to tweak damage of ship classes. 

For 2x more powerful homing missiles:
template:setWeaponDamageModifier("Homing", 2) 