### PR TITLE
Propagate CMAKE_INSTALL_PREFIX so that it can be changed on Linux.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -20,6 +20,12 @@ if(APPLE)
 set(CMAKE_INSTALL_PREFIX "./")
 endif()
 
+# set INSTALL_PREFIX for linux so that the built binary is able to find resources
+if(CMAKE_SYSTEM_NAME STREQUAL "Linux")
+set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -D INSTALL_PREFIX=\\\"${CMAKE_INSTALL_PREFIX}\\\"")
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -D INSTALL_PREFIX=\\\"${CMAKE_INSTALL_PREFIX}\\\"")
+endif()
+
 ## ensure c++11 is used
 if(NOT ${CMAKE_VERSION} VERSION_LESS 3.1)
     set(CMAKE_CXX_STANDARD 11)


### PR DESCRIPTION
On Linux, the game tries to find its assets in `/usr/local`, which is also the default value for `CMAKE_INSTALL_PREFIX`. This behavior can be changed by setting INSTALL_PREFIX during compilation, but right now that requires something like:

    cmake -DCMAKE_INSTALL_PREFIX=/home/user/.local \
          -DCMAKE_CXX_FLAGS='-DINSTALL_PREFIX=\"/home/user/.local\"' .

Which is quite unintuitive, and can result in a complete, but non-functional build if someone changes only `CMAKE_INSTALL_PREFIX`.

This pull request adds `-DINSTALL_PREFIX` to the flags automatically for Linux (because `INSTALL_PREFIX` is apparently used only on Linux).