### PR TITLE
Add a player ship selector to the GM screen.

### DIFF
--- a/src/screens/gm/gameMasterScreen.h
+++ b/src/screens/gm/gameMasterScreen.h
@@ -22,6 +22,7 @@ class GameMasterScreen : public GuiCanvas, public Updatable
 {
 private:
     TargetsContainer targets;
+    P<SpaceObject> target;
     GuiRadarView* main_radar;
     GuiOverlay* box_selection_overlay;
     GuiSelector* faction_selector;
@@ -38,6 +39,7 @@ private:
     GuiButton* player_comms_hail;
     GuiButton* ship_tweak_button;
     GuiButton* export_button;
+    GuiSelector* player_ship_selector;
     
     enum EClickAndDragState
     {


### PR DESCRIPTION
Adds a player ship selector to the GM screen if there are player ships in the scenario. Selecting a player ship centers the map over the selected ship and changes the GM target to that ship.