### PR TITLE
Allow displaying overlays, including comms, on main screen

### DIFF
--- a/src/screenComponents/commsOverlay.cpp
+++ b/src/screenComponents/commsOverlay.cpp
@@ -12,11 +12,14 @@
 GuiCommsOverlay::GuiCommsOverlay(GuiContainer* owner)
 : GuiElement(owner, "COMMS_OVERLAY")
 {
+    // Panel for reporting outgoing hails.
     opening_box = new GuiPanel(owner, "COMMS_OPENING_BOX");
     opening_box->hide()->setSize(800, 100)->setPosition(0, -250, ABottomCenter);
     (new GuiLabel(opening_box, "COMMS_OPENING_LABEL", "Opening communications...", 40))->setSize(GuiElement::GuiSizeMax, 50)->setPosition(0, 0, ATopCenter);
     opening_progress = new GuiProgressbar(opening_box, "COMMS_OPENING_PROGRESS", PlayerSpaceship::comms_channel_open_time, 0.0, 0.0);
     opening_progress->setSize(500, 40)->setPosition(50, -10, ABottomLeft);
+
+    // Cancel button closes the communication.
     opening_cancel = new GuiButton(opening_box, "COMMS_OPENING_CANCEL", "Cancel", []()
     {
         if (my_spaceship)
@@ -24,47 +27,63 @@ GuiCommsOverlay::GuiCommsOverlay(GuiContainer* owner)
     });
     opening_cancel->setSize(200, 40)->setPosition(-50, -10, ABottomRight);
 
+    // Panel for reporting incoming hails.
     hailed_box = new GuiPanel(owner, "COMMS_BEING_HAILED_BOX");
     hailed_box->hide()->setSize(800, 140)->setPosition(0, -250, ABottomCenter);
-    hailed_label = new GuiLabel(hailed_box, "COMMS_BEING_HAILED_BOX", "..", 40);
+    hailed_label = new GuiLabel(hailed_box, "COMMS_BEING_HAILED_LABEL", "..", 40);
     hailed_label->setSize(GuiElement::GuiSizeMax, 50)->setPosition(0, 20, ATopCenter);
-    (new GuiButton(hailed_box, "COMMS_BEING_HAILED_ANSWER", "Answer", []() {
+
+    // Buttons to answer or ignore hails.
+    hailed_answer = new GuiButton(hailed_box, "COMMS_BEING_HAILED_ANSWER", "Answer", []() {
         if (my_spaceship)
             my_spaceship->commandAnswerCommHail(true);
-    }))->setSize(300, 50)->setPosition(20, -20, ABottomLeft);
+    });
+    hailed_answer->setSize(300, 50)->setPosition(20, -20, ABottomLeft);
 
-    (new GuiButton(hailed_box, "COMMS_BEING_HAILED_ANSWER", "Ignore", []() {
+    hailed_ignore = new GuiButton(hailed_box, "COMMS_BEING_HAILED_IGNORE", "Ignore", []() {
         if (my_spaceship)
             my_spaceship->commandAnswerCommHail(false);
-    }))->setSize(300, 50)->setPosition(-20, -20, ABottomRight);
-    
+    });
+    hailed_ignore->setSize(300, 50)->setPosition(-20, -20, ABottomRight);
+
+    // Panel for unresponsive hails.
     no_response_box = new GuiPanel(owner, "COMMS_OPENING_BOX");
     no_response_box->hide()->setSize(800, 70)->setPosition(0, -250, ABottomCenter);
     (new GuiLabel(no_response_box, "COMMS_NO_REPONSE_LABEL", "No reply...", 40))->setSize(GuiElement::GuiSizeMax, GuiElement::GuiSizeMax)->setPosition(0, 0, ATopLeft);
+
+    // Button to acknowledge unresponsive hails.
     (new GuiButton(no_response_box, "COMMS_NO_REPLY_OK", "Ok", []() {
         if (my_spaceship)
             my_spaceship->commandCloseTextComm();
     }))->setSize(150, 50)->setPosition(-20, -10, ABottomRight);
 
+    // Panel for broken communications.
     broken_box = new GuiPanel(owner, "COMMS_BROKEN_BOX");
     broken_box->hide()->setSize(800, 70)->setPosition(0, -250, ABottomCenter);
-    (new GuiLabel(broken_box, "COMMS_BROKEN_LABEL", "Communications where suddenly cut", 40))->setSize(GuiElement::GuiSizeMax, GuiElement::GuiSizeMax)->setPosition(0, 0, ATopLeft);
+    (new GuiLabel(broken_box, "COMMS_BROKEN_LABEL", "Communications were suddenly cut", 40))->setSize(GuiElement::GuiSizeMax, GuiElement::GuiSizeMax)->setPosition(0, 0, ATopLeft);
+
+    // Button to acknowledge broken communications.
     (new GuiButton(broken_box, "COMMS_BROKEN_OK", "Ok", []() {
         if (my_spaceship)
             my_spaceship->commandCloseTextComm();
     }))->setSize(150, 50)->setPosition(-20, -10, ABottomRight);
 
+    // Panel for communications closed by the other object.
     closed_box = new GuiPanel(owner, "COMMS_CLOSED_BOX");
     closed_box->hide()->setSize(800, 70)->setPosition(0, -250, ABottomCenter);
     (new GuiLabel(closed_box, "COMMS_BROKEN_LABEL", "Other party closed communications", 40))->setSize(GuiElement::GuiSizeMax, GuiElement::GuiSizeMax)->setPosition(0, 0, ATopLeft);
+
+    // Button to acknowledge closed communications.
     (new GuiButton(closed_box, "COMMS_BROKEN_OK", "Ok", []() {
         if (my_spaceship)
             my_spaceship->commandCloseTextComm();
     }))->setSize(150, 50)->setPosition(-20, -10, ABottomRight);
-    
+
+    // Panel for chat communications with GMs and other player ships.
     chat_comms_box = new GuiPanel(owner, "COMMS_CHAT_BOX");
     chat_comms_box->hide()->setSize(800, 600)->setPosition(0, -100, ABottomCenter);
 
+    // Message entry field for chat.
     chat_comms_message_entry = new GuiTextEntry(chat_comms_box, "COMMS_CHAT_MESSAGE_ENTRY", "");
     chat_comms_message_entry->setPosition(20, -20, ABottomLeft)->setSize(640, 50);
     chat_comms_message_entry->enterCallback([this](string text){
@@ -72,42 +91,52 @@ GuiCommsOverlay::GuiCommsOverlay(GuiContainer* owner)
             my_spaceship->commandSendCommPlayer(chat_comms_message_entry->getText());
         chat_comms_message_entry->setText("");
     });
-    
+
+    // Text of incoming chat messages.
     chat_comms_text = new GuiScrollText(chat_comms_box, "COMMS_CHAT_TEXT", "");
     chat_comms_text->enableAutoScrollDown()->setPosition(20, 30, ATopLeft)->setSize(760, 500);
-    
-    (new GuiButton(chat_comms_box, "SEND_BUTTON", "Send", [this]() {
+
+    // Button to send a message.
+    chat_comms_send_button = new GuiButton(chat_comms_box, "SEND_BUTTON", "Send", [this]() {
         if (my_spaceship)
             my_spaceship->commandSendCommPlayer(chat_comms_message_entry->getText());
         chat_comms_message_entry->setText("");
-    }))->setPosition(-20, -20, ABottomRight)->setSize(120, 50);
+    });
+    chat_comms_send_button->setPosition(-20, -20, ABottomRight)->setSize(120, 50);
 
-    (new GuiButton(chat_comms_box, "CLOSE_BUTTON", "Close", [this]() {
+    // Button to close chat comms.
+    chat_comms_close_button = new GuiButton(chat_comms_box, "CLOSE_BUTTON", "Close", [this]() {
         if (my_spaceship)
             my_spaceship->commandCloseTextComm();
-    }))->setTextSize(20)->setPosition(-10, 0, ATopRight)->setSize(70, 30);
+    });
+    chat_comms_close_button->setTextSize(20)->setPosition(-10, 0, ATopRight)->setSize(70, 30);
 
+    // Panel for scripted comms with objects.
     script_comms_box = new GuiPanel(owner, "COMMS_SCRIPT_BOX");
     script_comms_box->hide()->setSize(800, 600)->setPosition(0, -100, ABottomCenter);
 
     script_comms_text = new GuiScrollText(script_comms_box, "COMMS_SCRIPT_TEXT", "");
     script_comms_text->setPosition(20, 30, ATopLeft)->setSize(760, 500);
     
-    script_comms_options = new GuiListbox(script_comms_box, "SCRIPT_COMMS_LIST", [this](int index, string value) {
+    // List possible responses to a scripted communication.
+    script_comms_options = new GuiListbox(script_comms_box, "COMMS_SCRIPT_LIST", [this](int index, string value) {
         script_comms_options->setOptions({});
         my_spaceship->commandSendComm(index);
     });
     script_comms_options->setPosition(20, -70, ABottomLeft)->setSize(700, 400);
-    
-    (new GuiButton(script_comms_box, "CLOSE_BUTTON", "Close", [this]() {
+
+    // Button to close scripted comms.
+    script_comms_close = new GuiButton(script_comms_box, "CLOSE_BUTTON", "Close", [this]() {
         script_comms_options->setOptions({});
         if (my_spaceship)
             my_spaceship->commandCloseTextComm();
-    }))->setTextSize(20)->setPosition(-20, -20, ABottomRight)->setSize(150, 50);
+    });
+    script_comms_close->setTextSize(20)->setPosition(-20, -20, ABottomRight)->setSize(150, 50);
 }
 
 void GuiCommsOverlay::onDraw(sf::RenderTarget& window)
 {
+    // If we're on a ship, show comms activity on draw.
     if (my_spaceship)
     {
         opening_box->setVisible(my_spaceship->isCommsOpening());
@@ -126,7 +155,8 @@ void GuiCommsOverlay::onDraw(sf::RenderTarget& window)
         
         script_comms_box->setVisible(my_spaceship->isCommsScriptOpen());
         script_comms_text->setText(my_spaceship->getCommsIncommingMessage());
-        
+
+        // Show the scripted comms options. If they've changed, update the lsit
         bool changed = script_comms_options->entryCount() != int(my_spaceship->getCommsReplyOptions().size());
         if (!changed && my_spaceship->getCommsReplyOptions().size() > 0)
             changed = my_spaceship->getCommsReplyOptions()[0] != script_comms_options->getEntryName(0);
@@ -140,4 +170,17 @@ void GuiCommsOverlay::onDraw(sf::RenderTarget& window)
             script_comms_text->setSize(760, 500 - display_options_count * 50);
         }
     }
+}
+
+void GuiCommsOverlay::clearElements()
+{
+    // Force all panels to hide, in case hiding the overlay doesn't hide its
+    // contents on draw.
+    opening_box->hide();
+    hailed_box->hide();
+    no_response_box->hide();
+    broken_box->hide();
+    closed_box->hide();
+    chat_comms_box->hide();
+    script_comms_box->hide();
 }

--- a/src/screenComponents/commsOverlay.h
+++ b/src/screenComponents/commsOverlay.h
@@ -20,6 +20,8 @@ private:
     
     GuiPanel* hailed_box;
     GuiLabel* hailed_label;
+    GuiButton* hailed_answer;
+    GuiButton* hailed_ignore;
 
     GuiPanel* no_response_box;
     GuiPanel* broken_box;
@@ -28,14 +30,18 @@ private:
     GuiPanel* chat_comms_box;
     GuiTextEntry* chat_comms_message_entry;
     GuiScrollText* chat_comms_text;
+    GuiButton* chat_comms_send_button;
+    GuiButton* chat_comms_close_button;
 
     GuiPanel* script_comms_box;
     GuiScrollText* script_comms_text;
     GuiListbox* script_comms_options;
+    GuiButton* script_comms_close;
 public:
     GuiCommsOverlay(GuiContainer* owner);
     
     virtual void onDraw(sf::RenderTarget& window);
+    void clearElements();
 };
 
 #endif//GUI_INDICATOR_OVERLAYS_H

--- a/src/screenComponents/mainScreenControls.cpp
+++ b/src/screenComponents/mainScreenControls.cpp
@@ -94,7 +94,7 @@ GuiMainScreenControls::GuiMainScreenControls(GuiContainer* owner)
         {
             if (my_spaceship)
             {
-                my_spaceship->commandMainScreenSetting(MSS_ShowComms);
+                my_spaceship->commandMainScreenOverlay(MSO_ShowComms);
                 onscreen_comms_active = true;
             }
             open_button->setValue(false);
@@ -107,7 +107,7 @@ GuiMainScreenControls::GuiMainScreenControls(GuiContainer* owner)
         {
             if (my_spaceship)
             {
-                my_spaceship->commandMainScreenSetting(MSS_HideComms);
+                my_spaceship->commandMainScreenOverlay(MSO_HideComms);
                 onscreen_comms_active = false;
             }
             open_button->setValue(false);

--- a/src/screenComponents/mainScreenControls.cpp
+++ b/src/screenComponents/mainScreenControls.cpp
@@ -18,6 +18,10 @@ GuiMainScreenControls::GuiMainScreenControls(GuiContainer* owner)
             tactical_button->setVisible(false);
         if (!gameGlobalInfo->allow_main_screen_long_range_radar)
             long_range_button->setVisible(false);
+        if (onscreen_comms_active)
+            show_comms_button->setVisible(false);
+        if (!onscreen_comms_active)
+            hide_comms_button->setVisible(false);
     });
     open_button->setValue(false);
     open_button->setSize(GuiElement::GuiSizeMax, 50);
@@ -73,7 +77,7 @@ GuiMainScreenControls::GuiMainScreenControls(GuiContainer* owner)
             button->setVisible(false);
     }));
     tactical_button = buttons.back();
-    buttons.push_back(new GuiButton(this, "MAIN_SCREEN_LONG_RANGE_BUTTON", "LongRange", [this]()
+    buttons.push_back(new GuiButton(this, "MAIN_SCREEN_LONG_RANGE_BUTTON", "Long Range", [this]()
     {
         if (my_spaceship)
         {
@@ -84,7 +88,35 @@ GuiMainScreenControls::GuiMainScreenControls(GuiContainer* owner)
             button->setVisible(false);
     }));
     long_range_button = buttons.back();
-    
+    if (my_player_info->crew_position[relayOfficer] || my_player_info->crew_position[operationsOfficer] || my_player_info->crew_position[singlePilot])
+    {
+        buttons.push_back(new GuiButton(this, "MAIN_SCREEN_SHOW_COMMS_BUTTON", "Show comms", [this]()
+        {
+            if (my_spaceship)
+            {
+                my_spaceship->commandMainScreenSetting(MSS_ShowComms);
+                onscreen_comms_active = true;
+            }
+            open_button->setValue(false);
+            for (GuiButton* button : buttons)
+                button->setVisible(false);
+        }));
+        show_comms_button = buttons.back();
+
+        buttons.push_back(new GuiButton(this, "MAIN_SCREEN_HIDE_COMMS_BUTTON", "Hide comms", [this]()
+        {
+            if (my_spaceship)
+            {
+                my_spaceship->commandMainScreenSetting(MSS_HideComms);
+                onscreen_comms_active = false;
+            }
+            open_button->setValue(false);
+            for (GuiButton* button : buttons)
+                button->setVisible(false);
+        }));
+        hide_comms_button = buttons.back();
+    }
+
     for(GuiButton* button : buttons)
         button->setSize(GuiElement::GuiSizeMax, 50)->setVisible(false);
 }

--- a/src/screenComponents/mainScreenControls.h
+++ b/src/screenComponents/mainScreenControls.h
@@ -13,6 +13,9 @@ private:
     std::vector<GuiButton*> buttons;
     GuiButton* tactical_button;
     GuiButton* long_range_button;
+    GuiButton* show_comms_button;
+    GuiButton* hide_comms_button;
+    bool onscreen_comms_active = false;
 public:
     GuiMainScreenControls(GuiContainer* owner);
 };

--- a/src/screens/mainScreen.cpp
+++ b/src/screens/mainScreen.cpp
@@ -131,11 +131,15 @@ void ScreenMainScreen::update(float delta)
             tactical_radar->hide();
             long_range_radar->show();
             break;
-        case MSS_ShowComms:
+        }
+
+        switch(my_spaceship->main_screen_overlay)
+        {
+        case MSO_ShowComms:
             onscreen_comms->clearElements();
             onscreen_comms->show();
             break;
-        case MSS_HideComms:
+        case MSO_HideComms:
             onscreen_comms->clearElements();
             onscreen_comms->hide();
             break;

--- a/src/screens/mainScreen.cpp
+++ b/src/screens/mainScreen.cpp
@@ -9,6 +9,7 @@
 #include "screenComponents/selfDestructIndicator.h"
 #include "screenComponents/globalMessage.h"
 #include "screenComponents/jumpIndicator.h"
+#include "screenComponents/commsOverlay.h"
 #include "screenComponents/viewport3d.h"
 #include "screenComponents/radarView.h"
 #include "screenComponents/shipDestroyedPopup.h"
@@ -32,6 +33,8 @@ ScreenMainScreen::ScreenMainScreen()
     long_range_radar->setPosition(0, 0, ATopLeft)->setSize(GuiElement::GuiSizeMax, GuiElement::GuiSizeMax);
     long_range_radar->setRangeIndicatorStepSize(5000.0f)->longRange()->enableCallsigns()->hide();
     long_range_radar->setFogOfWarStyle(GuiRadarView::NebulaFogOfWar);
+    onscreen_comms = new GuiCommsOverlay(this);
+    onscreen_comms->setSize(GuiElement::GuiSizeMax, GuiElement::GuiSizeMax)->setVisible(false);
 
     new GuiShipDestroyedPopup(this);
     
@@ -127,6 +130,14 @@ void ScreenMainScreen::update(float delta)
             viewport->hide();
             tactical_radar->hide();
             long_range_radar->show();
+            break;
+        case MSS_ShowComms:
+            onscreen_comms->clearElements();
+            onscreen_comms->show();
+            break;
+        case MSS_HideComms:
+            onscreen_comms->clearElements();
+            onscreen_comms->hide();
             break;
         }
     }

--- a/src/screens/mainScreen.h
+++ b/src/screens/mainScreen.h
@@ -7,6 +7,7 @@
 
 class GuiViewport3D;
 class GuiRadarView;
+class GuiCommsOverlay;
 
 class ScreenMainScreen : public GuiCanvas, public Updatable
 {
@@ -16,6 +17,7 @@ private:
     GuiRadarView* tactical_radar;
     GuiRadarView* long_range_radar;
     bool first_person;
+    GuiCommsOverlay* onscreen_comms;
 public:
     ScreenMainScreen();
     

--- a/src/spaceObjects/playerSpaceship.cpp
+++ b/src/spaceObjects/playerSpaceship.cpp
@@ -150,6 +150,7 @@ PlayerSpaceship::PlayerSpaceship()
 : SpaceShip("PlayerSpaceship", 5000)
 {
     main_screen_setting = MSS_Front;
+    main_screen_overlay = MSO_HideComms;
     hull_damage_indicator = 0.0;
     jump_indicator = 0.0;
     comms_state = CS_Inactive;
@@ -181,6 +182,7 @@ PlayerSpaceship::PlayerSpaceship()
     registerMemberReplication(&energy_level, 0.1);
     registerMemberReplication(&max_energy_level);
     registerMemberReplication(&main_screen_setting);
+    registerMemberReplication(&main_screen_overlay);
     registerMemberReplication(&scanning_delay, 0.5);
     registerMemberReplication(&scanning_complexity);
     registerMemberReplication(&scanning_depth);

--- a/src/spaceObjects/playerSpaceship.cpp
+++ b/src/spaceObjects/playerSpaceship.cpp
@@ -44,6 +44,7 @@ REGISTER_SCRIPT_SUBCLASS(PlayerSpaceship, SpaceShip)
     REGISTER_SCRIPT_CLASS_FUNCTION(PlayerSpaceship, commandFireTube);
     REGISTER_SCRIPT_CLASS_FUNCTION(PlayerSpaceship, commandSetShields);
     REGISTER_SCRIPT_CLASS_FUNCTION(PlayerSpaceship, commandMainScreenSetting);
+    REGISTER_SCRIPT_CLASS_FUNCTION(PlayerSpaceship, commandMainScreenOverlay);
     REGISTER_SCRIPT_CLASS_FUNCTION(PlayerSpaceship, commandScan);
     REGISTER_SCRIPT_CLASS_FUNCTION(PlayerSpaceship, commandSetSystemPowerRequest);
     REGISTER_SCRIPT_CLASS_FUNCTION(PlayerSpaceship, commandSetSystemCoolantRequest);
@@ -98,7 +99,7 @@ static const int16_t CMD_LOAD_TUBE = 0x0006;
 static const int16_t CMD_UNLOAD_TUBE = 0x0007;
 static const int16_t CMD_FIRE_TUBE = 0x0008;
 static const int16_t CMD_SET_SHIELDS = 0x0009;
-static const int16_t CMD_SET_MAIN_SCREEN_SETTING = 0x000A;
+static const int16_t CMD_SET_MAIN_SCREEN_SETTING = 0x000A; // Overlay is 0x0027
 static const int16_t CMD_SCAN_OBJECT = 0x000B;
 static const int16_t CMD_SCAN_DONE = 0x000C;
 static const int16_t CMD_SCAN_CANCEL = 0x000D;
@@ -127,6 +128,7 @@ static const int16_t CMD_LAUNCH_PROBE = 0x0023;
 static const int16_t CMD_SET_ALERT_LEVEL = 0x0024;
 static const int16_t CMD_SET_SCIENCE_LINK = 0x0025;
 static const int16_t CMD_ABORT_DOCK = 0x0026;
+static const int16_t CMD_SET_MAIN_SCREEN_OVERLAY = 0x0027;
 
 string alertLevelToString(EAlertLevel level)
 {
@@ -813,6 +815,9 @@ void PlayerSpaceship::onReceiveClientCommand(int32_t client_id, sf::Packet& pack
     case CMD_SET_MAIN_SCREEN_SETTING:
         packet >> main_screen_setting;
         break;
+    case CMD_SET_MAIN_SCREEN_OVERLAY:
+        packet >> main_screen_overlay;
+        break;
     case CMD_SCAN_OBJECT:
         {
             int32_t id;
@@ -1212,6 +1217,13 @@ void PlayerSpaceship::commandMainScreenSetting(EMainScreenSetting mainScreen)
 {
     sf::Packet packet;
     packet << CMD_SET_MAIN_SCREEN_SETTING << mainScreen;
+    sendClientCommand(packet);
+}
+
+void PlayerSpaceship::commandMainScreenOverlay(EMainScreenOverlay mainScreen)
+{
+    sf::Packet packet;
+    packet << CMD_SET_MAIN_SCREEN_OVERLAY << mainScreen;
     sendClientCommand(packet);
 }
 

--- a/src/spaceObjects/playerSpaceship.h
+++ b/src/spaceObjects/playerSpaceship.h
@@ -88,6 +88,7 @@ public:
     float scan_probe_recharge;
 
     EMainScreenSetting main_screen_setting;
+    EMainScreenOverlay main_screen_overlay;
 
     bool activate_self_destruct;
     uint32_t self_destruct_code[max_self_destruct_codes];
@@ -138,6 +139,7 @@ public:
     void commandFireTube(int8_t tubeNumber, float missile_target_angle);
     void commandSetShields(bool enabled);
     void commandMainScreenSetting(EMainScreenSetting mainScreen);
+    void commandMainScreenOverlay(EMainScreenOverlay mainScreen);
     void commandScan(P<SpaceObject> object);
     void commandSetSystemPowerRequest(ESystem system, float power_level);
     void commandSetSystemCoolantRequest(ESystem system, float coolant_level);

--- a/src/spaceObjects/spaceship.h
+++ b/src/spaceObjects/spaceship.h
@@ -13,7 +13,9 @@ enum EMainScreenSetting
     MSS_Left,
     MSS_Right,
     MSS_Tactical,
-    MSS_LongRange
+    MSS_LongRange,
+    MSS_ShowComms,
+    MSS_HideComms
 };
 template<> void convert<EMainScreenSetting>::param(lua_State* L, int& idx, EMainScreenSetting& mss);
 
@@ -44,7 +46,7 @@ class SpaceShip : public ShipTemplateBasedObject
 {
 public:
     constexpr static int max_frequency = 20;
-    constexpr static float combat_maneuver_charge_time = 20.0f; /*< Amount of time it takes to fully charge the combat meneuver system */
+    constexpr static float combat_maneuver_charge_time = 20.0f; /*< Amount of time it takes to fully charge the combat maneuver system */
     constexpr static float combat_maneuver_boost_max_time = 3.0f; /*< Amount of time we can boost with a fully charged combat maneuver system */
     constexpr static float combat_maneuver_strafe_max_time = 3.0f; /*< Amount of time we can strafe with a fully charged combat maneuver system */
     constexpr static float warp_charge_time = 4.0f;

--- a/src/spaceObjects/spaceship.h
+++ b/src/spaceObjects/spaceship.h
@@ -13,11 +13,16 @@ enum EMainScreenSetting
     MSS_Left,
     MSS_Right,
     MSS_Tactical,
-    MSS_LongRange,
-    MSS_ShowComms,
-    MSS_HideComms
+    MSS_LongRange
 };
 template<> void convert<EMainScreenSetting>::param(lua_State* L, int& idx, EMainScreenSetting& mss);
+
+enum EMainScreenOverlay
+{
+    MSO_HideComms = 0,
+    MSO_ShowComms
+};
+template<> void convert<EMainScreenOverlay>::param(lua_State* L, int& idx, EMainScreenOverlay& mso);
 
 enum EDockingState
 {
@@ -363,6 +368,7 @@ string getMissileWeaponName(EMissileWeapons missile);
 REGISTER_MULTIPLAYER_ENUM(EMissileWeapons);
 REGISTER_MULTIPLAYER_ENUM(EWeaponTubeState);
 REGISTER_MULTIPLAYER_ENUM(EMainScreenSetting);
+REGISTER_MULTIPLAYER_ENUM(EMainScreenOverlay);
 REGISTER_MULTIPLAYER_ENUM(EDockingState);
 REGISTER_MULTIPLAYER_ENUM(EScannedState);
 

--- a/src/spaceObjects/spaceship.hpp
+++ b/src/spaceObjects/spaceship.hpp
@@ -16,6 +16,10 @@ template<> void convert<EMainScreenSetting>::param(lua_State* L, int& idx, EMain
         mss = MSS_Tactical;
     else if (str == "longrange")
         mss = MSS_LongRange;
+    else if (str == "showcomms")
+        mss = MSS_ShowComms;
+    else if (str == "hidecomms")
+        mss = MSS_HideComms;
     else
         mss = MSS_Front;
 }

--- a/src/spaceObjects/spaceship.hpp
+++ b/src/spaceObjects/spaceship.hpp
@@ -16,12 +16,18 @@ template<> void convert<EMainScreenSetting>::param(lua_State* L, int& idx, EMain
         mss = MSS_Tactical;
     else if (str == "longrange")
         mss = MSS_LongRange;
-    else if (str == "showcomms")
-        mss = MSS_ShowComms;
-    else if (str == "hidecomms")
-        mss = MSS_HideComms;
     else
         mss = MSS_Front;
 }
 
+template<> void convert<EMainScreenOverlay>::param(lua_State* L, int& idx, EMainScreenOverlay& mso)
+{
+    string str = string(luaL_checkstring(L, idx++)).lower();
+    if (str == "hidecomms")
+        mso = MSO_HideComms;
+    else if (str == "showcomms")
+        mso = MSO_ShowComms;
+    else
+        mso = MSO_HideComms;
+}
 #endif /* _SPACEOBJECTS_HPP_ */


### PR DESCRIPTION
Resolves #18.

-   Create a separate ENum, handlers, and packet data for main screen overlays.
    This effectively creates a new main screen layer (MainScreenOverlays, over
    the viewport's MainScreenSettings), allowing one to be modified without
    affecting the other.

-   Add a comms overlay to the main screen, defaulting to hidden.

-   Add a button to the main screen controls to toggle onscreen comms.
    The button appears only if the player has a station capable of opening comms
    (Relay, Ops, or Single Pilot).

    ![comms-1](https://cloud.githubusercontent.com/assets/19192104/15987221/0a968078-2fd6-11e6-99d9-d99367583494.jpg)

    ![comms-2](https://cloud.githubusercontent.com/assets/19192104/15987222/0ddb7784-2fd6-11e6-90aa-e65fed2f469f.jpg)

-   Add a function to `commsOverlay` allowing its contents to be manually hidden.
    This works around a potential issue where the contents of the overlay aren't
    hidden when the overlay is hidden; they remain visible but aren't updated.

-   Fixes some button IDs and makes more buttons on the comms overlay variables
    for future customization.

