### PR TITLE
Add target lock view to main screen controls

### DIFF
--- a/src/screenComponents/mainScreenControls.cpp
+++ b/src/screenComponents/mainScreenControls.cpp
@@ -9,7 +9,8 @@ GuiMainScreenControls::GuiMainScreenControls(GuiContainer* owner)
 {
     setSize(250, GuiElement::GuiSizeMax);
     setPosition(-20, 70, ATopRight);
-    
+
+    // Set which buttons appear when opening the main screen controls.
     open_button = new GuiToggleButton(this, "MAIN_SCREEN_CONTROLS_SHOW", "Main screen", [this](bool value)
     {
         for(GuiButton* button : buttons)
@@ -25,7 +26,8 @@ GuiMainScreenControls::GuiMainScreenControls(GuiContainer* owner)
     });
     open_button->setValue(false);
     open_button->setSize(GuiElement::GuiSizeMax, 50);
-    
+
+    // Front, back, left, and right view buttons.
     buttons.push_back(new GuiButton(this, "MAIN_SCREEN_FRONT_BUTTON", "Front", [this]()
     {
         if (my_spaceship)
@@ -66,6 +68,24 @@ GuiMainScreenControls::GuiMainScreenControls(GuiContainer* owner)
         for(GuiButton* button : buttons)
             button->setVisible(false);
     }));
+
+    // If the player has control over weapons targeting, enable the target view
+    // option in the main screen controls.
+    if (my_player_info->crew_position[weaponsOfficer] || my_player_info->crew_position[tacticalOfficer] || my_player_info->crew_position[singlePilot])
+    {
+        buttons.push_back(new GuiButton(this, "MAIN_SCREEN_TARGET_BUTTON", "Target lock", [this]()
+        {
+            if (my_spaceship)
+            {
+                my_spaceship->commandMainScreenSetting(MSS_Target);
+            }
+            for (GuiButton* button : buttons)
+                button->setVisible(false);
+        }));
+        target_lock_button = buttons.back();
+    }
+
+    // Tactical radar button.
     buttons.push_back(new GuiButton(this, "MAIN_SCREEN_TACTICAL_BUTTON", "Tactical", [this]()
     {
         if (my_spaceship)
@@ -77,6 +97,8 @@ GuiMainScreenControls::GuiMainScreenControls(GuiContainer* owner)
             button->setVisible(false);
     }));
     tactical_button = buttons.back();
+
+    // Long-range radar button.
     buttons.push_back(new GuiButton(this, "MAIN_SCREEN_LONG_RANGE_BUTTON", "Long Range", [this]()
     {
         if (my_spaceship)
@@ -88,6 +110,9 @@ GuiMainScreenControls::GuiMainScreenControls(GuiContainer* owner)
             button->setVisible(false);
     }));
     long_range_button = buttons.back();
+
+    // If the player has control over comms, they can toggle the comms overlay
+    // on the main screen.
     if (my_player_info->crew_position[relayOfficer] || my_player_info->crew_position[operationsOfficer] || my_player_info->crew_position[singlePilot])
     {
         buttons.push_back(new GuiButton(this, "MAIN_SCREEN_SHOW_COMMS_BUTTON", "Show comms", [this]()

--- a/src/screenComponents/mainScreenControls.h
+++ b/src/screenComponents/mainScreenControls.h
@@ -11,6 +11,7 @@ class GuiMainScreenControls : public GuiAutoLayout
 private:
     GuiToggleButton* open_button;
     std::vector<GuiButton*> buttons;
+    GuiButton* target_lock_button;
     GuiButton* tactical_button;
     GuiButton* long_range_button;
     GuiButton* show_comms_button;

--- a/src/screens/mainScreen.cpp
+++ b/src/screens/mainScreen.cpp
@@ -71,12 +71,20 @@ void ScreenMainScreen::update(float delta)
 
     if (my_spaceship)
     {
+        P<SpaceObject> target_ship = my_spaceship->getTarget();
         float target_camera_yaw = my_spaceship->getRotation();
         switch(my_spaceship->main_screen_setting)
         {
         case MSS_Back: target_camera_yaw += 180; break;
         case MSS_Left: target_camera_yaw -= 90; break;
         case MSS_Right: target_camera_yaw += 90; break;
+        case MSS_Target:
+            if (target_ship)
+            {
+                sf::Vector2f target_camera_diff = my_spaceship->getPosition() - target_ship->getPosition();
+                target_camera_yaw = sf::vector2ToAngle(target_camera_diff) + 180;
+            }
+            break;
         default: break;
         }
         camera_pitch = 30.0f;
@@ -117,6 +125,7 @@ void ScreenMainScreen::update(float delta)
         case MSS_Back:
         case MSS_Left:
         case MSS_Right:
+        case MSS_Target:
             viewport->show();
             tactical_radar->hide();
             long_range_radar->hide();
@@ -215,6 +224,10 @@ void ScreenMainScreen::onKey(sf::Keyboard::Key key, int unicode)
     case sf::Keyboard::Down:
         if (my_spaceship)
             my_spaceship->commandMainScreenSetting(MSS_Back);
+        break;
+    case sf::Keyboard::T:
+        if (my_spaceship)
+            my_spaceship->commandMainScreenSetting(MSS_Target);
         break;
     case sf::Keyboard::Tab:
         if (my_spaceship && gameGlobalInfo->allow_main_screen_tactical_radar)

--- a/src/spaceObjects/spaceship.h
+++ b/src/spaceObjects/spaceship.h
@@ -12,6 +12,7 @@ enum EMainScreenSetting
     MSS_Back,
     MSS_Left,
     MSS_Right,
+    MSS_Target,
     MSS_Tactical,
     MSS_LongRange
 };

--- a/src/spaceObjects/spaceship.hpp
+++ b/src/spaceObjects/spaceship.hpp
@@ -1,5 +1,5 @@
-#ifndef _SPACEOBJECTS_HPP_
-#define _SPACEOBJECTS_HPP_
+#ifndef _SPACESHIP_HPP_
+#define _SPACESHIP_HPP_
 /* Define script conversion function for the EMainScreenSetting enum. */
 template<> void convert<EMainScreenSetting>::param(lua_State* L, int& idx, EMainScreenSetting& mss)
 {
@@ -12,6 +12,8 @@ template<> void convert<EMainScreenSetting>::param(lua_State* L, int& idx, EMain
         mss = MSS_Left;
     else if (str == "right")
         mss = MSS_Right;
+    else if (str == "target")
+        mss = MSS_Target;
     else if (str == "tactical")
         mss = MSS_Tactical;
     else if (str == "longrange")
@@ -30,4 +32,4 @@ template<> void convert<EMainScreenOverlay>::param(lua_State* L, int& idx, EMain
     else
         mso = MSO_HideComms;
 }
-#endif /* _SPACEOBJECTS_HPP_ */
+#endif /* _SPACESHIP_HPP_ */


### PR DESCRIPTION
If the player has a station capable of weapons targeting, add a button to the main screen controls to lock the camera onto the current weapons target.

-   Add the MSS_Target command to trigger the target lock view.
-   Add a button to send the MSS_Target command.