### PR TITLE
Add CPU tugs

### DIFF
--- a/scripts/comms_ship.lua
+++ b/scripts/comms_ship.lua
@@ -37,6 +37,21 @@ function friendlyComms(comms_data)
 			end
 		end
 	end)
+	addCommsReply("Go to a waypoint", function()
+		if player:getWaypointCount() == 0 then
+			setCommsMessage("No waypoints set. Please set a waypoint first.");
+			addCommsReply("Back", mainMenu)
+		else
+			setCommsMessage("Toward which waypoint should we move?");
+			for n=1,player:getWaypointCount() do
+				addCommsReply("Go to WP" .. n, function()
+					comms_target:orderFlyTowards(player:getWaypoint(n))
+					setCommsMessage("We are heading toward WP" .. n ..".");
+					addCommsReply("Back", mainMenu)
+				end)
+			end
+		end
+	end)
 	if comms_data.friendlyness > 0.2 then
 		addCommsReply("Assist me", function()
 			setCommsMessage("Heading toward you to assist.");
@@ -44,11 +59,6 @@ function friendlyComms(comms_data)
 			addCommsReply("Back", mainMenu)
 		end)
 	end
-	addCommsReply("Tow me", function()
-		setCommsMessage("Heading toward you to tow.");
-		comms_target:orderTowTarget(player)
-		addCommsReply("Back", mainMenu)
-        end)
 	addCommsReply("Report status", function()
 		msg = "Hull: " .. math.floor(comms_target:getHull() / comms_target:getHullMax() * 100) .. "%\n"
 		shields = comms_target:getShieldCount()

--- a/scripts/comms_ship.lua
+++ b/scripts/comms_ship.lua
@@ -44,6 +44,11 @@ function friendlyComms(comms_data)
 			addCommsReply("Back", mainMenu)
 		end)
 	end
+	addCommsReply("Tow me", function()
+		setCommsMessage("Heading toward you to tow.");
+		comms_target:orderTowTarget(player)
+		addCommsReply("Back", mainMenu)
+        end)
 	addCommsReply("Report status", function()
 		msg = "Hull: " .. math.floor(comms_target:getHull() / comms_target:getHullMax() * 100) .. "%\n"
 		shields = comms_target:getShieldCount()

--- a/scripts/comms_station.lua
+++ b/scripts/comms_station.lua
@@ -23,10 +23,12 @@ function mainMenu()
         services = {
             supplydrop = "friend",
             reinforcements = "friend",
+            tow = "friend"
         },
         service_cost = {
             supplydrop = 100,
             reinforcements = 150,
+            tow = 150
         },
         reputation_cost_multipliers = {
             friend = 1.0,
@@ -172,6 +174,17 @@ function handleUndockedState()
                         addCommsReply("Back", mainMenu)
                     end)
                 end
+            end
+            addCommsReply("Back", mainMenu)
+        end)
+    end
+    if isAllowedTo(comms_target.comms_data.services.tow) then
+        addCommsReply("We need to to be towed. ("..getServiceCost("tow").."rep)", function()
+            if player:takeReputationPoints(getServiceCost("tow")) then
+                ship = CpuShip():setFactionId(comms_target:getFactionId()):setPosition(comms_target:getPosition()):setTemplate("Small Tug"):setScanned(true):orderPickup(player)
+                setCommsMessage("We have dispatched " .. ship:getCallSign() .. " to pick you up.");
+            else
+                setCommsMessage("Not enough reputation!");
             end
             addCommsReply("Back", mainMenu)
         end)

--- a/scripts/shipTemplates_Frigates.lua
+++ b/scripts/shipTemplates_Frigates.lua
@@ -264,6 +264,19 @@ variation:addDoor(2, 5, true)
 variation:addDoor(5, 5, true)
 variation:addDoor(6, 5, true)
 
+--[[ Support craft ]]
+template = ShipTemplate():setName("Small Tug"):setClass("Frigate", "Support"):setModel("space_tug")
+template:setDescription([[An unarmed, unshielded tug capable of towing other craft. Nearly all of its power is devoted to its unique tractor system, which is powerful enough to push and pull ships larger than itself.]])
+template:setRadarTrace("radar_tug.png")
+template:setHull(50)
+template:setSpeed(30, 3.5, 5)
+template:setDockClasses("Starfighter", "Frigate", "Corvette")
+
+variation = template:copy("Small Jump Tug")
+variation:setDescription([[An unarmed, unshielded tug capable of towing light craft. Most of its power is devoted to its unique tractor system, which is powerful enough to push and pull ships its own size. It also boasts a jump drive configured to carry both itself and its towed craft at the expense of moving corvette-class ships.]])
+variation:setJumpDrive(true)
+variation:setDockClasses("Starfighter", "Frigate")
+
 --Support: mine layer
 --Support: mine sweeper
 --Support: science vessel

--- a/src/screens/gm/gameMasterScreen.cpp
+++ b/src/screens/gm/gameMasterScreen.cpp
@@ -389,6 +389,8 @@ void GameMasterScreen::onMouseUp(sf::Vector2f position)
                         }else{
                             if (!shift_down && target->canBeDockedBy(cpu_ship))
                                 cpu_ship->orderDock(target);
+                            else if (!shift_down && cpu_ship->canBeDockedBy(target))
+                                cpu_ship->orderPickup(target);
                             else
                                 cpu_ship->orderDefendTarget(target);
                         }

--- a/src/spaceObjects/artifact.cpp
+++ b/src/spaceObjects/artifact.cpp
@@ -87,6 +87,17 @@ void Artifact::allowPickup(bool allow)
     allow_pickup = allow;
 }
 
+bool Artifact::canBePickedUpBy(P<Collisionable> target)
+{
+    // TODO: Let non-player ships pick up artifacts?
+    P<PlayerSpaceship> ship = target;
+
+    if (ship && allow_pickup)
+        return true;
+    else
+        return false;
+}
+
 string Artifact::getExportLine()
 {
     string ret = "Artifact():setPosition(" + string(getPosition().x, 0) + ", " + string(getPosition().y, 0) + ")";

--- a/src/spaceObjects/artifact.h
+++ b/src/spaceObjects/artifact.h
@@ -21,7 +21,8 @@ public:
     void setModel(string name);
     void explode();
     void allowPickup(bool allow);
-    
+    virtual bool canBePickedUpBy(P<Collisionable> target) override;
+
     virtual string getExportLine();
 };
 

--- a/src/spaceObjects/cpuShip.cpp
+++ b/src/spaceObjects/cpuShip.cpp
@@ -38,6 +38,9 @@ REGISTER_SCRIPT_SUBCLASS(CpuShip, SpaceShip)
     REGISTER_SCRIPT_CLASS_FUNCTION(CpuShip, orderAttack);
     /// Order this ship to dock at a specific object (station or otherwise)
     REGISTER_SCRIPT_CLASS_FUNCTION(CpuShip, orderDock);
+    /// Order this ship to move within docking range of an object and initiate
+    /// docking on the target ship.
+    REGISTER_SCRIPT_CLASS_FUNCTION(CpuShip, orderPickup);
 }
 
 REGISTER_MULTIPLAYER_CLASS(CpuShip, "CpuShip");
@@ -181,6 +184,15 @@ void CpuShip::orderDock(P<SpaceObject> object)
     this->addBroadcast(FVF_Friendly, "Docking to " + object->getCallSign() + ".");
 }
 
+void CpuShip::orderPickup(P<SpaceObject> object)
+{
+    if (!object)
+        return;
+    orders = AI_Pickup;
+    order_target = object;
+    this->addBroadcast(FVF_Friendly, "Moving to pickup " + object->getCallSign() + ".");
+}
+
 void CpuShip::drawOnGMRadar(sf::RenderTarget& window, sf::Vector2f position, float scale, bool long_range)
 {
     SpaceShip::drawOnGMRadar(window, position, scale, long_range);
@@ -209,6 +221,7 @@ string CpuShip::getExportLine()
     case AI_FlyTowardsBlind: ret += ":orderFlyTowardsBlind(" + string(order_target_location.x, 0) + ", " + string(order_target_location.y, 0) + ")"; break;
     case AI_Attack: ret += ":orderAttack(?)"; break;
     case AI_Dock: ret += ":orderDock(?)"; break;
+    case AI_Pickup: ret += ":orderPickup(?)"; break;
     }
     return ret + getScriptExportModificationsOnTemplate();
 }
@@ -227,6 +240,7 @@ string getAIOrderString(EAIOrder order)
     case AI_FlyTowardsBlind: return "Fly towards (ignore all)";
     case AI_Attack: return "Attack";
     case AI_Dock: return "Dock";
+    case AI_Pickup: return "Pickup";
     }
     return "Unknown";
 }

--- a/src/spaceObjects/cpuShip.h
+++ b/src/spaceObjects/cpuShip.h
@@ -14,8 +14,9 @@ enum EAIOrder
     AI_FlyFormation,    //Fly [order_target_location] offset from [order_target]. Allows for nicely flying in formation.
     AI_FlyTowards,      //Fly towards [order_target_location], attacking enemies that get too close, but disengage and continue when enemy is too far.
     AI_FlyTowardsBlind, //Fly towards [order_target_location], not attacking anything
-    AI_Dock,            //Dock with target
-    AI_Attack,          //Attack [order_target] very specificly.
+    AI_Dock,            //Dock with target.
+    AI_Pickup,          //Move into docking range of [order_target].
+    AI_Attack           //Specifically attack [order_target].
 };
 
 
@@ -49,6 +50,7 @@ public:
     void orderFlyTowardsBlind(sf::Vector2f target);
     void orderAttack(P<SpaceObject> object);
     void orderDock(P<SpaceObject> object);
+    void orderPickup(P<SpaceObject> object);
 
     EAIOrder getOrder() { return orders; }
     sf::Vector2f getOrderTargetLocation() { return order_target_location; }

--- a/src/spaceObjects/spaceObject.h
+++ b/src/spaceObjects/spaceObject.h
@@ -114,6 +114,7 @@ public:
 
     virtual void setCallSign(string new_callsign) { callsign = new_callsign; }
     virtual string getCallSign() { return callsign; }
+    virtual bool canBePickedUpBy(P<Collisionable> obj) { return false; }
     virtual bool canBeDockedBy(P<SpaceObject> obj) { return false; }
     virtual bool hasShield() { return false; }
     virtual bool canHideInNebula() { return true; }

--- a/src/spaceObjects/supplyDrop.cpp
+++ b/src/spaceObjects/supplyDrop.cpp
@@ -65,6 +65,17 @@ void SupplyDrop::collide(Collisionable* target, float force)
     }
 }
 
+bool SupplyDrop::canBePickedUpBy(P<Collisionable> target)
+{
+    // TODO: Let non-player ships pick up supply drops?
+    // P<SpaceShip> ship = target;
+    P<PlayerSpaceship> ship = target;
+    if (ship && isFriendly(ship))
+        return true;
+    else
+        return false;
+}
+
 string SupplyDrop::getExportLine()
 {
     string ret = "SupplyDrop():setFaction(\"" + getFaction() + "\"):setPosition(" + string(getPosition().x, 0) + ", " + string(getPosition().y, 0) + ")";

--- a/src/spaceObjects/supplyDrop.h
+++ b/src/spaceObjects/supplyDrop.h
@@ -18,9 +18,10 @@ public:
 
     void setEnergy(float amount) { energy = amount; }
     void setWeaponStorage(EMissileWeapons weapon, int amount) { if (weapon != MW_None) weapon_storage[weapon] = amount; }
+    virtual bool canBePickedUpBy(P<Collisionable> target) override;
     
     virtual string getExportLine();
 };
 
-#endif//ASTEROID_H
+#endif//SUPPLY_DROP_H
 


### PR DESCRIPTION
-   Add AI_Pickup, which instructs a CPU ship to move to a target and trigger the target's docking request. This allows AI tugs and carriers to pick up idle, immobile, unmanned, or otherwise disabled ships.
-   Add Small Tug and Small Jump Tug support frigates.
-   Add a tow request to the station comms script, which dispatches a Small Tug to pick up the requesting player.
-   Add a fly-towards request to the ship comms script.
-   Add basic getter functions for whether artifacts and supply drops can be picked up.