### PR TITLE
Adjust database screen div distance

### DIFF
--- a/src/screenComponents/databaseView.cpp
+++ b/src/screenComponents/databaseView.cpp
@@ -41,7 +41,7 @@ DatabaseViewComponent::DatabaseViewComponent(GuiContainer* owner)
         }
         for(unsigned int n=0; n<entry->keyValuePairs.size(); n++)
         {
-            (new GuiKeyValueDisplay(layout, "", 0.6, entry->keyValuePairs[n].key, entry->keyValuePairs[n].value))->setSize(GuiElement::GuiSizeMax, 40);
+            (new GuiKeyValueDisplay(layout, "", 0.37, entry->keyValuePairs[n].key, entry->keyValuePairs[n].value))->setSize(GuiElement::GuiSizeMax, 40);
         }
         if (entry->model_data)
         {


### PR DESCRIPTION
Shifts the div distance to the left to help avoid overflowing shield key/value entries. Example results:

![untitled-2](https://cloud.githubusercontent.com/assets/19192104/15522454/5f7278bc-21c7-11e6-9af2-024a430eb69b.jpg)
![untitled-3](https://cloud.githubusercontent.com/assets/19192104/15522455/5f765bbc-21c7-11e6-9fa3-95fcfcded867.jpg)
![untitled-4](https://cloud.githubusercontent.com/assets/19192104/15522456/5f7979c8-21c7-11e6-815b-96889ad6e824.jpg)

Resolves #251.