### PR TITLE
Added SeriousProton as submodule

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "SeriousProton"]
+	path = SeriousProton
+	url = https://git@github.com/daid/SeriousProton

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -5,7 +5,7 @@ option(ENABLE_CRASH_LOGGER "Enable the drmingw crash logging facilities" OFF)
 
 # Check if serious proton dir is set.
 if(NOT DEFINED SERIOUS_PROTON_DIR)
- message(FATAL_ERROR "SERIOUS_PROTON_DIR was not set. Unable to continue")
+ set(SERIOUS_PROTON_DIR "${CMAKE_SOURCE_DIR}/SeriousProton/")
 endif(NOT DEFINED SERIOUS_PROTON_DIR)
 
 if(DEFINED ENABLE_CRASH_LOGGER)


### PR DESCRIPTION
Fix for Issue #417. Still supports setting the SeriousProton path in the command line, but if not set it defaults to `${CMAKE_SOURCE_DIR}/SeriousProton/`