### PR TITLE
Add option to toggle game log generation

### DIFF
--- a/src/epsilonServer.cpp
+++ b/src/epsilonServer.cpp
@@ -20,8 +20,7 @@ EpsilonServer::EpsilonServer()
     {
         state_logger = new GameStateLogger();
         state_logger->start();
-    } else if (state_logger)
-        state_logger->destroy();
+    }
 }
 
 EpsilonServer::~EpsilonServer()

--- a/src/epsilonServer.cpp
+++ b/src/epsilonServer.cpp
@@ -3,6 +3,7 @@
 #include "gameGlobalInfo.h"
 #include "gameStateLogger.h"
 #include "main.h"
+#include "preferenceManager.h"
 
 EpsilonServer::EpsilonServer()
 : GameServer("Server", VERSION_NUMBER)
@@ -15,8 +16,12 @@ EpsilonServer::EpsilonServer()
     for(unsigned int n=0; n<factionInfo.size(); n++)
         factionInfo[n]->reset();
 
-    state_logger = new GameStateLogger();
-    state_logger->start();
+    if (PreferencesManager::get("game_logs", "1").toInt())
+    {
+        state_logger = new GameStateLogger();
+        state_logger->start();
+    } else if (state_logger)
+        state_logger->destroy();
 }
 
 EpsilonServer::~EpsilonServer()

--- a/src/menus/serverCreationScreen.cpp
+++ b/src/menus/serverCreationScreen.cpp
@@ -143,7 +143,7 @@ ServerCreationScreen::ServerCreationScreen()
     GuiPanel* panel = new GuiPanel(right_panel, "SCENARIO_DESCRIPTION_BOX");
     panel->setSize(GuiElement::GuiSizeMax, 200);
     scenario_description = new GuiScrollText(panel, "SCENARIO_DESCRIPTION", "");
-    scenario_description->setTextSize(24)->setMargins(15, 15, 15, 25)->setSize(GuiElement::GuiSizeMax, GuiElement::GuiSizeMax);
+    scenario_description->setTextSize(24)->setMargins(15, 15, 30, 25)->setSize(GuiElement::GuiSizeMax, GuiElement::GuiSizeMax);
 
     // If the scenario has variations, show and select from them.
     variation_container = new GuiAutoLayout(right_panel, "VARIATION_CONTAINER", GuiAutoLayout::LayoutVerticalTopToBottom);
@@ -161,7 +161,7 @@ ServerCreationScreen::ServerCreationScreen()
     panel = new GuiPanel(variation_container, "VARIATION_DESCRIPTION_BOX");
     panel->setSize(GuiElement::GuiSizeMax, 150);
     variation_description = new GuiScrollText(panel, "VARIATION_DESCRIPTION", "");
-    variation_description->setTextSize(24)->setMargins(15, 15, 15, 25)->setSize(GuiElement::GuiSizeMax, GuiElement::GuiSizeMax);
+    variation_description->setTextSize(24)->setMargins(15, 15, 30, 25)->setSize(GuiElement::GuiSizeMax, GuiElement::GuiSizeMax);
 
     // Buttons beneath the columns.
     // Close server button.


### PR DESCRIPTION
Set `game_logs=1` by default in options.ini. Game logs can be disabled by switching that setting to 0.

Also tweaks description margins on server selection screen.