### PR TITLE
Restore shadow's correct target element.

### DIFF
--- a/src/screens/crew1/singlePilotScreen.cpp
+++ b/src/screens/crew1/singlePilotScreen.cpp
@@ -37,10 +37,10 @@ SinglePilotScreen::SinglePilotScreen(GuiContainer* owner)
     left_panel->setPosition(0, 0, ATopLeft)->setSize(1000, GuiElement::GuiSizeMax);
 
     // Render the radar shadow and background decorations.
-    background_gradient = new GuiOverlay(this, "BACKGROUND_GRADIENT", sf::Color::White);
+    background_gradient = new GuiOverlay(left_panel, "BACKGROUND_GRADIENT", sf::Color::White);
     background_gradient->setTextureCenter("gui/BackgroundGradientSingle");
 
-    background_crosses = new GuiOverlay(this, "BACKGROUND_CROSSES", sf::Color::White);
+    background_crosses = new GuiOverlay(left_panel, "BACKGROUND_CROSSES", sf::Color::White);
     background_crosses->setTextureTiled("gui/BackgroundCrosses");
 
     // Render the alert level color overlay.


### PR DESCRIPTION
Fixes an issue where [the shadow displays on top of everything or in the wrong location](https://github.com/daid/EmptyEpsilon/commit/235aafa2fe1f2dcaac9e2efcc808b2aaa186be8e#commitcomment-17875673) on the Single Pilot screen.