### PR TITLE
Basic pack logging.

### DIFF
--- a/packs/pack_gen.py
+++ b/packs/pack_gen.py
@@ -56,6 +56,7 @@ def buildPack(name):
 			files[filename] = data
 	os.chdir('..')
 	f = open(name + '.pack', 'wb')
+	flog = open(name + '.packlist', 'wb')
 	f.write(struct.pack('>i', FORMAT_VERSION))
 	f.write(struct.pack('>i', len(files)))
 	offset = 8
@@ -64,12 +65,14 @@ def buildPack(name):
 	for filename, data in files.items():
 		f.write(struct.pack('>B', len(filename)))
 		f.write(filename)
+		flog.write(filename + '\n')
 		f.write(struct.pack('>ii', offset, len(data)))
 		print offset, filename
 		offset += len(data)
 	for filename, data in files.items():
 		f.write(data)
 	f.close()
+	flog.close()
 
 def main():
 	for dir in os.listdir("."):


### PR DESCRIPTION
Make a rudimentary log of component filenames to a `.packlog` file when running the `pack_gen.py` script. 

This starts to resolve #187.