### PR TITLE
Add player page to GM tweaks panel

### DIFF
--- a/src/screens/gm/gameMasterScreen.cpp
+++ b/src/screens/gm/gameMasterScreen.cpp
@@ -224,7 +224,6 @@ void GameMasterScreen::update(float delta)
     // Record object type.
     for(P<SpaceObject> obj : targets.getTargets())
     {
-        has_object = true;
         if (P<SpaceShip>(obj))
             has_ship = true;
         else if (P<CpuShip>(obj))

--- a/src/screens/gm/gameMasterScreen.cpp
+++ b/src/screens/gm/gameMasterScreen.cpp
@@ -31,16 +31,18 @@ GameMasterScreen::GameMasterScreen()
     box_selection_overlay = new GuiOverlay(main_radar, "BOX_SELECTION", sf::Color(255, 255, 255, 32));
     box_selection_overlay->hide();
     
-    (new GuiToggleButton(this, "PAUSE_BUTTON", "Pause", [this](bool value) {
+    pause_button = new GuiToggleButton(this, "PAUSE_BUTTON", "Pause", [this](bool value) {
         if (!value)
             engine->setGameSpeed(1.0f);
         else
             engine->setGameSpeed(0.0f);
-    }))->setValue(engine->getGameSpeed() == 0.0f)->setPosition(20, 20, ATopLeft)->setSize(250, 50);
+    });
+    pause_button->setValue(engine->getGameSpeed() == 0.0f)->setPosition(20, 20, ATopLeft)->setSize(250, 50);
 
-    (new GuiToggleButton(this, "", "Intercept all comms", [this](bool value) {
+    intercept_comms_button = new GuiToggleButton(this, "INTERCEPT_COMMS_BUTTON", "Intercept all comms", [this](bool value) {
         gameGlobalInfo->intercept_all_comms_to_gm = value;
-    }))->setValue(gameGlobalInfo->intercept_all_comms_to_gm)->setTextSize(20)->setPosition(300, 20, ATopLeft)->setSize(200, 25);
+    });
+    intercept_comms_button->setValue(gameGlobalInfo->intercept_all_comms_to_gm)->setTextSize(20)->setPosition(300, 20, ATopLeft)->setSize(200, 25);
     
     faction_selector = new GuiSelector(this, "FACTION_SELECTOR", [this](int index, string value) {
         for(P<SpaceObject> obj : targets.getTargets())
@@ -52,9 +54,10 @@ GameMasterScreen::GameMasterScreen()
         faction_selector->addEntry(info->getName(), info->getName());
     faction_selector->setPosition(20, 70, ATopLeft)->setSize(250, 50);
     
-    (new GuiButton(this, "GLOBAL_MESSAGE_BUTTON", "Global message", [this]() {
+    global_message_button = new GuiButton(this, "GLOBAL_MESSAGE_BUTTON", "Global message", [this]() {
         global_message_entry->show();
-    }))->setPosition(20, -20, ABottomLeft)->setSize(250, 50);
+    });
+    global_message_button->setPosition(20, -20, ABottomLeft)->setSize(250, 50);
 
     player_ship_selector = new GuiSelector(this, "PLAYER_SHIP_SELECTOR", [this](int index, string value) {
         P<SpaceObject> ship = gameGlobalInfo->getPlayerShip(value.toInt());
@@ -70,14 +73,15 @@ GameMasterScreen::GameMasterScreen()
     });
     create_button->setPosition(20, -70, ABottomLeft)->setSize(250, 50);
 
-    export_button = new GuiButton(this, "EXPORT_BUTTON", "Copy scenario", [this]() {
+    copy_scenario_button = new GuiButton(this, "COPY_SCENARIO_BUTTON", "Copy scenario", [this]() {
         Clipboard::setClipboard(getScriptExport(false));
     });
-    export_button->setTextSize(20)->setPosition(-20, -20, ABottomRight)->setSize(125, 25);
+    copy_scenario_button->setTextSize(20)->setPosition(-20, -20, ABottomRight)->setSize(125, 25);
 
-    (new GuiButton(this, "EXPORT_BUTTON", "Copy selected", [this]() {
+    copy_selected_button = new GuiButton(this, "COPY_SELECTED_BUTTON", "Copy selected", [this]() {
         Clipboard::setClipboard(getScriptExport(true));
-    }))->setTextSize(20)->setPosition(-20, -45, ABottomRight)->setSize(125, 25);
+    });
+    copy_selected_button->setTextSize(20)->setPosition(-20, -45, ABottomRight)->setSize(125, 25);
 
     cancel_create_button = new GuiButton(this, "CANCEL_CREATE_BUTTON", "Cancel", [this]() {
         create_button->show();
@@ -85,17 +89,23 @@ GameMasterScreen::GameMasterScreen()
     });
     cancel_create_button->setPosition(20, -70, ABottomLeft)->setSize(250, 50)->hide();
 
-    ship_tweak_button = new GuiButton(this, "TWEAK_SHIP", "Tweak", [this]() {
+    tweak_button = new GuiButton(this, "TWEAK_OBJECT", "Tweak", [this]() {
         for(P<SpaceObject> obj : targets.getTargets())
         {
-            if (P<SpaceShip>(obj))
+            if (P<PlayerSpaceship>(obj))
+            {
+                player_tweak_dialog->open(obj);
+                break;
+            }
+            else if (P<SpaceShip>(obj))
             {
                 ship_tweak_dialog->open(obj);
                 break;
             }
         }
     });
-    ship_tweak_button->setPosition(20, -120, ABottomLeft)->setSize(250, 50)->hide();
+    tweak_button->setPosition(20, -120, ABottomLeft)->setSize(250, 50)->hide();
+
     player_comms_hail = new GuiButton(this, "HAIL_PLAYER", "Hail ship", [this]() {
         for(P<SpaceObject> obj : targets.getTargets())
         {
@@ -107,7 +117,7 @@ GameMasterScreen::GameMasterScreen()
         }
     });
     player_comms_hail->setPosition(20, -170, ABottomLeft)->setSize(250, 50)->hide();
-    
+
     info_layout = new GuiAutoLayout(this, "INFO_LAYOUT", GuiAutoLayout::LayoutVerticalTopToBottom);
     info_layout->setPosition(-20, 20, ATopRight)->setSize(300, GuiElement::GuiSizeMax);
     
@@ -138,7 +148,7 @@ GameMasterScreen::GameMasterScreen()
             if (P<CpuShip>(obj))
                 P<CpuShip>(obj)->orderRoaming();
     }))->setTextSize(20)->setSize(GuiElement::GuiSizeMax, 30);
-    (new GuiButton(order_layout, "ORDER_STAND_GROUND", "Stand Ground", [this]() {
+    (new GuiButton(order_layout, "ORDER_STAND_GROUND", "Stand ground", [this]() {
         for(P<SpaceObject> obj : targets.getTargets())
             if (P<CpuShip>(obj))
                 P<CpuShip>(obj)->orderStandGround();
@@ -157,7 +167,9 @@ GameMasterScreen::GameMasterScreen()
         chat_dialog_per_ship[n]->hide();
     }
 
-    ship_tweak_dialog = new GuiShipTweak(this);
+    player_tweak_dialog = new GuiObjectTweak(this, TW_Player);
+    player_tweak_dialog->hide();
+    ship_tweak_dialog = new GuiObjectTweak(this, TW_Ship);
     ship_tweak_dialog->hide();
 
     global_message_entry = new GuiGlobalMessageEntry(this);
@@ -209,28 +221,31 @@ void GameMasterScreen::update(float delta)
         }
     }
 
+    // Record object type.
     for(P<SpaceObject> obj : targets.getTargets())
     {
+        has_object = true;
         if (P<SpaceShip>(obj))
-        {
             has_ship = true;
-            if (P<CpuShip>(obj))
-                has_cpu_ship = true;
-            else if (P<PlayerSpaceship>(obj))
-                has_player_ship = true;
-        }
+        else if (P<CpuShip>(obj))
+            has_cpu_ship = true;
+        else if (P<PlayerSpaceship>(obj))
+            has_player_ship = true;
     }
-    if (player_ship_selector->entryCount() == 0)
-        player_ship_selector->hide();
-    else
-        player_ship_selector->show();
 
-    ship_tweak_button->setVisible(has_ship);
+    // Show player ship selector only if there are player ships.
+    player_ship_selector->setVisible(player_ship_selector->entryCount() > 0);
+
+    // Show tweak button.
+    tweak_button->setVisible(has_ship);
+
     order_layout->setVisible(has_cpu_ship);
     gm_script_options->setVisible(!has_cpu_ship);
     player_comms_hail->setVisible(has_player_ship);
     
     std::unordered_map<string, string> selection_info;
+
+    // For each selected object, determine and report their type.
     for(P<SpaceObject> obj : targets.getTargets())
     {
         std::unordered_map<string, string> info = obj->getGMInfo();
@@ -246,6 +261,7 @@ void GameMasterScreen::update(float delta)
             }
         }
     }
+
     if (targets.getTargets().size() == 1)
     {
         selection_info["Position"] = string(targets.getTargets()[0]->getPosition().x, 0) + "," + string(targets.getTargets()[0]->getPosition().y, 0);

--- a/src/screens/gm/gameMasterScreen.cpp
+++ b/src/screens/gm/gameMasterScreen.cpp
@@ -66,7 +66,7 @@ GameMasterScreen::GameMasterScreen()
         main_radar->setViewPosition(ship->getPosition());
         targets.set(ship);
     });
-    player_ship_selector->setPosition(270, -20, ABottomLeft)->setSize(250, 50);
+    player_ship_selector->setPosition(270, -20, ABottomLeft)->setSize(350, 50);
 
     create_button = new GuiButton(this, "CREATE_OBJECT_BUTTON", "Create...", [this]() {
         object_creation_screen->show();

--- a/src/screens/gm/gameMasterScreen.h
+++ b/src/screens/gm/gameMasterScreen.h
@@ -8,7 +8,7 @@
 
 class GuiGlobalMessageEntry;
 class GuiObjectCreationScreen;
-class GuiShipTweak;
+class GuiObjectTweak;
 class GuiRadarView;
 class GuiOverlay;
 class GuiSelector;
@@ -16,6 +16,7 @@ class GuiAutoLayout;
 class GuiKeyValueDisplay;
 class GuiListbox;
 class GuiButton;
+class GuiToggleButton;
 class GuiTextEntry;
 class GameMasterChatDialog;
 
@@ -32,15 +33,20 @@ private:
     std::vector<GameMasterChatDialog*> chat_dialog_per_ship;
     GuiGlobalMessageEntry* global_message_entry;
     GuiObjectCreationScreen* object_creation_screen;
-    GuiShipTweak* ship_tweak_dialog;
+    GuiObjectTweak* player_tweak_dialog;
+    GuiObjectTweak* ship_tweak_dialog;
     
     GuiAutoLayout* info_layout;
     std::vector<GuiKeyValueDisplay*> info_items;
     GuiListbox* gm_script_options;
     GuiAutoLayout* order_layout;
     GuiButton* player_comms_hail;
-    GuiButton* ship_tweak_button;
-    GuiButton* export_button;
+    GuiButton* global_message_button;
+    GuiToggleButton* pause_button;
+    GuiToggleButton* intercept_comms_button;
+    GuiButton* tweak_button;
+    GuiButton* copy_scenario_button;
+    GuiButton* copy_selected_button;
     GuiSelector* player_ship_selector;
     
     enum EClickAndDragState

--- a/src/screens/gm/tweak.cpp
+++ b/src/screens/gm/tweak.cpp
@@ -509,6 +509,14 @@ GuiShipTweakPlayer::GuiShipTweakPlayer(GuiContainer* owner)
         target->control_code = text;
     });
 
+    // Edit reputation.
+    (new GuiLabel(left_col, "", "Reputation:", 30))->setSize(GuiElement::GuiSizeMax, 50);
+
+    reputation = new GuiSlider(left_col, "", 0.0, 9999.0, 0.0, [this](float value) {
+        target->setReputationPoints(value);
+    });
+    reputation->addOverlay()->setSize(GuiElement::GuiSizeMax, 50);
+
     // Right column
     // Count and list ship positions and whether they're occupied.
     position_count = new GuiLabel(right_col, "", "Positions occupied: ", 30);
@@ -550,6 +558,9 @@ void GuiShipTweakPlayer::onDraw(sf::RenderTarget& window)
 
         // Update the total occupied position count.
         position_count->setText("Positions occupied: " + string(position_counter));
+
+        // Update rep.
+        reputation->setValue(player->getReputationPoints());
     }
 }
 

--- a/src/screens/gm/tweak.cpp
+++ b/src/screens/gm/tweak.cpp
@@ -1,15 +1,17 @@
 #include "tweak.h"
+#include "playerInfo.h"
 #include "spaceObjects/spaceship.h"
 
 #include "gui/gui2_listbox.h"
 #include "gui/gui2_autolayout.h"
+#include "gui/gui2_keyvaluedisplay.h"
 #include "gui/gui2_label.h"
 #include "gui/gui2_textentry.h"
 #include "gui/gui2_selector.h"
 #include "gui/gui2_slider.h"
 #include "gui/gui2_togglebutton.h"
 
-GuiShipTweak::GuiShipTweak(GuiContainer* owner)
+GuiObjectTweak::GuiObjectTweak(GuiContainer* owner, ETweakType tweak_type)
 : GuiPanel(owner, "GM_TWEAK_DIALOG")
 {
     setPosition(0, -100, ABottomCenter);
@@ -21,26 +23,37 @@ GuiShipTweak::GuiShipTweak(GuiContainer* owner)
             page->hide();
         pages[index]->show();
     });
+
     list->setSize(300, GuiElement::GuiSizeMax);
     list->setPosition(25, 25, ATopLeft);
-    
-    pages.push_back(new GuiShipTweakBase(this));
-    list->addEntry("Base", "");
-    pages.push_back(new GuiShipTweakShields(this));
-    list->addEntry("Shields", "");
-    pages.push_back(new GuiShipTweakMissileTubes(this));
-    list->addEntry("Tubes", "");
-    pages.push_back(new GuiShipTweakMissileWeapons(this));
-    list->addEntry("Missiles", "");
-    pages.push_back(new GuiShipTweakBeamweapons(this));
-    list->addEntry("Beams", "");
-    pages.push_back(new GuiShipTweakSystems(this));
-    list->addEntry("Systems", "");
+
+    if (tweak_type == TW_Ship || tweak_type == TW_Player)
+    {
+        pages.push_back(new GuiShipTweakBase(this));
+        list->addEntry("Base", "");
+        pages.push_back(new GuiShipTweakShields(this));
+        list->addEntry("Shields", "");
+        pages.push_back(new GuiShipTweakMissileTubes(this));
+        list->addEntry("Tubes", "");
+        pages.push_back(new GuiShipTweakMissileWeapons(this));
+        list->addEntry("Missiles", "");
+        pages.push_back(new GuiShipTweakBeamweapons(this));
+        list->addEntry("Beams", "");
+        pages.push_back(new GuiShipTweakSystems(this));
+        list->addEntry("Systems", "");
+    }
+
+    if (tweak_type == TW_Player)
+    {
+        pages.push_back(new GuiShipTweakPlayer(this));
+        list->addEntry("Player", "");
+    }
 
     for(GuiTweakPage* page : pages)
     {
         page->setSize(700, 600)->setPosition(0, 0, ABottomRight)->hide();
     }
+
     pages[0]->show();
     list->setSelectionIndex(0);
 
@@ -49,15 +62,17 @@ GuiShipTweak::GuiShipTweak(GuiContainer* owner)
     }))->setTextSize(20)->setPosition(-10, 0, ATopRight)->setSize(70, 30);
 }
 
-void GuiShipTweak::open(P<SpaceShip> target)
+void GuiObjectTweak::open(P<SpaceShip> target)
 {
     this->target = target;
+
     for(GuiTweakPage* page : pages)
         page->open(target);
+
     show();
 }
 
-void GuiShipTweak::onDraw(sf::RenderTarget& window)
+void GuiObjectTweak::onDraw(sf::RenderTarget& window)
 {
     GuiPanel::onDraw(window);
     
@@ -466,6 +481,79 @@ void GuiShipTweakSystems::onDraw(sf::RenderTarget& window)
 }
 
 void GuiShipTweakSystems::open(P<SpaceShip> target)
+{
+    this->target = target;
+}
+
+GuiShipTweakPlayer::GuiShipTweakPlayer(GuiContainer* owner)
+: GuiTweakPage(owner)
+{
+    // TODO: Add more player ship tweaks here.
+    // -   Ship-to-ship player transfer
+    // -   Reputation
+
+    // Add two columns.
+    GuiAutoLayout* left_col = new GuiAutoLayout(this, "LEFT_LAYOUT", GuiAutoLayout::LayoutVerticalTopToBottom);
+    left_col->setPosition(50, 25, ATopLeft)->setSize(300, GuiElement::GuiSizeMax);
+
+    GuiAutoLayout* right_col = new GuiAutoLayout(this, "RIGHT_LAYOUT", GuiAutoLayout::LayoutVerticalTopToBottom);
+    right_col->setPosition(-25, 25, ATopRight)->setSize(300, GuiElement::GuiSizeMax);
+
+    // Left column
+    // Edit control code.
+    (new GuiLabel(left_col, "", "Control code:", 30))->setSize(GuiElement::GuiSizeMax, 50);
+
+    control_code = new GuiTextEntry(left_col, "", "");
+    control_code->setSize(GuiElement::GuiSizeMax, 50);
+    control_code->callback([this](string text) {
+        target->control_code = text;
+    });
+
+    // Right column
+    // Count and list ship positions and whether they're occupied.
+    position_count = new GuiLabel(right_col, "", "Positions occupied: ", 30);
+    position_count->setSize(GuiElement::GuiSizeMax, 50);
+
+    for(int n = 0; n < max_crew_positions; n++)
+    {
+        string position_name = getCrewPositionName(ECrewPosition(n));
+
+        position[n] = new GuiKeyValueDisplay(right_col, "CREW_POSITION_" + position_name, 0.5, position_name, "-");
+        position[n]->setSize(GuiElement::GuiSizeMax, 30);
+    }
+}
+
+
+void GuiShipTweakPlayer::onDraw(sf::RenderTarget& window)
+{
+    P<PlayerSpaceship> player = target;
+
+    if (player)
+    {
+        // Update position list.
+        int position_counter = 0;
+
+        // Update the status of each crew position.
+        for(int n = 0; n < max_crew_positions; n++)
+        {
+            string position_name = getCrewPositionName(ECrewPosition(n));
+            string position_state = "-";
+
+            if (player->hasPlayerAtPosition(ECrewPosition(n)))
+            {
+                position_state = "Occupied";
+                position_counter += 1;
+            }
+
+            position[n]->setValue(position_state);
+        }
+
+        // Update the total occupied position count.
+        position_count->setText("Positions occupied: " + string(position_counter));
+    }
+}
+
+void GuiShipTweakPlayer::open(P<SpaceShip> target)
 {
     this->target = target;
 }

--- a/src/screens/gm/tweak.h
+++ b/src/screens/gm/tweak.h
@@ -159,6 +159,7 @@ private:
     P<PlayerSpaceship> target;
 
     GuiTextEntry* control_code;
+    GuiSlider* reputation;
     GuiLabel* position_count;
     GuiKeyValueDisplay* position[max_crew_positions];
 public:

--- a/src/screens/gm/tweak.h
+++ b/src/screens/gm/tweak.h
@@ -4,13 +4,24 @@
 #include "gui/gui2_panel.h"
 #include "missileWeaponData.h"
 #include "shipTemplate.h"
+#include "playerInfo.h"
+#include "spaceObjects/playerSpaceship.h"
 
 class SpaceShip;
+class GuiKeyValueDisplay;
 class GuiLabel;
 class GuiTextEntry;
 class GuiSlider;
 class GuiSelector;
 class GuiToggleButton;
+
+enum ETweakType
+{
+    TW_Object,  // TODO: Space object
+    TW_Ship,    // Ships
+    TW_Station, // TODO: Space stations
+    TW_Player   // Player ships
+};
 
 class GuiTweakPage : public GuiElement
 {
@@ -20,10 +31,10 @@ public:
     virtual void open(P<SpaceShip> target) = 0;
 };
 
-class GuiShipTweak : public GuiPanel
+class GuiObjectTweak : public GuiPanel
 {
 public:
-    GuiShipTweak(GuiContainer* owner);
+    GuiObjectTweak(GuiContainer* owner, ETweakType tweak_type);
     
     void open(P<SpaceShip> target);
 
@@ -142,4 +153,19 @@ public:
     virtual void onDraw(sf::RenderTarget& window) override;
 };
 
+class GuiShipTweakPlayer : public GuiTweakPage
+{
+private:
+    P<PlayerSpaceship> target;
+
+    GuiTextEntry* control_code;
+    GuiLabel* position_count;
+    GuiKeyValueDisplay* position[max_crew_positions];
+public:
+    GuiShipTweakPlayer(GuiContainer* owner);
+
+    virtual void open(P<SpaceShip> target);
+
+    virtual void onDraw(sf::RenderTarget& window) override;
+};
 #endif//GAME_MASTER_TWEAK_H

--- a/src/spaceObjects/spaceObject.cpp
+++ b/src/spaceObjects/spaceObject.cpp
@@ -44,6 +44,8 @@ REGISTER_SCRIPT_CLASS_NO_CREATE(SpaceObject)
     REGISTER_SCRIPT_CLASS_FUNCTION(SpaceObject, getCallSign);
     REGISTER_SCRIPT_CLASS_FUNCTION(SpaceObject, areEnemiesInRange);
     REGISTER_SCRIPT_CLASS_FUNCTION(SpaceObject, getObjectsInRange);
+    /// Sets the reputation to a value.
+    REGISTER_SCRIPT_CLASS_FUNCTION(SpaceObject, setReputationPoints);
     /// Return the current amount of reputation points.
     REGISTER_SCRIPT_CLASS_FUNCTION(SpaceObject, getReputationPoints);
     /// Take a certain amount of reputation points, returns true when there are enough points to take. Returns false when there are not enough points and does not lower the points.
@@ -309,6 +311,13 @@ PVector<SpaceObject> SpaceObject::getObjectsInRange(float range)
         }
     }
     return ret;
+}
+
+void SpaceObject::setReputationPoints(float amount)
+{
+    if (gameGlobalInfo->reputation_points.size() < faction_id)
+        return;
+    gameGlobalInfo->reputation_points[faction_id] = amount;
 }
 
 int SpaceObject::getReputationPoints()

--- a/src/spaceObjects/spaceObject.h
+++ b/src/spaceObjects/spaceObject.h
@@ -159,6 +159,7 @@ public:
     string getFaction() { return factionInfo[this->faction_id]->getName(); }
     void setFactionId(unsigned int faction_id) { this->faction_id = faction_id; }
     unsigned int getFactionId() { return faction_id; }
+    void setReputationPoints(float amount);
     int getReputationPoints();
     bool takeReputationPoints(float amount);
     void removeReputationPoints(float amount);


### PR DESCRIPTION
When tweaking a player ship from the GM screen, add a player page
to allow setting control codes and reputation, and to show which stations
on the ship are occupied.

![gm-player](https://cloud.githubusercontent.com/assets/19192104/16570970/58ef9a6a-4206-11e6-951c-2417ab671b3e.png)
