### PR TITLE
Set warp request on warp slider init

### DIFF
--- a/src/screenComponents/warpControls.cpp
+++ b/src/screenComponents/warpControls.cpp
@@ -9,33 +9,48 @@
 GuiWarpControls::GuiWarpControls(GuiContainer* owner, string id)
 : GuiElement(owner, id)
 {
+    // Build warp request slider.
     slider = new GuiSlider(this, id + "_SLIDER", 4.0, 0.0, 0.0, [this](float value) {
+        // Round the slider value to an int.
         int warp_level = value;
+
+        // Send a warp request command to our ship.
         if (my_spaceship)
             my_spaceship->commandWarp(warp_level);
+
+        // Set the slider value to the warp level.
         slider->setValue(warp_level);
     });
     slider->setPosition(0, 0, ATopLeft)->setSize(50, GuiElement::GuiSizeMax);
+
+    // Snap the slider to integers up to 4.
     slider->addSnapValue(0.0, 0.5);
     slider->addSnapValue(1.0, 0.5);
     slider->addSnapValue(2.0, 0.5);
     slider->addSnapValue(3.0, 0.5);
     slider->addSnapValue(4.0, 0.5);
-    
+
+    // Set the slider's value to the current warp request.
+    slider->setValue(my_spaceship->warp_request);
+
+    // Label the warp slider.
     label = new GuiKeyValueDisplay(this, id + "_LABEL", 0.5, "Warp", "0.0");
     label->setTextSize(30)->setPosition(50, 0, ATopLeft)->setSize(40, GuiElement::GuiSizeMax);
-    
+
+    // Prep the alert overlay.
     (new GuiPowerDamageIndicator(this, id + "_DPI", SYS_Warp, ATopCenter))->setSize(50, GuiElement::GuiSizeMax);
 }
 
 void GuiWarpControls::onDraw(sf::RenderTarget& window)
 {
+    // Update the label with the current warp factor.
     if (my_spaceship)
         label->setValue(string(my_spaceship->current_warp, 1));
 }
 
 void GuiWarpControls::onHotkey(const HotkeyResult& key)
 {
+    // Handle hotkey input. Warp is a HELMS-category shortcut.
     if (key.category == "HELMS" && my_spaceship)
     {
         if (key.hotkey == "WARP_0")

--- a/src/spaceObjects/spaceship.cpp
+++ b/src/spaceObjects/spaceship.cpp
@@ -456,7 +456,7 @@ void SpaceShip::update(float delta)
             impulse_request = 0.0;
         }
         if ((docking_state == DS_Docked) || (docking_state == DS_Docking))
-            warp_request= 0.0;
+            warp_request = 0.0;
     }
 
     float rotationDiff = sf::angleDifference(getRotation(), target_rotation);


### PR DESCRIPTION
When initializing the warp slider, set it to the current warp_request.

When leaving a crew screen while the warp slider is set to a value, then returning to a screen that contains a warp slider, the slider is set to 0 upon return instead of the warp request. This resolves this issue.