### PR TITLE
Added engineering crew variables

### DIFF
--- a/src/screens/crew6/engineeringScreen.cpp
+++ b/src/screens/crew6/engineeringScreen.cpp
@@ -15,9 +15,11 @@ EngineeringScreen::EngineeringScreen(GuiContainer* owner)
     hull_display->setTextSize(20)->setPosition(20, 140, ATopLeft)->setSize(240, 40);
     shields_display = new GuiKeyValueDisplay(this, "SHIELDS_DISPLAY", 0.45, "Shields", "");
     shields_display->setTextSize(20)->setPosition(20, 180, ATopLeft)->setSize(240, 40);
-    
-    (new GuiSelfDestructButton(this, "SELF_DESTRUCT"))->setPosition(20, 220, ATopLeft)->setSize(240, 100);
-    
+    crew_display = new GuiKeyValueDisplay(this, "ENGINEERING_CREW", 0.4, "Crew", "");
+    crew_display->setTextSize(20)->setPosition(20, 220, ATopLeft)->setSize(240, 40);
+
+    (new GuiSelfDestructButton(this, "SELF_DESTRUCT"))->setPosition(20, 260, ATopLeft)->setSize(240, 100);
+
     GuiAutoLayout* system_row_layouts = new GuiAutoLayout(this, "SYSTEM_ROWS", GuiAutoLayout::LayoutVerticalBottomToTop);
     system_row_layouts->setPosition(20, -20, ABottomLeft);
     system_row_layouts->setSize(GuiElement::GuiSizeMax, GuiElement::GuiSizeMax);
@@ -27,7 +29,7 @@ EngineeringScreen::EngineeringScreen(GuiContainer* owner)
         SystemRow info;
         info.layout = new GuiAutoLayout(system_row_layouts, id, GuiAutoLayout::LayoutHorizontalLeftToRight);
         info.layout->setSize(GuiElement::GuiSizeMax, 50);
-        
+
         info.button = new GuiToggleButton(info.layout, id + "_SELECT", getSystemName(ESystem(n)), [this, n](bool value){
             for(int idx=0; idx<SYS_COUNT; idx++)
             {
@@ -55,16 +57,16 @@ EngineeringScreen::EngineeringScreen(GuiContainer* owner)
         info.power_bar->setColor(sf::Color(192, 192, 0))->setSize(50, GuiElement::GuiSizeMax);
         info.coolant_bar = new GuiProgressbar(info.layout, id + "_COOLANT", 0.0, 10.0, 0.0);
         info.coolant_bar->setColor(sf::Color(0, 128, 128))->setSize(50, GuiElement::GuiSizeMax);
-        
+
         info.layout->moveToBack();
         system_rows.push_back(info);
     }
-    
+
     GuiBox* box = new GuiBox(this, "POWER_COOLANT_BOX");
     box->setPosition(110, -20, ABottomCenter)->setSize(270, 400);
     (new GuiLabel(box, "POWER_LABEL", "Power", 30))->setVertical()->setAlignment(ACenterLeft)->setPosition(20, 20, ATopLeft)->setSize(30, 360);
     (new GuiLabel(box, "COOLANT_LABEL", "Coolant", 30))->setVertical()->setAlignment(ACenterLeft)->setPosition(110, 20, ATopLeft)->setSize(30, 360);
-    
+
     power_slider = new GuiSlider(box, "POWER_SLIDER", 3.0, 0.0, 1.0, [this](float value) {
         if (my_spaceship)
             my_spaceship->commandSetSystemPower(selected_system, value);
@@ -77,7 +79,7 @@ EngineeringScreen::EngineeringScreen(GuiContainer* owner)
     coolant_slider->setPosition(140, 20, ATopLeft)->setSize(60, 360);
 
     (new GuiShieldFrequencySelect(this, "SHIELD_FREQ"))->setPosition(-20, -20, ABottomRight)->setSize(320, 400);
-    
+
     (new GuiShipInternalView(system_row_layouts, "SHIP_INTERNAL_VIEW", 48.0f))->setShip(my_spaceship)->setSize(GuiElement::GuiSizeMax, GuiElement::GuiSizeMax);
 }
 
@@ -96,19 +98,19 @@ void EngineeringScreen::onDraw(sf::RenderTarget& window)
         else
             hull_display->setColor(sf::Color::White);
         shields_display->setValue(string(my_spaceship->getShieldPercentage(0)) + "% " + string(my_spaceship->getShieldPercentage(1)) + "%");
-        
+
         for(int n=0; n<SYS_COUNT; n++)
         {
             SystemRow info = system_rows[n];
             info.layout->setVisible(my_spaceship->hasSystem(ESystem(n)));
-            
+
             float health = my_spaceship->systems[n].health;
             if (health < 0.0)
                 info.damage_bar->setValue(-health)->setColor(sf::Color(128, 32, 32));
             else
                 info.damage_bar->setValue(health)->setColor(sf::Color(64, 128 * health, 64 * health));
             info.damage_label->setText(string(int(health * 100)) + "%");
-            
+
             float heat = my_spaceship->systems[n].heat_level;
             info.heat_bar->setValue(heat)->setColor(sf::Color(128, 128 * (1.0 - heat), 0));
             float heating_diff = my_spaceship->systems[n].getHeatingDelta();
@@ -118,10 +120,12 @@ void EngineeringScreen::onDraw(sf::RenderTarget& window)
                 info.heat_arrow->setAngle(-90);
             info.heat_arrow->setVisible(heat > 0);
             info.heat_arrow->setColor(sf::Color(255, 255, 255, std::min(255, int(255 * fabs(heating_diff)))));
-            
+
             info.power_bar->setValue(my_spaceship->systems[n].power_level);
             info.coolant_bar->setValue(my_spaceship->systems[n].coolant_level);
         }
+
+        crew_display->setValue(string(my_spaceship->engineering_crew - my_spaceship->engineering_crew_injuried) + "/" + string(my_spaceship->engineering_crew));
     }
     GuiOverlay::onDraw(window);
 }

--- a/src/screens/crew6/engineeringScreen.h
+++ b/src/screens/crew6/engineeringScreen.h
@@ -12,7 +12,8 @@ private:
     GuiKeyValueDisplay* shields_display;
     GuiSlider* power_slider;
     GuiSlider* coolant_slider;
-    
+    GuiKeyValueDisplay* crew_display;
+
     class SystemRow
     {
     public:
@@ -29,7 +30,7 @@ private:
     ESystem selected_system;
 public:
     EngineeringScreen(GuiContainer* owner);
-    
+
     virtual void onDraw(sf::RenderTarget& window);
 };
 

--- a/src/screens/extra/damcon.cpp
+++ b/src/screens/extra/damcon.cpp
@@ -7,12 +7,14 @@ DamageControlScreen::DamageControlScreen(GuiContainer* owner)
 : GuiOverlay(owner, "DAMCON_SCREEN", sf::Color::Black)
 {
     (new GuiShipInternalView(this, "SHIP_INTERNAL_VIEW", 48.0f * 1.5f))->setShip(my_spaceship)->setPosition(300, 0, ATopLeft)->setSize(GuiElement::GuiSizeMax, GuiElement::GuiSizeMax);
-    
+
     GuiAutoLayout* system_health_layout = new GuiAutoLayout(this, "DAMCON_LAYOUT", GuiAutoLayout::LayoutVerticalTopToBottom);
     system_health_layout->setPosition(0, 0, ACenterLeft)->setSize(300, 600);
 
     hull_display = new GuiKeyValueDisplay(system_health_layout, "HULL", 0.8, "Hull", "0%");
     hull_display->setSize(GuiElement::GuiSizeMax, 40);
+    crew_display = new GuiKeyValueDisplay(system_health_layout, "CREW", 0.4, "Crew", "");
+    crew_display->setSize(GuiElement::GuiSizeMax, 40);
 
     for(unsigned int n=0; n<SYS_COUNT; n++)
     {
@@ -24,7 +26,7 @@ DamageControlScreen::DamageControlScreen(GuiContainer* owner)
 void DamageControlScreen::onDraw(sf::RenderTarget& window)
 {
     GuiOverlay::onDraw(window);
-    
+
     if (my_spaceship)
     {
         hull_display->setValue(string(int(100 * my_spaceship->hull_strength / my_spaceship->hull_max)) + "%");
@@ -32,6 +34,8 @@ void DamageControlScreen::onDraw(sf::RenderTarget& window)
             hull_display->setColor(sf::Color::Red);
         else
             hull_display->setColor(sf::Color::White);
+
+        crew_display->setValue(string(my_spaceship->engineering_crew - my_spaceship->engineering_crew_injuried) + "/" + string(my_spaceship->engineering_crew));
 
         for(unsigned int n=0; n<SYS_COUNT; n++)
         {

--- a/src/screens/extra/damcon.h
+++ b/src/screens/extra/damcon.h
@@ -8,10 +8,11 @@ class DamageControlScreen : public GuiOverlay
 {
 private:
     GuiKeyValueDisplay* hull_display;
+    GuiKeyValueDisplay* crew_display;
     GuiKeyValueDisplay* system_health[SYS_COUNT];
 public:
     DamageControlScreen(GuiContainer* owner);
-    
+
     void onDraw(sf::RenderTarget& window) override;
 };
 

--- a/src/shipTemplate.cpp
+++ b/src/shipTemplate.cpp
@@ -43,6 +43,7 @@ REGISTER_SCRIPT_CLASS(ShipTemplate)
     REGISTER_SCRIPT_CLASS_FUNCTION(ShipTemplate, addRoomSystem);
     REGISTER_SCRIPT_CLASS_FUNCTION(ShipTemplate, addDoor);
     REGISTER_SCRIPT_CLASS_FUNCTION(ShipTemplate, setRadarTrace);
+    REGISTER_SCRIPT_CLASS_FUNCTION(ShipTemplate, setEngineeringCrewMax);
 }
 
 /* Define script conversion function for the EMissileWeapons enum. */
@@ -122,6 +123,7 @@ ShipTemplate::ShipTemplate()
     for(int n=0; n<MW_Count; n++)
         weapon_storage[n] = 0;
     radar_trace = "RadarArrow.png";
+    engineering_crew_max = 50;
 }
 
 void ShipTemplate::setBeamTexture(int index, string texture)

--- a/src/shipTemplate.h
+++ b/src/shipTemplate.h
@@ -95,7 +95,7 @@ public:
     float impulse_acceleration;
     bool has_jump_drive, has_cloaking;
     int weapon_storage[MW_Count];
-
+    float engineering_crew_max;
     string radar_trace;
 
     std::vector<ShipRoomTemplate> rooms;
@@ -110,7 +110,7 @@ public:
     void setSizeClass(int size_class) { this->size_class = size_class; }
     void setMesh(string model, string color_texture, string specular_texture, string illumination_texture);
 
-    
+
     void setBeam(int index, float arc, float direction, float range, float cycle_time, float damage);
 
     /**
@@ -130,6 +130,7 @@ public:
     void addRoomSystem(sf::Vector2i position, sf::Vector2i size, ESystem system) { rooms.push_back(ShipRoomTemplate(position, size, system)); }
     void addDoor(sf::Vector2i position, bool horizontal) { doors.push_back(ShipDoorTemplate(position, horizontal)); }
     void setRadarTrace(string trace) { radar_trace=trace; }
+    void setEngineeringCrewMax(int total) { engineering_crew_max = total; }
 
     sf::Vector2i interiorSize();
     ESystem getSystemAtRoom(sf::Vector2i position);

--- a/src/spaceObjects/spaceship.cpp
+++ b/src/spaceObjects/spaceship.cpp
@@ -49,6 +49,7 @@ REGISTER_SCRIPT_SUBCLASS_NO_CREATE(SpaceShip, ShipTemplateBasedObject)
     /// For example, ship:setRadarTrace("RadarBlip.png") will show a dot instead of an arrow for this ship.
     /// Note: Icon is only shown after scanning, before the ship is scanned it is always shown as an arrow.
     REGISTER_SCRIPT_CLASS_FUNCTION(SpaceShip, setRadarTrace);
+    REGISTER_SCRIPT_CLASS_FUNCTION(SpaceShip, setEngineeringCrew);
 }
 
 /* Define script conversion function for the EMainScreenSetting enum. */
@@ -133,6 +134,9 @@ SpaceShip::SpaceShip(string multiplayerClassName, float multiplayer_significant_
     registerMemberReplication(&combat_maneuver_strafe_request);
     registerMemberReplication(&combat_maneuver_strafe_active, 0.2);
     registerMemberReplication(&radar_trace);
+    registerMemberReplication(&engineering_crew_max);
+    registerMemberReplication(&engineering_crew);
+    registerMemberReplication(&engineering_crew_injuried);
 
     for(int n=0; n<SYS_COUNT; n++)
     {
@@ -205,6 +209,10 @@ void SpaceShip::applyTemplateValues()
 
     ship_template->setCollisionData(this);
     model_info.setData(ship_template->model_data);
+
+    engineering_crew_max = ship_template->engineering_crew_max;
+    engineering_crew_injuried = 0;
+    engineering_crew = engineering_crew_max ;
 }
 
 #if FEATURE_3D_RENDERING

--- a/src/spaceObjects/spaceship.h
+++ b/src/spaceObjects/spaceship.h
@@ -70,6 +70,10 @@ public:
     constexpr static float jump_drive_min_distance = 5.0;
     constexpr static float jump_drive_max_distance = 50.0;
 
+    int engineering_crew_max;
+    int engineering_crew;
+    int engineering_crew_injuried;
+
     float energy_level;
     ShipSystem systems[SYS_COUNT];
     /*!
@@ -276,7 +280,7 @@ public:
      * \return float 0. to 1.
      */
     float getSystemEffectiveness(ESystem system);
-    
+
     virtual void applyTemplateValues();
 
     P<SpaceObject> getTarget();
@@ -339,6 +343,8 @@ public:
     int getWeaponTubeCount();
 
     void setRadarTrace(string trace) { radar_trace = trace; }
+
+    void setEngineeringCrew(int number) { engineering_crew = number; }
 };
 
 float frequencyVsFrequencyDamageFactor(int beam_frequency, int shield_frequency);


### PR DESCRIPTION
Created 3 engineering crew variables :

- engineering_crew_max, which is the max number of engineers in the spaceship. Defaults to 50, can be set in the template by setEngineeringCrewMax(int number)

- engineering_crew, which is the number of engineers currently on board. Equal to engineering_crew_max on ship spawn. Can be set on-the-fly via setEngineeringCrew(int number)
- engineering_crew_injuried, which is the number of engineers injuried.

Right now these values only display and have no incidence on repair rate. Furthermore, there is no mechanism to wound crew as of now.
