### PR TITLE
Move game state logging from server creation to start of scenario

### DIFF
--- a/src/epsilonServer.cpp
+++ b/src/epsilonServer.cpp
@@ -1,7 +1,6 @@
 #include "epsilonServer.h"
 #include "playerInfo.h"
 #include "gameGlobalInfo.h"
-#include "gameStateLogger.h"
 #include "main.h"
 
 EpsilonServer::EpsilonServer()
@@ -14,15 +13,10 @@ EpsilonServer::EpsilonServer()
     engine->setGameSpeed(0.0);
     for(unsigned int n=0; n<factionInfo.size(); n++)
         factionInfo[n]->reset();
-
-    state_logger = new GameStateLogger();
-    state_logger->start();
 }
 
 EpsilonServer::~EpsilonServer()
 {
-    if (state_logger)
-        state_logger->destroy();
 }
 
 void EpsilonServer::onNewClient(int32_t client_id)

--- a/src/epsilonServer.h
+++ b/src/epsilonServer.h
@@ -3,11 +3,8 @@
 
 #include "engine.h"
 
-class GameStateLogger;
-
 class EpsilonServer : public GameServer
 {
-    P<GameStateLogger> state_logger;
 public:
     EpsilonServer();
     virtual ~EpsilonServer();

--- a/src/gameGlobalInfo.cpp
+++ b/src/gameGlobalInfo.cpp
@@ -1,4 +1,5 @@
 #include "gameGlobalInfo.h"
+#include "preferenceManager.h"
 
 P<GameGlobalInfo> gameGlobalInfo;
 
@@ -160,12 +161,20 @@ void GameGlobalInfo::startScenario(string filename)
     P<ScriptObject> script = new ScriptObject();
     script->run(filename);
     engine->registerObject("scenario", script);
+
+    if (PreferencesManager::get("game_logs", "1").toInt())
+    {
+        state_logger = new GameStateLogger();
+        state_logger->start();
+    }
 }
 
 void GameGlobalInfo::destroy()
 {
     reset();
     MultiplayerObject::destroy();
+    if (state_logger)
+        state_logger->destroy();
 }
 
 string playerWarpJumpDriveToString(EPlayerWarpJumpDrive player_warp_jump_drive)

--- a/src/gameGlobalInfo.h
+++ b/src/gameGlobalInfo.h
@@ -4,7 +4,9 @@
 #include "spaceObjects/playerSpaceship.h"
 #include "script.h"
 #include "GMScriptCallback.h"
+#include "gameStateLogger.h"
 
+class GameStateLogger;
 class GameGlobalInfo;
 extern P<GameGlobalInfo> gameGlobalInfo;
 
@@ -33,6 +35,7 @@ enum EScanningComplexity
 
 class GameGlobalInfo : public MultiplayerObject, public Updatable
 {
+    P<GameStateLogger> state_logger;
 public:
     /*!
      * \brief Maximum number of player ships.


### PR DESCRIPTION
Game state logging starts when the EpsilonServer object is created, and us destroyed when the object is destroyed. However, the logger doesn't log anything that happens until a scenario starts. This isn't ideal for a few reasons:

-    Starting the server and closing it without starting a scenario results in a 0-length log file left in the logs folder.
-   Running multiple scenarios on the same server object results in all scenarios logged to the same file.

This PR:

-   Moves game state logging into the startScenario function of GameGlobalInfo. The logger starts when the scenario starts and is destroyed when the scenario is destroyed. A single server object should create a unique log file each time it starts a scenario.
-   Sets a `game_logs` Boolean option in PreferencesManager, with a default value of `true`/`1`.