### PR TITLE
Adjust comms overlay OK buttons, broken comms text.

### DIFF
--- a/src/screenComponents/commsOverlay.cpp
+++ b/src/screenComponents/commsOverlay.cpp
@@ -57,7 +57,7 @@ GuiCommsOverlay::GuiCommsOverlay(GuiContainer* owner)
     (new GuiButton(no_response_box, "COMMS_NO_REPLY_OK", "Ok", []() {
         if (my_spaceship)
             my_spaceship->commandCloseTextComm();
-    }))->setSize(150, 50)->setPosition(-20, -10, ABottomRight);
+    }))->setSize(100, 50)->setPosition(-20, -10, ABottomRight);
 
     // Panel for broken communications.
     broken_box = new GuiPanel(owner, "COMMS_BROKEN_BOX");
@@ -68,18 +68,18 @@ GuiCommsOverlay::GuiCommsOverlay(GuiContainer* owner)
     (new GuiButton(broken_box, "COMMS_BROKEN_OK", "Ok", []() {
         if (my_spaceship)
             my_spaceship->commandCloseTextComm();
-    }))->setSize(150, 50)->setPosition(-20, -10, ABottomRight);
+    }))->setSize(100, 50)->setPosition(-20, -10, ABottomRight);
 
     // Panel for communications closed by the other object.
     closed_box = new GuiPanel(owner, "COMMS_CLOSED_BOX");
     closed_box->hide()->setSize(800, 70)->setPosition(0, -250, ABottomCenter);
-    (new GuiLabel(closed_box, "COMMS_BROKEN_LABEL", "Other party closed communications", 40))->setSize(GuiElement::GuiSizeMax, GuiElement::GuiSizeMax)->setPosition(0, 0, ATopLeft);
+    (new GuiLabel(closed_box, "COMMS_BROKEN_LABEL", "Communications channel closed", 40))->setSize(GuiElement::GuiSizeMax, GuiElement::GuiSizeMax)->setPosition(0, 0, ATopLeft);
 
     // Button to acknowledge closed communications.
-    (new GuiButton(closed_box, "COMMS_BROKEN_OK", "Ok", []() {
+    (new GuiButton(closed_box, "COMMS_CLOSED_OK", "Ok", []() {
         if (my_spaceship)
             my_spaceship->commandCloseTextComm();
-    }))->setSize(150, 50)->setPosition(-20, -10, ABottomRight);
+    }))->setSize(100, 50)->setPosition(-20, -10, ABottomRight);
 
     // Panel for chat communications with GMs and other player ships.
     chat_comms_box = new GuiPanel(owner, "COMMS_CHAT_BOX");


### PR DESCRIPTION
-   Reduce size of OK buttons on comms overlay to avoid overlap.
-   Change BROKEN_COMMS text to be more generic since it appears when players close comms with the GM.