### PR TITLE
Move descriptions to database screen's rightmost column

### DIFF
--- a/src/screenComponents/databaseView.cpp
+++ b/src/screenComponents/databaseView.cpp
@@ -21,7 +21,7 @@ DatabaseViewComponent::DatabaseViewComponent(GuiContainer* owner)
         database_entry->setPosition(400, 50, ATopLeft)->setSize(GuiElement::GuiSizeMax, GuiElement::GuiSizeMax);
         
         GuiAutoLayout* layout = new GuiAutoLayout(database_entry, "DATABASE_ENTRY_LAYOUT", GuiAutoLayout::LayoutVerticalTopToBottom);
-        layout->setPosition(0, 0, ATopLeft)->setSize(400, GuiElement::GuiSizeMax);
+        layout->setPosition(0, 0, ATopLeft)->setMargins(25, 0)->setSize(400, GuiElement::GuiSizeMax);
         
         P<ScienceDatabase> entry;
         if (selected_entry)
@@ -43,16 +43,23 @@ DatabaseViewComponent::DatabaseViewComponent(GuiContainer* owner)
         {
             (new GuiKeyValueDisplay(layout, "", 0.6, entry->keyValuePairs[n].key, entry->keyValuePairs[n].value))->setSize(GuiElement::GuiSizeMax, 40);
         }
-        if (entry->longDescription.length() > 0)
-        {
-            (new GuiScrollText(layout, "DATABASE_LONG_DESCRIPTION", entry->longDescription))->setTextSize(20)->setSize(GuiElement::GuiSizeMax, GuiElement::GuiSizeMax);
-        }
         if (entry->model_data)
         {
-            float x = 400;
-            if (entry->keyValuePairs.size() == 0 && entry->longDescription.length() == 0)
+            float x = 450;
+            if (entry->keyValuePairs.size() == 0 && entry->longDescription.length() == 0) {
                 x = 0;
-            (new GuiRotatingModelView(database_entry, "DATABASE_MODEL_VIEW", entry->model_data))->setPosition(x, 0, ATopLeft)->setSize(GuiElement::GuiSizeMax, GuiElement::GuiSizeMatchWidth);
+            }
+            (new GuiRotatingModelView(database_entry, "DATABASE_MODEL_VIEW", entry->model_data))->setPosition(x, -50, ATopLeft)->setSize(GuiElement::GuiSizeMax, std::min(GuiElement::GuiSizeMatchWidth, 370.0f));
+
+            if (entry->longDescription.length() > 0)
+            {
+                (new GuiScrollText(database_entry, "DATABASE_LONG_DESCRIPTION", entry->longDescription))->setTextSize(24)->setPosition(450,0,ABottomLeft)->setMargins(0, 0, 50, 50)->setSize(GuiElement::GuiSizeMax, 240);
+            }
+        } else {
+            if (entry->longDescription.length() > 0)
+            {
+                (new GuiScrollText(database_entry, "DATABASE_LONG_DESCRIPTION", entry->longDescription))->setTextSize(24)->setPosition(450,0,ATopLeft)->setMargins(0, 0, 50, 50)->setSize(GuiElement::GuiSizeMax, GuiElement::GuiSizeMax);
+            }
         }
         if (entry->items.size() > 0)
         {
@@ -60,7 +67,7 @@ DatabaseViewComponent::DatabaseViewComponent(GuiContainer* owner)
             fillListBox();
         }
     });
-    item_list->setPosition(0, 0, ATopLeft)->setMargins(50, 50, 50, 150)->setSize(350, GuiElement::GuiSizeMax);
+    item_list->setPosition(0, 0, ATopLeft)->setMargins(50, 50, 50, 250)->setSize(350, GuiElement::GuiSizeMax);
     fillListBox();
 }
 


### PR DESCRIPTION
-   Move description text to the right column, beneath the model view.
    This avoids issues with ships like the Odin that have lots of key/value
    items, which can push the description off the bottom of the screen.
-   If there's no model view for a database item, expand the description
    to fill the right column.
-   Adjust the model view's size and positioning.
-   Increase the size of database text from 20 to 24, for readability.
-   Add some space between columns.