### PR TITLE
Hide the radar background gradient on database view

### DIFF
--- a/src/screenComponents/databaseView.cpp
+++ b/src/screenComponents/databaseView.cpp
@@ -115,7 +115,7 @@ void DatabaseViewComponent::display(P<ScienceDatabase> entry)
         }
     } else if (entry->longDescription.length() > 0)
     {
-        (new GuiScrollText(database_entry, "DATABASE_LONG_DESCRIPTION", entry->longDescription))->setTextSize(24)->setPosition(450,0,ATopLeft)->setMargins(0, 0, 50, 50)->setSize(GuiElement::GuiSizeMax, GuiElement::GuiSizeMax);
+        (new GuiScrollText(database_entry, "DATABASE_LONG_DESCRIPTION", entry->longDescription))->setTextSize(24)->setPosition(450,0,ATopLeft)->setMargins(0, 120, 50, 50)->setSize(GuiElement::GuiSizeMax, GuiElement::GuiSizeMax);
     }
     if (entry->items.size() > 0)
     {

--- a/src/screens/crew1/singlePilotScreen.cpp
+++ b/src/screens/crew1/singlePilotScreen.cpp
@@ -5,6 +5,7 @@
 
 #include "screenComponents/viewport3d.h"
 
+#include "screenComponents/alertOverlay.h"
 #include "screenComponents/combatManeuver.h"
 #include "screenComponents/radarView.h"
 #include "screenComponents/impulseControls.h"
@@ -35,9 +36,15 @@ SinglePilotScreen::SinglePilotScreen(GuiContainer* owner)
     left_panel = new GuiElement(this, "LEFT_PANEL");
     left_panel->setPosition(0, 0, ATopLeft)->setSize(1000, GuiElement::GuiSizeMax);
 
-    // Draw background textures in the left panel.
-    (new GuiOverlay(left_panel, "", sf::Color::White))->setTextureCenter("gui/BackgroundGradientSingle");
-    (new GuiOverlay(left_panel, "", sf::Color::White))->setTextureTiled("gui/BackgroundCrosses");
+    // Render the radar shadow and background decorations.
+    background_gradient = new GuiOverlay(this, "BACKGROUND_GRADIENT", sf::Color::White);
+    background_gradient->setTextureCenter("gui/BackgroundGradientSingle");
+
+    background_crosses = new GuiOverlay(this, "BACKGROUND_CROSSES", sf::Color::White);
+    background_crosses->setTextureTiled("gui/BackgroundCrosses");
+
+    // Render the alert level color overlay.
+    (new AlertLevelOverlay(this));
 
     // 5U tactical radar with piloting features.
     radar = new GuiRadarView(left_panel, "TACTICAL_RADAR", 5000.0, &targets);

--- a/src/screens/crew1/singlePilotScreen.h
+++ b/src/screens/crew1/singlePilotScreen.h
@@ -1,5 +1,5 @@
-#ifndef SINGLE_PILOR_SCREEN_H
-#define SINGLE_PILOR_SCREEN_H
+#ifndef SINGLE_PILOT_SCREEN_H
+#define SINGLE_PILOT_SCREEN_H
 
 #include "gui/gui2_overlay.h"
 #include "screenComponents/targetsContainer.h"
@@ -14,6 +14,9 @@ class GuiRotationDial;
 class SinglePilotScreen : public GuiOverlay
 {
 private:
+    GuiOverlay* background_gradient;
+    GuiOverlay* background_crosses;
+
     GuiViewport3D* viewport;
     GuiElement* left_panel;
 
@@ -35,5 +38,4 @@ public:
     virtual void onDraw(sf::RenderTarget& window);
 };
 
-#endif//ENGINEERING_ADVANCED_SCREEN_H
-
+#endif//SINGLE_PILOT_SCREEN_H

--- a/src/screens/crew4/tacticalScreen.cpp
+++ b/src/screens/crew4/tacticalScreen.cpp
@@ -22,8 +22,14 @@
 TacticalScreen::TacticalScreen(GuiContainer* owner)
 : GuiOverlay(owner, "TACTICAL_SCREEN", colorConfig.background)
 {
-    (new GuiOverlay(this, "", sf::Color::White))->setTextureCenter("gui/BackgroundGradient");
-    (new GuiOverlay(this, "", sf::Color::White))->setTextureTiled("gui/BackgroundCrosses");
+    // Render the radar shadow and background decorations.
+    background_gradient = new GuiOverlay(this, "BACKGROUND_GRADIENT", sf::Color::White);
+    background_gradient->setTextureCenter("gui/BackgroundGradientSingle");
+
+    background_crosses = new GuiOverlay(this, "BACKGROUND_CROSSES", sf::Color::White);
+    background_crosses->setTextureTiled("gui/BackgroundCrosses");
+
+    // Render the alert level color overlay.
     (new AlertLevelOverlay(this));
 
     // Short-range tactical radar with a 5U range.

--- a/src/screens/crew4/tacticalScreen.h
+++ b/src/screens/crew4/tacticalScreen.h
@@ -13,6 +13,9 @@ class GuiRotationDial;
 class TacticalScreen : public GuiOverlay
 {
 private:
+    GuiOverlay* background_gradient;
+    GuiOverlay* background_crosses;
+
     GuiKeyValueDisplay* energy_display;
     GuiKeyValueDisplay* heading_display;
     GuiKeyValueDisplay* velocity_display;

--- a/src/screens/crew6/engineeringScreen.cpp
+++ b/src/screens/crew6/engineeringScreen.cpp
@@ -18,7 +18,11 @@
 EngineeringScreen::EngineeringScreen(GuiContainer* owner)
 : GuiOverlay(owner, "ENGINEERING_SCREEN", colorConfig.background), selected_system(SYS_None)
 {
-    (new GuiOverlay(this, "", sf::Color::White))->setTextureTiled("gui/BackgroundCrosses");
+    // Render the background decorations.
+    background_crosses = new GuiOverlay(this, "BACKGROUND_CROSSES", sf::Color::White);
+    background_crosses->setTextureTiled("gui/BackgroundCrosses");
+
+    // Render the alert level color overlay.
     (new AlertLevelOverlay(this));
 
     energy_display = new GuiKeyValueDisplay(this, "ENERGY_DISPLAY", 0.45, "Energy", "");

--- a/src/screens/crew6/engineeringScreen.h
+++ b/src/screens/crew6/engineeringScreen.h
@@ -16,6 +16,9 @@ class GuiProgressbar;
 class EngineeringScreen : public GuiOverlay
 {
 private:
+    GuiOverlay* background_gradient;
+    GuiOverlay* background_crosses;
+
     GuiKeyValueDisplay* energy_display;
     GuiKeyValueDisplay* hull_display;
     GuiKeyValueDisplay* front_shield_display;

--- a/src/screens/crew6/helmsScreen.cpp
+++ b/src/screens/crew6/helmsScreen.cpp
@@ -17,8 +17,14 @@
 HelmsScreen::HelmsScreen(GuiContainer* owner)
 : GuiOverlay(owner, "HELMS_SCREEN", colorConfig.background)
 {
-    (new GuiOverlay(this, "", sf::Color::White))->setTextureCenter("gui/BackgroundGradient");
-    (new GuiOverlay(this, "", sf::Color::White))->setTextureTiled("gui/BackgroundCrosses");
+    // Render the radar shadow and background decorations.
+    background_gradient = new GuiOverlay(this, "BACKGROUND_GRADIENT", sf::Color::White);
+    background_gradient->setTextureCenter("gui/BackgroundGradient");
+
+    background_crosses = new GuiOverlay(this, "BACKGROUND_CROSSES", sf::Color::White);
+    background_crosses->setTextureTiled("gui/BackgroundCrosses");
+
+    // Render the alert level color overlay.
     (new AlertLevelOverlay(this));
 
     GuiRadarView* radar = new GuiRadarView(this, "HELMS_RADAR", 5000.0, nullptr);

--- a/src/screens/crew6/helmsScreen.h
+++ b/src/screens/crew6/helmsScreen.h
@@ -10,6 +10,9 @@ class GuiLabel;
 class HelmsScreen : public GuiOverlay
 {
 private:
+    GuiOverlay* background_gradient;
+    GuiOverlay* background_crosses;
+
     GuiKeyValueDisplay* energy_display;
     GuiKeyValueDisplay* heading_display;
     GuiKeyValueDisplay* velocity_display;

--- a/src/screens/crew6/scienceScreen.cpp
+++ b/src/screens/crew6/scienceScreen.cpp
@@ -88,6 +88,7 @@ ScienceScreen::ScienceScreen(GuiContainer* owner)
             {
                 view_mode_selection->setSelectionIndex(1);
                 radar_view->hide();
+                background_gradient->hide();
                 database_view->show();
             }
         }
@@ -155,6 +156,7 @@ ScienceScreen::ScienceScreen(GuiContainer* owner)
 
     view_mode_selection = new GuiListbox(this, "VIEW_SELECTION", [this](int index, string value) {
         radar_view->setVisible(index == 0);
+        background_gradient->setVisible(index == 0);
         database_view->setVisible(index == 1);
     });
     view_mode_selection->setOptions({"Radar", "Database"})->setSelectionIndex(0)->setPosition(20, -20, ABottomLeft)->setSize(200, 100);

--- a/src/screens/crew6/scienceScreen.cpp
+++ b/src/screens/crew6/scienceScreen.cpp
@@ -24,8 +24,14 @@ ScienceScreen::ScienceScreen(GuiContainer* owner)
 {
     targets.setAllowWaypointSelection();
 
-    (new GuiOverlay(this, "", sf::Color::White))->setTextureCenter("gui/BackgroundGradientOffset");
-    (new GuiOverlay(this, "", sf::Color::White))->setTextureTiled("gui/BackgroundCrosses");
+    // Render the radar shadow and background decorations.
+    background_gradient = new GuiOverlay(this, "BACKGROUND_GRADIENT", sf::Color::White);
+    background_gradient->setTextureCenter("gui/BackgroundGradientOffset");
+
+    background_crosses = new GuiOverlay(this, "BACKGROUND_CROSSES", sf::Color::White);
+    background_crosses->setTextureTiled("gui/BackgroundCrosses");
+
+    // Render the alert level color overlay.
     (new AlertLevelOverlay(this));
 
     radar_view = new GuiElement(this, "RADAR_VIEW");

--- a/src/screens/crew6/scienceScreen.h
+++ b/src/screens/crew6/scienceScreen.h
@@ -19,6 +19,9 @@ class DatabaseViewComponent;
 class ScienceScreen : public GuiOverlay
 {
 public:
+    GuiOverlay* background_gradient;
+    GuiOverlay* background_crosses;
+
     GuiElement* radar_view;
     DatabaseViewComponent* database_view;
 

--- a/src/screens/crew6/weaponsScreen.cpp
+++ b/src/screens/crew6/weaponsScreen.cpp
@@ -18,8 +18,14 @@
 WeaponsScreen::WeaponsScreen(GuiContainer* owner)
 : GuiOverlay(owner, "WEAPONS_SCREEN", colorConfig.background)
 {
-    (new GuiOverlay(this, "", sf::Color::White))->setTextureCenter("gui/BackgroundGradient");
-    (new GuiOverlay(this, "", sf::Color::White))->setTextureTiled("gui/BackgroundCrosses");
+    // Render the radar shadow and background decorations.
+    background_gradient = new GuiOverlay(this, "BACKGROUND_GRADIENT", sf::Color::White);
+    background_gradient->setTextureCenter("gui/BackgroundGradient");
+
+    background_crosses = new GuiOverlay(this, "BACKGROUND_CROSSES", sf::Color::White);
+    background_crosses->setTextureTiled("gui/BackgroundCrosses");
+
+    // Render the alert level color overlay.
     (new AlertLevelOverlay(this));
 
     radar = new GuiRadarView(this, "HELMS_RADAR", 5000.0, &targets);

--- a/src/screens/crew6/weaponsScreen.h
+++ b/src/screens/crew6/weaponsScreen.h
@@ -13,6 +13,9 @@ class GuiRotationDial;
 class WeaponsScreen : public GuiOverlay
 {
 private:
+    GuiOverlay* background_gradient;
+    GuiOverlay* background_crosses;
+
     TargetsContainer targets;
     GuiKeyValueDisplay* energy_display;
     GuiKeyValueDisplay* front_shield_display;
@@ -27,4 +30,4 @@ public:
     virtual void onDraw(sf::RenderTarget& window);
 };
 
-#endif//HELMS_SCREEN_H
+#endif//WEAPONS_SCREEN_H


### PR DESCRIPTION
Resolves the issue brought up by @Fouindor in #313.

-   Assigns the background gradient to a variable across stations so it can be more easily cleared or toggled.
-   Toggle the gradient when toggling the database view from Science.