### PR TITLE
Fix gaps in weapon direction/facing labels

### DIFF
--- a/src/scienceDatabase.cpp
+++ b/src/scienceDatabase.cpp
@@ -136,11 +136,11 @@ void fillDefaultDatabaseData()
             if (ship_template->beams[n].getRange() > 0)
             {
                 string name = "?";
-                if (ship_template->beams[n].getDirection() < 45 || ship_template->beams[n].getDirection() > 315)
+                if (ship_template->beams[n].getDirection() <= 45 || ship_template->beams[n].getDirection() >= 315)
                     name = "Front";
                 else if (ship_template->beams[n].getDirection() > 45 && ship_template->beams[n].getDirection() < 135)
                     name = "Right";
-                else if (ship_template->beams[n].getDirection() > 135 && ship_template->beams[n].getDirection() < 225)
+                else if (ship_template->beams[n].getDirection() >= 135 && ship_template->beams[n].getDirection() <= 225)
                     name = "Rear";
                 else if (ship_template->beams[n].getDirection() > 225 && ship_template->beams[n].getDirection() < 315)
                     name = "Left";

--- a/src/scienceDatabase.cpp
+++ b/src/scienceDatabase.cpp
@@ -136,14 +136,15 @@ void fillDefaultDatabaseData()
             if (ship_template->beams[n].getRange() > 0)
             {
                 string name = "?";
-                if (ship_template->beams[n].getDirection() <= 45 || ship_template->beams[n].getDirection() >= 315)
+                if (std::abs(sf::angleDifference(0.0f, ship_template->beams[n].getDirection())) <= 45)
                     name = "Front";
-                else if (ship_template->beams[n].getDirection() > 45 && ship_template->beams[n].getDirection() < 135)
+                if (std::abs(sf::angleDifference(90.0f, ship_template->beams[n].getDirection())) < 45)
                     name = "Right";
-                else if (ship_template->beams[n].getDirection() >= 135 && ship_template->beams[n].getDirection() <= 225)
-                    name = "Rear";
-                else if (ship_template->beams[n].getDirection() > 225 && ship_template->beams[n].getDirection() < 315)
+                if (std::abs(sf::angleDifference(-90.0f, ship_template->beams[n].getDirection())) < 45)
                     name = "Left";
+                if (std::abs(sf::angleDifference(180.0f, ship_template->beams[n].getDirection())) <= 45)
+                    name = "Rear";
+
                 entry->addKeyValue(name + " beam weapon", string(ship_template->beams[n].getDamage() / ship_template->beams[n].getCycleTime(), 2) + " DPS");
             }
         }

--- a/src/spaceObjects/spaceshipParts/weaponTube.cpp
+++ b/src/spaceObjects/spaceshipParts/weaponTube.cpp
@@ -283,13 +283,13 @@ EMissileWeapons WeaponTube::getLoadType()
 
 string WeaponTube::getTubeName()
 {
-    if (std::abs(sf::angleDifference(0.0f, direction)) < 45)
+    if (std::abs(sf::angleDifference(0.0f, direction)) <= 45)
         return "Front";
     if (std::abs(sf::angleDifference(90.0f, direction)) < 45)
         return "Right";
     if (std::abs(sf::angleDifference(-90.0f, direction)) < 45)
         return "Left";
-    if (std::abs(sf::angleDifference(180.0f, direction)) < 45)
+    if (std::abs(sf::angleDifference(180.0f, direction)) <= 45)
         return "Rear";
     return "?" + string(direction);
 }


### PR DESCRIPTION
Cover gaps at 45, 135, 225, and 315 degrees of ship beam weapon directions when determining facing for the database. This issue results in "?" appearing in the database for those beam weapons, such as the Odin's.

The new labels on weapon tubes also have gaps at these angles.