### PR TITLE
Fix control code issues

### DIFF
--- a/src/menus/shipSelectionScreen.cpp
+++ b/src/menus/shipSelectionScreen.cpp
@@ -370,7 +370,7 @@ void ShipSelectionScreen::updateReadyButton()
         // If the main screen button is both available and selected and a
         // player ship is also selected, and the player isn't being asked for a
         // command code, enable the Ready button.
-        if (my_spaceship && main_screen_button->isVisible() && main_screen_button->getValue() && !password_overlay->isVisible())
+        if (my_spaceship && main_screen_button->isVisible() && main_screen_button->getValue())
             ready_button->enable();
         // If the GM or spectator buttons are enabled, enable the Ready button.
         // TODO: Allow GM or spectator screens to require a control code.
@@ -387,7 +387,7 @@ void ShipSelectionScreen::updateReadyButton()
     }else{
         // If a player ship is selected and the player isn't being asked for a
         // control code, enable the Ready button. Otherwise, disable it.
-        if (my_spaceship && !password_overlay->isVisible())
+        if (my_spaceship)
             ready_button->enable();
         else
             ready_button->disable();

--- a/src/screens/gm/tweak.cpp
+++ b/src/screens/gm/tweak.cpp
@@ -531,7 +531,6 @@ GuiShipTweakPlayer::GuiShipTweakPlayer(GuiContainer* owner)
     }
 }
 
-
 void GuiShipTweakPlayer::onDraw(sf::RenderTarget& window)
 {
     P<PlayerSpaceship> player = target;
@@ -559,7 +558,7 @@ void GuiShipTweakPlayer::onDraw(sf::RenderTarget& window)
         // Update the total occupied position count.
         position_count->setText("Positions occupied: " + string(position_counter));
 
-        // Update rep.
+        // Update reputation points.
         reputation->setValue(player->getReputationPoints());
     }
 }
@@ -567,4 +566,12 @@ void GuiShipTweakPlayer::onDraw(sf::RenderTarget& window)
 void GuiShipTweakPlayer::open(P<SpaceShip> target)
 {
     this->target = target;
+
+    P<PlayerSpaceship> player = target;
+
+    if (player)
+    {
+        // Read ship's control code.
+        control_code->setText(player->control_code);
+    }
 }


### PR DESCRIPTION
-   Remove redundant Ready button state check for control codes on the ship selection screen.
-   Read the ship's control code when opening the player page in the GM tweak UI.