### PR TITLE
Expose radar signatures to scripts

### DIFF
--- a/src/screenComponents/rawScannerDataRadarOverlay.cpp
+++ b/src/screenComponents/rawScannerDataRadarOverlay.cpp
@@ -16,87 +16,127 @@ void RawScannerDataRadarOverlay::onDraw(sf::RenderTarget& window)
 
     sf::Vector2f view_position = radar->getViewPosition();
 
+    // Cap the number of signature points, which determines the raw data's
+    // resolution.
     const int point_count = 512;
     float radius = std::min(rect.width, rect.height) / 2.0f;
 
     RawRadarSignatureInfo signatures[point_count];
+
+    // For each SpaceObject ...
     foreach(SpaceObject, obj, space_object_list)
     {
+        // Don't measure our own ship.
         if (obj == my_spaceship)
             continue;
+
+        // Initialize angle, distance, and scale variables.
         float a_0, a_1;
         float dist = sf::length(obj->getPosition() - view_position);
         float scale = 1.0;
+
+        // If the object is more than twice as far away as the maximum radar
+        // range, disregard it.
         if (dist > distance * 2.0)
             continue;
+
+        // The further away the object is, the less its effect on radar data.
         if (dist > distance)
             scale = (dist - distance) / distance;
+
+        // If we're adjacent to the object ...
         if (dist <= obj->getRadius())
         {
+            // ... affect all angles of the radar.
             a_0 = 0.0f;
             a_1 = 360.0f;
         }else{
+            // Otherwise, measure the affected range of angles by the object's
+            // distance and radius.
             float a_diff = asinf(obj->getRadius() / dist) / M_PI * 180.0f;
             float a_center = sf::vector2ToAngle(obj->getPosition() - view_position);
             a_0 = a_center - a_diff;
             a_1 = a_center + a_diff;
         }
+
+        // Get the object's radar signature.
         RawRadarSignatureInfo info = obj->getRadarSignatureInfo();
-        for(float a=a_0; a<=a_1; a += 360.f / float(point_count))
+
+        // For each interval determined by the level of raw data resolution,
+        // initialize the signatures array.
+        for(float a = a_0; a <= a_1; a += 360.f / float(point_count))
         {
             int idx = (int(a / 360.0f * point_count) + point_count * 2) % point_count;
             signatures[idx] += info * scale;
         }
     }
 
+    // Initialize the data's amplitude along each of the three color bands.
     float amp_r[point_count];
     float amp_g[point_count];
     float amp_b[point_count];
 
-    for(int n=0; n<point_count; n++)
+    // For each data point ...
+    for(int n = 0; n < point_count; n++)
     {
+        // ... initialize its values in the array ...
         signatures[n].gravity = std::max(0.0f, std::min(1.0f, signatures[n].gravity));
         signatures[n].electrical = std::max(0.0f, std::min(1.0f, signatures[n].electrical));
         signatures[n].biological = std::max(0.0f, std::min(1.0f, signatures[n].biological));
 
+        // ... make some noise ...
         float r = random(-1, 1);
         float g = random(-1, 1);
         float b = random(-1, 1);
 
+        // ... and then modify the bands' values based on the object's signature.
+        // Biological signatures amplify the red and green bands.
         r += signatures[n].biological * 30;
         g += signatures[n].biological * 30;
 
+        // Electrical signatures amplify the red and blue bands.
         r += random(-20, 20) * signatures[n].electrical;
         b += random(-20, 20) * signatures[n].electrical;
-        
+
+        // Gravitational signatures amplify all bands, but especially modify
+        // the green and blue bands.
         r = r * (1.0f - signatures[n].gravity);
         g = g * (1.0f - signatures[n].gravity) + 40 * signatures[n].gravity;
         b = b * (1.0f - signatures[n].gravity) + 40 * signatures[n].gravity;
-        
+
+        // Apply the values to the radar bands.
         amp_r[n] = r;
         amp_g[n] = g;
         amp_b[n] = b;
     }
-    
+
+    // Create a vertex array containing each data point.
     sf::VertexArray a_r(sf::LinesStrip, point_count+1);
     sf::VertexArray a_g(sf::LinesStrip, point_count+1);
     sf::VertexArray a_b(sf::LinesStrip, point_count+1);
 
-    for(int n=0; n<point_count; n++)
+    // For each data point ...
+    for(int n = 0; n < point_count; n++)
     {
+        // ... set a baseline of 0 ...
         float r = 0.0;
         float g = 0.0;
         float b = 0.0;
+
+        // ... then sum the amplitude values ...
         for(int m = n - 2 + point_count; m <= n + 2 + point_count; m++)
         {
             r += amp_r[m % point_count];
             g += amp_g[m % point_count];
             b += amp_b[m % point_count];
         }
+
+        // ... divide them by 5 ...
         r /= 5;
         g /= 5;
         b /= 5;
-        
+
+        // ... and add vectors for each point.
         a_r[n].position.x = rect.left + rect.width / 2.0f;
         a_r[n].position.y = rect.top + rect.height / 2.0f;
         a_r[n].position += sf::vector2FromAngle(float(n) / float(point_count) * 360.0f) * (radius * (0.95f - r / 500));
@@ -112,9 +152,13 @@ void RawScannerDataRadarOverlay::onDraw(sf::RenderTarget& window)
         a_b[n].position += sf::vector2FromAngle(float(n) / float(point_count) * 360.0f) * (radius * (0.89f - b / 500));
         a_b[n].color = sf::Color(0, 0, 255);
     }
+
+    // Set a zero value at the "end" of the data point array.
     a_r[point_count] = a_r[0];
     a_g[point_count] = a_g[0];
     a_b[point_count] = a_b[0];
+
+    // Draw each band as a line.
     window.draw(a_r, sf::BlendAdd);
     window.draw(a_g, sf::BlendAdd);
     window.draw(a_b, sf::BlendAdd);

--- a/src/spaceObjects/asteroid.cpp
+++ b/src/spaceObjects/asteroid.cpp
@@ -21,6 +21,7 @@ Asteroid::Asteroid()
     rotation_speed = random(0.1, 0.8);
     z = random(-50, 50);
     size = getRadius();
+    setRadarSignatureInfo(0.05, 0, 0);
 
     registerMemberReplication(&z);
     registerMemberReplication(&size);

--- a/src/spaceObjects/asteroid.h
+++ b/src/spaceObjects/asteroid.h
@@ -12,8 +12,6 @@ public:
 
     Asteroid();
     
-    virtual RawRadarSignatureInfo getRadarSignatureInfo() { return RawRadarSignatureInfo(0.05, 0.0, 0.0); }
-
     virtual void draw3D();
 
     virtual void drawOnRadar(sf::RenderTarget& window, sf::Vector2f position, float scale, bool long_range);

--- a/src/spaceObjects/blackHole.cpp
+++ b/src/spaceObjects/blackHole.cpp
@@ -15,6 +15,7 @@ BlackHole::BlackHole()
 {
     update_delta = 0.0;
     PathPlannerManager::getInstance()->addAvoidObject(this, 7000);
+    setRadarSignatureInfo(0.9, 0, 0);
 }
 
 void BlackHole::update(float delta)

--- a/src/spaceObjects/blackHole.h
+++ b/src/spaceObjects/blackHole.h
@@ -18,8 +18,6 @@ public:
 
     virtual void collide(Collisionable* target, float force) override;
 
-    virtual RawRadarSignatureInfo getRadarSignatureInfo() { return RawRadarSignatureInfo(0.9, 0, 0); }
-    
     virtual string getExportLine() { return "BlackHole():setPosition(" + string(getPosition().x, 0) + ", " + string(getPosition().y, 0) + ")"; }
 };
 

--- a/src/spaceObjects/mine.cpp
+++ b/src/spaceObjects/mine.cpp
@@ -21,6 +21,7 @@ Mine::Mine()
     triggerTimeout = triggerDelay;
     ejectTimeout = 0.0;
     particleTimeout = 0.0;
+    setRadarSignatureInfo(0.0, 0.05, 0.0);
 
     PathPlannerManager::getInstance()->addAvoidObject(this, trigger_range * 1.2f);
 }

--- a/src/spaceObjects/mine.h
+++ b/src/spaceObjects/mine.h
@@ -36,5 +36,5 @@ private:
     const MissileWeaponData& data;
 };
 
-#endif//NUKE_H
+#endif//MINE_H
 

--- a/src/spaceObjects/nebula.cpp
+++ b/src/spaceObjects/nebula.cpp
@@ -6,7 +6,7 @@
 
 #include "scriptInterface.h"
 
-/// Nebulas block long range sensors in a 5km range.
+// Nebulae block long-range radar in a 5U range.
 REGISTER_SCRIPT_SUBCLASS(Nebula, SpaceObject)
 {
 }
@@ -17,9 +17,12 @@ REGISTER_MULTIPLAYER_CLASS(Nebula, "Nebula")
 Nebula::Nebula()
 : SpaceObject(5000, "Nebula")
 {
-    setCollisionRadius(1);  //Nebula need a big radius to render properly from a distance. But they do not really need collision. So set the collision radius to a tiny range.
+    // Nebulae need a large radius to render properly from a distance, but
+    // collision isn't important, so set the collision radius to a tiny range.
+    setCollisionRadius(1);
     setRotation(random(0, 360));
     radar_visual = irandom(1, 3);
+    setRadarSignatureInfo(0.0, 0.8, -1.0);
     
     registerMemberReplication(&radar_visual);
     

--- a/src/spaceObjects/nebula.h
+++ b/src/spaceObjects/nebula.h
@@ -32,8 +32,6 @@ public:
     static sf::Vector2f getFirstBlockedPosition(sf::Vector2f start, sf::Vector2f end);
     static PVector<Nebula> getNebulas();
     
-    virtual RawRadarSignatureInfo getRadarSignatureInfo() { return RawRadarSignatureInfo(0.0, 0.8, -1.0); }
-    
     virtual string getExportLine() { return "Nebula():setPosition(" + string(getPosition().x, 0) + ", " + string(getPosition().y, 0) + ")"; }
 };
 

--- a/src/spaceObjects/playerSpaceship.hpp
+++ b/src/spaceObjects/playerSpaceship.hpp
@@ -1,4 +1,3 @@
-
 #ifndef _PLAYERSPACESHIP_HPP_
 #define _PLAYERSPACESHIP_HPP_
 

--- a/src/spaceObjects/scanProbe.cpp
+++ b/src/spaceObjects/scanProbe.cpp
@@ -17,6 +17,7 @@ ScanProbe::ScanProbe()
     registerMemberReplication(&owner_id);
     registerMemberReplication(&target_position);
     registerMemberReplication(&lifetime, 60.0);
+    setRadarSignatureInfo(0.0, 0.2, 0);
     
     switch(irandom(1, 3))
     {

--- a/src/spaceObjects/spaceObject.cpp
+++ b/src/spaceObjects/spaceObject.cpp
@@ -63,6 +63,16 @@ REGISTER_SCRIPT_CLASS_NO_CREATE(SpaceObject)
     REGISTER_SCRIPT_CLASS_FUNCTION(SpaceObject, sendCommsMessage);
     /// Let this object take damage, the DamageInfo parameter can be empty, or a string which indicates if it's energy, kinetic or emp damage.
     REGISTER_SCRIPT_CLASS_FUNCTION(SpaceObject, takeDamage);
+    // Set the description of this object. The description is visible on the
+    // Science station.
+    REGISTER_SCRIPT_CLASS_FUNCTION(SpaceObject, setDescription);
+    REGISTER_SCRIPT_CLASS_FUNCTION(SpaceObject, getDescription);
+    // Set the radar signature of this object. Objects' signatures create noise
+    // on the Science station's raw radar signal ring.
+    REGISTER_SCRIPT_CLASS_FUNCTION(SpaceObject, setRadarSignatureInfo);
+    REGISTER_SCRIPT_CLASS_FUNCTION(SpaceObject, getRadarSignatureGravity);
+    REGISTER_SCRIPT_CLASS_FUNCTION(SpaceObject, getRadarSignatureElectrical);
+    REGISTER_SCRIPT_CLASS_FUNCTION(SpaceObject, getRadarSignatureBiological);
     /// Set the description of this object, description is visible at the science station.
     REGISTER_SCRIPT_CLASS_FUNCTION(SpaceObject, setDescription);
     REGISTER_SCRIPT_CLASS_FUNCTION(SpaceObject, getDescription);
@@ -100,6 +110,9 @@ SpaceObject::SpaceObject(float collision_range, string multiplayer_name, float m
     registerMemberReplication(&faction_id);
     registerMemberReplication(&scanned_by_faction);
     registerMemberReplication(&object_description);
+    registerMemberReplication(&radar_signature.gravity);
+    registerMemberReplication(&radar_signature.electrical);
+    registerMemberReplication(&radar_signature.biological);
     registerMemberReplication(&scanning_complexity_value);
     registerMemberReplication(&scanning_depth_value);
     registerCollisionableReplication(multiplayer_significant_range);
@@ -352,6 +365,7 @@ bool SpaceObject::sendCommsMessage(P<PlayerSpaceship> target, string message)
     return result;
 }
 
+// Define a script conversion function for the DamageInfo structure.
 template<> void convert<DamageInfo>::param(lua_State* L, int& idx, DamageInfo& di)
 {
     if (!lua_isstring(L, idx))

--- a/src/spaceObjects/spaceObject.h
+++ b/src/spaceObjects/spaceObject.h
@@ -54,6 +54,11 @@ public:
         return *this;
     }
 
+    bool operator!=(const RawRadarSignatureInfo& o)
+    {
+        return gravity != o.gravity || electrical != o.electrical || biological != o.biological;
+    }
+
     RawRadarSignatureInfo operator*(const float f) const
     {
         return RawRadarSignatureInfo(gravity * f, electrical * f, biological * f);
@@ -77,6 +82,7 @@ class SpaceObject : public Collisionable, public MultiplayerObject
     float object_radius;
     uint8_t faction_id;
     string object_description;
+    RawRadarSignatureInfo radar_signature;
 
     /*!
      * Scan state per faction. Implementation wise, this vector is resized when
@@ -99,14 +105,18 @@ public:
     float getRadius() { return object_radius; }
     void setRadius(float radius) { object_radius = radius; setCollisionRadius(radius); }
 
+    // Return the object's raw radar signature. The default signature is 0,0,0.
+    virtual RawRadarSignatureInfo getRadarSignatureInfo() { return radar_signature; }
+    void setRadarSignatureInfo(float grav, float elec, float bio) { radar_signature = RawRadarSignatureInfo(grav, elec, bio); }
+    float getRadarSignatureGravity() { return radar_signature.gravity; }
+    float getRadarSignatureElectrical() { return radar_signature.electrical; }
+    float getRadarSignatureBiological() { return radar_signature.biological; }
+
     string getDescription() { return object_description; }
     void setDescription(string description) { object_description = description; }
 
     float getHeading() { float ret = getRotation() - 270; while(ret < 0) ret += 360.0f; while(ret > 360.0f) ret -= 360.0f; return ret; }
     void setHeading(float heading) { setRotation(heading - 90); }
-
-    // Return the object's raw radar signature. The default signature is none.
-    virtual RawRadarSignatureInfo getRadarSignatureInfo() { return RawRadarSignatureInfo(0, 0, 0); }
 
 #if FEATURE_3D_RENDERING
     virtual void draw3D();
@@ -169,8 +179,5 @@ protected:
 
 // Define a script conversion function for the DamageInfo structure.
 template<> void convert<DamageInfo>::param(lua_State* L, int& idx, DamageInfo& di);
-
-// Define a script conversion function for the RawRadarSignatureInfo structure.
-template<> void convert<RawRadarSignatureInfo>::param(lua_State* L, int& idx, RawRadarSignatureInfo& rrsi);
 
 #endif//SPACE_OBJECT_H

--- a/src/spaceObjects/spaceObject.h
+++ b/src/spaceObjects/spaceObject.h
@@ -32,6 +32,7 @@ public:
     {}
 };
 
+// Radar signature data, used by rawScannerDataOverlay.
 class RawRadarSignatureInfo
 {
 public:
@@ -70,6 +71,7 @@ enum EScannedState
 class SpaceObject;
 class PlayerSpaceship;
 extern PVector<SpaceObject> space_object_list;
+
 class SpaceObject : public Collisionable, public MultiplayerObject
 {
     float object_radius;
@@ -77,10 +79,11 @@ class SpaceObject : public Collisionable, public MultiplayerObject
     string object_description;
 
     /*!
-     * Scan state per faction. Implementation wise, this vector is resized when a scan is done.
-     * Index in the vector is the faction ID.
-     * Which means the vector can be smaller then the number of factions available.
-     * When the vector is smaller then the required faction ID, the scan state is SS_NotScanned
+     * Scan state per faction. Implementation wise, this vector is resized when
+     * a scan is done. The vector is indexed by faction ID, which means the
+     * vector can be smaller than the number of available factions.
+     * When the vector is smaller then the required faction ID, the scan state
+     * is SS_NotScanned
      */
     std::vector<EScannedState> scanned_by_faction;
 public:
@@ -102,6 +105,7 @@ public:
     float getHeading() { float ret = getRotation() - 270; while(ret < 0) ret += 360.0f; while(ret > 360.0f) ret -= 360.0f; return ret; }
     void setHeading(float heading) { setRotation(heading - 90); }
 
+    // Return the object's raw radar signature. The default signature is none.
     virtual RawRadarSignatureInfo getRadarSignatureInfo() { return RawRadarSignatureInfo(0, 0, 0); }
 
 #if FEATURE_3D_RENDERING
@@ -163,7 +167,10 @@ protected:
     ModelInfo model_info;
 };
 
-/* Define script conversion function for the DamageInfo structure. */
+// Define a script conversion function for the DamageInfo structure.
 template<> void convert<DamageInfo>::param(lua_State* L, int& idx, DamageInfo& di);
+
+// Define a script conversion function for the RawRadarSignatureInfo structure.
+template<> void convert<RawRadarSignatureInfo>::param(lua_State* L, int& idx, RawRadarSignatureInfo& rrsi);
 
 #endif//SPACE_OBJECT_H

--- a/src/spaceObjects/spaceStation.cpp
+++ b/src/spaceObjects/spaceStation.cpp
@@ -19,6 +19,7 @@ SpaceStation::SpaceStation()
 : ShipTemplateBasedObject(300, "SpaceStation")
 {
     comms_script_name = "comms_station.lua";
+    setRadarSignatureInfo(0.2, 0.5, 0.5);
 
     callsign = "DS" + string(getMultiplayerId());
 }

--- a/src/spaceObjects/spaceStation.h
+++ b/src/spaceObjects/spaceStation.h
@@ -8,8 +8,6 @@ class SpaceStation : public ShipTemplateBasedObject
 public:
     SpaceStation();
     
-    virtual RawRadarSignatureInfo getRadarSignatureInfo() { return RawRadarSignatureInfo(0.2, 0.5, 0.5); }
-
     virtual void drawOnRadar(sf::RenderTarget& window, sf::Vector2f position, float scale, bool long_range);
     virtual bool canBeDockedBy(P<SpaceObject> obj);
     virtual void destroyedByDamage(DamageInfo& info);
@@ -18,4 +16,4 @@ public:
     virtual string getExportLine();
 };
 
-#endif//SPACE_SHIP_H
+#endif//SPACE_STATION_H

--- a/src/spaceObjects/spaceship.cpp
+++ b/src/spaceObjects/spaceship.cpp
@@ -158,11 +158,13 @@ SpaceShip::SpaceShip(string multiplayerClassName, float multiplayer_significant_
     {
         beam_weapons[n].setParent(this);
     }
+
     for(int n = 0; n < max_weapon_tubes; n++)
     {
         weapon_tube[n].setParent(this);
         weapon_tube[n].setIndex(n);
     }
+
     for(int n = 0; n < MW_Count; n++)
     {
         weapon_storage[n] = 0;
@@ -173,6 +175,8 @@ SpaceShip::SpaceShip(string multiplayerClassName, float multiplayer_significant_
 
     scanning_complexity_value = -1;
     scanning_depth_value = -1;
+
+    setRadarSignatureInfo(0.05, 0.3, 0.3);
 
     if (game_server)
         setCallSign(gameGlobalInfo->getNextShipCallsign());

--- a/src/spaceObjects/spaceship.h
+++ b/src/spaceObjects/spaceship.h
@@ -167,8 +167,6 @@ public:
 
     SpaceShip(string multiplayerClassName, float multiplayer_significant_range=-1);
 
-    virtual RawRadarSignatureInfo getRadarSignatureInfo() { return RawRadarSignatureInfo(0.05, 0.3, 0.3); }
-
 #if FEATURE_3D_RENDERING
     virtual void draw3DTransparent() override;
 #endif

--- a/src/spaceObjects/supplyDrop.cpp
+++ b/src/spaceObjects/supplyDrop.cpp
@@ -18,7 +18,10 @@ SupplyDrop::SupplyDrop()
 {
     for(int n=0; n<MW_Count; n++)
         weapon_storage[n] = 0;
+
     energy = 0.0;
+    setRadarSignatureInfo(0.0, 0.1, 0.1);
+
     model_info.setData("ammo_box");
 }
 

--- a/src/spaceObjects/supplyDrop.h
+++ b/src/spaceObjects/supplyDrop.h
@@ -22,5 +22,5 @@ public:
     virtual string getExportLine();
 };
 
-#endif//ASTEROID_H
+#endif//SUPPLY_DROP_H
 

--- a/src/spaceObjects/warpJammer.cpp
+++ b/src/spaceObjects/warpJammer.cpp
@@ -21,6 +21,7 @@ WarpJammer::WarpJammer()
     hull = 50;
 
     jammer_list.push_back(this);
+    setRadarSignatureInfo(0.05, 0.5, 0.0);
 
     registerMemberReplication(&range);
     

--- a/src/spaceObjects/warpJammer.h
+++ b/src/spaceObjects/warpJammer.h
@@ -1,5 +1,5 @@
-#ifndef SUPPLY_DROP_H
-#define SUPPLY_DROP_H
+#ifndef WARP_JAMMER_H
+#define WARP_JAMMER_H
 
 #include "spaceObject.h"
 
@@ -12,8 +12,6 @@ class WarpJammer : public SpaceObject
 public:
     WarpJammer();
     
-    virtual RawRadarSignatureInfo getRadarSignatureInfo() override { return RawRadarSignatureInfo(0.05, 0.5, 0.0); }
-
     void setRange(float range) { this->range = range; }
 
     virtual void drawOnRadar(sf::RenderTarget& window, sf::Vector2f position, float scale, bool long_range) override;
@@ -27,5 +25,5 @@ public:
     virtual string getExportLine() { return "WarpJammer():setFaction(\"" + getFaction() + "\"):setPosition(" + string(getPosition().x, 0) + ", " + string(getPosition().y, 0) + ")"; }
 };
 
-#endif//ASTEROID_H
+#endif//WARP_JAMMER_H
 

--- a/src/spaceObjects/wormHole.cpp
+++ b/src/spaceObjects/wormHole.cpp
@@ -12,7 +12,8 @@
 #define AVOIDANCE_MULTIPLIER      1.2
 #define TARGET_SPREAD             500
 
-/// A Wormhole object. Drags you in like a black hole and teleports when you're at the center.
+// A wormhole object that drags objects toward it like a black hole, and then
+// teleports them to another point when they reach its center.
 REGISTER_SCRIPT_SUBCLASS(WormHole, SpaceObject)
 {
     /// Set the target of this wormhole
@@ -26,7 +27,9 @@ WormHole::WormHole()
     pathPlanner = PathPlannerManager::getInstance();
     pathPlanner->addAvoidObject(this, (DEFAULT_COLLISION_RADIUS * AVOIDANCE_MULTIPLIER) );
     
-    // Which texture to show on radar
+    setRadarSignatureInfo(0.9, 0.0, 0.0);
+
+    // Choose a texture to show on radar
     radar_visual = irandom(1, 3);
     registerMemberReplication(&radar_visual);
     
@@ -86,7 +89,7 @@ void WormHole::drawOnRadar(sf::RenderTarget& window, sf::Vector2f position, floa
     window.draw(object_sprite, sf::RenderStates(sf::BlendAdd));
 }
 
-/* Draw a line towards the target position */
+// Draw a line toward the target position
 void WormHole::drawOnGMRadar(sf::RenderTarget& window, sf::Vector2f position, float scale, bool long_range)
 {    
     sf::VertexArray a(sf::Lines, 2);
@@ -132,11 +135,11 @@ void WormHole::collide(Collisionable* target, float collision_force)
                 obj->wormhole_alpha = 0.0;
     }
     
-    // warp postprocessor-alpha is calculated using alpha = (1 - (delay/10))
+    // Warp postprocessor-alpha is calculated using alpha = (1 - (delay/10))
     if (obj)
         obj->wormhole_alpha = ((distance / getRadius()) * ALPHA_MULTIPLIER);
     
-    //TODO Change setPosition to something Newtonianish. Now escaping is impossible
+    // TODO: Escaping is impossible. Change setPosition to something Newtonianish.
     target->setPosition(target->getPosition() + diff / distance * update_delta * force);
 }
 

--- a/src/spaceObjects/wormHole.h
+++ b/src/spaceObjects/wormHole.h
@@ -19,8 +19,6 @@ public:
 
     WormHole();
 
-    virtual RawRadarSignatureInfo getRadarSignatureInfo() { return RawRadarSignatureInfo(0.9, 0.0, 0.0); }
-
 #if FEATURE_3D_RENDERING
     virtual void draw3DTransparent();
 #endif//FEATURE_3D_RENDERING


### PR DESCRIPTION
-   Define spaceObject radar signatures in a `radar_signature` variable, rather than as fixed return values in `getRadarSignatureInfo()`.
-   Create `setRadarSignatureInfo(float grav, float elec, float bio)`, `getRadarSignatureGravity()`, `getRadarSignatureElectrical()`, and `getRadarSignatureBiological()`,  and expose them to scripts. Scripts and the HTTP API can use these functions to get and set an object's radar signature.
-   Add a `!=` operator to `RawRadarSignatureInfo`.
-   Replicate `radar_signature` to clients.
-   Add weak signatures to asteroids, mines, and scan probes.
-   Fix some incorrect `#ifndef`/`#define` directives and comments.
-   Comment the raw radar sensor code.