### PR TITLE
Add help overlay and keyboard hotkey display

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -91,6 +91,7 @@ set(SOURCES
 	src/screens/gm/tweak.cpp
 	src/screenComponents/aimLock.cpp
 	src/screenComponents/alertOverlay.cpp
+	src/screenComponents/helpOverlay.cpp
 	src/screenComponents/missileTubeControls.cpp
 	src/screenComponents/selfDestructIndicator.cpp
 	src/screenComponents/viewport3d.cpp

--- a/EmptyEpsilon.cbp
+++ b/EmptyEpsilon.cbp
@@ -596,6 +596,8 @@
 		<Unit filename="src/screenComponents/aimLock.h" />
 		<Unit filename="src/screenComponents/alertOverlay.cpp" />
 		<Unit filename="src/screenComponents/alertOverlay.h" />
+		<Unit filename="src/screenComponents/helpOverlay.cpp" />
+		<Unit filename="src/screenComponents/helpOverlay.h" />
 		<Unit filename="src/screenComponents/beamFrequencySelector.cpp" />
 		<Unit filename="src/screenComponents/beamFrequencySelector.h" />
 		<Unit filename="src/screenComponents/beamTargetSelector.cpp" />

--- a/src/gui/hotkeyConfig.cpp
+++ b/src/gui/hotkeyConfig.cpp
@@ -141,7 +141,6 @@ HotkeyConfig::HotkeyConfig()
     newKey("COMBAT_LEFT", "Combat maneuver left");
     newKey("COMBAT_RIGHT", "Combat maneuver right");
     newKey("COMBAT_BOOST", "Combat maneuver boost");
-
 }
 
 void HotkeyConfig::load()
@@ -184,6 +183,42 @@ void HotkeyConfig::newCategory(string key, string name)
 void HotkeyConfig::newKey(string key, string name)
 {
     categories.back().hotkeys.emplace_back(key, name);
+}
+
+std::vector<string> HotkeyConfig::getCategories()
+{
+    // Initialize return value.
+    std::vector<string> ret;
+
+    // Add each category to the return value.
+    for(HotkeyConfigCategory& cat : categories)
+    {
+        ret.push_back(cat.name);
+    }
+
+    return ret;
+}
+
+std::vector<std::pair<string, string>> HotkeyConfig::listHotkeysByCategory(string hotkey_category)
+{
+    std::vector<std::pair<string, string>> ret;
+
+    for(HotkeyConfigCategory& cat : categories)
+    {
+        if (cat.name == hotkey_category)
+        {
+            for(HotkeyConfigItem& item : cat.hotkeys)
+            {
+                for(auto key_name : sfml_key_names)
+                {
+                    if (key_name.second == item.hotkey.code)
+                        ret.push_back({item.name, key_name.first});
+                }
+            }
+        }
+    }
+
+    return ret;
 }
 
 HotkeyConfigItem::HotkeyConfigItem(string key, string name)

--- a/src/gui/hotkeyConfig.h
+++ b/src/gui/hotkeyConfig.h
@@ -37,6 +37,8 @@ public:
     HotkeyConfig();
 
     void load();
+    std::vector<string> getCategories();
+    std::vector<std::pair<string, string>> listHotkeysByCategory(string hotkey_category);
     
     HotkeyResult getHotkey(sf::Event::KeyEvent key);
 private:

--- a/src/screenComponents/helpOverlay.cpp
+++ b/src/screenComponents/helpOverlay.cpp
@@ -1,0 +1,36 @@
+#include "helpOverlay.h"
+
+#include "gui/gui2_button.h"
+#include "gui/gui2_canvas.h"
+#include "gui/gui2_label.h"
+#include "gui/gui2_panel.h"
+#include "gui/gui2_scrolltext.h"
+
+GuiHelpOverlay::GuiHelpOverlay(GuiCanvas* owner, string title, string contents)
+: GuiElement(owner, "HELP_OVERLAY"), owner(owner)
+{
+    setSize(GuiElement::GuiSizeMax, GuiElement::GuiSizeMax);
+    
+    frame = new GuiPanel(this, "HELP_FRAME");
+    frame->setPosition(0, 0, ACenter)->setSize(500, 700)->hide();
+    
+    (new GuiLabel(frame, "HELP_LABEL", title, 50))->setPosition(0, 25, ATopCenter)->setSize(GuiElement::GuiSizeMax, 60);
+
+    text = new GuiScrollText(frame, "HELP_TEXT", contents);
+    text->setTextSize(30)->setPosition(0, 110, ATopCenter)->setSize(450, 520);
+
+    (new GuiButton(frame, "HELP_BUTTON", "Close", [this]() {
+        frame->hide();
+    }))->setPosition(0, -25, ABottomCenter)->setSize(300, 50);
+}
+
+void GuiHelpOverlay::setText(string new_text)
+{
+    help_text = new_text;
+}
+
+void GuiHelpOverlay::onDraw(sf::RenderTarget& window)
+{
+    if (frame->isVisible())
+        text->setText(help_text);
+}

--- a/src/screenComponents/helpOverlay.h
+++ b/src/screenComponents/helpOverlay.h
@@ -1,0 +1,25 @@
+#ifndef HELP_OVERLAY_H
+#define HELP_OVERLAY_H
+
+#include "gui/gui2_element.h"
+
+class GuiCanvas;
+class GuiPanel;
+class GuiScrollText;
+
+class GuiHelpOverlay : public GuiElement
+{
+private:
+    GuiCanvas* owner;
+    GuiScrollText* text;
+
+    string help_text = "";
+public:
+    GuiHelpOverlay(GuiCanvas* owner, string title = "", string contents = "");
+    GuiPanel* frame;
+
+    virtual void setText(string new_text);
+    virtual void onDraw(sf::RenderTarget& window);
+};
+
+#endif//HELP_OVERLAY_H

--- a/src/screens/crewStationScreen.h
+++ b/src/screens/crewStationScreen.h
@@ -2,13 +2,17 @@
 #define CREW_STATION_SCREEN_H
 
 #include "engine.h"
-#include "gui/gui2_canvas.h"
-#include "screenComponents/viewport3d.h"
 #include "threatLevelEstimate.h"
 
+#include "gui/gui2_canvas.h"
+
+#include "screenComponents/helpOverlay.h"
+#include "screenComponents/viewport3d.h"
+
 class GuiButton;
-class GuiToggleButton;
+class GuiHelpOverlay;
 class GuiPanel;
+class GuiToggleButton;
 
 class CrewStationScreen : public GuiCanvas, public Updatable
 {
@@ -16,11 +20,16 @@ class CrewStationScreen : public GuiCanvas, public Updatable
 private:
     GuiButton* select_station_button;
     GuiPanel* button_strip;
+    GuiHelpOverlay* keyboard_help;
     struct CrewTabInfo {
         GuiToggleButton* button;
         GuiElement* element;
     };
     std::vector<CrewTabInfo> tabs;
+    string keyboard_general = "";
+    void showNextTab(int offset=1);
+    void showTab(GuiElement* element);
+    GuiElement* findTab(string name);
 public:
     CrewStationScreen();
     void addStationTab(GuiElement* element, string name, string icon);
@@ -29,12 +38,6 @@ public:
     virtual void update(float delta) override;
     virtual void onHotkey(const HotkeyResult& key) override;
     virtual void onKey(sf::Event::KeyEvent key, int unicode) override;
-
-private:
-    void showNextTab(int offset=1);
-    void showTab(GuiElement* element);
-    GuiElement* findTab(string name);
 };
 
 #endif//CREW_STATION_SCREEN_H
-


### PR DESCRIPTION
Provides a toggleable text overlay, and applies that overlay to
display hotkeys relevant to the current crew screen. Only
configured hotkeys appear in the window.

-   Add a help overlay element (`GuiHelpOverlay()`) to crew
    stations (any using `CrewStationScreen()`).
-   Bind help display to `/`.
-   Add getters for categories and hotkey lists to
    `HotkeyConfig`.
-   Get and parse crew station hotkeys.
-   Render list of configured hotkeys for the current crew
    station to the help overlay, and update the list when
    switching between stations.

![shortcuts](https://cloud.githubusercontent.com/assets/19192104/16867840/0e0cf5c6-4a29-11e6-93d4-0656ff9d8e8d.png)