### PR TITLE
Revise options menu, add sound volume control

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -226,6 +226,7 @@ int main(int argc, char** argv)
     }
 
     soundManager->setMusicVolume(PreferencesManager::get("music_volume", "50").toFloat());
+    soundManager->setMasterSoundVolume(PreferencesManager::get("sound_volume", "50").toFloat());
 
     if (PreferencesManager::get("disable_shaders").toInt())
         PostProcessor::setEnable(false);
@@ -311,8 +312,9 @@ int main(int argc, char** argv)
         PreferencesManager::set("fullscreen", windowManager->isFullscreen() ? 1 : 0);
     }
 
-    // Set the default music_volume option to the current volume.
+    // Set the default music_volume and sound_volume to the current volume.
     PreferencesManager::set("music_volume", soundManager->getMusicVolume());
+    PreferencesManager::set("sound_volume", soundManager->getMasterSoundVolume());
 
     // Enable music on the main screen only by default.
     if (PreferencesManager::get("music_enabled").empty())

--- a/src/menus/optionsMenu.cpp
+++ b/src/menus/optionsMenu.cpp
@@ -18,15 +18,25 @@ OptionsMenu::OptionsMenu()
     new GuiOverlay(this, "", colorConfig.background);
     (new GuiOverlay(this, "", sf::Color::White))->setTextureTiled("gui/BackgroundCrosses");
 
-    (new GuiButton(this, "FULLSCREEN", "Fullscreen toggle", []()
+    // Left column, manual layout. Draw first element at 50px from top.
+    int top = 50;
+
+    // Graphics options.
+    (new GuiLabel(this, "GRAPHICS_OPTIONS_LABEL", "Graphics Options", 30))->addBackground()->setPosition(50, top, ATopLeft)->setSize(300, 50);
+
+    // Fullscreen toggle.
+    top += 50;
+    (new GuiButton(this, "FULLSCREEN_TOGGLE", "Fullscreen toggle", []()
     {
         P<WindowManager> windowManager = engine->getObject("windowManager");
         windowManager->setFullscreen(!windowManager->isFullscreen());
-    }))->setPosition(50, 100, ATopLeft)->setSize(300, 50);
+    }))->setPosition(50, top, ATopLeft)->setSize(300, 50);
 
-    // Add fsaa selector.
+    // FSAA configuration.
     int fsaa = std::max(1, windowManager->getFSAA());
     int fsaa_index = 0;
+
+    // Convert selector index to an FSAA amount.
     switch(fsaa)
     {
         case 8: fsaa_index = 3; break;
@@ -34,49 +44,107 @@ OptionsMenu::OptionsMenu()
         case 2: fsaa_index = 1; break;
         default: fsaa_index = 0; break;
     }
+
+    // FSAA selector.
+    top += 50;
     (new GuiSelector(this, "FSAA", [](int index, string value)
     {
         P<WindowManager> windowManager = engine->getObject("windowManager");
         static const int fsaa[] = { 0, 2, 4, 8 };
         windowManager->setFSAA(fsaa[index]);
-    }))->setOptions({"FSAA: off", "FSAA: 2x", "FSAA: 4x", "FSAA: 8x"})->setSelectionIndex(fsaa_index)->setPosition(50, 160, ATopLeft)->setSize(300, 50);
+    }))->setOptions({"FSAA: off", "FSAA: 2x", "FSAA: 4x", "FSAA: 8x"})->setSelectionIndex(fsaa_index)->setPosition(50, top, ATopLeft)->setSize(300, 50);
 
-    // Add music selection
-    (new GuiLabel(this, "MUSIC_ENABLED_LABEL", "Music", 30))->addBackground()->setPosition(50, 220, ATopLeft)->setSize(300, 50);
+    // Sound options.
+    top += 60;
+    (new GuiLabel(this, "SOUND_OPTIONS_LABEL", "Sound Options", 30))->addBackground()->setPosition(50, top, ATopLeft)->setSize(300, 50);
 
+    // Sound volume slider.
+    top += 50;
+    sound_volume_slider = new GuiSlider(this, "SOUND_VOLUME_SLIDER", 0.0f, 100.0f, soundManager->getMasterSoundVolume(), [this](float volume)
+    {
+        soundManager->setMasterSoundVolume(volume);
+        sound_volume_overlay_label->setText("Sound Volume: " + string(soundManager->getMasterSoundVolume()) + "%");
+    });
+    sound_volume_slider->setPosition(50, top, ATopLeft)->setSize(300, 50);
+
+    // Override overlay label.
+    sound_volume_overlay_label = new GuiLabel(sound_volume_slider, "SOUND_VOLUME_SLIDER_LABEL", "Sound Volume: " + string(soundManager->getMasterSoundVolume()) + "%", 30);
+    sound_volume_overlay_label->setSize(GuiElement::GuiSizeMax, GuiElement::GuiSizeMax);
+
+    // Music volume slider.
+    top += 50;
+    music_volume_slider = new GuiSlider(this, "MUSIC_VOLUME_SLIDER", 0.0f, 100.0f, soundManager->getMusicVolume(), [this](float volume)
+    {
+        soundManager->setMusicVolume(volume);
+        music_volume_overlay_label->setText("Music Volume: " + string(soundManager->getMusicVolume()) + "%");
+    });
+    music_volume_slider->setPosition(50, top, ATopLeft)->setSize(300, 50);
+
+    // Override overlay label.
+    music_volume_overlay_label = new GuiLabel(music_volume_slider, "MUSIC_VOLUME_SLIDER_LABEL", "Music Volume: " + string(soundManager->getMusicVolume()) + "%", 30);
+    music_volume_overlay_label->setSize(GuiElement::GuiSizeMax, GuiElement::GuiSizeMax);
+
+    // Music playback state.
+    top += 60;
+    (new GuiLabel(this, "MUSIC_PLAYBACK_LABEL", "Music Playback", 30))->addBackground()->setPosition(50, top, ATopLeft)->setSize(300, 50);
+
+    // Determine when music is enabled.
     int music_enabled_index = PreferencesManager::get("music_enabled", "2").toInt();
+    top += 50;
     (new GuiSelector(this, "MUSIC_ENABLED", [](int index, string value)
     {
         // 0: Always off
         // 1: Always on
         // 2: On if main screen, off otherwise (default)
         PreferencesManager::set("music_enabled", string(index));
-    }))->setOptions({"Disabled", "Enabled", "Main Screen only"})->setSelectionIndex(music_enabled_index)->setPosition(50, 270, ATopLeft)->setSize(300, 50);
+    }))->setOptions({"Disabled", "Enabled", "Main Screen only"})->setSelectionIndex(music_enabled_index)->setPosition(50, top, ATopLeft)->setSize(300, 50);
 
-    (new GuiLabel(this, "MUSIC_VOL_LABEL", "Music volume", 30))->addBackground()->setPosition(50, 330, ATopLeft)->setSize(300, 50);
+    // Right column, manual layout. Draw first element 50px from top.
+    top = 50;
 
-    (new GuiSlider(this, "MUSIC_VOL", 0, 100, soundManager->getMusicVolume(), [](float volume)
-    {
-        soundManager->setMusicVolume(volume);
-    }))->setPosition(50, 380, ATopLeft)->setSize(300, 50);
+    // Music preview jukebox.
+    (new GuiLabel(this, "MUSIC_PREVIEW_LABEL", "Preview Soundtrack", 30))->addBackground()->setPosition(-50, top, ATopRight)->setSize(600, 50);
 
-    (new GuiButton(this, "BACK", "Back", [this]()
-    {
-        destroy();
-        returnToMainMenu();
-    }))->setPosition(50, -50, ABottomLeft)->setSize(300, 50);
-
-    (new GuiLabel(this, "MUSIC_SELECT_LABEL", "Select Soundtrack", 30))->addBackground()->setPosition(-50, 50, ATopRight)->setSize(600, 50);
+    // Draw list of available music. Grabs every ogg file in the music folder
+    // and lists them by filename.
+    // TODO: Associate ambient and combat music within the list.
+    top += 50;
     GuiListbox* music_list = new GuiListbox(this, "MUSIC_PLAY", [this](int index, string value)
     {
         soundManager->playMusic(value);
     });
-    music_list->setPosition(-50, 100, ATopRight)->setSize(600, 800);
+    music_list->setPosition(-50, top, ATopRight)->setSize(600, 800);
 
     std::vector<string> music_filenames = findResources("music/*.ogg");
     std::sort(music_filenames.begin(), music_filenames.end());
     for(string filename : music_filenames)
     {
         music_list->addEntry(filename.substr(filename.rfind("/") + 1, filename.rfind(".")), filename);
+    }
+
+    // Bottom GUI.
+    // Back button.
+    (new GuiButton(this, "BACK", "Back", [this]()
+    {
+        // Close this menu, stop the music, and return to the main menu.
+        destroy();
+        soundManager->stopMusic();
+        returnToMainMenu();
+    }))->setPosition(50, -50, ABottomLeft)->setSize(300, 50);
+}
+
+void OptionsMenu::onKey(sf::Event::KeyEvent key, int unicode)
+{
+    switch(key.code)
+    {
+    //TODO: This is more generic code and is duplicated.
+    case sf::Keyboard::Escape:
+    case sf::Keyboard::Home:
+        destroy();
+        soundManager->stopMusic();
+        returnToMainMenu();
+        break;
+    default:
+        break;
     }
 }

--- a/src/menus/optionsMenu.cpp
+++ b/src/menus/optionsMenu.cpp
@@ -63,12 +63,12 @@ OptionsMenu::OptionsMenu()
     sound_volume_slider = new GuiSlider(this, "SOUND_VOLUME_SLIDER", 0.0f, 100.0f, soundManager->getMasterSoundVolume(), [this](float volume)
     {
         soundManager->setMasterSoundVolume(volume);
-        sound_volume_overlay_label->setText("Sound Volume: " + string(soundManager->getMasterSoundVolume()) + "%");
+        sound_volume_overlay_label->setText("Sound Volume: " + string(int(soundManager->getMasterSoundVolume())) + "%");
     });
     sound_volume_slider->setPosition(50, top, ATopLeft)->setSize(300, 50);
 
     // Override overlay label.
-    sound_volume_overlay_label = new GuiLabel(sound_volume_slider, "SOUND_VOLUME_SLIDER_LABEL", "Sound Volume: " + string(soundManager->getMasterSoundVolume()) + "%", 30);
+    sound_volume_overlay_label = new GuiLabel(sound_volume_slider, "SOUND_VOLUME_SLIDER_LABEL", "Sound Volume: " + string(int(soundManager->getMasterSoundVolume())) + "%", 30);
     sound_volume_overlay_label->setSize(GuiElement::GuiSizeMax, GuiElement::GuiSizeMax);
 
     // Music volume slider.
@@ -76,12 +76,12 @@ OptionsMenu::OptionsMenu()
     music_volume_slider = new GuiSlider(this, "MUSIC_VOLUME_SLIDER", 0.0f, 100.0f, soundManager->getMusicVolume(), [this](float volume)
     {
         soundManager->setMusicVolume(volume);
-        music_volume_overlay_label->setText("Music Volume: " + string(soundManager->getMusicVolume()) + "%");
+        music_volume_overlay_label->setText("Music Volume: " + string(int(soundManager->getMusicVolume())) + "%");
     });
     music_volume_slider->setPosition(50, top, ATopLeft)->setSize(300, 50);
 
     // Override overlay label.
-    music_volume_overlay_label = new GuiLabel(music_volume_slider, "MUSIC_VOLUME_SLIDER_LABEL", "Music Volume: " + string(soundManager->getMusicVolume()) + "%", 30);
+    music_volume_overlay_label = new GuiLabel(music_volume_slider, "MUSIC_VOLUME_SLIDER_LABEL", "Music Volume: " + string(int(soundManager->getMusicVolume())) + "%", 30);
     music_volume_overlay_label->setSize(GuiElement::GuiSizeMax, GuiElement::GuiSizeMax);
 
     // Music playback state.

--- a/src/menus/optionsMenu.h
+++ b/src/menus/optionsMenu.h
@@ -1,12 +1,21 @@
-#ifndef OPTION_MENU_H
-#define OPTION_MENU_H
+#ifndef OPTIONS_MENU_H
+#define OPTIONS_MENU_H
 
 #include "gui/gui2_canvas.h"
 
+class GuiSlider;
+class GuiLabel;
+
 class OptionsMenu : public GuiCanvas
 {
+private:
+    GuiSlider* sound_volume_slider;
+    GuiSlider* music_volume_slider;
+    GuiLabel* sound_volume_overlay_label;
+    GuiLabel* music_volume_overlay_label;
 public:
     OptionsMenu();
-};
 
-#endif//MAIN_MENUS_H
+    void onKey(sf::Event::KeyEvent key, int unicode);
+};
+#endif//OPTIONS_MENU_H


### PR DESCRIPTION
-   Add a slider to control sound volume on the options screen.

-   Revise the options screen layout.
    
![options-rev](https://cloud.githubusercontent.com/assets/19192104/16786678/6d69b8e0-484b-11e6-8fd0-77633a988b2c.png)

-   Save sound volume to `options.ini` as `sound_volume`.

Relies on [SeriousProton PR #17](https://github.com/daid/SeriousProton/pull/17).