### PR TITLE
Add toggle for sharing energy with docked ships

### DIFF
--- a/src/shipTemplate.cpp
+++ b/src/shipTemplate.cpp
@@ -51,6 +51,8 @@ REGISTER_SCRIPT_CLASS(ShipTemplate)
     REGISTER_SCRIPT_CLASS_FUNCTION(ShipTemplate, setCombatManeuver);
     /// Set the warp speed for warp level 1 for this ship. Setting this will indicate that this ship has a warpdrive. (normal value is 1000)
     REGISTER_SCRIPT_CLASS_FUNCTION(ShipTemplate, setWarpSpeed);
+    /// Set if this ship shares energy with docked ships. Example: template:setSharesEnergy(false)
+    REGISTER_SCRIPT_CLASS_FUNCTION(ShipTemplate, setSharesEnergy);
     /// Set if this ship has a jump drive. Example: template:setJumpDrive(true)
     REGISTER_SCRIPT_CLASS_FUNCTION(ShipTemplate, setJumpDrive);
     REGISTER_SCRIPT_CLASS_FUNCTION(ShipTemplate, setJumpDriveRange);
@@ -93,6 +95,7 @@ ShipTemplate::ShipTemplate()
     combat_maneuver_boost_speed = 0.0f;
     combat_maneuver_strafe_speed = 0.0f;
     warp_speed = 0.0;
+    shares_energy = true;
     has_jump_drive = false;
     jump_drive_min_distance = 5000.0;
     jump_drive_max_distance = 50000.0;
@@ -329,6 +332,11 @@ void ShipTemplate::setWarpSpeed(float warp)
     warp_speed = warp;
 }
 
+void ShipTemplate::setSharesEnergy(bool enabled)
+{
+    shares_energy = enabled;
+}
+
 void ShipTemplate::setJumpDrive(bool enabled)
 {
     has_jump_drive = enabled;
@@ -397,6 +405,7 @@ P<ShipTemplate> ShipTemplate::copy(string new_name)
     result->impulse_acceleration;
     result->combat_maneuver_boost_speed;
     result->combat_maneuver_strafe_speed;
+    result->shares_energy = shares_energy;
     result->has_jump_drive = has_jump_drive;
     result->has_cloaking = has_cloaking;
     for(int n=0; n<MW_Count; n++)

--- a/src/shipTemplate.h
+++ b/src/shipTemplate.h
@@ -98,6 +98,7 @@ public:
     float impulse_acceleration;
     float combat_maneuver_boost_speed;
     float combat_maneuver_strafe_speed;
+    bool shares_energy;
     bool has_jump_drive, has_cloaking;
     float jump_drive_min_distance;
     float jump_drive_max_distance;
@@ -141,6 +142,7 @@ public:
     void setSpeed(float impulse, float turn, float acceleration);
     void setCombatManeuver(float boost, float strafe);
     void setWarpSpeed(float warp);
+    void setSharesEnergy(bool enabled);
     void setJumpDrive(bool enabled);
     void setJumpDriveRange(float min, float max) { jump_drive_min_distance = min; jump_drive_max_distance = max; }
     void setCloaking(bool enabled);

--- a/src/spaceObjects/playerSpaceship.cpp
+++ b/src/spaceObjects/playerSpaceship.cpp
@@ -261,7 +261,7 @@ void PlayerSpaceship::update(float delta)
     {
         P<SpaceShip> docked_with_ship = docking_target;
         float energy_request = std::min(delta * 10.0f, max_energy_level - energy_level);
-        if (!docked_with_ship || docked_with_ship->useEnergy(energy_request))
+        if (!docked_with_ship || (docked_with_ship->shares_energy && docked_with_ship->useEnergy(energy_request)))
             energy_level += energy_request;
         if (!docked_with_ship)  //Only recharge probes and hull when we are not docked to a ship (and thus a station). Bit hackish for now.
         {

--- a/src/spaceObjects/spaceship.h
+++ b/src/spaceObjects/spaceship.h
@@ -133,6 +133,7 @@ public:
     float combat_maneuver_boost_speed; /*< [config] Speed to indicate how fast we will fly forwards with a full boost */
     float combat_maneuver_strafe_speed; /*< [config] Speed to indicate how fast we will fly sideways with a full strafe */
 
+    bool shares_energy;       //[config]
     bool has_jump_drive;      //[config]
     float jump_drive_charge; //[output]
     float jump_distance;     //[output]
@@ -244,6 +245,8 @@ public:
 
     /// Dummy virtual function to use energy. Only player ships currently model energy use.
     virtual bool useEnergy(float amount) { return true; }
+    virtual bool getSharesEnergy() { return shares_energy; }
+    virtual void setSharesEnergy(bool enabled) { shares_energy = enabled; }
 
     /// Dummy virtual function to add heat on a system. The player ship class has an actual implementation of this as only player ships model heat right now.
     virtual void addHeat(ESystem system, float amount) {}


### PR DESCRIPTION
Let ship templates set whether to distribute energy to other ships
docked with it (enabled by default; no change compared to current
behavior).

For instance, to disable energy sharing with docked ships, add this
to a ship's template:

    template:setSharesEnergy(false)