### PR TITLE
Edit ship and station comms scripts

### DIFF
--- a/scripts/comms_ship.lua
+++ b/scripts/comms_ship.lua
@@ -22,15 +22,16 @@ function friendlyComms(comms_data)
 	else
 		setCommsMessage("Sir, how can we assist?");
 	end
-	addCommsReply("Defend a location", function()
+	addCommsReply("Defend a waypoint", function()
 		if player:getWaypointCount() == 0 then
-			setCommsMessage("No waypoints set, please set a waypoint first.");
+			setCommsMessage("No waypoints set. Please set a waypoint first.");
+			addCommsReply("Back", mainMenu)
 		else
-			setCommsMessage("Which waypoint do we need to defend?");
+			setCommsMessage("Which waypoint should we defend?");
 			for n=1,player:getWaypointCount() do
-				addCommsReply("Defend at WP" .. n, function()
+				addCommsReply("Defend WP" .. n, function()
 					comms_target:orderDefendLocation(player:getWaypoint(n))
-					setCommsMessage("We are heading to assist at WP" .. n);
+					setCommsMessage("We are heading to assist at WP" .. n ..".");
 					addCommsReply("Back", mainMenu)
 				end)
 			end
@@ -38,12 +39,12 @@ function friendlyComms(comms_data)
 	end)
 	if comms_data.friendlyness > 0.2 then
 		addCommsReply("Assist me", function()
-			setCommsMessage("Heading towards you to assist you");
+			setCommsMessage("Heading toward you to assist.");
 			comms_target:orderDefendTarget(player)
 			addCommsReply("Back", mainMenu)
 		end)
 	end
-	addCommsReply("What is your status?", function()
+	addCommsReply("Report status", function()
 		msg = "Hull: " .. math.floor(comms_target:getHull() / comms_target:getHullMax() * 100) .. "%\n"
 		shields = comms_target:getShieldCount()
 		if shields == 1 then
@@ -60,7 +61,7 @@ function friendlyComms(comms_data)
 		missile_types = {'Homing', 'Nuke', 'Mine', 'EMP', 'HVLI'}
 		for i, missile_type in ipairs(missile_types) do
 			if comms_target:getWeaponStorageMax(missile_type) > 0 then
-					msg = msg .. missile_type .. " Missiles: " .. comms_target:getWeaponStorage(missile_type) .. "/" .. comms_target:getWeaponStorageMax(missile_type) .. "\n"
+					msg = msg .. missile_type .. " Missiles: " .. math.floor(comms_target:getWeaponStorage(missile_type)) .. "/" .. math.floor(comms_target:getWeaponStorageMax(missile_type)) .. "\n"
 			end
 		end
 
@@ -70,7 +71,7 @@ function friendlyComms(comms_data)
 	for _, obj in ipairs(comms_target:getObjectsInRange(5000)) do
 		if obj.typeName == "SpaceStation" and not comms_target:isEnemy(obj) then
 			addCommsReply("Dock at " .. obj:getCallSign(), function()
-				setCommsMessage("Docking at " .. obj:getCallSign());
+				setCommsMessage("Docking at " .. obj:getCallSign() .. ".");
 				comms_target:orderDock(obj)
 				addCommsReply("Back", mainMenu)
 			end)
@@ -84,7 +85,7 @@ function enemyComms(comms_data)
 		faction = comms_target:getFaction()
 		taunt_option = "We will see to your destruction!"
 		taunt_success_reply = "Your bloodline will end here!"
-		taunt_failed_reply = "Your feable threats are meaningless."
+		taunt_failed_reply = "Your feeble threats are meaningless."
 		if faction == "Kraylor" then
 			setCommsMessage("Ktzzzsss.\nYou will DIEEee weaklingsss!");
 		elseif faction == "Arlenians" then
@@ -92,12 +93,17 @@ function enemyComms(comms_data)
 		elseif faction == "Exuari" then
 			setCommsMessage("Stay out of our way, or your death will amuse us extremely!");
 		elseif faction == "Ghosts" then
-			setCommsMessage("One zero one.\nNo binary communication detected.\nSwitching to universal english.\nGenerating approprate response for target\n:Do not fucking cross us:\nCommunication halted.");
+			setCommsMessage("One zero one.\nNo binary communication detected.\nSwitching to universal speech.\nGenerating appropriate response for target from human language archives.\n:Do not fucking cross us:\nCommunication halted.");
 			taunt_option = "EXECUTE: SELFDESTRUCT"
 			taunt_success_reply = "Rogue command received. Targeting source."
 			taunt_failed_reply = "External command ignored."
+		elseif faction == "Ktlitans" then
+			setCommsMessage("The hive suffers no threats. Opposition to any of us is opposition to us all.\nStand down or prepare to donate your corpses toward our nutrition.");
+			taunt_option = "<Transmit 'The Itsy-Bitsy Spider' on all wavelengths>"
+			taunt_success_reply = "We do not need permission to pluck apart such an insignificant threat."
+			taunt_failed_reply = "The hive has greater priorities than exterminating pests."
 		else
-			setCommsMessage("Mind your own buisness!");
+			setCommsMessage("Mind your own business!");
 		end
 		comms_data.friendlyness = comms_data.friendlyness - random(0, 10)
 		addCommsReply(taunt_option, function()
@@ -115,7 +121,7 @@ end
 
 function neutralComms(comms_data)
 	if comms_data.friendlyness > 50 then
-		setCommsMessage("Sorry, no time to chat with you.\nWe are on an important mission.");
+		setCommsMessage("Sorry, we have no time to chat with you.\nWe are on an important mission.");
 	else
 		setCommsMessage("We have nothing for you.\nGood day.");
 	end

--- a/scripts/comms_ship.lua
+++ b/scripts/comms_ship.lua
@@ -45,17 +45,17 @@ function friendlyComms(comms_data)
 	end
 	addCommsReply("What is your status?", function()
 		msg = "Hull: " .. math.floor(comms_target:getHull() / comms_target:getHullMax() * 100) .. "%\n"
-        shields = comms_target:getShieldCount()
-        if shields == 1 then
-            msg = msg .. "Shield: " .. math.floor(comms_target:getShieldLevel(0) / comms_target:getShieldMax(0) * 100) .. "%\n"
-        elseif shields == 2 then
-            msg = msg .. "Front Shield: " .. math.floor(comms_target:getShieldLevel(0) / comms_target:getShieldMax(0) * 100) .. "%\n"
-            msg = msg .. "Rear Shield: " .. math.floor(comms_target:getShieldLevel(1) / comms_target:getShieldMax(1) * 100) .. "%\n"
-        else
-            for n=0,shields-1 do
-                msg = msg .. "Shield " .. n .. ": " .. math.floor(comms_target:getShieldLevel(n) / comms_target:getShieldMax(n) * 100) .. "%\n"
-            end
-        end
+		shields = comms_target:getShieldCount()
+		if shields == 1 then
+			msg = msg .. "Shield: " .. math.floor(comms_target:getShieldLevel(0) / comms_target:getShieldMax(0) * 100) .. "%\n"
+		elseif shields == 2 then
+			msg = msg .. "Front Shield: " .. math.floor(comms_target:getShieldLevel(0) / comms_target:getShieldMax(0) * 100) .. "%\n"
+			msg = msg .. "Rear Shield: " .. math.floor(comms_target:getShieldLevel(1) / comms_target:getShieldMax(1) * 100) .. "%\n"
+		else
+			for n=0,shields-1 do
+				msg = msg .. "Shield " .. n .. ": " .. math.floor(comms_target:getShieldLevel(n) / comms_target:getShieldMax(n) * 100) .. "%\n"
+			end
+		end
 		if comms_target:getWeaponStorageMax("Homing") > 0 then
 			msg = msg .. "Missiles: " .. comms_target:getWeaponStorage("Homing") .. "/" .. comms_target:getWeaponStorageMax("Homing") .. "\n"
 		end

--- a/scripts/comms_ship.lua
+++ b/scripts/comms_ship.lua
@@ -56,8 +56,12 @@ function friendlyComms(comms_data)
 				msg = msg .. "Shield " .. n .. ": " .. math.floor(comms_target:getShieldLevel(n) / comms_target:getShieldMax(n) * 100) .. "%\n"
 			end
 		end
-		if comms_target:getWeaponStorageMax("Homing") > 0 then
-			msg = msg .. "Missiles: " .. comms_target:getWeaponStorage("Homing") .. "/" .. comms_target:getWeaponStorageMax("Homing") .. "\n"
+
+		missile_types = {'Homing', 'Nuke', 'Mine', 'EMP', 'HVLI'}
+		for i, missile_type in ipairs(missile_types) do
+			if comms_target:getWeaponStorageMax(missile_type) > 0 then
+					msg = msg .. missile_type .. " Missiles: " .. comms_target:getWeaponStorage(missile_type) .. "/" .. comms_target:getWeaponStorageMax(missile_type) .. "\n"
+			end
 		end
 
 		setCommsMessage(msg);

--- a/scripts/comms_supply_drop.lua
+++ b/scripts/comms_supply_drop.lua
@@ -1,9 +1,9 @@
 -- Name: Supply ship comms
--- Description: Striped comms that do not allow any interaction. Used for transport ships.
+-- Description: Stripped comms that do not allow any interaction. Used for transport ships.
 
 function mainMenu()
 	if player:isFriendly(comms_target) then
-		setCommsMessage("Currently transporting goods.");
+		setCommsMessage("Transporting goods.");
 		return true
 	end
 	if player:isEnemy(comms_target) then


### PR DESCRIPTION
-   Move station services (supply drop and 
    reinforcements) into a services object, similar
    to the weapons/weapon_cost objects.
-   Use variables for service costs costs. Costs are
    not changed.
-   Fix typos and edit station comms scripts.
-   Fix typos and edit ship comms text.
-   Add other missile types to friendly status reports.
-   Add faction comms for Ktlitans.
-   Make indentation internally consistent.