### PR TITLE
Factor shields into engineering energy usage indicator.

### DIFF
--- a/src/screens/crew6/engineeringScreen.cpp
+++ b/src/screens/crew6/engineeringScreen.cpp
@@ -134,7 +134,7 @@ void EngineeringScreen::onDraw(sf::RenderTarget& window)
 {
     if (my_spaceship)
     {
-        energy_display->setValue(string(int(my_spaceship->energy_level)) + " (" + string(my_spaceship->getNetPowerUsage()) + ")");
+        energy_display->setValue(string(int(my_spaceship->energy_level)) + " (" + string(my_spaceship->getNetPowerUsage() - (my_spaceship->getShieldsActive() * my_spaceship->energy_shield_use_per_second * 12.5f)) + ")");
         if (my_spaceship->energy_level < 100)
             energy_display->setColor(sf::Color::Red);
         else


### PR DESCRIPTION
Workaround for #344. Does so in the Engineering screen calculation rather than in getNetPowerUsage, which might be preferable.