### PR TITLE
Added new AI repair state

### DIFF
--- a/scripts/comms_ship.lua
+++ b/scripts/comms_ship.lua
@@ -77,12 +77,6 @@ function friendlyComms(comms_data)
 			end)
 		end
 	end
-	
-	addCommsReply("Repair at the nearest station.", function()
-		setCommsMessage("Roger, we'll try to find a station in range.");
-		comms_target:orderRepair()
-		addCommsReply("Back", mainMenu)
-	end)
 	return true
 end
 

--- a/scripts/comms_ship.lua
+++ b/scripts/comms_ship.lua
@@ -77,6 +77,12 @@ function friendlyComms(comms_data)
 			end)
 		end
 	end
+	
+	addCommsReply("Repair at the nearest station.", function()
+		setCommsMessage("Roger, we'll try to find a station in range.");
+		comms_target:orderRepair()
+		addCommsReply("Back", mainMenu)
+	end)
 	return true
 end
 

--- a/src/ai/ai.cpp
+++ b/src/ai/ai.cpp
@@ -428,45 +428,44 @@ void ShipAI::runOrders()
         }
         break;
 
-        case AI_Repair:            //Repair at the nearest station
-        if (owner->docking_state == DS_NotDocking)
+    case AI_Repair:            //Repair at the nearest station
+        P<SpaceStation> supply_station;
+        bool missiles_full = 1;
+        for(int n=0; n<MW_Count; n++)
         {
-            P<SpaceStation> supply_station;
-
-            if (owner->hasJumpDrive() || owner->hasWarpDrive())
-                supply_station = searchFriendlyStation(100000.0);
-            else
-                supply_station = searchFriendlyStation(15000.0);
-
-            if (supply_station)
+            if  (owner->weapon_storage[n] != owner->weapon_storage_max[n])
             {
-                float dist = sf::length(owner->getPosition() - supply_station->getPosition());
-                if (dist < 950 + supply_station->getRadius())
-                {
-                    owner->requestDock(supply_station);
-                }else{
-                    flyTowards(supply_station->getPosition());
-                }
-            }
-            else
-            {
-                owner->orderResume();  //No friendly station in range to dock, revert orders.
+                missiles_full = 0;
             }
         }
-        else if (owner->docking_state == DS_Docked)
-        {
-            bool missiles_full = 1;
-            for(int n=0; n<MW_Count; n++)
-            {
-                if  (owner->weapon_storage[n] != owner->weapon_storage_max[n])
-                {
-                    missiles_full = 0;
-                }
-            }
 
-            if (missiles_full && owner->getHull() == owner->getHullMax())
+        if (missiles_full && owner->getHull() == owner->getHullMax())
+        {
+            owner->orderResume();
+        }
+        else
+        {
+            if (owner->docking_state == DS_NotDocking)
             {
-                owner->orderResume();
+                if (owner->hasJumpDrive() || owner->hasWarpDrive())
+                    supply_station = searchFriendlyStation(100000.0);
+                else
+                    supply_station = searchFriendlyStation(15000.0);
+
+                if (supply_station)
+                {
+                    float dist = sf::length(owner->getPosition() - supply_station->getPosition());
+                    if (dist < 950 + supply_station->getRadius())
+                    {
+                        owner->requestDock(supply_station);
+                    }else{
+                        flyTowards(supply_station->getPosition());
+                    }
+                }
+                else
+                {
+                    owner->orderResume();  //No friendly station in range to dock, revert orders.
+                }
             }
         }
         break;

--- a/src/ai/ai.cpp
+++ b/src/ai/ai.cpp
@@ -353,7 +353,7 @@ void ShipAI::runOrders()
             if (owner->hasJumpDrive() || owner->hasWarpDrive())
                 supply_station = searchFriendlyStation(100000.0);
             else
-                supply_station = searchFriendlyStation(15000.0)
+                supply_station = searchFriendlyStation(15000.0);
 
             if (supply_station)
             {
@@ -438,14 +438,14 @@ void ShipAI::runOrders()
             else
                 supply_station = searchFriendlyStation(15000.0);
 
-            if (friendly_station)
+            if (supply_station)
             {
-                float dist = sf::length(owner->getPosition() - friendly_station->getPosition());
-                if (dist < 950 + friendly_station->getRadius())
+                float dist = sf::length(owner->getPosition() - supply_station->getPosition());
+                if (dist < 950 + supply_station->getRadius())
                 {
-                    owner->requestDock(friendly_station);
+                    owner->requestDock(supply_station);
                 }else{
-                    flyTowards(friendly_station->getPosition());
+                    flyTowards(supply_station->getPosition());
                 }
             }
             else

--- a/src/ai/ai.cpp
+++ b/src/ai/ai.cpp
@@ -348,8 +348,12 @@ void ShipAI::runOrders()
                 flyTowards(owner->getOrderTargetLocation());
             }
         }else{
+            P<SpaceStation> supply_station;
 
-            P<SpaceStation> supply_station = searchFriendlyStation(15000.0);
+            if (owner->hasJumpDrive() || owner->hasWarpDrive())
+                supply_station = searchFriendlyStation(100000.0);
+            else
+                supply_station = searchFriendlyStation(15000.0)
 
             if (supply_station)
             {
@@ -427,7 +431,12 @@ void ShipAI::runOrders()
         case AI_Repair:            //Repair at the nearest station
         if (owner->docking_state == DS_NotDocking)
         {
-            P<SpaceStation> friendly_station = searchFriendlyStation(15000.0);
+            P<SpaceStation> supply_station;
+
+            if (owner->hasJumpDrive() || owner->hasWarpDrive())
+                supply_station = searchFriendlyStation(100000.0);
+            else
+                supply_station = searchFriendlyStation(15000.0);
 
             if (friendly_station)
             {

--- a/src/ai/ai.h
+++ b/src/ai/ai.h
@@ -3,6 +3,7 @@
 
 #include <SFML/System.hpp>
 #include "pathPlanner.h"
+#include "spaceObjects/spaceStation.h"
 
 ///Forward declaration
 class CpuShip;
@@ -31,7 +32,7 @@ protected:
     };
     EWeaponDirection weapon_direction;
     EMissileWeapons best_missile_type;
-    
+
     float update_target_delay;
 
     PathPlanner pathPlanner;
@@ -77,6 +78,8 @@ protected:
      * Used for missiles, as they require some intelligence to fire.
      */
     float calculateFiringSolution(P<SpaceObject> target, int tube_index);
+
+    P<SpaceStation> searchFriendlyStation(float range);
 
     /// Because the GameMasterUI needs to be touching privates. Hmm.
     friend class GameMasterUI;

--- a/src/spaceObjects/cpuShip.cpp
+++ b/src/spaceObjects/cpuShip.cpp
@@ -30,7 +30,7 @@ REGISTER_SCRIPT_SUBCLASS(CpuShip, SpaceShip)
     REGISTER_SCRIPT_CLASS_FUNCTION(CpuShip, orderDefendTarget);
     /// Order this ship to fly in formation with another ship. It will attack nearby enemies.
     REGISTER_SCRIPT_CLASS_FUNCTION(CpuShip, orderFlyFormation);
-    /// Order this ship to fly to a location, attacking everything alogn the way.
+    /// Order this ship to fly to a location, attacking everything along the way.
     REGISTER_SCRIPT_CLASS_FUNCTION(CpuShip, orderFlyTowards);
     /// Order this ship to fly to a location, without attacking anything
     REGISTER_SCRIPT_CLASS_FUNCTION(CpuShip, orderFlyTowardsBlind);
@@ -46,6 +46,7 @@ CpuShip::CpuShip()
 {
     setFactionId(2);
     orders = AI_Idle;
+    previous_orders = AI_Idle;
 
     setRotation(random(0, 360));
     target_rotation = getRotation();
@@ -213,6 +214,20 @@ void CpuShip::orderDock(P<SpaceObject> object)
     this->addBroadcast(FVF_Friendly, "Docking to " + object->getCallSign() + ".");
 }
 
+void CpuShip::orderRepair()
+{
+    if (orders != AI_Repair)
+    {
+        previous_orders = orders;
+        orders = AI_Repair;
+    }
+}
+
+void CpuShip::orderResume()
+{
+    orders = previous_orders;
+}
+
 void CpuShip::drawOnGMRadar(sf::RenderTarget& window, sf::Vector2f position, float scale, bool long_range)
 {
     SpaceShip::drawOnGMRadar(window, position, scale, long_range);
@@ -241,6 +256,7 @@ string CpuShip::getExportLine()
     case AI_FlyTowardsBlind: ret += ":orderFlyTowardsBlind(" + string(order_target_location.x, 0) + ", " + string(order_target_location.y, 0) + ")"; break;
     case AI_Attack: ret += ":orderAttack(?)"; break;
     case AI_Dock: ret += ":orderDock(?)"; break;
+    case AI_Repair: ret += ":orderRepair()"; break;
     }
     return ret + getScriptExportModificationsOnTemplate();
 }
@@ -259,6 +275,7 @@ string getAIOrderString(EAIOrder order)
     case AI_FlyTowardsBlind: return "Fly towards (ignore all)";
     case AI_Attack: return "Attack";
     case AI_Dock: return "Dock";
+    case AI_Repair: return "Repair";
     }
     return "Unknown";
 }

--- a/src/spaceObjects/cpuShip.h
+++ b/src/spaceObjects/cpuShip.h
@@ -16,6 +16,7 @@ enum EAIOrder
     AI_FlyTowardsBlind, //Fly towards [order_target_location], not attacking anything
     AI_Dock,            //Dock with target
     AI_Attack,          //Attack [order_target] very specificly.
+    AI_Repair,          //Order to rearm and repair to the nearest friendly station.
 };
 
 
@@ -26,6 +27,7 @@ class CpuShip : public SpaceShip
     static constexpr float missile_resupply_time = 10.0f;
 
     EAIOrder orders;                    //Server only
+    EAIOrder previous_orders;           //Server only
     sf::Vector2f order_target_location; //Server only
     P<SpaceObject> order_target;        //Server only
     ShipAI* ai;
@@ -50,6 +52,8 @@ public:
     void orderFlyTowardsBlind(sf::Vector2f target);
     void orderAttack(P<SpaceObject> object);
     void orderDock(P<SpaceObject> object);
+    void orderRepair();
+    void orderResume();
 
     EAIOrder getOrder() { return orders; }
     sf::Vector2f getOrderTargetLocation() { return order_target_location; }


### PR DESCRIPTION
I've added a new AI state : Repair. When a ship enters in repair mode, it set its previous order aside, tries to find a friendly station in range dock to it, and resume its previous orders when it has full hull and missiles.

An exemple is added in Roaming mode, when the ship has neither missiles nor beam (ok, now a ship will switch to repair mode only when they have no beams and no missiles)

There is still work to do on when to switch to repair mode (when hull is very damaged, ...).