### PR TITLE
Set RESOURCE_BASE_DIR on all Unix-like platforms

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -18,12 +18,9 @@ set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall")
 # install resources, scripts, and packs to app bundle instead of system dir.
 if(APPLE)
 set(CMAKE_INSTALL_PREFIX "./")
-endif()
-
-# set INSTALL_PREFIX for linux so that the built binary is able to find resources
-if(CMAKE_SYSTEM_NAME STREQUAL "Linux")
-set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -D INSTALL_PREFIX=\\\"${CMAKE_INSTALL_PREFIX}\\\"")
-set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -D INSTALL_PREFIX=\\\"${CMAKE_INSTALL_PREFIX}\\\"")
+elseif(UNIX)
+# Set RESOURCE_BASE_DIR on Unix so the built binary is able to find resources
+add_definitions(-DRESOURCE_BASE_DIR="${CMAKE_INSTALL_PREFIX}/share/emptyepsilon/")
 endif()
 
 ## ensure c++11 is used

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -32,13 +32,6 @@
 #include <libgen.h>
 #endif
 
-#ifdef __linux__
-#ifndef INSTALL_PREFIX
-#define INSTALL_PREFIX "/usr/local"
-#endif
-#define RESOURCE_BASE_DIR INSTALL_PREFIX "/share/emptyepsilon/"
-#endif
-
 sf::Vector3f camera_position;
 float camera_yaw;
 float camera_pitch;


### PR DESCRIPTION
Set RESOURCE_BASE_DIR directly from CMake for non-Apple Unix platforms.
This fixes the missing resource directory when compiling on FreeBSD.