### PR TITLE
Move music to clients and add option to toggle music

### DIFF
--- a/src/epsilonServer.cpp
+++ b/src/epsilonServer.cpp
@@ -15,23 +15,12 @@ EpsilonServer::EpsilonServer()
     for(unsigned int n=0; n<factionInfo.size(); n++)
         factionInfo[n]->reset();
 
-    threat_estimate = new ThreatLevelEstimate();
-    threat_estimate->setCallbacks([](){
-        LOG(INFO) << "Switching to ambient music";
-        soundManager->playMusicSet(findResources("music/ambient/*.ogg"));
-    }, []() {
-        LOG(INFO) << "Switching to combat music";
-        soundManager->playMusicSet(findResources("music/combat/*.ogg"));
-    });
-    
     state_logger = new GameStateLogger();
     state_logger->start();
 }
 
 EpsilonServer::~EpsilonServer()
 {
-    if (threat_estimate)
-        threat_estimate->destroy();
     if (state_logger)
         state_logger->destroy();
 }

--- a/src/epsilonServer.h
+++ b/src/epsilonServer.h
@@ -2,13 +2,11 @@
 #define REDONCULUS_SERVER_H
 
 #include "engine.h"
-#include "threatLevelEstimate.h"
 
 class GameStateLogger;
 
 class EpsilonServer : public GameServer
 {
-    P<ThreatLevelEstimate> threat_estimate;
     P<GameStateLogger> state_logger;
 public:
     EpsilonServer();

--- a/src/featureDefs.h
+++ b/src/featureDefs.h
@@ -1,6 +1,7 @@
 #ifndef FEATURES_H
 #define FEATURES_H
 
+// Android doesn't bundle 3D models or music.
 #ifndef FEATURE_3D_RENDERING
 
 # ifdef __ANDROID__

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -300,13 +300,22 @@ int main(int argc, char** argv)
     returnToMainMenu();
     engine->runMainLoop();
 
+    // Set FSAA and fullscreen defaults from windowManager.
     P<WindowManager> windowManager = engine->getObject("windowManager");
     if (windowManager)
     {
         PreferencesManager::set("fsaa", windowManager->getFSAA());
         PreferencesManager::set("fullscreen", windowManager->isFullscreen() ? 1 : 0);
     }
+
+    // Set the default music_volume option to the current volume.
     PreferencesManager::set("music_volume", soundManager->getMusicVolume());
+
+    // Enable music on the main screen only by default.
+    if (PreferencesManager::get("music_enabled").empty())
+        PreferencesManager::set("music_enabled", "2");
+
+    // Set shaders to default.
     PreferencesManager::set("disable_shaders", PostProcessor::isEnabled() ? 0 : 1);
 
     if (PreferencesManager::get("headless") == "")

--- a/src/menus/optionsMenu.cpp
+++ b/src/menus/optionsMenu.cpp
@@ -1,6 +1,7 @@
 #include "engine.h"
 #include "optionsMenu.h"
 #include "main.h"
+#include "preferenceManager.h"
 
 #include "gui/gui2_overlay.h"
 #include "gui/gui2_button.h"
@@ -8,6 +9,7 @@
 #include "gui/gui2_label.h"
 #include "gui/gui2_slider.h"
 #include "gui/gui2_listbox.h"
+#include "gui/gui2_keyvaluedisplay.h"
 
 OptionsMenu::OptionsMenu()
 {
@@ -24,27 +26,39 @@ OptionsMenu::OptionsMenu()
 
     // Add fsaa selector.
     int fsaa = std::max(1, windowManager->getFSAA());
-    int index = 0;
+    int fsaa_index = 0;
     switch(fsaa)
     {
-        case 8: index = 3; break;
-        case 4: index = 2; break;
-        case 2: index = 1; break;
-        default: index = 0; break;
+        case 8: fsaa_index = 3; break;
+        case 4: fsaa_index = 2; break;
+        case 2: fsaa_index = 1; break;
+        default: fsaa_index = 0; break;
     }
     (new GuiSelector(this, "FSAA", [](int index, string value)
     {
         P<WindowManager> windowManager = engine->getObject("windowManager");
-		static const int fsaa[] = { 0, 2, 4, 8 };
+        static const int fsaa[] = { 0, 2, 4, 8 };
         windowManager->setFSAA(fsaa[index]);
-    }))->setOptions({"FSAA: off", "FSAA: 2x", "FSAA: 4x", "FSAA: 8x"})->setSelectionIndex(index)->setPosition(50, 160, ATopLeft)->setSize(300, 50);
+    }))->setOptions({"FSAA: off", "FSAA: 2x", "FSAA: 4x", "FSAA: 8x"})->setSelectionIndex(fsaa_index)->setPosition(50, 160, ATopLeft)->setSize(300, 50);
 
     // Add music selection
-    (new GuiLabel(this, "MUSIC_VOL_LABEL", "Music Volume", 30))->addBackground()->setPosition(50, 220, ATopLeft)->setSize(300, 50);
+    (new GuiLabel(this, "MUSIC_ENABLED_LABEL", "Music", 30))->addBackground()->setPosition(50, 220, ATopLeft)->setSize(300, 50);
+
+    int music_enabled_index = std::stoi(PreferencesManager::get("music_enabled", "2"));
+    (new GuiSelector(this, "MUSIC_ENABLED", [](int index, string value)
+    {
+        // 0: Always off
+        // 1: Always on
+        // 2: On if main screen, off otherwise (default)
+        PreferencesManager::set("music_enabled", string(index));
+    }))->setOptions({"Disabled", "Enabled", "Main Screen only"})->setSelectionIndex(music_enabled_index)->setPosition(50, 270, ATopLeft)->setSize(300, 50);
+
+    (new GuiLabel(this, "MUSIC_VOL_LABEL", "Music volume", 30))->addBackground()->setPosition(50, 330, ATopLeft)->setSize(300, 50);
+
     (new GuiSlider(this, "MUSIC_VOL", 0, 100, soundManager->getMusicVolume(), [](float volume)
     {
         soundManager->setMusicVolume(volume);
-    }))->setPosition(50, 270, ATopLeft)->setSize(300, 50);
+    }))->setPosition(50, 380, ATopLeft)->setSize(300, 50);
 
     (new GuiButton(this, "BACK", "Back", [this]()
     {

--- a/src/screens/crewStationScreen.h
+++ b/src/screens/crewStationScreen.h
@@ -4,6 +4,7 @@
 #include "engine.h"
 #include "gui/gui2_canvas.h"
 #include "screenComponents/viewport3d.h"
+#include "threatLevelEstimate.h"
 
 class GuiButton;
 class GuiToggleButton;
@@ -11,6 +12,7 @@ class GuiPanel;
 
 class CrewStationScreen : public GuiCanvas, public Updatable
 {
+    P<ThreatLevelEstimate> threat_estimate;
 private:
     GuiButton* select_station_button;
     GuiPanel* button_strip;

--- a/src/screens/mainScreen.cpp
+++ b/src/screens/mainScreen.cpp
@@ -3,6 +3,7 @@
 #include "mainScreen.h"
 #include "main.h"
 #include "epsilonServer.h"
+#include "preferenceManager.h"
 #include "menus/shipSelectionScreen.h"
 
 #include "screenComponents/indicatorOverlays.h"
@@ -39,7 +40,19 @@ ScreenMainScreen::ScreenMainScreen()
     new GuiSelfDestructIndicator(this);
     new GuiGlobalMessage(this);
     new GuiIndicatorOverlays(this);
-    
+
+    if (PreferencesManager::get("music_enabled") != "0")
+    {
+        threat_estimate = new ThreatLevelEstimate();
+        threat_estimate->setCallbacks([](){
+            LOG(INFO) << "Switching to ambient music";
+            soundManager->playMusicSet(findResources("music/ambient/*.ogg"));
+        }, []() {
+            LOG(INFO) << "Switching to combat music";
+            soundManager->playMusicSet(findResources("music/combat/*.ogg"));
+        });
+    }
+
     first_person = false;
 }
 
@@ -47,6 +60,7 @@ void ScreenMainScreen::update(float delta)
 {
     if (game_client && game_client->getStatus() == GameClient::Disconnected)
     {
+        soundManager->stopMusic();
         destroy();
         disconnectFromServer();
         returnToMainMenu();
@@ -203,6 +217,7 @@ void ScreenMainScreen::onKey(sf::Keyboard::Key key, int unicode)
     //TODO: This is more generic code and is duplicated.
     case sf::Keyboard::Escape:
     case sf::Keyboard::Home:
+        soundManager->stopMusic();
         destroy();
         new ShipSelectionScreen();
         break;

--- a/src/screens/mainScreen.h
+++ b/src/screens/mainScreen.h
@@ -3,12 +3,14 @@
 
 #include "engine.h"
 #include "gui/gui2_canvas.h"
+#include "threatLevelEstimate.h"
 
 class GuiViewport3D;
 class GuiRadarView;
 
 class ScreenMainScreen : public GuiCanvas, public Updatable
 {
+    P<ThreatLevelEstimate> threat_estimate;
 private:
     GuiViewport3D* viewport;
     GuiRadarView* tactical_radar;


### PR DESCRIPTION
-   Move threat estimation from server to crew screens.
    -   This also moves music playback and switching from server to clients, which resolves at least part of #212 (headless servers playing music).
-   Create `music_enabled` option in `options.ini` and the options screen. Values:
    -   0: Client never plays music during game.
    -   1: Client always plays music during game.
    -   2 (default): Client plays music only when running the main screen.
-   Add music_enabled selector to option menu.

I'm not sure if this introduces issues with Android, which doesn't bundle music.