### PR TITLE
Fix timing scenario

### DIFF
--- a/scripts/scenario_02_beacon.lua
+++ b/scripts/scenario_02_beacon.lua
@@ -1,6 +1,6 @@
 -- Name: Beacon of light series
 -- Description: The beacon of light scenario, build from the series at EmptyEpsilon.org.
---- Near the far outpost of Orion-5, Kraylor attacks are increasing. A diplomat went missing, and your mission will start with recovering him.
+--- Near the far outpost of Orion-5, Kraylor attacks are increasing. A diplomat went missing, and your mission will start with recovering him. (Must use Epsilon as ship)
 -- Type: Mission
 
 -- Init is run when the scenario is started. Create your initial world
@@ -253,8 +253,9 @@ function missionStopTransport(delta)
         transport_target:setImpulseMaxSpeed(70):setJumpDrive(true)
         mission_state = missionTransportWaitForRecovery
         mission_timer = 40
-        
-        transport_recovery_team = CpuShip():setTemplate("Flavia"):setFaction("Human Navy"):setPosition(-22000, 30000)
+		
+        local x, y = transport_target:getPosition()
+        transport_recovery_team = CpuShip():setTemplate("Flavia"):setFaction("Human Navy"):setPosition(x - random(8000, 10000), y + random(8000, 10000))
         transport_recovery_team:setCallSign("RTRV"):setScanned(true)
         transport_recovery_team:orderFlyTowardsBlind(transport_target:getPosition()):setCommsScript("")
     end


### PR DESCRIPTION
Basically our team fought and killed the same ship 10+ times, got super boring to the point where we gave up. (The rescue ship took way to long, like 40 to a 70 minutes) So I changed the spawn of the rescue ship to closer to save others from the headache we had. (Super fun up this point by the way)

1-4 attacks would be perfect.

Also added in description that you must epsilon as ship to complete mission. (First time we tried the mission, it was not working, turned out we needed to be eplison ship, cant use a new ship)