### PR TITLE
Two more options for the main screen

### DIFF
--- a/src/gameGlobalInfo.cpp
+++ b/src/gameGlobalInfo.cpp
@@ -33,6 +33,8 @@ GameGlobalInfo::GameGlobalInfo()
     use_system_damage = true;
     allow_main_screen_tactical_radar = true;
     allow_main_screen_long_range_radar = true;
+    allow_main_screen_global_range_radar = true;
+    allow_main_screen_ship_state = true;
     
     intercept_all_comms_to_gm = false;
 

--- a/src/gameGlobalInfo.cpp
+++ b/src/gameGlobalInfo.cpp
@@ -48,6 +48,8 @@ GameGlobalInfo::GameGlobalInfo()
     registerMemberReplication(&use_system_damage);
     registerMemberReplication(&allow_main_screen_tactical_radar);
     registerMemberReplication(&allow_main_screen_long_range_radar);
+    registerMemberReplication(&allow_main_screen_global_range_radar);
+    registerMemberReplication(&allow_main_screen_ship_state);
 
     for(unsigned int n=0; n<factionInfo.size(); n++)
         reputation_points.push_back(0);

--- a/src/gameGlobalInfo.h
+++ b/src/gameGlobalInfo.h
@@ -71,6 +71,8 @@ public:
     bool use_system_damage;
     bool allow_main_screen_tactical_radar;
     bool allow_main_screen_long_range_radar;
+    bool allow_main_screen_global_range_radar;
+    bool allow_main_screen_ship_state;
     string variation = "None";
 
     //List of script functions that can be called from the GM interface (Server only!)

--- a/src/menus/serverCreationScreen.cpp
+++ b/src/menus/serverCreationScreen.cpp
@@ -109,6 +109,15 @@ ServerCreationScreen::ServerCreationScreen()
         gameGlobalInfo->allow_main_screen_long_range_radar = value == 1;
     }))->setValue(gameGlobalInfo->allow_main_screen_long_range_radar)->setSize(275, GuiElement::GuiSizeMax)->setPosition(0, 0, ACenterRight);
 
+    row = new GuiAutoLayout(left_panel, "", GuiAutoLayout::LayoutHorizontalLeftToRight);
+    row->setSize(GuiElement::GuiSizeMax, 50);
+    (new GuiToggleButton(row, "MAIN_GLOBAL_RANGE_TOGGLE", "Global radar", [](bool value) {
+        gameGlobalInfo->allow_main_screen_global_range_radar = value == 1;
+    }))->setValue(gameGlobalInfo->allow_main_screen_global_range_radar)->setSize(275, GuiElement::GuiSizeMax)->setPosition(0, 0, ACenterLeft);
+    (new GuiToggleButton(row, "MAIN_SHIP_STATE", "Ship State", [](bool value) {
+        gameGlobalInfo->allow_main_screen_ship_state_radar = value == 1;
+    }))->setValue(gameGlobalInfo->allow_main_screen_ship_state_radar)->setSize(275, GuiElement::GuiSizeMax)->setPosition(0, 0, ACenterRight);
+    
     // Game rules section.
     (new GuiLabel(left_panel, "GAME_RULES_LABEL", "Game rules", 30))->addBackground()->setSize(GuiElement::GuiSizeMax, 50);
 

--- a/src/menus/serverCreationScreen.cpp
+++ b/src/menus/serverCreationScreen.cpp
@@ -245,6 +245,8 @@ void ServerCreationScreen::startScenario()
     PreferencesManager::set("server_config_use_system_damage", string(int(gameGlobalInfo->use_system_damage)));
     PreferencesManager::set("server_config_allow_main_screen_tactical_radar", string(int(gameGlobalInfo->allow_main_screen_tactical_radar)));
     PreferencesManager::set("server_config_allow_main_screen_long_range_radar", string(int(gameGlobalInfo->allow_main_screen_long_range_radar)));
+    PreferencesManager::set("server_config_allow_main_screen_global_range_radar", string(int(gameGlobalInfo->allow_main_screen_global_range_radar)));
+    PreferencesManager::set("server_config_allow_main_screen_ship_state", string(int(gameGlobalInfo->allow_main_screen_ship_state)));
 
     // Start the selected scenario.
     gameGlobalInfo->startScenario(selected_scenario_filename);

--- a/src/menus/serverCreationScreen.cpp
+++ b/src/menus/serverCreationScreen.cpp
@@ -31,6 +31,8 @@ ServerCreationScreen::ServerCreationScreen()
     gameGlobalInfo->use_system_damage = PreferencesManager::get("server_config_use_system_damage", "1").toInt();
     gameGlobalInfo->allow_main_screen_tactical_radar = PreferencesManager::get("server_config_allow_main_screen_tactical_radar", "1").toInt();
     gameGlobalInfo->allow_main_screen_long_range_radar = PreferencesManager::get("server_config_allow_main_screen_long_range_radar", "1").toInt();
+    gameGlobalInfo->allow_main_screen_global_range_radar = PreferencesManager::get("server_config_allow_main_screen_global_range_radar", "1").toInt();
+    gameGlobalInfo->allow_main_screen_ship_state = PreferencesManager::get("server_config_allow_main_screen_ship_state", "1").toInt();
 
     // Create a two-column layout.
     GuiElement* container = new GuiAutoLayout(this, "", GuiAutoLayout::ELayoutMode::LayoutVerticalColumns);
@@ -115,8 +117,8 @@ ServerCreationScreen::ServerCreationScreen()
         gameGlobalInfo->allow_main_screen_global_range_radar = value == 1;
     }))->setValue(gameGlobalInfo->allow_main_screen_global_range_radar)->setSize(275, GuiElement::GuiSizeMax)->setPosition(0, 0, ACenterLeft);
     (new GuiToggleButton(row, "MAIN_SHIP_STATE", "Ship State", [](bool value) {
-        gameGlobalInfo->allow_main_screen_ship_state_radar = value == 1;
-    }))->setValue(gameGlobalInfo->allow_main_screen_ship_state_radar)->setSize(275, GuiElement::GuiSizeMax)->setPosition(0, 0, ACenterRight);
+        gameGlobalInfo->allow_main_screen_ship_state = value == 1;
+    }))->setValue(gameGlobalInfo->allow_main_screen_ship_state)->setSize(275, GuiElement::GuiSizeMax)->setPosition(0, 0, ACenterRight);
     
     // Game rules section.
     (new GuiLabel(left_panel, "GAME_RULES_LABEL", "Game rules", 30))->addBackground()->setSize(GuiElement::GuiSizeMax, 50);

--- a/src/screenComponents/mainScreenControls.cpp
+++ b/src/screenComponents/mainScreenControls.cpp
@@ -110,6 +110,19 @@ GuiMainScreenControls::GuiMainScreenControls(GuiContainer* owner)
             button->setVisible(false);
     }));
     long_range_button = buttons.back();
+    
+     // Ship State button.
+    buttons.push_back(new GuiButton(this, "MAIN_SCREEN_SHIP_STATE_BUTTON", "Ship State", [this]()
+    {
+        if (my_spaceship)
+        {
+            my_spaceship->commandMainScreenSetting(MSS_ShipState);
+        }
+        open_button->setValue(false);
+        for(GuiButton* button : buttons)
+            button->setVisible(false);
+    }));
+    ship_state_button = buttons.back();
 
     // If the player has control over comms, they can toggle the comms overlay
     // on the main screen.

--- a/src/screenComponents/mainScreenControls.cpp
+++ b/src/screenComponents/mainScreenControls.cpp
@@ -111,6 +111,19 @@ GuiMainScreenControls::GuiMainScreenControls(GuiContainer* owner)
     }));
     long_range_button = buttons.back();
     
+    // Global-range radar button.
+    buttons.push_back(new GuiButton(this, "MAIN_SCREEN_GLOBAL_RANGE_BUTTON", "Global Range", [this]()
+    {
+        if (my_spaceship)
+        {
+            my_spaceship->commandMainScreenSetting(MSS_GlobalRange);
+        }
+        open_button->setValue(false);
+        for(GuiButton* button : buttons)
+            button->setVisible(false);
+    }));
+    global_range_button = buttons.back();
+    
      // Ship State button.
     buttons.push_back(new GuiButton(this, "MAIN_SCREEN_SHIP_STATE_BUTTON", "Ship State", [this]()
     {

--- a/src/screenComponents/mainScreenControls.cpp
+++ b/src/screenComponents/mainScreenControls.cpp
@@ -19,6 +19,10 @@ GuiMainScreenControls::GuiMainScreenControls(GuiContainer* owner)
             tactical_button->setVisible(false);
         if (!gameGlobalInfo->allow_main_screen_long_range_radar)
             long_range_button->setVisible(false);
+        if (!gameGlobalInfo->allow_main_screen_global_range_radar)
+            global_range_button->setVisible(false);
+        if (!gameGlobalInfo->allow_main_screen_ship_state)
+            ship_state_button->setVisible(false);
         if (show_comms_button && onscreen_comms_active)
             show_comms_button->setVisible(false);
         if (hide_comms_button && !onscreen_comms_active)

--- a/src/screenComponents/mainScreenControls.h
+++ b/src/screenComponents/mainScreenControls.h
@@ -14,6 +14,7 @@ private:
     GuiButton* target_lock_button;
     GuiButton* tactical_button;
     GuiButton* long_range_button;
+    GuiButton* global_range_button;
     GuiButton* ship_state_button;
     GuiButton* show_comms_button;
     GuiButton* hide_comms_button;

--- a/src/screenComponents/mainScreenControls.h
+++ b/src/screenComponents/mainScreenControls.h
@@ -14,6 +14,7 @@ private:
     GuiButton* target_lock_button;
     GuiButton* tactical_button;
     GuiButton* long_range_button;
+    GuiButton* ship_state_button;
     GuiButton* show_comms_button;
     GuiButton* hide_comms_button;
     bool onscreen_comms_active = false;

--- a/src/screens/mainScreen.cpp
+++ b/src/screens/mainScreen.cpp
@@ -248,24 +248,42 @@ void ScreenMainScreen::onClick(sf::Vector2f mouse_position)
                 my_spaceship->commandMainScreenSetting(MSS_Tactical);
             else if (gameGlobalInfo->allow_main_screen_long_range_radar)
                 my_spaceship->commandMainScreenSetting(MSS_LongRange);
+            else if (gameGlobalInfo->allow_main_screen_global_range_radar)
+                my_spaceship->commandMainScreenSetting(MSS_GlobalRange);
+            else if (gameGlobalInfo->allow_main_screen_ship_state)
+                my_spaceship->commandMainScreenSetting(MSS_ShipState);
             break;
         case MSS_Tactical:
             if (gameGlobalInfo->allow_main_screen_long_range_radar)
                 my_spaceship->commandMainScreenSetting(MSS_LongRange);
-            else
+            else if (gameGlobalInfo->allow_main_screen_global_range_radar)
+                my_spaceship->commandMainScreenSetting(MSS_GlobalRange);
+            else if (gameGlobalInfo->allow_main_screen_ship_state)
                 my_spaceship->commandMainScreenSetting(MSS_ShipState);
             break;
         case MSS_LongRange:
-            my_spaceship->commandMainScreenSetting(MSS_GlobalRange);
+            if (gameGlobalInfo->allow_main_screen_global_range_radar)
+                my_spaceship->commandMainScreenSetting(MSS_GlobalRange);
+            else if (gameGlobalInfo->allow_main_screen_ship_state)
+                my_spaceship->commandMainScreenSetting(MSS_ShipState);
+            else if (gameGlobalInfo->allow_main_screen_tactical_radar)
+                my_spaceship->commandMainScreenSetting(MSS_Tactical);
             break;
         case MSS_GlobalRange:
-            my_spaceship->commandMainScreenSetting(MSS_ShipState);
+            if (gameGlobalInfo->allow_main_screen_ship_state)
+                my_spaceship->commandMainScreenSetting(MSS_ShipState);
+            else if (gameGlobalInfo->allow_main_screen_tactical_radar)
+                my_spaceship->commandMainScreenSetting(MSS_Tactical);
+            else if (gameGlobalInfo->allow_main_screen_long_range_radar)
+                my_spaceship->commandMainScreenSetting(MSS_LongRange);
             break;
         case MSS_ShipState:
             if (gameGlobalInfo->allow_main_screen_tactical_radar)
                 my_spaceship->commandMainScreenSetting(MSS_Tactical);
             else if (gameGlobalInfo->allow_main_screen_long_range_radar)
                 my_spaceship->commandMainScreenSetting(MSS_LongRange);
+            else if (gameGlobalInfo->allow_main_screen_global_range_radar)
+                my_spaceship->commandMainScreenSetting(MSS_GlobalRange);
             break;
         }
     }

--- a/src/screens/mainScreen.cpp
+++ b/src/screens/mainScreen.cpp
@@ -36,7 +36,7 @@ ScreenMainScreen::ScreenMainScreen()
     long_range_radar->setRangeIndicatorStepSize(5000.0f)->longRange()->enableCallsigns()->hide();
     long_range_radar->setFogOfWarStyle(GuiRadarView::NebulaFogOfWar);
 
-    global_range_radar = new GuiRadarView(this, "GLOBAL", 80000.0f, nullptr);
+    global_range_radar = new GuiRadarView(this, "GLOBAL", 50000.0f, nullptr);
     global_range_radar->setPosition(0, 0, ATopLeft)->setSize(GuiElement::GuiSizeMax, GuiElement::GuiSizeMax);
     global_range_radar->setAutoCentering(true);
     global_range_radar->longRange()->enableWaypoints()->enableCallsigns()->setStyle(GuiRadarView::Rectangular)->setFogOfWarStyle(GuiRadarView::FriendlysShortRangeFogOfWar);

--- a/src/screens/mainScreen.cpp
+++ b/src/screens/mainScreen.cpp
@@ -40,12 +40,14 @@ ScreenMainScreen::ScreenMainScreen()
     global_range_radar->setPosition(0, 0, ATopLeft)->setSize(GuiElement::GuiSizeMax, GuiElement::GuiSizeMax);
     global_range_radar->setAutoCentering(true);
     global_range_radar->longRange()->enableWaypoints()->enableCallsigns()->setStyle(GuiRadarView::Rectangular)->setFogOfWarStyle(GuiRadarView::FriendlysShortRangeFogOfWar);
-    
+    global_range_radar->hide();
+        
     onscreen_comms = new GuiCommsOverlay(this);
     onscreen_comms->setSize(GuiElement::GuiSizeMax, GuiElement::GuiSizeMax)->setVisible(false);
     
     ship_state = new DamageControlScreen(this);
     ship_state->setPosition(0, 0, ATopLeft)->setSize(GuiElement::GuiSizeMax, GuiElement::GuiSizeMax);
+    ship_state->hide();
     
     new GuiShipDestroyedPopup(this);
     

--- a/src/screens/mainScreen.cpp
+++ b/src/screens/mainScreen.cpp
@@ -232,10 +232,17 @@ void ScreenMainScreen::onClick(sf::Vector2f mouse_position)
         case MSS_Tactical:
             if (gameGlobalInfo->allow_main_screen_long_range_radar)
                 my_spaceship->commandMainScreenSetting(MSS_LongRange);
+            else
+                my_spaceship->commandMainScreenSetting(MSS_ShipState);
             break;
         case MSS_LongRange:
+            my_spaceship->commandMainScreenSetting(MSS_ShipState);
+            break;
+        case MSS_ShipState:
             if (gameGlobalInfo->allow_main_screen_tactical_radar)
                 my_spaceship->commandMainScreenSetting(MSS_Tactical);
+            else if (gameGlobalInfo->allow_main_screen_long_range_radar)
+                my_spaceship->commandMainScreenSetting(MSS_LongRange);
             break;
         }
     }

--- a/src/screens/mainScreen.cpp
+++ b/src/screens/mainScreen.cpp
@@ -15,6 +15,7 @@
 #include "screenComponents/shipDestroyedPopup.h"
 
 #include "screens/extra/damcon.h"
+#include "screens/crew6/relayScreen.h"
 
 #include "gui/gui2_overlay.h"
 
@@ -35,6 +36,8 @@ ScreenMainScreen::ScreenMainScreen()
     long_range_radar->setPosition(0, 0, ATopLeft)->setSize(GuiElement::GuiSizeMax, GuiElement::GuiSizeMax);
     long_range_radar->setRangeIndicatorStepSize(5000.0f)->longRange()->enableCallsigns()->hide();
     long_range_radar->setFogOfWarStyle(GuiRadarView::NebulaFogOfWar);
+    global_range_radar = new RelayScreen(this);
+    global_range_radar->setPosition(0, 0, ATopLeft)->setSize(GuiElement::GuiSizeMax, GuiElement::GuiSizeMax);
     onscreen_comms = new GuiCommsOverlay(this);
     onscreen_comms->setSize(GuiElement::GuiSizeMax, GuiElement::GuiSizeMax)->setVisible(false);
     
@@ -135,21 +138,35 @@ void ScreenMainScreen::update(float delta)
             viewport->show();
             tactical_radar->hide();
             long_range_radar->hide();
+            global_range_radar->hide();
+            ship_state->hide();
             break;
         case MSS_Tactical:
             viewport->hide();
             tactical_radar->show();
             long_range_radar->hide();
+            global_range_radar->hide();
+            ship_state->hide();
             break;
         case MSS_LongRange:
             viewport->hide();
             tactical_radar->hide();
             long_range_radar->show();
+            global_range_radar->hide();
+            ship_state->hide();
+            break;
+        case MSS_GlobalRange:
+            viewport->hide();
+            tactical_radar->hide();
+            long_range_radar->hide();
+            global_range_radar->show();
+            ship_state->hide();
             break;
         case MSS_ShipState:
             viewport->hide();
             tactical_radar->hide();
             long_range_radar->hide();
+            global_range_radar->hide();
             ship_state->show();
             break;
         }
@@ -236,6 +253,9 @@ void ScreenMainScreen::onClick(sf::Vector2f mouse_position)
                 my_spaceship->commandMainScreenSetting(MSS_ShipState);
             break;
         case MSS_LongRange:
+            my_spaceship->commandMainScreenSetting(MSS_GlobalRange);
+            break;
+        case MSS_GlobalRange:
             my_spaceship->commandMainScreenSetting(MSS_ShipState);
             break;
         case MSS_ShipState:

--- a/src/screens/mainScreen.cpp
+++ b/src/screens/mainScreen.cpp
@@ -15,7 +15,6 @@
 #include "screenComponents/shipDestroyedPopup.h"
 
 #include "screens/extra/damcon.h"
-#include "screens/crew6/relayScreen.h"
 
 #include "gui/gui2_overlay.h"
 
@@ -36,8 +35,12 @@ ScreenMainScreen::ScreenMainScreen()
     long_range_radar->setPosition(0, 0, ATopLeft)->setSize(GuiElement::GuiSizeMax, GuiElement::GuiSizeMax);
     long_range_radar->setRangeIndicatorStepSize(5000.0f)->longRange()->enableCallsigns()->hide();
     long_range_radar->setFogOfWarStyle(GuiRadarView::NebulaFogOfWar);
-    global_range_radar = new RelayScreen(this);
+
+    global_range_radar = new GuiRadarView(this, "GLOBAL", 80000.0f, nullptr);
     global_range_radar->setPosition(0, 0, ATopLeft)->setSize(GuiElement::GuiSizeMax, GuiElement::GuiSizeMax);
+    global_range_radar->setAutoCentering(true);
+    global_range_radar->longRange()->enableWaypoints()->enableCallsigns()->setStyle(GuiRadarView::Rectangular)->setFogOfWarStyle(GuiRadarView::FriendlysShortRangeFogOfWar);
+    
     onscreen_comms = new GuiCommsOverlay(this);
     onscreen_comms->setSize(GuiElement::GuiSizeMax, GuiElement::GuiSizeMax)->setVisible(false);
     

--- a/src/screens/mainScreen.cpp
+++ b/src/screens/mainScreen.cpp
@@ -14,6 +14,8 @@
 #include "screenComponents/radarView.h"
 #include "screenComponents/shipDestroyedPopup.h"
 
+#include "screens/extra/damcon.h"
+
 #include "gui/gui2_overlay.h"
 
 ScreenMainScreen::ScreenMainScreen()
@@ -35,7 +37,10 @@ ScreenMainScreen::ScreenMainScreen()
     long_range_radar->setFogOfWarStyle(GuiRadarView::NebulaFogOfWar);
     onscreen_comms = new GuiCommsOverlay(this);
     onscreen_comms->setSize(GuiElement::GuiSizeMax, GuiElement::GuiSizeMax)->setVisible(false);
-
+    
+    ship_state = new DamageControlScreen(this);
+    ship_state->setPosition(0, 0, ATopLeft)->setSize(GuiElement::GuiSizeMax, GuiElement::GuiSizeMax);
+    
     new GuiShipDestroyedPopup(this);
     
     new GuiJumpIndicator(this);
@@ -140,6 +145,12 @@ void ScreenMainScreen::update(float delta)
             viewport->hide();
             tactical_radar->hide();
             long_range_radar->show();
+            break;
+        case MSS_ShipState:
+            viewport->hide();
+            tactical_radar->hide();
+            long_range_radar->hide();
+            ship_state->show();
             break;
         }
 

--- a/src/screens/mainScreen.h
+++ b/src/screens/mainScreen.h
@@ -8,6 +8,7 @@
 class GuiViewport3D;
 class GuiRadarView;
 class GuiCommsOverlay;
+class DamageControlScreen;
 
 class ScreenMainScreen : public GuiCanvas, public Updatable
 {

--- a/src/screens/mainScreen.h
+++ b/src/screens/mainScreen.h
@@ -9,6 +9,7 @@ class GuiViewport3D;
 class GuiRadarView;
 class GuiCommsOverlay;
 class DamageControlScreen;
+class RelayScreen;
 
 class ScreenMainScreen : public GuiCanvas, public Updatable
 {
@@ -17,6 +18,7 @@ private:
     GuiViewport3D* viewport;
     GuiRadarView* tactical_radar;
     GuiRadarView* long_range_radar;
+    RelayScreen* global_range_radar;
     bool first_person;
     GuiCommsOverlay* onscreen_comms;
     int impulse_sound = -1;

--- a/src/screens/mainScreen.h
+++ b/src/screens/mainScreen.h
@@ -19,6 +19,7 @@ private:
     bool first_person;
     GuiCommsOverlay* onscreen_comms;
     int impulse_sound = -1;
+    DamageControlScreen*ship_state ;
 public:
     ScreenMainScreen();
     

--- a/src/screens/mainScreen.h
+++ b/src/screens/mainScreen.h
@@ -18,7 +18,7 @@ private:
     GuiViewport3D* viewport;
     GuiRadarView* tactical_radar;
     GuiRadarView* long_range_radar;
-    RelayScreen* global_range_radar;
+    GuiRadarView* global_range_radar;
     bool first_person;
     GuiCommsOverlay* onscreen_comms;
     int impulse_sound = -1;

--- a/src/spaceObjects/spaceship.h
+++ b/src/spaceObjects/spaceship.h
@@ -14,7 +14,8 @@ enum EMainScreenSetting
     MSS_Right,
     MSS_Target,
     MSS_Tactical,
-    MSS_LongRange
+    MSS_LongRange,
+    MSS_ShipState
 };
 template<> void convert<EMainScreenSetting>::param(lua_State* L, int& idx, EMainScreenSetting& mss);
 

--- a/src/spaceObjects/spaceship.h
+++ b/src/spaceObjects/spaceship.h
@@ -15,6 +15,7 @@ enum EMainScreenSetting
     MSS_Target,
     MSS_Tactical,
     MSS_LongRange,
+    MSS_GlobalRange,
     MSS_ShipState
 };
 template<> void convert<EMainScreenSetting>::param(lua_State* L, int& idx, EMainScreenSetting& mss);

--- a/src/spaceObjects/spaceship.hpp
+++ b/src/spaceObjects/spaceship.hpp
@@ -18,6 +18,8 @@ template<> void convert<EMainScreenSetting>::param(lua_State* L, int& idx, EMain
         mss = MSS_Tactical;
     else if (str == "longrange")
         mss = MSS_LongRange;
+    else if (str == "globalrange")
+        mss = MSS_GlobalRange;
     else if (str == "shipstate")
         mss = MSS_ShipState;
     else

--- a/src/spaceObjects/spaceship.hpp
+++ b/src/spaceObjects/spaceship.hpp
@@ -18,6 +18,8 @@ template<> void convert<EMainScreenSetting>::param(lua_State* L, int& idx, EMain
         mss = MSS_Tactical;
     else if (str == "longrange")
         mss = MSS_LongRange;
+    else if (str == "shipstate")
+        mss = MSS_ShipState;
     else
         mss = MSS_Front;
 }


### PR DESCRIPTION
Hi,

I organized a live test of EE last week-end and my players ask me to add more options for the main screen. The captains thought they had not enough informations and they would to see the actual state of the ship and a larger radar (even with few information on it).

So I propose to add the damcon view and the relay radar as options to the main screen.

I add options in server creation to choose if you want or not these options in your session.