### PR TITLE
Implement turreted beams

### DIFF
--- a/src/beamTemplate.cpp
+++ b/src/beamTemplate.cpp
@@ -1,9 +1,12 @@
+#include <iostream>
 #include "beamTemplate.h"
 
 BeamTemplate::BeamTemplate()
 {
     direction = 0;
     range = 0;
+    turret_direction = 0;
+    turret_rotation_rate = 0;
     cycle_time = 0;
     damage = 0;
     beam_texture = "beam_orange.png";
@@ -65,6 +68,65 @@ void BeamTemplate::setRange(float range)
         this->range = range;
 }
 
+float BeamTemplate::getTurretDirection()
+{
+    std::cout << "BeamTemplate::getTurretDirection: " << turret_direction << "\n";
+    return turret_direction;
+}
+
+void BeamTemplate::setTurretDirection(float direction)
+{
+    // Clamp values
+    while(direction < 0)
+        direction += 360;
+    while(direction > 360)
+        direction -= 360;
+    this->turret_direction = direction;
+    std::cout << "BeamTemplate::setTurretDirection\n";
+    std::cout << "               direction: " << direction << "\n";
+    std::cout << "  this->turret_direction: " << this->turret_direction << "\n";
+}
+
+float BeamTemplate::getTurretArc()
+{
+    std::cout << "BeamTemplate::getTurretArc: " << turret_arc << "\n";
+    return turret_arc;
+}
+
+void BeamTemplate::setTurretArc(float arc)
+{
+    while(arc < 0)
+        arc += 360;
+    while(arc > 360)
+        arc -=360;
+    this->turret_arc = arc;
+    std::cout << "BeamTemplate::setTurretArc" << "\n";
+    std::cout << "               arc: " << arc << "\n";
+    std::cout << "  this->turret_arc: " << this->turret_arc << "\n";
+}
+
+float BeamTemplate::getTurretRotationRate()
+{
+    std::cout << "BeamTemplate::getTurretRotationRate: " << turret_rotation_rate << "\n";
+    return turret_rotation_rate;
+}
+
+void BeamTemplate::setTurretRotationRate(float rotation_rate)
+{
+    if (rotation_rate < 0)
+        this->turret_rotation_rate = 0.0;
+    // 25 is an arbitrary limit. Values greater than 25.0 are nearly
+    // instantaneous.
+    else if (rotation_rate > 25.0)
+        this->turret_rotation_rate = 25.0;
+    else
+        this->turret_rotation_rate = rotation_rate;
+
+    std::cout << "BeamTemplate::setTurretRotationRate" << "\n";
+    std::cout << "               rotation_rate: " << rotation_rate << "\n";
+    std::cout << "  this->turret_rotation_rate: " << this->turret_rotation_rate << "\n";
+}
+
 float BeamTemplate::getCycleTime()
 {
     return cycle_time;
@@ -117,6 +179,16 @@ BeamTemplate& BeamTemplate::operator=(const BeamTemplate& other)
     direction = other.direction;
     arc = other.arc;
     range = other.range;
+    std::cout << "BeamTemplate::operator=" << "\n";
+    turret_direction = other.turret_direction;
+    std::cout << "            turret_direction: " << turret_direction << "\n";
+    std::cout << "      other.turret_direction: " << other.turret_direction << "\n";
+    turret_arc = other.turret_arc;
+    std::cout << "                  turret_arc: " << turret_arc << "\n";
+    std::cout << "            other.turret_arc: " << other.turret_arc << "\n";
+    turret_arc = other.turret_rotation_rate;
+    std::cout << "        turret_rotation_rate: " << turret_rotation_rate << "\n";
+    std::cout << "  other.turret_rotation_rate: " << other.turret_rotation_rate << "\n";
     cycle_time = other.cycle_time;
     damage = other.damage;
     energy_per_beam_fire = other.energy_per_beam_fire;

--- a/src/beamTemplate.h
+++ b/src/beamTemplate.h
@@ -10,7 +10,6 @@ class BeamTemplate : public sf::NonCopyable
 public:
     BeamTemplate();
 
-
     string getBeamTexture();
 
     void setBeamTexture(string texture);
@@ -32,6 +31,15 @@ public:
     float getRange();
     void setRange(float range);
 
+    float getTurretDirection();
+    void setTurretDirection(float direction);
+
+    float getTurretArc();
+    void setTurretArc(float arc);
+
+    float getTurretRotationRate();
+    void setTurretRotationRate(float rotation_rate);
+
     float getCycleTime();
     void setCycleTime(float cycle_time);
 
@@ -48,9 +56,12 @@ public:
 
 protected:
     string beam_texture;
-    float direction; //Value between 0 and 360 (degrees)
-    float arc; //Value between 0 and 360
-    float range; // value greater than 0
+    float direction; // Value between 0 and 360 (degrees)
+    float arc; // Value between 0 and 360
+    float range; // Value greater than 0
+    float turret_direction; // Value between 0 and 360 (degrees)
+    float turret_arc; // Value between 0 and 360
+    float turret_rotation_rate; // Value between 0 and 25 (degrees/tick)
     float cycle_time; // Value greater than 0
     float damage;
     float energy_per_beam_fire;

--- a/src/gameStateLogger.cpp
+++ b/src/gameStateLogger.cpp
@@ -455,9 +455,11 @@ void GameStateLogger::writeShipEntry(JSONGenerator& json, P<SpaceShip> ship)
                     config.startArray("beams");
                 has_beam_weapons = true;
                 JSONGenerator beam = config.arrayCreateDict();
-                beam.write("range", ship->beam_weapons[n].getRange());
                 beam.write("arc", ship->beam_weapons[n].getArc());
                 beam.write("direction", ship->beam_weapons[n].getDirection());
+                beam.write("range", ship->beam_weapons[n].getRange());
+                beam.write("turret_arc", ship->beam_weapons[n].getTurretArc());
+                beam.write("turret_direction", ship->beam_weapons[n].getTurretDirection());
                 beam.write("damage", ship->beam_weapons[n].getDamage());
                 beam.write("cycle_time", ship->beam_weapons[n].getCycleTime());
             }

--- a/src/screens/gm/tweak.cpp
+++ b/src/screens/gm/tweak.cpp
@@ -349,16 +349,43 @@ GuiShipTweakBeamweapons::GuiShipTweakBeamweapons(GuiContainer* owner)
     index_selector->setSelectionIndex(0);
 
     (new GuiLabel(right_col, "", "Arc:", 20))->setSize(GuiElement::GuiSizeMax, 30);
-    arc_slider = new GuiSlider(right_col, "", 0.0, 360, 0.0, [this](float value) {
+    arc_slider = new GuiSlider(right_col, "", 0.0, 360.0, 0.0, [this](float value) {
         target->beam_weapons[beam_index].setArc(roundf(value));
     });
     arc_slider->addOverlay()->setSize(GuiElement::GuiSizeMax, 40);
 
     (new GuiLabel(right_col, "", "Direction:", 20))->setSize(GuiElement::GuiSizeMax, 30);
-    direction_slider = new GuiSlider(right_col, "", -180.0, 180, 0.0, [this](float value) {
+    direction_slider = new GuiSlider(right_col, "", -180.0, 180.0, 0.0, [this](float value) {
         target->beam_weapons[beam_index].setDirection(roundf(value));
     });
     direction_slider->addOverlay()->setSize(GuiElement::GuiSizeMax, 40);
+
+    (new GuiLabel(right_col, "", "Turret Arc:", 20))->setSize(GuiElement::GuiSizeMax, 30);
+    turret_arc_slider = new GuiSlider(right_col, "", 0.0, 360.0, 0.0, [this](float value) {
+        target->beam_weapons[beam_index].setTurretArc(roundf(value));
+    });
+    turret_arc_slider->addOverlay()->setSize(GuiElement::GuiSizeMax, 40);
+
+    (new GuiLabel(right_col, "", "Turret Direction:", 20))->setSize(GuiElement::GuiSizeMax, 30);
+    turret_direction_slider = new GuiSlider(right_col, "", -180.0, 180.0, 0.0, [this](float value) {
+        target->beam_weapons[beam_index].setTurretDirection(roundf(value));
+    });
+    turret_direction_slider->addOverlay()->setSize(GuiElement::GuiSizeMax, 40);
+
+    (new GuiLabel(right_col, "", "Turret Rotation Rate:", 20))->setSize(GuiElement::GuiSizeMax, 30);
+    // 25 is an arbitrary limit for granularity; values greater than 25 result
+    // in practicaly instantaneous turret rotation.
+    turret_rotation_rate_slider = new GuiSlider(right_col, "", 0.0, 250.0, 0.0, [this](float value) {
+        // Divide a large value for granularity.
+        if (value > 0)
+            target->beam_weapons[beam_index].setTurretRotationRate(value / 10.0);
+        else
+            target->beam_weapons[beam_index].setTurretRotationRate(0.0);
+    });
+    turret_rotation_rate_slider->setSize(GuiElement::GuiSizeMax, 40);
+    // Override overlay label.
+    turret_rotation_rate_overlay_label = new GuiLabel(turret_rotation_rate_slider, "", "", 30);
+    turret_rotation_rate_overlay_label->setSize(GuiElement::GuiSizeMax, GuiElement::GuiSizeMax);
 
     (new GuiLabel(right_col, "", "Range:", 20))->setSize(GuiElement::GuiSizeMax, 30);
     range_slider = new GuiSlider(right_col, "", 0.0, 5000.0, 0.0, [this](float value) {
@@ -386,6 +413,10 @@ void GuiShipTweakBeamweapons::onDraw(sf::RenderTarget& window)
     arc_slider->setValue(target->beam_weapons[beam_index].getArc());
     direction_slider->setValue(sf::angleDifference(0.0f, target->beam_weapons[beam_index].getDirection()));
     range_slider->setValue(target->beam_weapons[beam_index].getRange());
+    turret_arc_slider->setValue(target->beam_weapons[beam_index].getTurretArc());
+    turret_direction_slider->setValue(sf::angleDifference(0.0f, target->beam_weapons[beam_index].getTurretDirection()));
+    turret_rotation_rate_slider->setValue(target->beam_weapons[beam_index].getTurretRotationRate() * 10.0f);
+    turret_rotation_rate_overlay_label->setText(string(target->beam_weapons[beam_index].getTurretRotationRate()));
     cycle_time_slider->setValue(target->beam_weapons[beam_index].getCycleTime());
     damage_slider->setValue(target->beam_weapons[beam_index].getDamage());
 }

--- a/src/screens/gm/tweak.h
+++ b/src/screens/gm/tweak.h
@@ -6,6 +6,7 @@
 #include "shipTemplate.h"
 
 class SpaceShip;
+class GuiLabel;
 class GuiTextEntry;
 class GuiSlider;
 class GuiSelector;
@@ -111,6 +112,10 @@ private:
     GuiSlider* arc_slider;
     GuiSlider* direction_slider;
     GuiSlider* range_slider;
+    GuiSlider* turret_arc_slider;
+    GuiSlider* turret_direction_slider;
+    GuiSlider* turret_rotation_rate_slider;
+    GuiLabel* turret_rotation_rate_overlay_label;
     GuiSlider* cycle_time_slider;
     GuiSlider* damage_slider;
 public:

--- a/src/shipTemplate.cpp
+++ b/src/shipTemplate.cpp
@@ -29,6 +29,8 @@ REGISTER_SCRIPT_CLASS(ShipTemplate)
     REGISTER_SCRIPT_CLASS_FUNCTION(ShipTemplate, setBeam);
     /// Setup a beam weapon.
     REGISTER_SCRIPT_CLASS_FUNCTION(ShipTemplate, setBeamWeapon);
+    /// Setup a beam's turret.
+    REGISTER_SCRIPT_CLASS_FUNCTION(ShipTemplate, setBeamWeaponTurret);
     /// Setup a beam weapon texture
     REGISTER_SCRIPT_CLASS_FUNCTION(ShipTemplate, setBeamTexture);
     REGISTER_SCRIPT_CLASS_FUNCTION(ShipTemplate, setBeamWeaponEnergyPerFire);
@@ -201,6 +203,15 @@ void ShipTemplate::setBeamWeapon(int index, float arc, float direction, float ra
     beams[index].setRange(range);
     beams[index].setCycleTime(cycle_time);
     beams[index].setDamage(damage);
+}
+
+void ShipTemplate::setBeamWeaponTurret(int index, float arc, float direction, float rotation_rate)
+{
+    if (index < 0 || index > max_beam_weapons)
+        return;
+    beams[index].setTurretArc(arc);
+    beams[index].setTurretDirection(direction);
+    beams[index].setTurretRotationRate(rotation_rate);
 }
 
 sf::Vector2i ShipTemplate::interiorSize()

--- a/src/shipTemplate.h
+++ b/src/shipTemplate.h
@@ -127,6 +127,7 @@ public:
 
     void setBeam(int index, float arc, float direction, float range, float cycle_time, float damage);
     void setBeamWeapon(int index, float arc, float direction, float range, float cycle_time, float damage);
+    void setBeamWeaponTurret(int index, float arc, float direction, float rotation_rate);
 
     /**
      * Convenience function to set the texture of a beam by index.

--- a/src/spaceObjects/spaceship.h
+++ b/src/spaceObjects/spaceship.h
@@ -318,6 +318,28 @@ public:
     float getBeamWeaponArc(int index) { if (index < 0 || index >= max_beam_weapons) return 0.0; return beam_weapons[index].getArc(); }
     float getBeamWeaponDirection(int index) { if (index < 0 || index >= max_beam_weapons) return 0.0; return beam_weapons[index].getDirection(); }
     float getBeamWeaponRange(int index) { if (index < 0 || index >= max_beam_weapons) return 0.0; return beam_weapons[index].getRange(); }
+
+    float getBeamWeaponTurretArc(int index) 
+    {
+        if (index < 0 || index >= max_beam_weapons)
+            return 0.0;
+        return beam_weapons[index].getTurretArc();
+    }
+
+    float getBeamWeaponTurretDirection(int index)
+    {
+        if (index < 0 || index >= max_beam_weapons)
+            return 0.0;
+        return beam_weapons[index].getTurretDirection();
+    }
+
+    float getBeamWeaponTurretRotationRate(int index)
+    {
+        if (index < 0 || index >= max_beam_weapons)
+            return 0.0;
+        return beam_weapons[index].getTurretRotationRate();
+    }
+
     float getBeamWeaponCycleTime(int index) { if (index < 0 || index >= max_beam_weapons) return 0.0; return beam_weapons[index].getCycleTime(); }
     float getBeamWeaponDamage(int index) { if (index < 0 || index >= max_beam_weapons) return 0.0; return beam_weapons[index].getDamage(); }
     float getBeamWeaponEnergyPerFire(int index) { if (index < 0 || index >= max_beam_weapons) return 0.0; return beam_weapons[index].getEnergyPerFire(); }
@@ -334,6 +356,15 @@ public:
         beam_weapons[index].setRange(range);
         beam_weapons[index].setCycleTime(cycle_time);
         beam_weapons[index].setDamage(damage);
+    }
+
+    void setBeamWeaponTurret(int index, float arc, float direction, float rotation_rate)
+    {
+        if (index < 0 || index >= max_beam_weapons)
+            return;
+        beam_weapons[index].setTurretArc(arc);
+        beam_weapons[index].setTurretDirection(direction);
+        beam_weapons[index].setTurretRotationRate(rotation_rate);
     }
 
     void setBeamWeaponTexture(int index, string texture)

--- a/src/spaceObjects/spaceshipParts/beamWeapon.cpp
+++ b/src/spaceObjects/spaceshipParts/beamWeapon.cpp
@@ -8,6 +8,9 @@ BeamWeapon::BeamWeapon()
     arc = 0;
     direction = 0;
     range = 0;
+    turret_arc = 0.0;
+    turret_direction = 0.0;
+    turret_rotation_rate = 0.0;
     cycle_time = 6.0;
     cooldown = 0.0;
     damage = 1.0;
@@ -24,6 +27,9 @@ void BeamWeapon::setParent(SpaceShip* parent)
     parent->registerMemberReplication(&arc);
     parent->registerMemberReplication(&direction);
     parent->registerMemberReplication(&range);
+    parent->registerMemberReplication(&turret_arc);
+    parent->registerMemberReplication(&turret_direction);
+    parent->registerMemberReplication(&turret_rotation_rate);
     parent->registerMemberReplication(&cycle_time);
     parent->registerMemberReplication(&cooldown, 0.5);
 }
@@ -56,6 +62,42 @@ void BeamWeapon::setRange(float range)
 float BeamWeapon::getRange()
 {
     return range;
+}
+
+void BeamWeapon::setTurretArc(float arc)
+{
+    LOG(INFO) << "BeamWeapon::setTurretArc: " << arc;
+    this->turret_arc = arc;
+}
+
+float BeamWeapon::getTurretArc()
+{
+    LOG(INFO) << "BeamWeapon::getTurretArc: " << turret_arc;
+    return turret_arc;
+}
+
+void BeamWeapon::setTurretDirection(float direction)
+{
+    LOG(INFO) << "BeamWeapon::setTurretDirection: " << direction;
+    this->turret_direction = direction;
+}
+
+float BeamWeapon::getTurretDirection()
+{
+    LOG(INFO) << "BeamWeapon::getTurretDirection: " << turret_direction;
+    return turret_direction;
+}
+
+void BeamWeapon::setTurretRotationRate(float rotation_rate)
+{
+    LOG(INFO) << "BeamWeapon::setTurretRotationRate: " << rotation_rate;
+    this->turret_rotation_rate = rotation_rate;
+}
+
+float BeamWeapon::getTurretRotationRate()
+{
+    LOG(INFO) << "BeamWeapon::getTurretRotationRate: " << turret_rotation_rate;
+    return turret_rotation_rate;
 }
 
 void BeamWeapon::setCycleTime(float cycle_time)
@@ -129,26 +171,70 @@ void BeamWeapon::update(float delta)
         cooldown -= delta * parent->getSystemEffectiveness(SYS_BeamWeapons);
 
     P<SpaceObject> target = parent->getTarget();
-    if (game_server && range > 0.0 && target && parent->isEnemy(target) && delta > 0 && parent->current_warp == 0.0 && parent->docking_state == DS_NotDocking) // Only fire beam weapons if we are on the server, have a target, and are not paused.
-    {
-        if (cooldown <= 0.0)
-        {
-            sf::Vector2f diff = target->getPosition() - (parent->getPosition() + sf::rotateVector(sf::Vector2f(position.x, position.y), parent->getRotation()));
-            float distance = sf::length(diff) - target->getRadius() / 2.0;
-            float angle = sf::vector2ToAngle(diff);
 
-            if (distance < range)
+    // Check on beam weapons only if we are on the server, have a target, and
+    // not paused, and if the beams are cooled down or have a turret arc.
+    if (game_server && range > 0.0 && target && parent->isEnemy(target) && delta > 0 && parent->current_warp == 0.0 && parent->docking_state == DS_NotDocking)
+    {
+        // Get the angle to the target.
+        sf::Vector2f diff = target->getPosition() - (parent->getPosition() + sf::rotateVector(sf::Vector2f(position.x, position.y), parent->getRotation()));
+        float distance = sf::length(diff) - target->getRadius() / 2.0;
+
+        // We also only care if the target is within no more than its
+        // range * 1.3, which is when we want to start rotating the turret.
+        // TODO: Add a manual aim override similar to weapon tubes.
+        if (distance < range * 1.3)
+        {
+            float angle = sf::vector2ToAngle(diff);
+            float angle_diff = sf::angleDifference(direction + parent->getRotation(), angle);
+
+            if (turret_arc > 0)
             {
-                float angleDiff = sf::angleDifference(direction + parent->getRotation(), angle);
-                if (abs(angleDiff) < arc / 2.0)
+                // Get the target's angle relative to the turret's direction.
+                float turret_angle_diff = sf::angleDifference(turret_direction + parent->getRotation(), angle);
+
+                // If the turret can rotate ...
+                if (turret_rotation_rate > 0)
                 {
-                    if (parent->useEnergy(energy_per_beam_fire))
+                    // ... and if the target is within the turret's arc ...
+                    if (fabsf(turret_angle_diff) < turret_arc / 2.0)
                     {
-                        parent->addHeat(SYS_BeamWeapons, heat_per_beam_fire);
-                        fire(target, parent->beam_system_target);
+                        // ... rotate the turret's beam toward the target.
+                        if (fabsf(angle_diff) > 0)
+                        {
+                            direction += (angle_diff / fabsf(angle_diff)) * std::min(turret_rotation_rate, fabsf(angle_diff));
+                        }
+                    // If the target is outside of the turret's arc ...
+                    } else {
+                        // ... rotate the turret's beam toward the turret's
+                        // direction to reset it.
+                        float reset_angle_diff = sf::angleDifference(direction, turret_direction);
+
+                        if (fabsf(reset_angle_diff) > 0)
+                        {
+                            direction += (reset_angle_diff / fabsf(reset_angle_diff)) * std::min(turret_rotation_rate, fabsf(reset_angle_diff));
+                        }
                     }
                 }
             }
+
+            // If the target is in the beam's arc and range, the beam has cooled
+            // down, and the beam can consume enough energy to fire ...
+            if (distance < range && cooldown <= 0.0 && fabsf(angle_diff) < arc / 2.0 && parent->useEnergy(energy_per_beam_fire))
+            {
+                // ... add heat to the beam and zap the target.
+                parent->addHeat(SYS_BeamWeapons, heat_per_beam_fire);
+                fire(target, parent->beam_system_target);
+            }
+        }
+    // If the beam is turreted and can move, but doesn't have a target, reset it
+    // if necessary.
+    } else if (game_server && range > 0.0 && delta > 0 && turret_arc > 0.0 && direction != turret_direction && turret_rotation_rate > 0) {
+        float reset_angle_diff = sf::angleDifference(direction, turret_direction);
+
+        if (fabsf(reset_angle_diff) > 0)
+        {
+            direction += (reset_angle_diff / fabsf(reset_angle_diff)) * std::min(turret_rotation_rate, fabsf(reset_angle_diff));
         }
     }
 }

--- a/src/spaceObjects/spaceshipParts/beamWeapon.h
+++ b/src/spaceObjects/spaceshipParts/beamWeapon.h
@@ -24,6 +24,15 @@ public:
     void setRange(float range);
     float getRange();
 
+    void setTurretArc(float arc);
+    float getTurretArc();
+
+    void setTurretDirection(float direction);
+    float getTurretDirection();
+
+    void setTurretRotationRate(float rotation_rate);
+    float getTurretRotationRate();
+
     void setCycleTime(float cycle_time);
     float getCycleTime();
     
@@ -53,6 +62,9 @@ protected:
     float arc;
     float direction;
     float range;
+    float turret_arc;
+    float turret_direction;
+    float turret_rotation_rate;
     float cycle_time;
     float damage;//Server side only
     float energy_per_beam_fire;//Server side only


### PR DESCRIPTION
Resolves #227.

-   Add variables, getters, and setters for turreted beams.
-   Add beam rotation mechanics.
-   Draw turret bounds on short-range radar.
-   Implement configurable turret arc, direction, and rotation rate.
-   Implement GM screen tweak UI sliders.

To implement, add `setBeamWeaponTurret(<INDEX>, <ARC>, <DIRECTION>, <ROTATION_RATE>)` to a shipTemplate, with the index of the beam to make turreted.

For example, this creates two 10-degree beams, one on each side of a ship, within 90-degree turret arcs that rotate at 0.25 degrees per tick (~15 deg/sec):

``` Lua
variation:setBeamWeapon(0, 10, 270, 1500.0, 6.0, 8)
variation:setBeamWeapon(1, 10,  90, 1500.0, 6.0, 8)

--                          Idx, Arc, Dir, Rotation
variation:setBeamWeaponTurret(0, 90, 270, 0.25)
variation:setBeamWeaponTurret(1, 90, 90, 0.25)
```

![turret](https://cloud.githubusercontent.com/assets/19192104/16287740/5d42edc6-389a-11e6-89c4-5773087c449e.png)
