### PR TITLE
Standardize or revise include guards

### DIFF
--- a/src/ai/ai.h
+++ b/src/ai/ai.h
@@ -1,5 +1,5 @@
-#ifndef SHIP_AI_H
-#define SHIP_AI_H
+#ifndef AI_H
+#define AI_H
 
 #include <SFML/System.hpp>
 #include "pathPlanner.h"
@@ -82,4 +82,4 @@ protected:
     friend class GameMasterUI;
 };
 
-#endif//SHIP_AI_H
+#endif//AI_H

--- a/src/ai/aiFactory.h
+++ b/src/ai/aiFactory.h
@@ -1,5 +1,5 @@
-#ifndef SHIP_AI_FACTORY_H
-#define SHIP_AI_FACTORY_H
+#ifndef AI_FACTORY_H
+#define AI_FACTORY_H
 
 #include "engine.h"
 
@@ -26,4 +26,4 @@ public:
     static ShipAI* c ## _factory_function (CpuShip* owner) { return new c(owner); } \
     ShipAIFactory c ## _factory(n, c ## _factory_function )
 
-#endif//SHIP_AI_FACTORY_H
+#endif//AI_FACTORY_H

--- a/src/ai/missileVolleyAI.h
+++ b/src/ai/missileVolleyAI.h
@@ -1,5 +1,5 @@
-#ifndef FIGHTER_AI_H
-#define FIGHTER_AI_H
+#ifndef MISSILE_VOLLEY_AI_H
+#define MISSILE_VOLLEY_AI_H
 
 #include "ai.h"
 
@@ -29,4 +29,4 @@ public:
 };
 
 
-#endif//FIGHTER_AI_H
+#endif//MISSILE_VOLLEY_AI_H

--- a/src/beamTemplate.h
+++ b/src/beamTemplate.h
@@ -68,4 +68,4 @@ protected:
     float heat_per_beam_fire;
 };
 
-#endif //BEAM_TEMPLATE_H
+#endif//BEAM_TEMPLATE_H

--- a/src/commsScriptInterface.h
+++ b/src/commsScriptInterface.h
@@ -24,5 +24,4 @@ private:
     P<SpaceObject> target;
 };
 
-
 #endif//COMMS_SCRIPT_INTERFACE_H

--- a/src/epsilonServer.h
+++ b/src/epsilonServer.h
@@ -1,5 +1,5 @@
-#ifndef REDONCULUS_SERVER_H
-#define REDONCULUS_SERVER_H
+#ifndef EPSILON_SERVER_H
+#define EPSILON_SERVER_H
 
 #include "engine.h"
 
@@ -15,4 +15,4 @@ public:
 
 void disconnectFromServer();
 
-#endif//REDONCULUS_SERVER_H
+#endif//EPSILON_SERVER_H

--- a/src/factionInfo.h
+++ b/src/factionInfo.h
@@ -71,9 +71,8 @@ public:
 
     static unsigned int findFactionId(string name);
 protected:
-
     string name;
     string description;
 };
 
-#endif//Faction_INFO_H
+#endif//FACTION_INFO_H

--- a/src/featureDefs.h
+++ b/src/featureDefs.h
@@ -1,5 +1,5 @@
-#ifndef FEATURES_H
-#define FEATURES_H
+#ifndef FEATURE_DEFS_H
+#define FEATURE_DEFS_H
 
 // Android doesn't bundle 3D models or music.
 #ifndef FEATURE_3D_RENDERING
@@ -14,4 +14,4 @@
 
 #define DISTANCE_UNIT_1K "u"
 
-#endif//FEATURES_H
+#endif//FEATURE_DEFS_H

--- a/src/gui/gui2_advancedscrolltext.h
+++ b/src/gui/gui2_advancedscrolltext.h
@@ -1,5 +1,5 @@
-#ifndef GUI2_ADVANCED_SCROLL_TEST_H
-#define GUI2_ADVANCED_SCROLL_TEST_H
+#ifndef GUI2_ADVANCEDSCROLLTEXT_H
+#define GUI2_ADVANCEDSCROLLTEXT_H
 
 #include "gui2_element.h"
 #include "gui2_scrollbar.h"
@@ -36,4 +36,4 @@ public:
     virtual void onDraw(sf::RenderTarget& window);
 };
 
-#endif//GUI2_ADVANCED_SCROLL_TEST_H
+#endif//GUI2_ADVANCEDSCROLLTEXT_H

--- a/src/gui/gui2_arrow.h
+++ b/src/gui/gui2_arrow.h
@@ -17,4 +17,4 @@ public:
     GuiArrow* setAngle(float angle) { this->angle = angle; return this; }
 };
 
-#endif//GUI2_BOX_H
+#endif//GUI2_ARROW_H

--- a/src/gui/gui2_arrowbutton.h
+++ b/src/gui/gui2_arrowbutton.h
@@ -13,4 +13,4 @@ public:
     virtual void onDraw(sf::RenderTarget& window);
 };
 
-#endif//GUI2_BUTTON_H
+#endif//GUI2_ARROWBUTTON_H

--- a/src/gui/gui2_autolayout.h
+++ b/src/gui/gui2_autolayout.h
@@ -1,5 +1,5 @@
-#ifndef GUI2_AUTO_LAYOUT_H
-#define GUI2_AUTO_LAYOUT_H
+#ifndef GUI2_AUTOLAYOUT_H
+#define GUI2_AUTOLAYOUT_H
 
 #include "gui2_element.h"
 
@@ -27,4 +27,4 @@ protected:
     virtual void drawElements(sf::FloatRect parent_rect, sf::RenderTarget& window);
 };
 
-#endif//GUI2_AUTO_LAYOUT_H
+#endif//GUI2_AUTOLAYOUT_H

--- a/src/gui/gui2_entrylist.h
+++ b/src/gui/gui2_entrylist.h
@@ -1,5 +1,5 @@
-#ifndef GUI2_ENTRY_LIST_H
-#define GUI2_ENTRY_LIST_H
+#ifndef GUI2_ENTRYLIST_H
+#define GUI2_ENTRYLIST_H
 
 #include "gui2_element.h"
 #include "gui2_button.h"
@@ -49,5 +49,4 @@ private:
     virtual void entriesChanged();
 };
 
-#endif//GUI2_ENTRY_LIST_H
-
+#endif//GUI2_ENTRYLIST_H

--- a/src/gui/gui2_image.h
+++ b/src/gui/gui2_image.h
@@ -18,4 +18,4 @@ public:
     GuiImage* setAngle(float angle) { this->angle = angle; return this; }
 };
 
-#endif//GUI2_BOX_H
+#endif//GUI2_IMAGE_H

--- a/src/gui/gui2_keyvaluedisplay.h
+++ b/src/gui/gui2_keyvaluedisplay.h
@@ -1,5 +1,5 @@
-#ifndef GUI_KEY_VALUE_DISPLAY_H
-#define GUI_KEY_VALUE_DISPLAY_H
+#ifndef GUI_KEYVALUEDISPLAY_H
+#define GUI_KEYVALUEDISPLAY_H
 
 #include "gui2_element.h"
 
@@ -24,4 +24,4 @@ public:
     GuiKeyValueDisplay* setIcon(string icon_texture);
 };
 
-#endif//GUI_KEY_VALUE_DISPLAY_H
+#endif//GUI_KEYVALUEDISPLAY_H

--- a/src/gui/gui2_label.h
+++ b/src/gui/gui2_label.h
@@ -26,5 +26,4 @@ public:
     GuiLabel* setBold(bool bold=true);
 };
 
-
 #endif//GUI2_LABEL_H

--- a/src/gui/gui2_listbox.h
+++ b/src/gui/gui2_listbox.h
@@ -1,5 +1,5 @@
-#ifndef LISTBOX_H
-#define LISTBOX_H
+#ifndef GUI2_LISTBOX_H
+#define GUI2_LISTBOX_H
 
 #include "gui2_element.h"
 #include "gui2_entrylist.h"
@@ -30,4 +30,4 @@ private:
     virtual void entriesChanged();
 };
 
-#endif//LISTBOX_H
+#endif//GUI2_LISTBOX_H

--- a/src/gui/gui2_panel.h
+++ b/src/gui/gui2_panel.h
@@ -12,5 +12,4 @@ public:
     virtual bool onMouseDown(sf::Vector2f position) override;
 };
 
-#endif//GUI2_BOX_H
-
+#endif//GUI2_PANEL_H

--- a/src/gui/gui2_progressbar.h
+++ b/src/gui/gui2_progressbar.h
@@ -1,5 +1,5 @@
-#ifndef GUI2_PROGRESS_BAR_H
-#define GUI2_PROGRESS_BAR_H
+#ifndef GUI2_PROGRESSBAR_H
+#define GUI2_PROGRESSBAR_H
 
 #include "gui2_element.h"
 
@@ -25,4 +25,4 @@ public:
     GuiProgressbar* setDrawBackground(bool drawBackground);
 };
 
-#endif//GUI2_PROGRESS_BAR_H
+#endif//GUI2_PROGRESSBAR_H

--- a/src/gui/gui2_resizabledialog.h
+++ b/src/gui/gui2_resizabledialog.h
@@ -1,5 +1,5 @@
-#ifndef GUI2_RESIZABLE_DIALOG_H
-#define GUI2_RESIZABLE_DIALOG_H
+#ifndef GUI2_RESIZABLEDIALOG_H
+#define GUI2_RESIZABLEDIALOG_H
 
 #include "gui2_panel.h"
 
@@ -45,4 +45,4 @@ protected:
     GuiElement* contents;
 };
 
-#endif//GUI2_RESIZABLE_DIALOG_H
+#endif//GUI2_RESIZABLEDIALOG_H

--- a/src/gui/gui2_rotationdial.h
+++ b/src/gui/gui2_rotationdial.h
@@ -1,5 +1,5 @@
-#ifndef GUI2_ROTATION_DAIL_H
-#define GUI2_ROTATION_DAIL_H
+#ifndef GUI2_ROTATIONDIAL_H
+#define GUI2_ROTATIONDIAL_H
 
 #include "gui2_element.h"
 
@@ -24,4 +24,4 @@ public:
     float getValue();
 };
 
-#endif//GUI2_ROTATION_DAIL_H
+#endif//GUI2_ROTATIONDIAL_H

--- a/src/gui/gui2_scrollbar.h
+++ b/src/gui/gui2_scrollbar.h
@@ -33,4 +33,4 @@ public:
     int getMin();
 };
 
-#endif//GUI2_SLIDER_H
+#endif//GUI2_SCROLLBAR_H

--- a/src/gui/gui2_scrolltext.h
+++ b/src/gui/gui2_scrolltext.h
@@ -1,5 +1,5 @@
-#ifndef GUI_SCROLL_TEXT_H
-#define GUI_SCROLL_TEXT_H
+#ifndef GUI_SCROLLTEXT_H
+#define GUI_SCROLLTEXT_H
 
 #include "gui2_element.h"
 #include "gui2_scrollbar.h"
@@ -26,4 +26,4 @@ public:
     virtual void onDraw(sf::RenderTarget& window);
 };
 
-#endif//GUI_SCROLL_TEXT_H
+#endif//GUI_SCROLLTEXT_H

--- a/src/gui/gui2_slider.h
+++ b/src/gui/gui2_slider.h
@@ -67,4 +67,3 @@ public:
 };
 
 #endif//GUI2_SLIDER_H
-

--- a/src/gui/gui2_togglebutton.h
+++ b/src/gui/gui2_togglebutton.h
@@ -1,5 +1,5 @@
-#ifndef GUI2_TOGGLE_BUTTON_H
-#define GUI2_TOGGLE_BUTTON_H
+#ifndef GUI2_TOGGLEBUTTON_H
+#define GUI2_TOGGLEBUTTON_H
 
 #include "gui2_button.h"
 
@@ -20,4 +20,4 @@ private:
     void onClick();
 };
 
-#endif//GUI2_TOGGLE_BUTTON_H
+#endif//GUI2_TOGGLEBUTTON_H

--- a/src/gui/scriptError.h
+++ b/src/gui/scriptError.h
@@ -1,5 +1,5 @@
-#ifndef GUI_SCRIPT_ERROR_H
-#define GUI_SCRIPT_ERROR_H
+#ifndef SCRIPT_ERROR_H
+#define SCRIPT_ERROR_H
 
 #include "engine.h"
 
@@ -11,5 +11,4 @@ public:
     virtual void render(sf::RenderTarget& window);
 };
 
-
-#endif//GUI_SCRIPT_ERROR_H
+#endif//SCRIPT_ERROR_H

--- a/src/hardware/dmx512SerialDevice.h
+++ b/src/hardware/dmx512SerialDevice.h
@@ -35,5 +35,4 @@ private:
     void updateLoop();
 };
 
-
 #endif//DMX512_SERIAL_DEVICE_H

--- a/src/hardware/enttecDMXProDevice.h
+++ b/src/hardware/enttecDMXProDevice.h
@@ -35,5 +35,4 @@ private:
     void updateLoop();
 };
 
-
-#endif//DMX512_SERIAL_DEVICE_H
+#endif//ENTTEC_DMX_PRO_DEVICE_H

--- a/src/hardware/sACNDMXDevice.h
+++ b/src/hardware/sACNDMXDevice.h
@@ -1,5 +1,5 @@
-#ifndef ACN_DMX_DEVICE_H
-#define ACN_DMX_DEVICE_H
+#ifndef S_ACN_DMX_DEVICE_H
+#define S_ACN_DMX_DEVICE_H
 
 #include <SFML/System.hpp>
 #include <SFML/Network.hpp>
@@ -43,5 +43,4 @@ private:
     void updateLoop();
 };
 
-
-#endif//ACN_DMX_DEVICE_H
+#endif//S_ACN_DMX_DEVICE_H

--- a/src/hardware/uDMXDevice.h
+++ b/src/hardware/uDMXDevice.h
@@ -1,5 +1,5 @@
-#ifndef UDMX_SERIAL_DEVICE_H
-#define UDMX_SERIAL_DEVICE_H
+#ifndef UDMX_DEVICE_H
+#define UDMX_DEVICE_H
 
 #include <SFML/System.hpp>
 #include <stdint.h>
@@ -22,6 +22,4 @@ public:
     virtual int getChannelCount();
 };
 
-
-#endif//DMX512_SERIAL_DEVICE_H
-
+#endif//UDMX_DEVICE_H

--- a/src/hardware/virtualOutputDevice.h
+++ b/src/hardware/virtualOutputDevice.h
@@ -45,5 +45,4 @@ public:
     void render(sf::RenderTarget& window);
 };
 
-
-#endif//DMX512_SERIAL_DEVICE_H
+#endif//VIRTUAL_OUTPUT_DEVICE_H

--- a/src/screenComponents/aimLock.h
+++ b/src/screenComponents/aimLock.h
@@ -1,5 +1,5 @@
-#ifndef GUI_AIM_LOCK_H
-#define GUI_AIM_LOCK_H
+#ifndef AIM_LOCK_H
+#define AIM_LOCK_H
 
 #include "gui/gui2_togglebutton.h"
 
@@ -15,4 +15,4 @@ private:
     GuiRotationDial* missile_aim;
 };
 
-#endif//GUI_AIM_LOCK_H
+#endif//AIM_LOCK_H

--- a/src/screenComponents/beamFrequencySelector.h
+++ b/src/screenComponents/beamFrequencySelector.h
@@ -1,5 +1,5 @@
-#ifndef GUI_BEAM_FREQUENCY_SELECTOR_H
-#define GUI_BEAM_FREQUENCY_SELECTOR_H
+#ifndef BEAM_FREQUENCY_SELECTOR_H
+#define BEAM_FREQUENCY_SELECTOR_H
 
 #include "gui/gui2_selector.h"
 
@@ -9,4 +9,4 @@ public:
     GuiBeamFrequencySelector(GuiContainer* owner, string id);
 };
 
-#endif//GUI_BEAM_FREQUENCY_SELECTOR_H
+#endif//BEAM_FREQUENCY_SELECTOR_H

--- a/src/screenComponents/beamTargetSelector.h
+++ b/src/screenComponents/beamTargetSelector.h
@@ -1,5 +1,5 @@
-#ifndef GUI_BEAM_TARGET_SELECTOR_H
-#define GUI_BEAM_TARGET_SELECTOR_H
+#ifndef BEAM_TARGET_SELECTOR_H
+#define BEAM_TARGET_SELECTOR_H
 
 #include "gui/gui2_selector.h"
 
@@ -9,4 +9,4 @@ public:
     GuiBeamTargetSelector(GuiContainer* owner, string id);
 };
 
-#endif//GUI_BEAM_TARGET_SELECTOR_H
+#endif//BEAM_TARGET_SELECTOR_H

--- a/src/screenComponents/combatManeuver.h
+++ b/src/screenComponents/combatManeuver.h
@@ -1,5 +1,5 @@
-#ifndef GUI_COMBAT_MANEUVER_H
-#define GUI_COMBAT_MANEUVER_H
+#ifndef COMBAT_MANEUVER_H
+#define COMBAT_MANEUVER_H
 
 #include "gui/gui2_element.h"
 
@@ -21,4 +21,4 @@ public:
     void setStrafeValue(float value);
 };
 
-#endif//GUI_COMBAT_MANEUVER_H
+#endif//COMBAT_MANEUVER_H

--- a/src/screenComponents/commsOverlay.h
+++ b/src/screenComponents/commsOverlay.h
@@ -1,5 +1,5 @@
-#ifndef GUI_COMMS_OVERLAY_H
-#define GUI_COMMS_OVERLAY_H
+#ifndef COMMS_OVERLAY_H
+#define COMMS_OVERLAY_H
 
 #include "gui/gui2_element.h"
 
@@ -44,5 +44,4 @@ public:
     void clearElements();
 };
 
-#endif//GUI_INDICATOR_OVERLAYS_H
-
+#endif//COMMS_OVERLAY_H

--- a/src/screenComponents/databaseView.h
+++ b/src/screenComponents/databaseView.h
@@ -1,5 +1,5 @@
-#ifndef DATABASE_VIEW_COMPONENT_H
-#define DATABASE_VIEW_COMPONENT_H
+#ifndef DATABASE_VIEW_H
+#define DATABASE_VIEW_H
 
 #include "gui/gui2_element.h"
 
@@ -24,4 +24,4 @@ private:
     GuiElement* database_entry;
 };
 
-#endif//DATABASE_VIEW_COMPONENT_H
+#endif//DATABASE_VIEW_H

--- a/src/screenComponents/dockingButton.h
+++ b/src/screenComponents/dockingButton.h
@@ -1,5 +1,5 @@
-#ifndef GUI_DOCKING_BUTTON_H
-#define GUI_DOCKING_BUTTON_H
+#ifndef DOCKING_BUTTON_H
+#define DOCKING_BUTTON_H
 
 #include "gui/gui2_button.h"
 
@@ -17,4 +17,4 @@ private:
     P<SpaceObject> findDockingTarget();
 };
 
-#endif//GUI_DOCKING_BUTTON_H
+#endif//DOCKING_BUTTON_H

--- a/src/screenComponents/frequencyCurve.h
+++ b/src/screenComponents/frequencyCurve.h
@@ -1,5 +1,5 @@
-#ifndef GUI_FREQUENCY_CURVE_H
-#define GUI_FREQUENCY_CURVE_H
+#ifndef FREQUENCY_CURVE_H
+#define FREQUENCY_CURVE_H
 
 #include "gui/gui2_panel.h"
 
@@ -17,4 +17,4 @@ public:
     GuiFrequencyCurve* setFrequency(int frequency) { this->frequency = frequency; return this; }
 };
 
-#endif//GUI_FREQUENCY_CURVE_H
+#endif//FREQUENCY_CURVE_H

--- a/src/screenComponents/globalMessage.h
+++ b/src/screenComponents/globalMessage.h
@@ -1,5 +1,5 @@
-#ifndef GUI_GLOBAL_MESSAGE_H
-#define GUI_GLOBAL_MESSAGE_H
+#ifndef GLOBAL_MESSAGE_H
+#define GLOBAL_MESSAGE_H
 
 #include "gui/gui2_element.h"
 
@@ -17,4 +17,4 @@ public:
     virtual void onDraw(sf::RenderTarget& window);
 };
 
-#endif//GUI_SELF_DESTRUCT_INDICATOR_H
+#endif//GLOBAL_MESSAGE_H

--- a/src/screenComponents/impulseControls.h
+++ b/src/screenComponents/impulseControls.h
@@ -1,5 +1,5 @@
-#ifndef GUI_IMPULSE_CONTROLS_H
-#define GUI_IMPULSE_CONTROLS_H
+#ifndef IMPULSE_CONTROLS_H
+#define IMPULSE_CONTROLS_H
 
 #include "gui/gui2_element.h"
 
@@ -18,4 +18,4 @@ public:
     virtual void onHotkey(const HotkeyResult& key) override;
 };
 
-#endif//GUI_IMPULSE_CONTROLS_H
+#endif//IMPULSE_CONTROLS_H

--- a/src/screenComponents/indicatorOverlays.h
+++ b/src/screenComponents/indicatorOverlays.h
@@ -1,5 +1,5 @@
-#ifndef GUI_INDICATOR_OVERLAYS_H
-#define GUI_INDICATOR_OVERLAYS_H
+#ifndef INDICATOR_OVERLAYS_H
+#define INDICATOR_OVERLAYS_H
 
 #include "gui/gui2_element.h"
 
@@ -34,4 +34,4 @@ private:
     void drawAlertLevel(sf::RenderTarget& window);
 };
 
-#endif//GUI_INDICATOR_OVERLAYS_H
+#endif//INDICATOR_OVERLAYS_H

--- a/src/screenComponents/jumpControls.h
+++ b/src/screenComponents/jumpControls.h
@@ -1,5 +1,5 @@
-#ifndef GUI_JUMP_CONTROLS_H
-#define GUI_JUMP_CONTROLS_H
+#ifndef JUMP_CONTROLS_H
+#define JUMP_CONTROLS_H
 
 #include "gui/gui2_element.h"
 
@@ -22,4 +22,4 @@ public:
     virtual void onHotkey(const HotkeyResult& key) override;
 };
 
-#endif//GUI_JUMP_CONTROLS_H
+#endif//JUMP_CONTROLS_H

--- a/src/screenComponents/jumpIndicator.h
+++ b/src/screenComponents/jumpIndicator.h
@@ -1,5 +1,5 @@
-#ifndef GUI_JUMP_INDICATOR_H
-#define GUI_JUMP_INDICATOR_H
+#ifndef JUMP_INDICATOR_H
+#define JUMP_INDICATOR_H
 
 #include "gui/gui2_element.h"
 
@@ -17,4 +17,4 @@ public:
     virtual void onDraw(sf::RenderTarget& window);
 };
 
-#endif//GUI_SELF_DESTRUCT_INDICATOR_H
+#endif//JUMP_INDICATOR_H

--- a/src/screenComponents/missileTubeControls.h
+++ b/src/screenComponents/missileTubeControls.h
@@ -1,5 +1,5 @@
-#ifndef GUI_MISSILE_TUBE_CONTROLS_H
-#define GUI_MISSILE_TUBE_CONTROLS_H
+#ifndef MISSILE_TUBE_CONTROLS_H
+#define MISSILE_TUBE_CONTROLS_H
 
 #include "gui/gui2_autolayout.h"
 #include "missileWeaponData.h"
@@ -41,4 +41,4 @@ public:
     bool getManualAim();
 };
 
-#endif//GUI_MISSILE_TUBE_CONTROLS_H
+#endif//MISSILE_TUBE_CONTROLS_H

--- a/src/screenComponents/noiseOverlay.h
+++ b/src/screenComponents/noiseOverlay.h
@@ -1,5 +1,5 @@
-#ifndef GUI_NOISE_OVERLAY_H
-#define GUI_NOISE_OVERLAY_H
+#ifndef NOISE_OVERLAY_H
+#define NOISE_OVERLAY_H
 
 #include "gui/gui2_element.h"
 
@@ -11,4 +11,4 @@ public:
     virtual void onDraw(sf::RenderTarget& window);
 };
 
-#endif//GUI_NOISE_OVERLAY_H
+#endif//NOISE_OVERLAY_H

--- a/src/screenComponents/openCommsButton.h
+++ b/src/screenComponents/openCommsButton.h
@@ -1,5 +1,5 @@
-#ifndef GUI_OPEN_COMMS_BUTTON_H
-#define GUI_OPEN_COMMS_BUTTON_H
+#ifndef OPEN_COMMS_BUTTON_H
+#define OPEN_COMMS_BUTTON_H
 
 #include "gui/gui2_button.h"
 
@@ -14,4 +14,4 @@ public:
     virtual void onDraw(sf::RenderTarget& window);
 };
 
-#endif//GUI_OPEN_COMMS_BUTTON_H
+#endif//OPEN_COMMS_BUTTON_H

--- a/src/screenComponents/powerDamageIndicator.h
+++ b/src/screenComponents/powerDamageIndicator.h
@@ -1,5 +1,5 @@
-#ifndef GUI_POWER_DAMAGE_INDICATOR_H
-#define GUI_POWER_DAMAGE_INDICATOR_H
+#ifndef POWER_DAMAGE_INDICATOR_H
+#define POWER_DAMAGE_INDICATOR_H
 
 #include "gui/gui2_element.h"
 #include "shipTemplate.h"
@@ -23,4 +23,4 @@ private:
     void drawIcon(sf::RenderTarget& window, string icon_name, sf::Color color);
 };
 
-#endif//GUI_POWER_DAMAGE_INDICATOR_H
+#endif//POWER_DAMAGE_INDICATOR_H

--- a/src/screenComponents/radarView.h
+++ b/src/screenComponents/radarView.h
@@ -1,5 +1,5 @@
-#ifndef GUI_RADAR_VIEW_H
-#define GUI_RADAR_VIEW_H
+#ifndef RADAR_VIEW_H
+#define RADAR_VIEW_H
 
 #include "gui/gui2_element.h"
 
@@ -128,4 +128,4 @@ private:
     void drawRadarCutoff(sf::RenderTarget& window);
 };
 
-#endif//GUI_RADAR_VIEW_H
+#endif//RADAR_VIEW_H

--- a/src/screenComponents/rotatingModelView.h
+++ b/src/screenComponents/rotatingModelView.h
@@ -1,5 +1,5 @@
-#ifndef GUI_ROTATING_MODEL_VIEW_H
-#define GUI_ROTATING_MODEL_VIEW_H
+#ifndef ROTATING_MODEL_VIEW_H
+#define ROTATING_MODEL_VIEW_H
 
 #include "gui/gui2_element.h"
 #include "modelData.h"
@@ -14,5 +14,4 @@ public:
     virtual void onDraw(sf::RenderTarget& window);
 };
 
-#endif//GUI_COMBAT_MANEUVER_H
-
+#endif//ROTATING_MODEL_VIEW_H

--- a/src/screenComponents/scanTargetButton.h
+++ b/src/screenComponents/scanTargetButton.h
@@ -1,5 +1,5 @@
-#ifndef GUI_SCAN_TARGET_BUTTON_H
-#define GUI_SCAN_TARGET_BUTTON_H
+#ifndef SCAN_TARGET_BUTTON_H
+#define SCAN_TARGET_BUTTON_H
 
 #include "gui/gui2_element.h"
 
@@ -19,4 +19,4 @@ public:
     virtual void onDraw(sf::RenderTarget& window);
 };
 
-#endif//GUI_SCAN_TARGET_BUTTON_H
+#endif//SCAN_TARGET_BUTTON_H

--- a/src/screenComponents/scanningDialog.h
+++ b/src/screenComponents/scanningDialog.h
@@ -1,5 +1,5 @@
-#ifndef GUI_SCANNING_DIALOG_H
-#define GUI_SCANNING_DIALOG_H
+#ifndef SCANNING_DIALOG_H
+#define SCANNING_DIALOG_H
 
 #include "gui/gui2_element.h"
 #include "signalQualityIndicator.h"
@@ -35,4 +35,4 @@ public:
     void updateSignal();
 };
 
-#endif//GUI_SCANNING_DIALOG_H
+#endif//SCANNING_DIALOG_H

--- a/src/screenComponents/selfDestructButton.h
+++ b/src/screenComponents/selfDestructButton.h
@@ -1,5 +1,5 @@
-#ifndef GUI_SELF_DESTRUCT_BUTTON_H
-#define GUI_SELF_DESTRUCT_BUTTON_H
+#ifndef SELF_DESTRUCT_BUTTON_H
+#define SELF_DESTRUCT_BUTTON_H
 
 #include "gui/gui2_element.h"
 
@@ -17,4 +17,4 @@ public:
     virtual void onDraw(sf::RenderTarget& window);
 };
 
-#endif//GUI_SELF_DESTRUCT_BUTTON_H
+#endif//SELF_DESTRUCT_BUTTON_H

--- a/src/screenComponents/selfDestructEntry.h
+++ b/src/screenComponents/selfDestructEntry.h
@@ -1,5 +1,5 @@
-#ifndef GUI_SELF_DESTRUCT_ENTRY_H
-#define GUI_SELF_DESTRUCT_ENTRY_H
+#ifndef SELF_DESTRUCT_ENTRY_H
+#define SELF_DESTRUCT_ENTRY_H
 
 #include "gui/gui2_element.h"
 #include "spaceObjects/playerSpaceship.h"
@@ -26,4 +26,4 @@ public:
     void enablePosition(ECrewPosition position) { has_position[position] = true; }
 };
 
-#endif//GUI_SELF_DESTRUCT_ENTRY_H
+#endif//SELF_DESTRUCT_ENTRY_H

--- a/src/screenComponents/selfDestructIndicator.h
+++ b/src/screenComponents/selfDestructIndicator.h
@@ -1,5 +1,5 @@
-#ifndef GUI_SELF_DESTRUCT_INDICATOR_H
-#define GUI_SELF_DESTRUCT_INDICATOR_H
+#ifndef SELF_DESTRUCT_INDICATOR_H
+#define SELF_DESTRUCT_INDICATOR_H
 
 #include "gui/gui2_element.h"
 
@@ -17,4 +17,4 @@ public:
     virtual void onDraw(sf::RenderTarget& window);
 };
 
-#endif//GUI_SELF_DESTRUCT_INDICATOR_H
+#endif//SELF_DESTRUCT_INDICATOR_H

--- a/src/screenComponents/shieldFreqencySelect.h
+++ b/src/screenComponents/shieldFreqencySelect.h
@@ -1,5 +1,5 @@
-#ifndef GUI_SHIELD_FREQUENCY_SELECT_H
-#define GUI_SHIELD_FREQUENCY_SELECT_H
+#ifndef SHIELD_FREQUENCY_SELECT_H
+#define SHIELD_FREQUENCY_SELECT_H
 
 #include "gui/gui2_element.h"
 
@@ -19,4 +19,4 @@ public:
     virtual void onDraw(sf::RenderTarget& window);
 };
 
-#endif//GUI_SHIELD_FREQUENCY_SELECT_H
+#endif//SHIELD_FREQUENCY_SELECT_H

--- a/src/screenComponents/shieldsEnableButton.h
+++ b/src/screenComponents/shieldsEnableButton.h
@@ -1,5 +1,5 @@
-#ifndef GUI_SHIELDS_ENABLE_H
-#define GUI_SHIELDS_ENABLE_H
+#ifndef SHIELDS_ENABLE_BUTTON_H
+#define SHIELDS_ENABLE_BUTTON_H
 
 #include "gui/gui2_element.h"
 
@@ -17,4 +17,4 @@ public:
     virtual void onDraw(sf::RenderTarget& window);
 };
 
-#endif//GUI_SHIELDS_ENABLE_H
+#endif//SHIELDS_ENABLE_BUTTON_H

--- a/src/screenComponents/shipDestroyedPopup.h
+++ b/src/screenComponents/shipDestroyedPopup.h
@@ -1,5 +1,5 @@
-#ifndef GUI_SHIP_DESTROYED_RETURN_TIMEOUT_H
-#define GUI_SHIP_DESTROYED_RETURN_TIMEOUT_H
+#ifndef SHIP_DESTROYED_POPUP_H
+#define SHIP_DESTROYED_POPUP_H
 
 #include "gui/gui2_element.h"
 
@@ -18,4 +18,4 @@ public:
     virtual void onDraw(sf::RenderTarget& window);
 };
 
-#endif//GUI_SHIP_DESTROYED_RETURN_TIMEOUT_H
+#endif//SHIP_DESTROYED_POPUP_H

--- a/src/screenComponents/shipInternalView.h
+++ b/src/screenComponents/shipInternalView.h
@@ -1,5 +1,5 @@
-#ifndef GUI_SHIP_INTERNAL_VIEW_H
-#define GUI_SHIP_INTERNAL_VIEW_H
+#ifndef SHIP_INTERNAL_VIEW_H
+#define SHIP_INTERNAL_VIEW_H
 
 #include "gui/gui2_element.h"
 #include "spaceObjects/spaceship.h"
@@ -94,4 +94,4 @@ public:
     virtual void onMouseUp(sf::Vector2f position);
 };
 
-#endif//GUI_SHIP_INTERNAL_VIEW_H
+#endif//SHIP_INTERNAL_VIEW_H

--- a/src/screenComponents/signalQualityIndicator.h
+++ b/src/screenComponents/signalQualityIndicator.h
@@ -1,5 +1,5 @@
-#ifndef GUI_SIGNAL_QUALITY_INDICATOR_H
-#define GUI_SIGNAL_QUALITY_INDICATOR_H
+#ifndef SIGNAL_QUALITY_INDICATOR_H
+#define SIGNAL_QUALITY_INDICATOR_H
 
 #include <math.h>
 
@@ -22,4 +22,4 @@ public:
     void setPhaseError(float f) { error_phase = std::min(fabsf(f), 1.0f); }
 };
 
-#endif//GUI_SIGNAL_QUALITY_INDICATOR_H
+#endif//SIGNAL_QUALITY_INDICATOR_H

--- a/src/screenComponents/viewport3d.h
+++ b/src/screenComponents/viewport3d.h
@@ -1,5 +1,5 @@
-#ifndef GUI_VIEWPORT_3D_H
-#define GUI_VIEWPORT_3D_H
+#ifndef VIEWPORT_3D_H
+#define VIEWPORT_3D_H
 
 #include "gui/gui2_element.h"
 
@@ -24,4 +24,4 @@ private:
     sf::Vector3f worldToScreen(sf::RenderTarget& window, sf::Vector3f world);
 };
 
-#endif//GUI_VIEWPORT_3D_H
+#endif//VIEWPORT_3D_H

--- a/src/screenComponents/warpControls.h
+++ b/src/screenComponents/warpControls.h
@@ -1,5 +1,5 @@
-#ifndef GUI_WARP_CONTROLS_H
-#define GUI_WARP_CONTROLS_H
+#ifndef WARP_CONTROLS_H
+#define WARP_CONTROLS_H
 
 #include "gui/gui2_element.h"
 
@@ -18,4 +18,4 @@ public:
     virtual void onHotkey(const HotkeyResult& key) override;
 };
 
-#endif//GUI_WARP_CONTROLS_H
+#endif//WARP_CONTROLS_H

--- a/src/screens/crew6/relayScreen.h
+++ b/src/screens/crew6/relayScreen.h
@@ -51,4 +51,3 @@ public:
 };
 
 #endif//RELAY_SCREEN_H
-

--- a/src/screens/crewStationScreen.h
+++ b/src/screens/crewStationScreen.h
@@ -37,4 +37,3 @@ private:
 };
 
 #endif//CREW_STATION_SCREEN_H
-

--- a/src/screens/extra/damcon.h
+++ b/src/screens/extra/damcon.h
@@ -1,5 +1,5 @@
-#ifndef DAMCON_SCREEN_H
-#define DAMCON_SCREEN_H
+#ifndef DAMCON_H
+#define DAMCON_H
 
 #include "gui/gui2_overlay.h"
 #include "shipTemplate.h"
@@ -17,4 +17,4 @@ public:
     void onDraw(sf::RenderTarget& window) override;
 };
 
-#endif//DAMCON_SCREEN_H
+#endif//DAMCON_H

--- a/src/screens/extra/powerManagement.h
+++ b/src/screens/extra/powerManagement.h
@@ -1,5 +1,5 @@
-#ifndef POWER_MANAGEMENT_SCREEN_H
-#define POWER_MANAGEMENT_SCREEN_H
+#ifndef POWER_MANAGEMENT_H
+#define POWER_MANAGEMENT_H
 
 #include "gui/gui2_overlay.h"
 #include "shipTemplate.h"
@@ -28,4 +28,4 @@ public:
     void onDraw(sf::RenderTarget& window) override;
 };
 
-#endif//POWER_MANAGEMENT_SCREEN_H
+#endif//POWER_MANAGEMENT_H

--- a/src/screens/gm/chatDialog.h
+++ b/src/screens/gm/chatDialog.h
@@ -1,5 +1,5 @@
-#ifndef GAME_MASTER_CHAT_DIALOG_H
-#define GAME_MASTER_CHAT_DIALOG_H
+#ifndef CHAT_DIALOG_H
+#define CHAT_DIALOG_H
 
 #include "gui/gui2_resizabledialog.h"
 
@@ -31,4 +31,4 @@ private:
     void drawLine(sf::RenderTarget& window, sf::Vector2f target);
 };
 
-#endif//GAME_MASTER_CHAT_DIALOG_H
+#endif//CHAT_DIALOG_H

--- a/src/screens/gm/tweak.h
+++ b/src/screens/gm/tweak.h
@@ -1,5 +1,5 @@
-#ifndef GAME_MASTER_TWEAK_H
-#define GAME_MASTER_TWEAK_H
+#ifndef TWEAK_H
+#define TWEAK_H
 
 #include "gui/gui2_panel.h"
 #include "missileWeaponData.h"
@@ -189,4 +189,4 @@ public:
 
     virtual void onDraw(sf::RenderTarget& window) override;
 };
-#endif//GAME_MASTER_TWEAK_H
+#endif//TWEAK_H

--- a/src/screens/windowScreen.h
+++ b/src/screens/windowScreen.h
@@ -19,4 +19,4 @@ public:
     virtual void onKey(sf::Event::KeyEvent key, int unicode) override;
 };
 
-#endif//MAIN_SCREEN_H
+#endif//WINDOW_SCREEN_H

--- a/src/script.h
+++ b/src/script.h
@@ -1,5 +1,5 @@
-#ifndef GAMESCRIPT_H
-#define GAMESCRIPT_H
+#ifndef SCRIPT_H
+#define SCRIPT_H
 
 #include "engine.h"
 
@@ -13,4 +13,4 @@ public:
     virtual ~Script();
 };
 
-#endif//GAMESCRIPT_H
+#endif//SCRIPT_H

--- a/src/spaceObjects/EMPMissile.h
+++ b/src/spaceObjects/EMPMissile.h
@@ -14,5 +14,4 @@ public:
     virtual void hitObject(P<SpaceObject> object);
 };
 
-#endif//NUKE_H
-
+#endif//EMP_MISSILE_H

--- a/src/spaceObjects/hvli.h
+++ b/src/spaceObjects/hvli.h
@@ -14,4 +14,4 @@ public:
     virtual void hitObject(P<SpaceObject> object);
 };
 
-#endif//HOMING_MISSLE_H
+#endif//HVLI_H

--- a/src/spaceObjects/mine.h
+++ b/src/spaceObjects/mine.h
@@ -37,4 +37,3 @@ private:
 };
 
 #endif//MINE_H
-

--- a/src/spaceObjects/nuke.h
+++ b/src/spaceObjects/nuke.h
@@ -15,4 +15,3 @@ public:
 };
 
 #endif//NUKE_H
-

--- a/src/spaceObjects/spaceship.h
+++ b/src/spaceObjects/spaceship.h
@@ -1,5 +1,5 @@
-#ifndef SPACE_SHIP_H
-#define SPACE_SHIP_H
+#ifndef SPACESHIP_H
+#define SPACESHIP_H
 
 #include "shipTemplateBasedObject.h"
 #include "spaceStation.h"
@@ -409,4 +409,4 @@ string frequencyToString(int frequency);
 #include "spaceship.hpp"
 #endif
 
-#endif//SPACE_SHIP_H
+#endif//SPACESHIP_H

--- a/src/spaceObjects/spaceshipParts/beamWeapon.h
+++ b/src/spaceObjects/spaceshipParts/beamWeapon.h
@@ -74,4 +74,4 @@ protected:
     string beam_texture;
 };
 
-#endif //BEAM_WEAPON_H
+#endif//BEAM_WEAPON_H

--- a/src/spaceObjects/supplyDrop.h
+++ b/src/spaceObjects/supplyDrop.h
@@ -23,4 +23,3 @@ public:
 };
 
 #endif//SUPPLY_DROP_H
-

--- a/src/spaceObjects/warpJammer.h
+++ b/src/spaceObjects/warpJammer.h
@@ -26,4 +26,3 @@ public:
 };
 
 #endif//WARP_JAMMER_H
-

--- a/src/spaceObjects/wormHole.h
+++ b/src/spaceObjects/wormHole.h
@@ -1,5 +1,5 @@
-#ifndef WORMHOLE_H
-#define WORMHOLE_H
+#ifndef WORM_HOLE_H
+#define WORM_HOLE_H
 
 #include "nebula.h"
 #include "spaceObject.h"
@@ -16,7 +16,6 @@ class WormHole : public SpaceObject, public Updatable
     NebulaCloud clouds[cloud_count];
 
 public:
-
     WormHole();
 
 #if FEATURE_3D_RENDERING
@@ -32,5 +31,4 @@ public:
     virtual string getExportLine() { return "WormHole():setPosition(" + string(getPosition().x, 0) + ", " + string(getPosition().y, 0) + "):setTargetPosition(" + string(target_position.x, 0) + ", " + string(target_position.y, 0) + ")"; }
 };
 
-#endif//WORMHOLE_H
-
+#endif//WORM_HOLE_H

--- a/src/threatLevelEstimate.h
+++ b/src/threatLevelEstimate.h
@@ -1,5 +1,5 @@
-#ifndef THREAD_LEVEL_ESTIMATE_H
-#define THREAD_LEVEL_ESTIMATE_H
+#ifndef THREAT_LEVEL_ESTIMATE_H
+#define THREAT_LEVEL_ESTIMATE_H
 
 #include "engine.h"
 
@@ -30,4 +30,4 @@ private:
     float getThreatFor(P<SpaceShip> ship);
 };
 
-#endif//THREAD_LEVEL_ESTIMATE_H
+#endif//THREAT_LEVEL_ESTIMATE_H


### PR DESCRIPTION
Many include guards (`#ifndef FILE_H #define FILE_H`) inconsistently correspond to their filenames, some don't match the filename, and a few have typos. Comments on the guard's `#endif` directive also sometimes don't match the filenames. Resolve these inconsistencies.