### PR TITLE
Move setCallSign to spaceObject

### DIFF
--- a/src/spaceObjects/scanProbe.cpp
+++ b/src/spaceObjects/scanProbe.cpp
@@ -30,6 +30,8 @@ ScanProbe::ScanProbe()
         model_info.setData("SensorBuoyMKIII");
         break;
     }
+
+    setCallSign(string(getMultiplayerId()) + "P");
 }
 
 void ScanProbe::update(float delta)

--- a/src/spaceObjects/scanProbe.h
+++ b/src/spaceObjects/scanProbe.h
@@ -25,8 +25,6 @@ public:
     void setTarget(sf::Vector2f target) { target_position = target; }
     sf::Vector2f getTarget() { return target_position; }
     void setOwner(P<SpaceObject> owner);
-
-    virtual string getCallSign() { return ""; }
 };
 
 #endif//SCAN_PROBE_H

--- a/src/spaceObjects/shipTemplateBasedObject.cpp
+++ b/src/spaceObjects/shipTemplateBasedObject.cpp
@@ -10,8 +10,6 @@ REGISTER_SCRIPT_SUBCLASS_NO_CREATE(ShipTemplateBasedObject, SpaceObject)
     /// Set the class name of this object. Normally the class name is copied from the template name (Ex "Cruiser") but you can override it with this function.
     REGISTER_SCRIPT_CLASS_FUNCTION(ShipTemplateBasedObject, setTypeName);
     REGISTER_SCRIPT_CLASS_FUNCTION(ShipTemplateBasedObject, getTypeName);
-    /// Set a custom callsign for this object. Objects get assigned random callsigns at creation, but you can overrule this from scenario scripts.
-    REGISTER_SCRIPT_CLASS_FUNCTION(ShipTemplateBasedObject, setCallSign);
     /// Get the current amount of hull
     REGISTER_SCRIPT_CLASS_FUNCTION(ShipTemplateBasedObject, getHull);
     /// Get the maximum hull value
@@ -77,7 +75,6 @@ ShipTemplateBasedObject::ShipTemplateBasedObject(float collision_range, string m
         registerMemberReplication(&shield_max[n]);
         registerMemberReplication(&shield_hit_effect[n], 0.5);
     }
-    registerMemberReplication(&callsign);
     registerMemberReplication(&radar_trace);
 
     callsign = "[" + string(getMultiplayerId()) + "]";

--- a/src/spaceObjects/shipTemplateBasedObject.h
+++ b/src/spaceObjects/shipTemplateBasedObject.h
@@ -18,7 +18,6 @@ public:
     string template_name;
     string type_name;
     string radar_trace;
-    string callsign;
     P<ShipTemplate> ship_template;
 
     int shield_count;
@@ -51,7 +50,6 @@ public:
     void setShipTemplate(string template_name) { LOG(WARNING) << "Depricated \"setShipTemplate\" function called."; setTemplate(template_name); }
     void setTypeName(string type_name) { this->type_name = type_name; }
     string getTypeName() { return type_name; }
-    void setCallSign(string new_callsign) { callsign = new_callsign; }
 
     float getHull() { return hull_strength; }
     float getHullMax() { return hull_max; }

--- a/src/spaceObjects/spaceObject.cpp
+++ b/src/spaceObjects/spaceObject.cpp
@@ -39,6 +39,8 @@ REGISTER_SCRIPT_CLASS_NO_CREATE(SpaceObject)
     REGISTER_SCRIPT_CLASS_FUNCTION(SpaceObject, setCommsFunction);
     REGISTER_SCRIPT_CLASS_FUNCTION(SpaceObject, isEnemy);
     REGISTER_SCRIPT_CLASS_FUNCTION(SpaceObject, isFriendly);
+    /// Set a custom callsign for this object. Objects get assigned random callsigns at creation, but you can overrule this from scenario scripts.
+    REGISTER_SCRIPT_CLASS_FUNCTION(SpaceObject, setCallSign);
     REGISTER_SCRIPT_CLASS_FUNCTION(SpaceObject, getCallSign);
     REGISTER_SCRIPT_CLASS_FUNCTION(SpaceObject, areEnemiesInRange);
     REGISTER_SCRIPT_CLASS_FUNCTION(SpaceObject, getObjectsInRange);
@@ -94,6 +96,7 @@ SpaceObject::SpaceObject(float collision_range, string multiplayer_name, float m
     scanning_complexity_value = 0;
     scanning_depth_value = 0;
 
+    registerMemberReplication(&callsign);
     registerMemberReplication(&faction_id);
     registerMemberReplication(&scanned_by_faction);
     registerMemberReplication(&object_description);

--- a/src/spaceObjects/spaceObject.h
+++ b/src/spaceObjects/spaceObject.h
@@ -113,7 +113,7 @@ public:
     virtual void destroy();
 
     virtual void setCallSign(string new_callsign) { callsign = new_callsign; }
-    virtual string getCallSign() { return ""; }
+    virtual string getCallSign() { return callsign; }
     virtual bool canBeDockedBy(P<SpaceObject> obj) { return false; }
     virtual bool hasShield() { return false; }
     virtual bool canHideInNebula() { return true; }

--- a/src/spaceObjects/spaceObject.h
+++ b/src/spaceObjects/spaceObject.h
@@ -89,6 +89,7 @@ public:
 
     int scanning_complexity_value;
     int scanning_depth_value;
+    string callsign;
 
     SpaceObject(float collisionRange, string multiplayerName, float multiplayer_significant_range=-1);
 
@@ -111,6 +112,7 @@ public:
     virtual void drawOnGMRadar(sf::RenderTarget& window, sf::Vector2f position, float scale, bool longRange);
     virtual void destroy();
 
+    virtual void setCallSign(string new_callsign) { callsign = new_callsign; }
     virtual string getCallSign() { return ""; }
     virtual bool canBeDockedBy(P<SpaceObject> obj) { return false; }
     virtual bool hasShield() { return false; }


### PR DESCRIPTION
Resolves #137.

-   Move setCallSign to spaceObject.
-   getCallSign now returns callsigns by default.
-   Adds callsigns to probes (`string(getMultiplayerId()) + P`, such as 326P).