### PR TITLE
Move active shield energy draw to getNetPowerUsage()

### DIFF
--- a/src/screens/crew6/engineeringScreen.cpp
+++ b/src/screens/crew6/engineeringScreen.cpp
@@ -134,7 +134,8 @@ void EngineeringScreen::onDraw(sf::RenderTarget& window)
 {
     if (my_spaceship)
     {
-        energy_display->setValue(string(int(my_spaceship->energy_level)) + " (" + string(my_spaceship->getNetPowerUsage()) + ")");
+        // getNetPowerUsage returns energy use per 1/12.5 (0.08) of a second.
+        energy_display->setValue(string(int(my_spaceship->energy_level)) + " (" + string(my_spaceship->getNetPowerUsage() * 0.08f) + "/s)");
         if (my_spaceship->energy_level < 100)
             energy_display->setColor(sf::Color::Red);
         else

--- a/src/spaceObjects/playerSpaceship.cpp
+++ b/src/spaceObjects/playerSpaceship.cpp
@@ -347,9 +347,6 @@ void PlayerSpaceship::update(float delta)
                 comms_state = CS_ChannelBroken;
         }
 
-        if (shields_active)
-            useEnergy(delta * energy_shield_use_per_second);
-
         energy_level += delta * getNetPowerUsage() * 0.08;
         for(int n=0; n<SYS_COUNT; n++)
         {
@@ -601,6 +598,9 @@ float PlayerSpaceship::getNetPowerUsage()
             net_power -= system_power_user_factor[n] * systems[n].power_level;
         }
     }
+    if (shields_active)
+        net_power -= energy_shield_use_per_second;
+
     return net_power;
 }
 

--- a/src/spaceObjects/playerSpaceship.h
+++ b/src/spaceObjects/playerSpaceship.h
@@ -31,7 +31,7 @@ enum EAlertLevel
 class PlayerSpaceship : public SpaceShip
 {
 public:
-    constexpr static float energy_shield_use_per_second = 1.5f;
+    constexpr static float energy_shield_use_per_second = 18.75f;
     constexpr static float energy_warp_per_second = 1.0f;
     constexpr static float system_heatup_per_second = 0.05f;
     constexpr static float system_power_level_change_per_second = 0.3;


### PR DESCRIPTION
Resolves #344.

-   Increases `energy_shield_use_per_second` from 1.5 to 18.75 (1.5 * 12.5) to compensate for net power usage being reduced to 1/12.5 during energy draw assessment.
-   Reduces net power in getNetPowerUsage() instead of drawing via useEnergy(). This shouldn't affect gameplay since there were no consequences of useEnergy() failing.
-   Updates Engineering screen to display the power draw interval in energy used per second, instead of per 1/12.5 of a second.

I'm not sure whether [L411](https://github.com/daid/EmptyEpsilon/blob/master/src/spaceObjects/playerSpaceship.cpp#L411) (calculating whether to reset warp factor due to lack of energy) needs to be modified. It doesn't use the `energy_shield_use_per_second` constant, just an inline `1.5`.