### PR TITLE
Update ops and science screen controls

### DIFF
--- a/src/screens/crew4/operationsScreen.cpp
+++ b/src/screens/crew4/operationsScreen.cpp
@@ -6,6 +6,6 @@
 OperationScreen::OperationScreen(GuiContainer* owner)
 : ScienceScreen(owner)
 {
-    (new GuiOpenCommsButton(this, "OPEN_COMMS_BUTTON", &targets))->setPosition(20, 20, ATopLeft)->setSize(250, 50);
-    (new GuiCommsOverlay(this))->setSize(GuiElement::GuiSizeMax, GuiElement::GuiSizeMax);
+    (new GuiOpenCommsButton(this->radar_view, "OPEN_COMMS_BUTTON", &targets))->setPosition(-270, -20, ABottomRight)->setSize(200, 50);
+    (new GuiCommsOverlay(this->radar_view))->setSize(GuiElement::GuiSizeMax, GuiElement::GuiSizeMax);
 }

--- a/src/screens/crew6/scienceScreen.cpp
+++ b/src/screens/crew6/scienceScreen.cpp
@@ -170,6 +170,9 @@ void ScienceScreen::onDraw(sf::RenderTarget& window)
         if (view_distance < 5000.0f)
             view_distance = 5000.0f;
         science_radar->setDistance(view_distance);
+        // Keep the zoom slider in sync.
+        zoom_slider->setValue(view_distance);
+        zoom_label->setText("Zoom: " + string(gameGlobalInfo->long_range_radar_range / view_distance, 1) + "x");
     }
 
     if (!my_spaceship)


### PR DESCRIPTION
-   Prevent ops comms button and overlay from appearing on database view.
-   Move ops comms button to avoid radar overlap.
-   Synchronize science zoom slider behavior with mouse wheel zoom.