### PR TITLE
Ship selection screen improvements

### DIFF
--- a/src/gui/gui2_entrylist.cpp
+++ b/src/gui/gui2_entrylist.cpp
@@ -27,6 +27,31 @@ GuiEntryList* GuiEntryList::setOptions(std::vector<string> options, std::vector<
     return this;
 }
 
+void GuiEntryList::setEntryName(int index, string name)
+{
+    if (index < 0 || index >= (int)entries.size())
+        return;
+    entries[index].name = name;
+    entriesChanged();
+}
+
+void GuiEntryList::setEntryValue(int index, string value)
+{
+    if (index < 0 || index >= (int)entries.size())
+        return;
+    entries[index].value = value;
+    entriesChanged();
+}
+
+void GuiEntryList::setEntry(int index, string name, string value)
+{
+    if (index < 0 || index >= (int)entries.size())
+        return;
+    entries[index].value = value;
+    entries[index].name = name;
+    entriesChanged();
+}
+
 int GuiEntryList::addEntry(string name, string value)
 {
     entries.emplace_back(name, value);

--- a/src/gui/gui2_entrylist.h
+++ b/src/gui/gui2_entrylist.h
@@ -29,6 +29,10 @@ public:
     GuiEntryList* setOptions(std::vector<string> options);
     GuiEntryList* setOptions(std::vector<string> options, std::vector<string> values);
 
+    void setEntryName(int index, string name);
+    void setEntryValue(int index, string value);
+    void setEntry(int index, string name, string value);
+
     int addEntry(string name, string value);
     int indexByValue(string value);
     void removeEntry(int index);

--- a/src/menus/shipSelectionScreen.cpp
+++ b/src/menus/shipSelectionScreen.cpp
@@ -12,6 +12,7 @@
 #include "gui/gui2_autolayout.h"
 #include "gui/gui2_label.h"
 #include "gui/gui2_selector.h"
+#include "gui/gui2_slider.h"
 #include "gui/gui2_togglebutton.h"
 #include "gui/gui2_panel.h"
 #include "gui/gui2_listbox.h"
@@ -21,23 +22,28 @@ ShipSelectionScreen::ShipSelectionScreen()
     new GuiOverlay(this, "", colorConfig.background);
     (new GuiOverlay(this, "", sf::Color::White))->setTextureTiled("gui/BackgroundCrosses");
 
-    //Easiest place to ensure that positional sound is disabled on console views. As soon as a 3D view is rendered positional sound is enabled again.
+    // Easiest place to ensure that positional sound is disabled on console
+    // views. As soon as a 3D view is rendered, positional sound is re-enabled.
     soundManager->disablePositionalSound();
 
+    // Draw a container with two columns.
     GuiElement* container = new GuiAutoLayout(this, "", GuiAutoLayout::ELayoutMode::LayoutVerticalColumns);
     container->setSize(GuiElement::GuiSizeMax, GuiElement::GuiSizeMax);
     GuiElement* left_container = new GuiElement(container, "");
     GuiElement* right_container = new GuiElement(container, "");
 
+    // List the station types and stations in the right column.
     GuiAutoLayout* stations_layout = new GuiAutoLayout(right_container, "CREW_POSITION_BUTTON_LAYOUT", GuiAutoLayout::LayoutVerticalTopToBottom);
     stations_layout->setPosition(0, 50, ATopCenter)->setSize(400, 500);
     (new GuiLabel(stations_layout, "CREW_POSITION_SELECT_LABEL", "Select your station", 30))->addBackground()->setSize(GuiElement::GuiSizeMax, 50);
 
+    // Crew type selector
     crew_type_selector = new GuiSelector(stations_layout, "CREW_TYPE_SELECTION", [this](int index, string value) {
         updateCrewTypeOptions();
     });
     crew_type_selector->setOptions({"6/5 player crew", "4/3 player crew", "1 player crew/extras", "Alternative options"})->setSize(GuiElement::GuiSizeMax, 50);
 
+    // Main screen button
     main_screen_button = new GuiToggleButton(stations_layout, "MAIN_SCREEN_BUTTON", "Main screen", [this](bool value) {
         for(int n=0; n<max_crew_positions; n++)
         {
@@ -46,7 +52,9 @@ ShipSelectionScreen::ShipSelectionScreen()
         }
     });
     main_screen_button->setSize(GuiElement::GuiSizeMax, 50);
-    for(int n=0; n<max_crew_positions; n++)
+
+    // Crew position buttons, with icons if they have them.
+    for(int n = 0; n < max_crew_positions; n++)
     {
         crew_position_button[n] = new GuiToggleButton(stations_layout, "CREW_" + getCrewPositionName(ECrewPosition(n)) + "_BUTTON", getCrewPositionName(ECrewPosition(n)), [this, n](bool value){
             main_screen_button->setValue(false);
@@ -56,31 +64,39 @@ ShipSelectionScreen::ShipSelectionScreen()
         crew_position_button[n]->setIcon(getCrewPositionIcon(ECrewPosition(n)));
     }
 
+    // Main screen controls button
     main_screen_controls_button = new GuiToggleButton(stations_layout, "MAIN_SCREEN_CONTROLS_ENABLE", "Main screen controls", [](bool value) {
         my_player_info->commandSetMainScreenControl(value);
     });
     main_screen_controls_button->setValue(my_player_info->main_screen_control)->setSize(GuiElement::GuiSizeMax, 50);
     
+    // Game master button
     game_master_button = new GuiToggleButton(stations_layout, "GAME_MASTER_BUTTON", "Game master", [this](bool value) {
         window_button->setValue(false);
         topdown_button->setValue(false);
         cinematic_view_button->setValue(false);
     });
     game_master_button->setSize(GuiElement::GuiSizeMax, 50);
-    window_button = new GuiToggleButton(stations_layout, "WINDOW_BUTTON", "Ship window", [this](bool value) {
+
+    // Ship window button and angle slider
+    window_button_row = new GuiAutoLayout(stations_layout, "", GuiAutoLayout::LayoutHorizontalLeftToRight);
+    window_button_row->setSize(GuiElement::GuiSizeMax, 50);
+    window_button = new GuiToggleButton(window_button_row, "WINDOW_BUTTON", "Ship window", [this](bool value) {
         game_master_button->setValue(false);
         topdown_button->setValue(false);
         cinematic_view_button->setValue(false);
     });
-    window_button->setSize(GuiElement::GuiSizeMax, 50);
-    window_angle = new GuiSelector(stations_layout, "WINDOW_ANGLE", nullptr);
-    for(int n=0; n<360; n+=15)
-        window_angle->addEntry(string(n) + " degrees", string(n));
-    window_angle->setSelectionIndex(0);
-    window_angle->setSize(GuiElement::GuiSizeMax, 50);
+    window_button->setSize(175, 50);
 
-    // Top down view button
-    topdown_button = new GuiToggleButton(stations_layout, "TOP_DOWN_3D_BUTTON", "Top down 3D", [this](bool value) {
+    window_angle = new GuiSlider(window_button_row, "WINDOW_ANGLE", 0.0, 359.0, 0.0, [this](float value) {
+        window_angle_label->setText(string(int(window_angle->getValue())) + " degrees");
+    });
+    window_angle->setSize(GuiElement::GuiSizeMax, 50);
+    window_angle_label = new GuiLabel(window_angle, "WINDOW_ANGLE_LABEL", "0 degrees", 30);
+    window_angle_label->setSize(GuiElement::GuiSizeMax, GuiElement::GuiSizeMax);
+
+    // Top-down view button
+    topdown_button = new GuiToggleButton(stations_layout, "TOP_DOWN_3D_BUTTON", "Top-down 3D view", [this](bool value) {
         game_master_button->setValue(false);
         window_button->setValue(false);
         cinematic_view_button->setValue(false);
@@ -95,14 +111,19 @@ ShipSelectionScreen::ShipSelectionScreen()
     });
     cinematic_view_button->setSize(GuiElement::GuiSizeMax, 50);
     
+    // If this is the server, add a panel to create player ships.
     if (game_server)
     {
         (new GuiPanel(left_container, "CREATE_SHIP_BOX"))->setPosition(0, 50, ATopCenter)->setSize(550, 700);
     }
+
+    // Player ship selection panel
     (new GuiPanel(left_container, "SHIP_SELECTION_BOX"))->setPosition(0, 50, ATopCenter)->setSize(550, 560);
-    (new GuiLabel(left_container, "SHIP_SELECTION_LABEL", "Select ship:", 30))->addBackground()->setPosition(0, 50, ATopCenter)->setSize(510, 50);
+    (new GuiLabel(left_container, "SHIP_SELECTION_LABEL", "Select ship", 30))->addBackground()->setPosition(0, 50, ATopCenter)->setSize(510, 50);
     no_ships_label = new GuiLabel(left_container, "SHIP_SELECTION_NO_SHIPS_LABEL", "Waiting for server to spawn a ship", 30);
     no_ships_label->setPosition(0, 100, ATopCenter)->setSize(460, 50);
+
+    // Player ship list
     player_ship_list = new GuiListbox(left_container, "PLAYER_SHIP_LIST", [this](int index, string value) {
         P<PlayerSpaceship> ship = gameGlobalInfo->getPlayerShip(value.toInt());
         if (ship)
@@ -114,10 +135,11 @@ ShipSelectionScreen::ShipSelectionScreen()
     });
     player_ship_list->setPosition(0, 100, ATopCenter)->setSize(490, 500);
 
-
+    // If this is the server, add buttons and a selector to create player ships
     if (game_server)
     {
         GuiSelector* ship_template_selector = new GuiSelector(left_container, "CREATE_SHIP_SELECTOR", nullptr);
+        // List only ships with templates designated for player use.
         std::vector<string> template_names = ShipTemplate::getTemplateNameList(ShipTemplate::PlayerShip);
         std::sort(template_names.begin(), template_names.end());
         for(string& template_name : template_names)
@@ -128,6 +150,8 @@ ShipSelectionScreen::ShipSelectionScreen()
         ship_template_selector->setSelectionIndex(0);
         ship_template_selector->setPosition(0, 630, ATopCenter)->setSize(490, 50);
         
+        // Spawn a ship of the selected template near 0,0 and give it a random
+        // heading.
         (new GuiButton(left_container, "CREATE_SHIP_BUTTON", "Spawn player ship", [this, ship_template_selector]() {
             P<PlayerSpaceship> ship = new PlayerSpaceship();
             if (ship)
@@ -140,26 +164,37 @@ ShipSelectionScreen::ShipSelectionScreen()
             }
         }))->setPosition(0, 680, ATopCenter)->setSize(490, 50);
 
+        // If this is the server, the "back" button goes to the server creation
+        // screen.
         (new GuiButton(left_container, "DISCONNECT", "Scenario selection", [this]() {
             destroy();
             new ServerCreationScreen();
         }))->setPosition(0, -50, ABottomCenter)->setSize(300, 50);
     }else{
+        // If this is a client, the "back" button disconnects from the server
+        // and returns to the main menu.
         (new GuiButton(left_container, "DISCONNECT", "Disconnect", [this]() {
             destroy();
             disconnectFromServer();
             returnToMainMenu();
         }))->setPosition(0, -50, ABottomCenter)->setSize(300, 50);
     }
-    ready_button = new GuiButton(right_container, "READY_BUTTON", "Ready", [this]() {this->onReadyClick();});
+
+    // The "Ready" button.
+    ready_button = new GuiButton(right_container, "READY_BUTTON", "Ready", [this]() {
+        this->onReadyClick();
+    });
     ready_button->setPosition(0, -50, ABottomCenter)->setSize(300, 50);
-    
+
+    // Default crew type selector to 6/5 person crew screens.
     crew_type_selector->setSelectionIndex(0);
     updateCrewTypeOptions();
 }
 
 void ShipSelectionScreen::update(float delta)
 {
+    // If this is a client and is disconnected from the server, destroy the
+    // screen and return to the main menu.
     if (game_client && game_client->getStatus() == GameClient::Disconnected)
     {
         destroy();
@@ -168,45 +203,87 @@ void ShipSelectionScreen::update(float delta)
         return;
     }
     
-    for(int n=0; n<GameGlobalInfo::max_player_ships; n++)
+    // Update the player ship list with all player ships.
+    for(int n = 0; n < GameGlobalInfo::max_player_ships; n++)
     {
         P<PlayerSpaceship> ship = gameGlobalInfo->getPlayerShip(n);
         if (ship)
         {
+            string ship_name = ship->getFaction() + " " + ship->getTypeName() + " " + ship->getCallSign();
+            // If a player ship isn't in already in the list, add it.
             if (player_ship_list->indexByValue(string(n)) == -1)
             {
-                int index = player_ship_list->addEntry(ship->getTypeName() + " " + ship->getCallSign(), string(n));
+                int index = player_ship_list->addEntry(ship_name, string(n));
                 if (my_spaceship == ship)
                     player_ship_list->setSelectionIndex(index);
             }
+
+            // If the ship is crewed, count how many positions are filled.
+            int ship_position_count = 0;
+            for (int n = 0; n < max_crew_positions; n++)
+            {
+                if (ship->hasPlayerAtPosition(ECrewPosition(n)))
+                    ship_position_count += 1;
+            }
+            player_ship_list->setEntryName(n, ship_name + " (" + string(ship_position_count) + ")");
         }else{
             if (player_ship_list->indexByValue(string(n)) != -1)
                 player_ship_list->removeEntry(player_ship_list->indexByValue(string(n)));
         }
     }
+    // If a position already has a player on the currently selected player ship,
+    // indicate that on the button.
+    for(int n = 0; n < max_crew_positions; n++)
+    {
+        string button_text = getCrewPositionName(ECrewPosition(n));
+        if (my_spaceship)
+        {
+            if (my_spaceship->hasPlayerAtPosition(ECrewPosition(n)))
+            {
+                crew_position_button[n]->setText(button_text + " (occupied)");
+            } else {
+                crew_position_button[n]->setText(button_text);
+            }
+        }
+    }
+
+    // If there aren't any player ships, show a label stating so.
     if (player_ship_list->entryCount() > 0)
     {
         no_ships_label->hide();
     }else{
         no_ships_label->show();
     }
-    
+
+    // Update the Ready button's state, which might have changed based on the
+    // presence or absence of player ships.
     updateReadyButton();
 }
 
 void ShipSelectionScreen::updateReadyButton()
 {
+    // Update the Ready button based on crew position button states.
+    // If the player is capable of displaying the main screen...
     if (my_player_info->isMainScreen())
     {
+        // If the main screen button is both available and selected and a
+        // player ship is also selected, enable the Ready button.
         if (my_spaceship && main_screen_button->isVisible() && main_screen_button->getValue())
             ready_button->enable();
+        // If the GM or spectator buttons are enabled, enable the Ready button.
         else if (game_master_button->getValue() || topdown_button->getValue() || cinematic_view_button->getValue())
             ready_button->enable();
+        // If a player ship and the window view are selected, enable the Ready
+        // button.
         else if (my_spaceship && window_button->getValue())
             ready_button->enable();
+        // Otherwise, disable the Ready button.
         else
             ready_button->disable();
+    // If the player can't display the main screen...
     }else{
+        // If a player ship is selected, enable the Ready button. Otherwise,
+        // disable it.
         if (my_spaceship)
             ready_button->enable();
         else
@@ -216,6 +293,7 @@ void ShipSelectionScreen::updateReadyButton()
 
 void ShipSelectionScreen::updateCrewTypeOptions()
 {
+    // Hide and unselect alternative and view screens.
     game_master_button->hide();
     window_button->hide();
     window_angle->hide();
@@ -227,18 +305,24 @@ void ShipSelectionScreen::updateCrewTypeOptions()
     window_button->setValue(false);
     topdown_button->setValue(false);
     cinematic_view_button->setValue(false);
-    for(int n=0; n<max_crew_positions; n++)
+
+    // Hide and unselect each crew position button.
+    for(int n = 0; n < max_crew_positions; n++)
     {
         crew_position_button[n]->setValue(false)->hide();
     }
+
+    // Choose which set of screens to list from the crew type selector index.
     switch(crew_type_selector->getSelectionIndex())
     {
     case 0:
-        for(int n=helmsOfficer; n<=relayOfficer; n++)
+        for(int n = helmsOfficer; n <= relayOfficer; n++)
+        {
             crew_position_button[n]->show();
+        }
         break;
     case 1:
-        for(int n=tacticalOfficer; n<=operationsOfficer; n++)
+        for(int n = tacticalOfficer; n <= operationsOfficer; n++)
             crew_position_button[n]->show();
         break;
     case 2:
@@ -256,18 +340,28 @@ void ShipSelectionScreen::updateCrewTypeOptions()
         cinematic_view_button->setVisible(canDoMainScreen());
         break;
     }
-    for(int n=0; n<max_crew_positions; n++)
+
+    // For each crew position, unselect the position if the button is hidden
+    // and select the button if the current player has already selected that
+    // position.
+    for(int n = 0; n < max_crew_positions; n++)
     {
         if (!crew_position_button[n]->isVisible())
             my_player_info->commandSetCrewPosition(ECrewPosition(n), false);
         else
             crew_position_button[n]->setValue(my_player_info->crew_position[n]);
     }
+
+    // Update the state of the Ready button, because position changes can
+    // affect player readiness.
     updateReadyButton();
 }
 
 void ShipSelectionScreen::onReadyClick()
 {
+    // When the Ready button is clicked, destroy the ship selection screen and
+    // create the position's screen. If selecting a non-player screen, set the
+    // ship ID to -1 (no ship).
     if (game_master_button->getValue())
     {
         my_player_info->commandSetShipId(-1);
@@ -276,7 +370,7 @@ void ShipSelectionScreen::onReadyClick()
     }else if (window_button->getValue())
     {
         destroy();
-        new WindowScreen(window_angle->getSelectionValue().toInt());
+        new WindowScreen(int(window_angle->getValue()));
     }else if(topdown_button->getValue())
     {
         my_player_info->commandSetShipId(-1);

--- a/src/menus/shipSelectionScreen.h
+++ b/src/menus/shipSelectionScreen.h
@@ -4,9 +4,11 @@
 #include "playerInfo.h"
 #include "gui/gui2_canvas.h"
 
+class GuiAutoLayout;
 class GuiLabel;
 class GuiListbox;
 class GuiSelector;
+class GuiSlider;
 class GuiButton;
 class GuiToggleButton;
 
@@ -22,8 +24,10 @@ private:
     GuiToggleButton* crew_position_button[max_crew_positions];
     GuiToggleButton* main_screen_controls_button;
     GuiToggleButton* game_master_button;
+    GuiAutoLayout* window_button_row;
     GuiToggleButton* window_button;
-    GuiSelector* window_angle;
+    GuiSlider* window_angle;
+    GuiLabel* window_angle_label;
     GuiToggleButton* topdown_button;
     GuiToggleButton* cinematic_view_button;
     


### PR DESCRIPTION
-   Resolve #194.

    -   Check which stations are occupied on a player ship, then
        displays a count on the ship and an indicator on the station.

    -   Adds the faction to player ship names to help PvP scenarios.

        ![Indicators](https://cloud.githubusercontent.com/assets/19192104/15979882/c632de5a-2f1b-11e6-970a-432e1f301615.png)

-   Add public single-entry setter functions to GuiEntryList to
    avoid having to destroy the entire list when changing an
    entry's name or value. (This supports updating the
    ship/position button text.)

-   Convert the ship window angle selector to a slider, because
    the selector can't fit all options on the screen at once.

    ![Ship window angle slider](https://cloud.githubusercontent.com/assets/19192104/15979913/f7488f3a-2f1b-11e6-94be-66a3ee7ee528.png)

-   Add comments to `shipSelectionScreen.cpp`.