### PR TITLE
Allow GMs to tweak object callsign and description

### DIFF
--- a/src/screens/crew6/scienceScreen.cpp
+++ b/src/screens/crew6/scienceScreen.cpp
@@ -295,10 +295,13 @@ void ScienceScreen::onDraw(sf::RenderTarget& window)
 
         if (description.size() > 0)
         {
-            info_description->setText(description);
+            LOG(INFO) << "Show description in sidebar: " << description;
+            info_description->setText(description)->show();
 
             if (!sidebar_pager->indexByValue("Description"))
+            {
                 sidebar_pager->addEntry("Description", "Description");
+            }
         }
         else
         {

--- a/src/screens/gm/gameMasterScreen.cpp
+++ b/src/screens/gm/gameMasterScreen.cpp
@@ -102,6 +102,11 @@ GameMasterScreen::GameMasterScreen()
                 ship_tweak_dialog->open(obj);
                 break;
             }
+            else
+            {
+                object_tweak_dialog->open(obj);
+                break;
+            }
         }
     });
     tweak_button->setPosition(20, -120, ABottomLeft)->setSize(250, 50)->hide();
@@ -171,6 +176,8 @@ GameMasterScreen::GameMasterScreen()
     player_tweak_dialog->hide();
     ship_tweak_dialog = new GuiObjectTweak(this, TW_Ship);
     ship_tweak_dialog->hide();
+    object_tweak_dialog = new GuiObjectTweak(this, TW_Object);
+    object_tweak_dialog->hide();
 
     global_message_entry = new GuiGlobalMessageEntry(this);
     global_message_entry->hide();
@@ -195,6 +202,7 @@ void GameMasterScreen::update(float delta)
             main_radar->longRange();
     }
     
+    bool has_object = false;
     bool has_ship = false;
     bool has_cpu_ship = false;
     bool has_player_ship = false;
@@ -224,6 +232,7 @@ void GameMasterScreen::update(float delta)
     // Record object type.
     for(P<SpaceObject> obj : targets.getTargets())
     {
+        has_object = true;
         if (P<SpaceShip>(obj))
             has_ship = true;
         else if (P<CpuShip>(obj))
@@ -236,7 +245,7 @@ void GameMasterScreen::update(float delta)
     player_ship_selector->setVisible(player_ship_selector->entryCount() > 0);
 
     // Show tweak button.
-    tweak_button->setVisible(has_ship);
+    tweak_button->setVisible(has_object);
 
     order_layout->setVisible(has_cpu_ship);
     gm_script_options->setVisible(!has_cpu_ship);

--- a/src/screens/gm/gameMasterScreen.h
+++ b/src/screens/gm/gameMasterScreen.h
@@ -35,6 +35,7 @@ private:
     GuiObjectCreationScreen* object_creation_screen;
     GuiObjectTweak* player_tweak_dialog;
     GuiObjectTweak* ship_tweak_dialog;
+    GuiObjectTweak* object_tweak_dialog;
     
     GuiAutoLayout* info_layout;
     std::vector<GuiKeyValueDisplay*> info_items;

--- a/src/screens/gm/tweak.cpp
+++ b/src/screens/gm/tweak.cpp
@@ -49,6 +49,12 @@ GuiObjectTweak::GuiObjectTweak(GuiContainer* owner, ETweakType tweak_type)
         list->addEntry("Player", "");
     }
 
+    if (tweak_type == TW_Object)
+    {
+        pages.push_back(new GuiObjectTweakBase(this));
+        list->addEntry("Base", "");
+    }
+
     for(GuiTweakPage* page : pages)
     {
         page->setSize(700, 600)->setPosition(0, 0, ABottomRight)->hide();
@@ -594,4 +600,36 @@ void GuiShipTweakPlayer::open(P<SpaceObject> target)
         // Read ship's control code.
         control_code->setText(player->control_code);
     }
+}
+
+GuiObjectTweakBase::GuiObjectTweakBase(GuiContainer* owner)
+: GuiTweakPage(owner)
+{
+    GuiAutoLayout* left_col = new GuiAutoLayout(this, "LEFT_LAYOUT", GuiAutoLayout::LayoutVerticalTopToBottom);
+    left_col->setPosition(50, 25, ATopLeft)->setSize(300, GuiElement::GuiSizeMax);
+
+    GuiAutoLayout* right_col = new GuiAutoLayout(this, "RIGHT_LAYOUT", GuiAutoLayout::LayoutVerticalTopToBottom);
+    right_col->setPosition(-25, 25, ATopRight)->setSize(300, GuiElement::GuiSizeMax);
+
+    // Left column
+    (new GuiLabel(left_col, "", "Callsign:", 30))->setSize(GuiElement::GuiSizeMax, 50);
+
+    callsign = new GuiTextEntry(left_col, "", "");
+    callsign->setSize(GuiElement::GuiSizeMax, 50);
+    callsign->callback([this](string text) {
+        target->callsign = text;
+    });
+
+    // Right column
+}
+
+void GuiObjectTweakBase::onDraw(sf::RenderTarget& window)
+{
+}
+
+void GuiObjectTweakBase::open(P<SpaceObject> target)
+{
+    this->target = target;
+    
+    callsign->setText(target->callsign);
 }

--- a/src/screens/gm/tweak.cpp
+++ b/src/screens/gm/tweak.cpp
@@ -148,6 +148,17 @@ GuiShipTweakBase::GuiShipTweakBase(GuiContainer* owner)
         target->hull_strength = std::min(roundf(value), target->hull_max);
     });
     hull_slider->addOverlay()->setSize(GuiElement::GuiSizeMax, 40);
+
+    // Edit object's description.
+    // TODO: Fix long strings in GuiTextEntry, or make a new GUI element for
+    // editing long strings.
+    (new GuiLabel(right_col, "", "Description:", 30))->setSize(GuiElement::GuiSizeMax, 50);
+
+    description = new GuiTextEntry(right_col, "", "");
+    description->setSize(GuiElement::GuiSizeMax, 50);
+    description->callback([this](string text) {
+        target->setDescription(text);
+    });
 }
 
 void GuiShipTweakBase::onDraw(sf::RenderTarget& window)
@@ -162,6 +173,7 @@ void GuiShipTweakBase::open(P<SpaceObject> target)
     
     type_name->setText(ship->getTypeName());
     callsign->setText(ship->callsign);
+    description->setText(ship->getDescription());
     warp_toggle->setValue(ship->has_warp_drive);
     jump_toggle->setValue(ship->hasJumpDrive());
     impulse_speed_slider->setValue(ship->impulse_max_speed);
@@ -612,12 +624,24 @@ GuiObjectTweakBase::GuiObjectTweakBase(GuiContainer* owner)
     right_col->setPosition(-25, 25, ATopRight)->setSize(300, GuiElement::GuiSizeMax);
 
     // Left column
+    // Edit object's callsign.
     (new GuiLabel(left_col, "", "Callsign:", 30))->setSize(GuiElement::GuiSizeMax, 50);
 
     callsign = new GuiTextEntry(left_col, "", "");
     callsign->setSize(GuiElement::GuiSizeMax, 50);
     callsign->callback([this](string text) {
         target->callsign = text;
+    });
+
+    // Edit object's description.
+    // TODO: Fix long strings in GuiTextEntry, or make a new GUI element for
+    // editing long strings.
+    (new GuiLabel(left_col, "", "Description:", 30))->setSize(GuiElement::GuiSizeMax, 50);
+
+    description = new GuiTextEntry(left_col, "", "");
+    description->setSize(GuiElement::GuiSizeMax, 50);
+    description->callback([this](string text) {
+        target->setDescription(text);
     });
 
     // Right column
@@ -632,4 +656,8 @@ void GuiObjectTweakBase::open(P<SpaceObject> target)
     this->target = target;
     
     callsign->setText(target->callsign);
+    // TODO: Fix long strings in GuiTextEntry, or make a new GUI element for
+    // editing long strings.
+    description->setText(target->getDescription());
+
 }

--- a/src/screens/gm/tweak.cpp
+++ b/src/screens/gm/tweak.cpp
@@ -527,7 +527,7 @@ GuiShipTweakPlayer::GuiShipTweakPlayer(GuiContainer* owner)
     reputation_point_slider = new GuiSlider(left_col, "", 0.0, 9999.0, 0.0, [this](float value) {
         target->setReputationPoints(value);
     });
-    reputation_point_slider->addOverlay()->setSize(GuiElement::GuiSizeMax, 50);
+    reputation_point_slider->addOverlay()->setSize(GuiElement::GuiSizeMax, 40);
 
     // Edit energy level.
     (new GuiLabel(left_col, "", "Max energy:", 30))->setSize(GuiElement::GuiSizeMax, 50);
@@ -536,14 +536,14 @@ GuiShipTweakPlayer::GuiShipTweakPlayer(GuiContainer* owner)
         target->max_energy_level = value;
         target->energy_level = std::min(target->energy_level, target->max_energy_level);
     });
-    max_energy_level_slider->addOverlay()->setSize(GuiElement::GuiSizeMax, 50);
+    max_energy_level_slider->addOverlay()->setSize(GuiElement::GuiSizeMax, 40);
 
     (new GuiLabel(left_col, "", "Current energy:", 30))->setSize(GuiElement::GuiSizeMax, 50);
 
     energy_level_slider = new GuiSlider(left_col, "", 0.0, 2000, 0.0, [this](float value) {
         target->energy_level = std::min(value, target->max_energy_level);
     });
-    energy_level_slider->addOverlay()->setSize(GuiElement::GuiSizeMax, 50);
+    energy_level_slider->addOverlay()->setSize(GuiElement::GuiSizeMax, 40);
 
     // Right column
     // Count and list ship positions and whether they're occupied.

--- a/src/screens/gm/tweak.cpp
+++ b/src/screens/gm/tweak.cpp
@@ -62,7 +62,7 @@ GuiObjectTweak::GuiObjectTweak(GuiContainer* owner, ETweakType tweak_type)
     }))->setTextSize(20)->setPosition(-10, 0, ATopRight)->setSize(70, 30);
 }
 
-void GuiObjectTweak::open(P<SpaceShip> target)
+void GuiObjectTweak::open(P<SpaceObject> target)
 {
     this->target = target;
 
@@ -149,7 +149,7 @@ void GuiShipTweakBase::onDraw(sf::RenderTarget& window)
     hull_slider->setValue(target->hull_strength);
 }
 
-void GuiShipTweakBase::open(P<SpaceShip> target)
+void GuiShipTweakBase::open(P<SpaceObject> target)
 {
     this->target = target;
     
@@ -209,7 +209,7 @@ void GuiShipTweakMissileWeapons::onDraw(sf::RenderTarget& window)
     }
 }
 
-void GuiShipTweakMissileWeapons::open(P<SpaceShip> target)
+void GuiShipTweakMissileWeapons::open(P<SpaceObject> target)
 {
     for(int n=0; n<MW_Count; n++)
         missile_storage_amount_slider[n]->setValue(float(target->weapon_storage_max[n]));
@@ -289,7 +289,7 @@ void GuiShipTweakMissileTubes::onDraw(sf::RenderTarget& window)
     }
 }
 
-void GuiShipTweakMissileTubes::open(P<SpaceShip> target)
+void GuiShipTweakMissileTubes::open(P<SpaceObject> target)
 {
     missile_tube_amount_selector->setSelectionIndex(target->weapon_tube_count);
 
@@ -333,7 +333,7 @@ void GuiShipTweakShields::onDraw(sf::RenderTarget& window)
     }
 }
 
-void GuiShipTweakShields::open(P<SpaceShip> target)
+void GuiShipTweakShields::open(P<SpaceObject> target)
 {
     this->target = target;
 
@@ -436,7 +436,7 @@ void GuiShipTweakBeamweapons::onDraw(sf::RenderTarget& window)
     damage_slider->setValue(target->beam_weapons[beam_index].getDamage());
 }
 
-void GuiShipTweakBeamweapons::open(P<SpaceShip> target)
+void GuiShipTweakBeamweapons::open(P<SpaceObject> target)
 {
     this->target = target;
 }
@@ -480,7 +480,7 @@ void GuiShipTweakSystems::onDraw(sf::RenderTarget& window)
     }
 }
 
-void GuiShipTweakSystems::open(P<SpaceShip> target)
+void GuiShipTweakSystems::open(P<SpaceObject> target)
 {
     this->target = target;
 }
@@ -583,7 +583,7 @@ void GuiShipTweakPlayer::onDraw(sf::RenderTarget& window)
     }
 }
 
-void GuiShipTweakPlayer::open(P<SpaceShip> target)
+void GuiShipTweakPlayer::open(P<SpaceObject> target)
 {
     this->target = target;
 

--- a/src/screens/gm/tweak.h
+++ b/src/screens/gm/tweak.h
@@ -176,6 +176,8 @@ class GuiObjectTweakBase : public GuiTweakPage
 {
 private:
     P<SpaceObject> target;
+
+    GuiTextEntry* callsign;
 public:
     GuiObjectTweakBase(GuiContainer* owner);
 

--- a/src/screens/gm/tweak.h
+++ b/src/screens/gm/tweak.h
@@ -51,6 +51,7 @@ private:
 
     GuiTextEntry* type_name;
     GuiTextEntry* callsign;
+    GuiTextEntry* description;
     GuiToggleButton* warp_toggle;
     GuiToggleButton* jump_toggle;
     GuiSlider* impulse_speed_slider;
@@ -178,6 +179,7 @@ private:
     P<SpaceObject> target;
 
     GuiTextEntry* callsign;
+    GuiTextEntry* description;
 public:
     GuiObjectTweakBase(GuiContainer* owner);
 

--- a/src/screens/gm/tweak.h
+++ b/src/screens/gm/tweak.h
@@ -171,4 +171,16 @@ public:
 
     virtual void onDraw(sf::RenderTarget& window) override;
 };
+
+class GuiObjectTweakBase : public GuiTweakPage
+{
+private:
+    P<SpaceObject> target;
+public:
+    GuiObjectTweakBase(GuiContainer* owner);
+
+    virtual void open(P<SpaceObject> target);
+
+    virtual void onDraw(sf::RenderTarget& window) override;
+};
 #endif//GAME_MASTER_TWEAK_H

--- a/src/screens/gm/tweak.h
+++ b/src/screens/gm/tweak.h
@@ -47,7 +47,7 @@ private:
 class GuiShipTweakBase : public GuiTweakPage
 {
 private:
-    P<SpaceObject> target;
+    P<SpaceShip> target;
 
     GuiTextEntry* type_name;
     GuiTextEntry* callsign;
@@ -68,7 +68,7 @@ public:
 class GuiShipTweakMissileWeapons : public GuiTweakPage
 {
 private:
-    P<SpaceObject> target;
+    P<SpaceShip> target;
 
     GuiSlider* missile_storage_amount_slider[MW_Count];
     GuiSlider* missile_current_amount_slider[MW_Count];
@@ -83,7 +83,7 @@ public:
 class GuiShipTweakMissileTubes : public GuiTweakPage
 {
 private:
-    P<SpaceObject> target;
+    P<SpaceShip> target;
 
     int tube_index;
     GuiSelector* index_selector;
@@ -102,7 +102,7 @@ public:
 class GuiShipTweakShields : public GuiTweakPage
 {
 private:
-    P<SpaceObject> target;
+    P<SpaceShip> target;
 
     GuiSlider* shield_max_slider[max_shield_count];
     GuiSlider* shield_slider[max_shield_count];
@@ -117,7 +117,7 @@ public:
 class GuiShipTweakBeamweapons : public GuiTweakPage
 {
 private:
-    P<SpaceObject> target;
+    P<SpaceShip> target;
 
     int beam_index;
     GuiSlider* arc_slider;
@@ -140,7 +140,7 @@ public:
 class GuiShipTweakSystems : public GuiTweakPage
 {
 private:
-    P<SpaceObject> target;
+    P<SpaceShip> target;
 
     GuiSlider* system_damage[SYS_COUNT];
     GuiSlider* system_heat[SYS_COUNT];

--- a/src/screens/gm/tweak.h
+++ b/src/screens/gm/tweak.h
@@ -28,7 +28,7 @@ class GuiTweakPage : public GuiElement
 public:
     GuiTweakPage(GuiContainer* owner) : GuiElement(owner, "") {}
 
-    virtual void open(P<SpaceShip> target) = 0;
+    virtual void open(P<SpaceObject> target) = 0;
 };
 
 class GuiObjectTweak : public GuiPanel
@@ -36,18 +36,18 @@ class GuiObjectTweak : public GuiPanel
 public:
     GuiObjectTweak(GuiContainer* owner, ETweakType tweak_type);
     
-    void open(P<SpaceShip> target);
+    void open(P<SpaceObject> target);
 
     virtual void onDraw(sf::RenderTarget& window) override;
 private:
-    P<SpaceShip> target;
+    P<SpaceObject> target;
     std::vector<GuiTweakPage*> pages;
 };
 
 class GuiShipTweakBase : public GuiTweakPage
 {
 private:
-    P<SpaceShip> target;
+    P<SpaceObject> target;
 
     GuiTextEntry* type_name;
     GuiTextEntry* callsign;
@@ -62,13 +62,13 @@ public:
 
     virtual void onDraw(sf::RenderTarget& window) override;
     
-    virtual void open(P<SpaceShip> target) override;
+    virtual void open(P<SpaceObject> target) override;
 };
 
 class GuiShipTweakMissileWeapons : public GuiTweakPage
 {
 private:
-    P<SpaceShip> target;
+    P<SpaceObject> target;
 
     GuiSlider* missile_storage_amount_slider[MW_Count];
     GuiSlider* missile_current_amount_slider[MW_Count];
@@ -77,13 +77,13 @@ public:
 
     virtual void onDraw(sf::RenderTarget& window) override;
     
-    virtual void open(P<SpaceShip> target) override;
+    virtual void open(P<SpaceObject> target) override;
 };
 
 class GuiShipTweakMissileTubes : public GuiTweakPage
 {
 private:
-    P<SpaceShip> target;
+    P<SpaceObject> target;
 
     int tube_index;
     GuiSelector* index_selector;
@@ -96,13 +96,13 @@ public:
 
     virtual void onDraw(sf::RenderTarget& window) override;
     
-    virtual void open(P<SpaceShip> target) override;
+    virtual void open(P<SpaceObject> target) override;
 };
 
 class GuiShipTweakShields : public GuiTweakPage
 {
 private:
-    P<SpaceShip> target;
+    P<SpaceObject> target;
 
     GuiSlider* shield_max_slider[max_shield_count];
     GuiSlider* shield_slider[max_shield_count];
@@ -111,13 +111,13 @@ public:
 
     virtual void onDraw(sf::RenderTarget& window) override;
     
-    virtual void open(P<SpaceShip> target) override;
+    virtual void open(P<SpaceObject> target) override;
 };
 
 class GuiShipTweakBeamweapons : public GuiTweakPage
 {
 private:
-    P<SpaceShip> target;
+    P<SpaceObject> target;
 
     int beam_index;
     GuiSlider* arc_slider;
@@ -132,7 +132,7 @@ private:
 public:
     GuiShipTweakBeamweapons(GuiContainer* owner);
 
-    virtual void open(P<SpaceShip> target) override;
+    virtual void open(P<SpaceObject> target) override;
 
     virtual void onDraw(sf::RenderTarget& window) override;
 };
@@ -140,7 +140,7 @@ public:
 class GuiShipTweakSystems : public GuiTweakPage
 {
 private:
-    P<SpaceShip> target;
+    P<SpaceObject> target;
 
     GuiSlider* system_damage[SYS_COUNT];
     GuiSlider* system_heat[SYS_COUNT];
@@ -148,7 +148,7 @@ private:
 public:
     GuiShipTweakSystems(GuiContainer* owner);
 
-    virtual void open(P<SpaceShip> target) override;
+    virtual void open(P<SpaceObject> target) override;
 
     virtual void onDraw(sf::RenderTarget& window) override;
 };
@@ -167,7 +167,7 @@ private:
 public:
     GuiShipTweakPlayer(GuiContainer* owner);
 
-    virtual void open(P<SpaceShip> target);
+    virtual void open(P<SpaceObject> target);
 
     virtual void onDraw(sf::RenderTarget& window) override;
 };


### PR DESCRIPTION
Resolves most of #348.

-   Revise GM tweak panel to work with SpaceObjects instead of SpaceShips, and to convert object types in the `open()` function.
-   Add a page to tweak an object's callsign and description.
-   Add description field to the ship tweak page.

![tweak-obj-1](https://cloud.githubusercontent.com/assets/19192104/16614398/da5dbb70-4325-11e6-8cd8-a1b66e0346eb.png)

![tweak-obj-2](https://cloud.githubusercontent.com/assets/19192104/16614399/da610f6e-4325-11e6-8d8a-b21168d879e1.png)