### PR TITLE
Added Neither option to Jump/Warp choice

### DIFF
--- a/src/gameGlobalInfo.h
+++ b/src/gameGlobalInfo.h
@@ -23,6 +23,7 @@ enum EPlayerWarpJumpDrive
     PWJ_WarpDrive,
     PWJ_JumpDrive,
     PWJ_WarpAndJumpDrive,
+    PWJ_None,
     PWJ_MAX,
 };
 enum EScanningComplexity

--- a/src/menus/serverCreationScreen.cpp
+++ b/src/menus/serverCreationScreen.cpp
@@ -86,7 +86,7 @@ ServerCreationScreen::ServerCreationScreen()
     (new GuiLabel(row, "WARP_JUMP_LABEL", "Warp/Jump: ", 30))->setAlignment(ACenterRight)->setSize(250, GuiElement::GuiSizeMax);
     (new GuiSelector(row, "WARP_JUMP_SELECT", [](int index, string value) {
         gameGlobalInfo->player_warp_jump_drive_setting = EPlayerWarpJumpDrive(index);
-    }))->setOptions({"Ship default", "Warp drive", "Jump drive", "Both"})->setSelectionIndex((int)gameGlobalInfo->player_warp_jump_drive_setting)->setSize(GuiElement::GuiSizeMax, GuiElement::GuiSizeMax);
+    }))->setOptions({"Ship default", "Warp drive", "Jump drive", "Both", "Neither"})->setSelectionIndex((int)gameGlobalInfo->player_warp_jump_drive_setting)->setSize(GuiElement::GuiSizeMax, GuiElement::GuiSizeMax);
 
     // Radar range limit row.
     row = new GuiAutoLayout(left_panel, "", GuiAutoLayout::LayoutHorizontalLeftToRight);

--- a/src/spaceObjects/playerSpaceship.cpp
+++ b/src/spaceObjects/playerSpaceship.cpp
@@ -595,6 +595,10 @@ void PlayerSpaceship::applyTemplateValues()
         setWarpDrive(true);
         setJumpDrive(true);
         break;
+    case PWJ_None:
+        setWarpDrive(false);
+        setJumpDrive(false);
+        break;
     }
 
     // Set the ship's number of repair crews in Engineering from the ship's


### PR DESCRIPTION
I added the Neither-option to the Player Ship Options, so we can create a player-ship without Jump- and warp-drive.