### PR TITLE
Cinematic view

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -67,6 +67,7 @@ set(SOURCES
 	src/menus/optionsMenu.cpp
 	src/menus/shipSelectionScreen.cpp
 	src/menus/autoConnectScreen.cpp
+	src/screens/cinematicViewScreen.cpp
 	src/screens/crewStationScreen.cpp
 	src/screens/topDownScreen.cpp
 	src/screens/windowScreen.cpp

--- a/src/menus/shipSelectionScreen.cpp
+++ b/src/menus/shipSelectionScreen.cpp
@@ -6,6 +6,7 @@
 #include "gameGlobalInfo.h"
 #include "screens/windowScreen.h"
 #include "screens/topDownScreen.h"
+#include "screens/cinematicViewScreen.h"
 #include "screens/gm/gameMasterScreen.h"
 
 #include "gui/gui2_autolayout.h"
@@ -63,11 +64,13 @@ ShipSelectionScreen::ShipSelectionScreen()
     game_master_button = new GuiToggleButton(stations_layout, "GAME_MASTER_BUTTON", "Game master", [this](bool value) {
         window_button->setValue(false);
         topdown_button->setValue(false);
+        cinematic_view_button->setValue(false);
     });
     game_master_button->setSize(GuiElement::GuiSizeMax, 50);
     window_button = new GuiToggleButton(stations_layout, "WINDOW_BUTTON", "Ship window", [this](bool value) {
         game_master_button->setValue(false);
         topdown_button->setValue(false);
+        cinematic_view_button->setValue(false);
     });
     window_button->setSize(GuiElement::GuiSizeMax, 50);
     window_angle = new GuiSelector(stations_layout, "WINDOW_ANGLE", nullptr);
@@ -75,11 +78,22 @@ ShipSelectionScreen::ShipSelectionScreen()
         window_angle->addEntry(string(n) + " degrees", string(n));
     window_angle->setSelectionIndex(0);
     window_angle->setSize(GuiElement::GuiSizeMax, 50);
+
+    // Top down view button
     topdown_button = new GuiToggleButton(stations_layout, "TOP_DOWN_3D_BUTTON", "Top down 3D", [this](bool value) {
         game_master_button->setValue(false);
         window_button->setValue(false);
+        cinematic_view_button->setValue(false);
     });
     topdown_button->setSize(GuiElement::GuiSizeMax, 50);
+
+    // Cinematic view button
+    cinematic_view_button = new GuiToggleButton(stations_layout, "CINEMATIC_VIEW_BUTTON", "Cinematic view", [this](bool value) {
+        game_master_button->setValue(false);
+        window_button->setValue(false);
+        topdown_button->setValue(false);
+    });
+    cinematic_view_button->setSize(GuiElement::GuiSizeMax, 50);
     
     if (game_server)
     {
@@ -186,7 +200,7 @@ void ShipSelectionScreen::updateReadyButton()
     {
         if (my_spaceship && main_screen_button->isVisible() && main_screen_button->getValue())
             ready_button->enable();
-        else if (game_master_button->getValue() || topdown_button->getValue())
+        else if (game_master_button->getValue() || topdown_button->getValue() || cinematic_view_button->getValue())
             ready_button->enable();
         else if (my_spaceship && window_button->getValue())
             ready_button->enable();
@@ -206,11 +220,13 @@ void ShipSelectionScreen::updateCrewTypeOptions()
     window_button->hide();
     window_angle->hide();
     topdown_button->hide();
+    cinematic_view_button->hide();
     main_screen_button->setVisible(canDoMainScreen());
     main_screen_button->setValue(false);
     game_master_button->setValue(false);
     window_button->setValue(false);
     topdown_button->setValue(false);
+    cinematic_view_button->setValue(false);
     for(int n=0; n<max_crew_positions; n++)
     {
         crew_position_button[n]->setValue(false)->hide();
@@ -237,6 +253,7 @@ void ShipSelectionScreen::updateCrewTypeOptions()
         window_button->setVisible(canDoMainScreen());
         window_angle->setVisible(canDoMainScreen());
         topdown_button->setVisible(canDoMainScreen());
+        cinematic_view_button->setVisible(canDoMainScreen());
         break;
     }
     for(int n=0; n<max_crew_positions; n++)
@@ -265,6 +282,11 @@ void ShipSelectionScreen::onReadyClick()
         my_player_info->commandSetShipId(-1);
         destroy();
         new TopDownScreen();
+    }else if(cinematic_view_button->getValue())
+    {
+        my_player_info->commandSetShipId(-1);
+        destroy();
+        new CinematicViewScreen();
     }else{
         destroy();
         my_player_info->spawnUI();

--- a/src/menus/shipSelectionScreen.h
+++ b/src/menus/shipSelectionScreen.h
@@ -25,6 +25,7 @@ private:
     GuiToggleButton* window_button;
     GuiSelector* window_angle;
     GuiToggleButton* topdown_button;
+    GuiToggleButton* cinematic_view_button;
     
 public:
     ShipSelectionScreen();

--- a/src/screens/cinematicViewScreen.cpp
+++ b/src/screens/cinematicViewScreen.cpp
@@ -129,8 +129,8 @@ void CinematicViewScreen::update(float delta)
             tot_distance_3D = sf::length(tot_diff_3D);
 
             // Position the camera over the selected ship.
-            camera_position.x = target_position_2D.x + (10.0f * sf::normalize(tot_diff_2D).x);
-            camera_position.y = target_position_2D.y + (10.0f * sf::normalize(tot_diff_2D).y);
+            camera_position.x = target_position_2D.x - (100.0f * sf::normalize(tot_diff_2D).x);
+            camera_position.y = target_position_2D.y - (100.0f * sf::normalize(tot_diff_2D).y);
             camera_position.z = 100.0f;
 
             // Set the camera angle to point at the selected ship's target.
@@ -150,7 +150,6 @@ void CinematicViewScreen::update(float delta)
             camera_position.x = camera_destination.x;
             camera_position.y = camera_destination.y;
         } else {
-
             // Calculate the angles between the camera and the ship.
             angle_yaw = sf::vector2ToAngle(diff_2D);
             angle_pitch = (atan(camera_position.z / distance_3D)) * (180 / pi);

--- a/src/screens/cinematicViewScreen.cpp
+++ b/src/screens/cinematicViewScreen.cpp
@@ -1,0 +1,254 @@
+#include "playerInfo.h"
+#include "gameGlobalInfo.h"
+#include "cinematicViewScreen.h"
+#include "epsilonServer.h"
+#include "main.h"
+#include "menus/shipSelectionScreen.h"
+
+#include "screenComponents/indicatorOverlays.h"
+#include "gui/gui2_selector.h"
+#include "gui/gui2_togglebutton.h"
+
+CinematicViewScreen::CinematicViewScreen()
+{
+    // Create a full-screen viewport.
+    viewport = new GuiViewport3D(this, "VIEWPORT");
+    viewport->setPosition(0, 0, ATopLeft)->setSize(GuiElement::GuiSizeMax, GuiElement::GuiSizeMax);
+
+    // Initialize the camera's vertical position.
+    camera_position.z = 100.0;
+    // Initialize an angled top-down view with the top of the screen pointing
+    // toward heading 0.
+    camera_yaw = -90.0f;
+    camera_pitch = 45.0f;
+
+    // Let the screen operator select a player ship to lock the camera onto.
+    camera_lock_selector = new GuiSelector(this, "CAMERA_LOCK_SELECTOR", [this](int index, string value) {
+        P<PlayerSpaceship> ship = gameGlobalInfo->getPlayerShip(value.toInt());
+        if (ship)
+            target = ship;
+    });
+    camera_lock_selector->setPosition(20, -80, ABottomLeft)->setSize(300, 50)->hide();
+
+    // Toggle whether to lock the camera onto a ship.
+    camera_lock_toggle = new GuiToggleButton(this, "CAMERA_LOCK_TOGGLE", "Lock camera on ship", [this](bool value) {});
+    camera_lock_toggle->setPosition(20, -20, ABottomLeft)->setSize(300, 50)->hide();
+
+    new GuiIndicatorOverlays(this);
+}
+
+void CinematicViewScreen::update(float delta)
+{
+    // If this is a client and it is disconnected, exit.
+    if (game_client && game_client->getStatus() == GameClient::Disconnected)
+    {
+        destroy();
+        disconnectFromServer();
+        returnToMainMenu();
+        return;
+    }
+
+    // Enable mouse wheel zoom.
+    float mouse_wheel_delta = InputHandler::getMouseWheelDelta();
+    if (mouse_wheel_delta != 0.0)
+    {
+        camera_position.z = camera_position.z * (1.0 - (mouse_wheel_delta) * 0.1f);
+        if (camera_position.z > 10000.0)
+            camera_position.z = 10000.0;
+        if (camera_position.z < 200.0)
+            camera_position.z = 200.0;
+    }
+
+    // TODO: Add mouselook.
+
+    // Add and remove entries from the player ship list.
+    // TODO: Allow any ship or station to be the camera target.
+    for(int n=0; n<GameGlobalInfo::max_player_ships; n++)
+    {
+        P<PlayerSpaceship> ship = gameGlobalInfo->getPlayerShip(n);
+        if (ship)
+        {
+            if (camera_lock_selector->indexByValue(string(n)) == -1)
+                camera_lock_selector->addEntry(ship->getTypeName() + " " + ship->getCallSign(), string(n));
+        }else{
+            if (camera_lock_selector->indexByValue(string(n)) != -1)
+                camera_lock_selector->removeEntry(camera_lock_selector->indexByValue(string(n)));
+        }
+    }
+
+    // Plot headings from the camera to the locked player ship.
+    // Set camera_yaw and camera_pitch to those values.
+
+    // If lock is enabled and a ship is selected...
+    if (camera_lock_toggle->getValue() && target)
+    {
+        // const double pi = 3.1415926535897932384626433832795;
+        const double pi = M_PI;
+
+        // Get the selected ship's current position.
+        sf::Vector2f target_position_2D = target->getPosition();
+        // Copy the selected ship's position into a Vector3 for camera angle
+        // calculations.
+        sf::Vector3f target_position_3D;
+        target_position_3D.x = target_position_2D.x;
+        target_position_3D.y = target_position_2D.y;
+        target_position_3D.z = 0;
+
+        // Copy the camera position into a Vector2 for camera angle
+        // calculations.
+        sf::Vector2f camera_position_2D;
+        camera_position_2D.x = camera_position.x;
+        camera_position_2D.y = camera_position.y;
+
+        // Calculate the distance from the camera to the selected ship.
+        sf::Vector2f diff = target_position_2D - camera_position_2D;
+        sf::Vector3f diff_3D = target_position_3D - camera_position;
+
+        float distance = sf::length(diff);
+        float distance_3D = sf::length(diff_3D);
+
+        // Get the ship's current heading and velocity.
+        float target_rotation = target->getRotation();
+        // float target_velocity = sf::length(target->getVelocity());
+
+        // We want the camera to always be less than 1U from the selected ship.
+        float camera_distance = 1000.0f;
+
+        // If the ship moves more than 1U from the camera ...
+        if (distance > camera_distance)
+        {
+            // Set a vector 5 degrees to the right of the selected ship's
+            // rotation.
+            sf::Vector2f camera_rotation_vector = sf::vector2FromAngle(target_rotation + 5);
+
+            // Plot a destination on that vector at a distance of 1U.
+            sf::Vector2f camera_destination = target_position_2D + camera_rotation_vector * camera_distance;
+
+            // Move the camera's X and Y coordinates to this vector.
+            camera_position.x = camera_destination.x;
+            camera_position.y = camera_destination.y;
+        }
+        /* else{
+            // Park the camera at a photogenic angle at high speeds.
+            camera_position.x = target_position_2D.x;
+            camera_position.y = target_position_2D.y;
+        } */
+
+        // Calculate the angles between the camera and the ship.
+        float angle_yaw = sf::vector2ToAngle(diff);
+        float angle_pitch = (atan(camera_position.z / distance_3D)) * (180 / pi);
+
+        // Point the camera at the ship.
+        camera_yaw = angle_yaw;
+        camera_pitch = angle_pitch;
+    }
+
+    // TODO: If locked player ship has a hostile weapons target...
+    //           Move the camera to rotate around the player ship, pointing at
+    //             the player ship's weapons target.
+
+#ifdef DEBUG
+    if (sf::Keyboard::isKeyPressed(sf::Keyboard::Z))
+    {
+        camera_position.x = target->getPosition().x;
+        camera_position.y = target->getPosition().y;
+        camera_position.z = 3000.0;
+        camera_pitch = 90.0f;
+    }
+#endif
+}
+
+void CinematicViewScreen::onKey(sf::Keyboard::Key key, int unicode)
+{
+    switch(key)
+    {
+    // Toggle UI visibility with the H key.
+    case sf::Keyboard::H:
+        if (camera_lock_toggle->isVisible() || camera_lock_selector->isVisible())
+        {
+            camera_lock_toggle->hide();
+            camera_lock_selector->hide();
+        }else{
+            camera_lock_toggle->show();
+            camera_lock_selector->show();
+        }
+        break;
+    // Toggle camera lock with the L key.
+    case sf::Keyboard::L:
+        camera_lock_toggle->setValue(!camera_lock_toggle->getValue());
+        break;
+    // Cycle through player ships with the J and K keys.
+    case sf::Keyboard::J:
+        camera_lock_selector->setSelectionIndex(camera_lock_selector->getSelectionIndex() - 1);
+        if (camera_lock_selector->getSelectionIndex() < 0)
+            camera_lock_selector->setSelectionIndex(camera_lock_selector->entryCount() - 1);
+        target = gameGlobalInfo->getPlayerShip(camera_lock_selector->getEntryValue(camera_lock_selector->getSelectionIndex()).toInt());
+        break;
+    case sf::Keyboard::K:
+        camera_lock_selector->setSelectionIndex(camera_lock_selector->getSelectionIndex() + 1);
+        if (camera_lock_selector->getSelectionIndex() >= camera_lock_selector->entryCount())
+            camera_lock_selector->setSelectionIndex(0);
+        target = gameGlobalInfo->getPlayerShip(camera_lock_selector->getEntryValue(camera_lock_selector->getSelectionIndex()).toInt());
+        break;
+    // WASD controls for the camera.
+    // TODO: If unlocked, W moves the camera forward on its current heading.
+    //       If locked, W moves the camera toward the target.
+    case sf::Keyboard::W:
+        if (!camera_lock_toggle->getValue())
+            camera_position.y = camera_position.y - (50 * (camera_position.z / 1000));
+        break;
+    // TODO: If unlocked, A moves the camera laterally to the left of its
+    //         current heading.
+    //       If locked, A moves the camera counterclockwise around the
+    //         target.
+    case sf::Keyboard::A:
+        if (!camera_lock_toggle->getValue())
+            camera_position.x = camera_position.x - (50 * (camera_position.z / 1000));
+        break;
+    // TODO: If unlocked, S moves the camera laterally to the right of its
+    //         current heading.
+    //       If locked, S moves the camera clockwise around the target.
+    case sf::Keyboard::S:
+        if (!camera_lock_toggle->getValue())
+            camera_position.y = camera_position.y + (50 * (camera_position.z / 1000));
+        break;
+    // TODO: If unlocked, D moves the camera backward from its current heading.
+    //       If locked, D moves the camera away from the target.
+    case sf::Keyboard::D:
+        if (!camera_lock_toggle->getValue())
+            camera_position.x = camera_position.x + (50 * (camera_position.z / 1000));
+        break;
+    // TODO: If unlocked, R moves the camera vertically upward from its current
+    //         heading, and F moves it downward.
+    //       If locked, R moves the camera vertically upward around the target,
+    //         and F moves it downward.
+    case sf::Keyboard::R:
+        if (camera_position.z > 200.0)
+            camera_position.z = camera_position.z - 100;
+        else
+            camera_position.z = 1000.0;
+        break;
+    case sf::Keyboard::F:
+        if (camera_position.z < 10000.0)
+            camera_position.z = camera_position.z + 100;
+        else
+            camera_position.z = 10000.0;
+        break;
+    // TODO: If unlocked, the arrow keys turn the camera.
+    // TODO: X resets the camera to a default relative position and heading.
+    // TODO: This is more generic code and is duplicated.
+    // Exit the screen with the escape or home keys.
+    case sf::Keyboard::Escape:
+    case sf::Keyboard::Home:
+        destroy();
+        new ShipSelectionScreen();
+        break;
+    // If this is the server, pause the game with the P key.
+    case sf::Keyboard::P:
+        if (game_server)
+            engine->setGameSpeed(0.0);
+        break;
+    default:
+        break;
+    }
+}

--- a/src/screens/cinematicViewScreen.cpp
+++ b/src/screens/cinematicViewScreen.cpp
@@ -82,7 +82,7 @@ void CinematicViewScreen::update(float delta)
     // If lock is enabled and a ship is selected...
     if (camera_lock_toggle->getValue() && target)
     {
-        // const double pi = 3.1415926535897932384626433832795;
+        // M_PI = 3.1415926535897932384626433832795;
         const double pi = M_PI;
 
         // Get the selected ship's current position.
@@ -114,8 +114,33 @@ void CinematicViewScreen::update(float delta)
         // We want the camera to always be less than 1U from the selected ship.
         float camera_distance = 1000.0f;
 
-        // If the ship moves more than 1U from the camera ...
-        if (distance > camera_distance)
+        // Check if our selected ship has a weapons target.
+        P<SpaceObject> target_of_target = target->getTarget();
+
+        // Initialize angles.
+        float angle_yaw;
+        float angle_pitch;
+
+        if (target_of_target)
+        {
+            camera_position.x = target_position_2D.x;
+            camera_position.y = target_position_2D.y;
+            camera_position.z = 100.0f;
+
+            sf::Vector2f tot_position_2D = target_of_target->getPosition();
+            sf::Vector3f tot_position_3D;
+            tot_position_3D.x = tot_position_2D.x;
+            tot_position_3D.y = tot_position_3D.y;
+            tot_position_3D.z = 0;
+            sf::Vector2f tot_diff = tot_position_2D - camera_position_2D;
+            sf::Vector3f tot_diff_3D = tot_position_3D - camera_position;
+            float tot_distance = sf::length(tot_diff);
+            float tot_distance_3D = sf::length(tot_diff_3D);
+
+            angle_yaw = sf::vector2ToAngle(tot_diff);
+            angle_pitch = (atan(camera_position.z / tot_distance_3D)) * (180 / pi);
+        } else if (distance > camera_distance)
+        // If the selected ship moves more than 1U from the camera ...
         {
             // Set a vector 5 degrees to the right of the selected ship's
             // rotation.
@@ -124,9 +149,13 @@ void CinematicViewScreen::update(float delta)
             // Plot a destination on that vector at a distance of 1U.
             sf::Vector2f camera_destination = target_position_2D + camera_rotation_vector * camera_distance;
 
-            // Move the camera's X and Y coordinates to this vector.
+            // Move the camera's X and Y coordinates to this destination.
             camera_position.x = camera_destination.x;
             camera_position.y = camera_destination.y;
+        } else {
+            // Calculate the angles between the camera and the ship.
+            angle_yaw = sf::vector2ToAngle(diff);
+            angle_pitch = (atan(camera_position.z / distance_3D)) * (180 / pi);
         }
         /* else{
             // Park the camera at a photogenic angle at high speeds.
@@ -134,18 +163,10 @@ void CinematicViewScreen::update(float delta)
             camera_position.y = target_position_2D.y;
         } */
 
-        // Calculate the angles between the camera and the ship.
-        float angle_yaw = sf::vector2ToAngle(diff);
-        float angle_pitch = (atan(camera_position.z / distance_3D)) * (180 / pi);
-
-        // Point the camera at the ship.
+        // Point the camera.
         camera_yaw = angle_yaw;
         camera_pitch = angle_pitch;
     }
-
-    // TODO: If locked player ship has a hostile weapons target...
-    //           Move the camera to rotate around the player ship, pointing at
-    //             the player ship's weapons target.
 
 #ifdef DEBUG
     if (sf::Keyboard::isKeyPressed(sf::Keyboard::Z))

--- a/src/screens/cinematicViewScreen.h
+++ b/src/screens/cinematicViewScreen.h
@@ -1,0 +1,27 @@
+#ifndef CINEMATIC_VIEW_SCREEN_H
+#define CINEMATIC_VIEW_SCREEN_H
+
+#include "engine.h"
+#include "gui/gui2_canvas.h"
+#include "gui/gui2_label.h"
+#include "screenComponents/viewport3d.h"
+
+class GuiSelector;
+class GuiToggleButton;
+
+class CinematicViewScreen : public GuiCanvas, public Updatable
+{
+private:
+    GuiViewport3D* viewport;
+    P<SpaceObject> target;
+    GuiSelector* camera_lock_selector;
+    GuiToggleButton* camera_lock_toggle;
+public:
+    CinematicViewScreen();
+    
+    virtual void update(float delta);
+    
+    virtual void onKey(sf::Keyboard::Key key, int unicode);
+};
+
+#endif//CINEMATIC_VIEW_SCREEN_H

--- a/src/screens/cinematicViewScreen.h
+++ b/src/screens/cinematicViewScreen.h
@@ -12,10 +12,41 @@ class GuiToggleButton;
 class CinematicViewScreen : public GuiCanvas, public Updatable
 {
 private:
+    const double pi = M_PI;
+
     GuiViewport3D* viewport;
     P<PlayerSpaceship> target;
     GuiSelector* camera_lock_selector;
     GuiToggleButton* camera_lock_toggle;
+    GuiToggleButton* camera_lock_tot_toggle;
+    float camera_distance;
+    sf::Vector2f camera_rotation_vector;
+    sf::Vector2f camera_destination;
+    float angle_yaw;
+    float angle_pitch;
+
+    sf::Vector2f diff_2D;
+    sf::Vector3f diff_3D;
+    float distance_2D;
+    float distance_3D;
+
+    sf::Vector2f target_position_2D;
+    sf::Vector3f target_position_3D;
+    // camera_position is a Vector3, so no need to declare one here.
+    sf::Vector2f camera_position_2D;
+    float target_rotation;
+    float target_velocity;
+
+    P<SpaceObject> target_of_target;
+
+    sf::Vector2f tot_position_2D;
+    sf::Vector3f tot_position_3D;
+    sf::Vector2f tot_diff_2D;
+    sf::Vector3f tot_diff_3D;
+    float tot_angle;
+    float tot_distance_2D;
+    float tot_distance_3D;
+
 public:
     CinematicViewScreen();
     

--- a/src/screens/cinematicViewScreen.h
+++ b/src/screens/cinematicViewScreen.h
@@ -13,7 +13,7 @@ class CinematicViewScreen : public GuiCanvas, public Updatable
 {
 private:
     GuiViewport3D* viewport;
-    P<SpaceObject> target;
+    P<PlayerSpaceship> target;
     GuiSelector* camera_lock_selector;
     GuiToggleButton* camera_lock_toggle;
 public:


### PR DESCRIPTION
Adds a low-angle spectating viewscreen. When locked on a player ship, it provides a fly-by camera (tracks the moving ship from a stationary point) and target lock camera (from the locked ship's viewpoint, the camera tracks the selected weapons target).