### PR TITLE
Add control codes for ship selection

### DIFF
--- a/src/menus/shipSelectionScreen.cpp
+++ b/src/menus/shipSelectionScreen.cpp
@@ -251,7 +251,7 @@ ShipSelectionScreen::ShipSelectionScreen()
                 LOG(INFO) << "Password doesn't match control code. Attempt: " << password;
                 my_player_info->commandSetShipId(-1);
                 // Notify the player.
-                password_label->setText("Incorrect control code. Re-enter code:");
+                password_label->setText("Incorrect control code. Re-enter code for " + ship->getCallSign() + ":");
                 // Reset the dialog.
                 password_entry->setText("");
             }
@@ -262,7 +262,7 @@ ShipSelectionScreen::ShipSelectionScreen()
                 // Set the player ship.
                 my_player_info->commandSetShipId(ship->getMultiplayerId());
                 // Notify the player.
-                password_label->setText("Control code accepted.\nGranting access to " + ship->getCallSign());
+                password_label->setText("Control code accepted.\nGranting access to " + ship->getCallSign() + ".");
                 // Reset and hide the password field.
                 password_entry->setText("");
                 password_entry->hide();

--- a/src/menus/shipSelectionScreen.h
+++ b/src/menus/shipSelectionScreen.h
@@ -7,18 +7,32 @@
 class GuiAutoLayout;
 class GuiLabel;
 class GuiListbox;
+class GuiOverlay;
 class GuiSelector;
 class GuiSlider;
+class GuiPanel;
 class GuiButton;
 class GuiToggleButton;
+class GuiTextEntry;
 
 class ShipSelectionScreen : public GuiCanvas, public Updatable
 {
 private:
+    GuiAutoLayout* container;
+    GuiElement* left_container;
+    GuiElement* right_container;
+
     GuiLabel* no_ships_label;
     GuiListbox* player_ship_list;
     GuiButton* ready_button;
     GuiSelector* crew_type_selector;
+    GuiOverlay* password_overlay;
+    GuiLabel* password_label;
+    GuiPanel* password_entry_box;
+    GuiTextEntry* password_entry;
+    GuiButton* password_entry_ok;
+    GuiButton* password_cancel;
+    GuiButton* password_confirmation;
     
     GuiToggleButton* main_screen_button;
     GuiToggleButton* crew_position_button[max_crew_positions];

--- a/src/spaceObjects/playerSpaceship.cpp
+++ b/src/spaceObjects/playerSpaceship.cpp
@@ -98,6 +98,8 @@ REGISTER_SCRIPT_SUBCLASS(PlayerSpaceship, SpaceShip)
     // Use this command on ships to require less player interaction, especially
     // when combined with commandSetAutoRepair/auto_repair_enabled.
     REGISTER_SCRIPT_CLASS_FUNCTION(PlayerSpaceship, setAutoCoolant);
+    // Set a password to join the ship.
+    REGISTER_SCRIPT_CLASS_FUNCTION(PlayerSpaceship, setControlCode);
 }
 
 float PlayerSpaceship::system_power_user_factor[] = {
@@ -192,11 +194,12 @@ PlayerSpaceship::PlayerSpaceship()
     scan_probe_recharge = 0.0;
     alert_level = AL_Normal;
     shields_active = false;
+    control_code = "";
 
     setFactionId(1);
 
     // For now, set player ships to always be fully scanned to all other ships
-    for(unsigned int faction_id=0; faction_id<factionInfo.size(); faction_id++)
+    for(unsigned int faction_id = 0; faction_id < factionInfo.size(); faction_id++)
         setScannedStateForFaction(faction_id, SS_FullScan);
 
     updateMemberReplicationUpdateDelay(&target_rotation, 0.1);
@@ -226,6 +229,7 @@ PlayerSpaceship::PlayerSpaceship()
     registerMemberReplication(&self_destruct_countdown, 0.2);
     registerMemberReplication(&alert_level);
     registerMemberReplication(&linked_science_probe_id);
+    registerMemberReplication(&control_code);
 
     // Determine which stations must provide self-destruct confirmation codes.
     for(int n = 0; n < max_self_destruct_codes; n++)

--- a/src/spaceObjects/playerSpaceship.h
+++ b/src/spaceObjects/playerSpaceship.h
@@ -88,6 +88,8 @@ public:
     bool auto_coolant_enabled;
     // Whether shields are up (true) or down
     bool shields_active;
+    // Password to join a ship. Default is empty.
+    string control_code;
 
 private:
     // soundManager index of the shield object
@@ -231,6 +233,9 @@ public:
     // Waypoint functions
     int getWaypointCount() { return waypoints.size(); }
     sf::Vector2f getWaypoint(int index) { if (index > 0 && index <= int(waypoints.size())) return waypoints[index - 1]; return sf::Vector2f(0, 0); }
+
+    // Ship control code/password setter
+    void setControlCode(string code) { control_code = code; }
 
     // Radar function
     virtual void drawOnGMRadar(sf::RenderTarget& window, sf::Vector2f position, float scale, bool long_range) override;

--- a/src/spaceObjects/playerSpaceship.h
+++ b/src/spaceObjects/playerSpaceship.h
@@ -8,45 +8,53 @@
 
 enum ECommsState
 {
-    CS_Inactive,
-    CS_OpeningChannel,
-    CS_BeingHailed,
-    CS_BeingHailedByGM,
-    CS_ChannelOpen,
-    CS_ChannelOpenPlayer,
-    CS_ChannelOpenGM,
-    CS_ChannelFailed,
-    CS_ChannelBroken,
-    CS_ChannelClosed
+    CS_Inactive,          // No active comms
+    CS_OpeningChannel,    // Opening a comms channel
+    CS_BeingHailed,       // Receiving a hail from an object
+    CS_BeingHailedByGM,   //                   ... the GM
+    CS_ChannelOpen,       // Comms open to an object
+    CS_ChannelOpenPlayer, //           ... another player
+    CS_ChannelOpenGM,     //           ... the GM
+    CS_ChannelFailed,     // Comms failed to connect
+    CS_ChannelBroken,     // Comms broken by other side
+    CS_ChannelClosed      // Comms manually closed
 };
 
 enum EAlertLevel
 {
-    AL_Normal,
-    AL_YellowAlert,
-    AL_RedAlert,
-    AL_MAX
+    AL_Normal,      // No alert state
+    AL_YellowAlert, // Yellow
+    AL_RedAlert,    // Red
+    AL_MAX          // ?
 };
 
 class PlayerSpaceship : public SpaceShip
 {
 public:
+    // Power consumption and generation base rates
     constexpr static float energy_shield_use_per_second = 1.5f;
     constexpr static float energy_warp_per_second = 1.0f;
     constexpr static float system_heatup_per_second = 0.05f;
     constexpr static float system_power_level_change_per_second = 0.3;
+    // Coolant change rate
     constexpr static float system_coolant_level_change_per_second = 1.2;
+    // Total coolant
     constexpr static float max_coolant = 10.0;
+    // Overheat subsystem damage rate
     constexpr static float damage_per_second_on_overheat = 0.08f;
+    // Base time it takes to perform an action
     constexpr static float shield_calibration_time = 25.0f;
     constexpr static float comms_channel_open_time = 2.0;
-    constexpr static int max_self_destruct_codes = 3;
-    constexpr static int max_scan_probes = 8;
     constexpr static float scan_probe_charge_time = 10.0f;
     constexpr static float max_scanning_delay = 6.0;
-    
+    // Maximum number of self-destruction confirmation codes
+    constexpr static int max_self_destruct_codes = 3;
+    // Scan probe capacity
+    constexpr static int max_scan_probes = 8;
+    // Subsystem effectiveness base rates
     static float system_power_user_factor[];
 
+    // Content of a line in the ship's log
     class ShipLogEntry
     {
     public:
@@ -61,29 +69,39 @@ public:
         bool operator!=(const ShipLogEntry& e) { return prefix != e.prefix || text != e.text || color != e.color; }
     };
 
+    // Visual indicators of hull damage and in-progress jumps
     float hull_damage_indicator;
     float jump_indicator;
-    P<SpaceObject> scanning_target; //Server only
+    // Target of a scan. Server-only value
+    P<SpaceObject> scanning_target;
+    // Time in seconds to scan an object if scanning_complexity is 0 (none)
     float scanning_delay;
+    // Number of sliders during a scan
     int scanning_complexity;
+    // Number of times an object must be scanned to achieve a fully scanned
+    // state
     int scanning_depth;
+    // Time in seconds it takes to recalibrate shields
     float shield_calibration_delay;
+    // Ship automation features, mostly for single-person ships like fighters
     bool auto_repair_enabled;
     bool auto_coolant_enabled;
+    // Whether shields are up (true) or down
     bool shields_active;
 
 private:
-    // soundManager indexes of sf::Sound objects.
+    // soundManager index of the shield object
     int shield_sound;
+    // Comms variables
     ECommsState comms_state;
     float comms_open_delay;
     string comms_target_name;
     string comms_incomming_message;
-    P<SpaceObject> comms_target;    //Server only
+    P<SpaceObject> comms_target; // Server only
     std::vector<int> comms_reply_id;
     std::vector<string> comms_reply_message;
-    CommsScriptInterface comms_script_interface;  //Server only
-
+    CommsScriptInterface comms_script_interface; // Server only
+    // Ship's log container
     std::vector<ShipLogEntry> ships_log;
 
 public:
@@ -91,7 +109,9 @@ public:
     int scan_probe_stock;
     float scan_probe_recharge;
 
+    // Main screen content
     EMainScreenSetting main_screen_setting;
+    // Content overlaid on the main screen, such as comms
     EMainScreenOverlay main_screen_overlay;
 
     bool activate_self_destruct;
@@ -107,6 +127,7 @@ public:
 
     PlayerSpaceship();
 
+    // Comms functions
     bool isCommsInactive() { return comms_state == CS_Inactive; }
     bool isCommsOpening() { return comms_state == CS_OpeningChannel; }
     bool isCommsBeingHailed() { return comms_state == CS_BeingHailed || comms_state == CS_BeingHailedByGM; }
@@ -132,6 +153,7 @@ public:
     void addCommsReply(int32_t id, string message);
     void closeComms();
 
+    // Client command functions
     void onReceiveClientCommand(int32_t client_id, sf::Packet& packet);
     void commandTargetRotation(float target);
     void commandImpulse(float target);
@@ -173,41 +195,47 @@ public:
     void commandScanCancel();
     void commandSetAlertLevel(EAlertLevel level);
 
+    // Template function
     virtual void applyTemplateValues() override;
 
+    // Ship status functions
     virtual void executeJump(float distance) override;
     virtual void takeHullDamage(float damage_amount, DamageInfo& info) override;
     void setSystemCoolantRequest(ESystem system, float request);
+    void setAutoCoolant(bool active) { auto_coolant_enabled = active; }
+    int getRepairCrewCount();
+    void setRepairCrewCount(int amount);
+    EAlertLevel getAlertLevel() { return alert_level; }
 
+    // Ship update functions
     virtual void update(float delta) override;
     virtual bool useEnergy(float amount) override;
     virtual void addHeat(ESystem system, float amount) override;
 
     float getNetSystemEnergyUsage();
 
+    // Ship's log functions
     void addToShipLog(string message, sf::Color color);
     void addToShipLogBy(string message, P<SpaceObject> target);
     const std::vector<ShipLogEntry>& getShipsLog() const;
-    
+
+    // Ship's crew functions
     void transferPlayersToShip(P<PlayerSpaceship> other_ship);
     void transferPlayersAtPositionToShip(ECrewPosition position, P<PlayerSpaceship> other_ship);
     bool hasPlayerAtPosition(ECrewPosition position);
 
+    // Ship shields functions
     virtual bool getShieldsActive() override { return shields_active; }
     void setShieldsActive(bool active) { shields_active = active; }
-    
-    void setAutoCoolant(bool active) { auto_coolant_enabled = active; }
 
+    // Waypoint functions
     int getWaypointCount() { return waypoints.size(); }
     sf::Vector2f getWaypoint(int index) { if (index > 0 && index <= int(waypoints.size())) return waypoints[index - 1]; return sf::Vector2f(0, 0); }
 
-    int getRepairCrewCount();
-    void setRepairCrewCount(int amount);
-
+    // Radar function
     virtual void drawOnGMRadar(sf::RenderTarget& window, sf::Vector2f position, float scale, bool long_range) override;
 
-    EAlertLevel getAlertLevel() { return alert_level; }
-
+    // Script export function
     virtual string getExportLine();
 };
 REGISTER_MULTIPLAYER_ENUM(ECommsState);


### PR DESCRIPTION
Resolves #196.

-   Add control codes, which prevent a player from selecting a
    a ship from the ship selection screen unless they enter a password.

-   Add a password entry dialog.

-   Add `setControlCode(string control_code)`. To add a control
    code to a ship via script or ship template, use this function.

    For example:

    ``` lua
    player = PlayerSpaceship():setFaction("Human Navy"):setTemplate("Atlantis"):setControlCode("wangodango")
    ```

    ![controlcode-1](https://cloud.githubusercontent.com/assets/19192104/16541416/fd4d8882-4036-11e6-9a0e-7e87bd93322d.png)

    ![controlcode-2](https://cloud.githubusercontent.com/assets/19192104/16541417/fd4fe172-4036-11e6-9704-a9446961ee0b.png)

    ![controlcode-3](https://cloud.githubusercontent.com/assets/19192104/16541418/fd53e57e-4036-11e6-84d7-846b0d95715a.png)

-   Add comments to `playerSpaceship`.