### PR TITLE
Link to last-modified sorted list of downloads

### DIFF
--- a/index.html
+++ b/index.html
@@ -842,7 +842,7 @@ end
 	</div>
 	<div id="tabs-download">
 		<h2>Download</h2>
-		<p id="downloads-info">Downloads for Windows and Android are available at: <a href="http://software.ultimaker.com/EmptyEpsilon/">[download list]</a></p>
+		<p id="downloads-info">Downloads for Windows and Android are available at: <a href="http://software.ultimaker.com/EmptyEpsilon/?C=M;O=D">[download list]</a></p>
 		<p>You need to use the same version number for all users or else the game will not work correctly. Mixing different version numbers is not supported.</p>
 		<p>Storage for downloads provided by <a href="http://ultimaker.com/">Ultimaker</a>. Many thanks that they allow us to use their build and download servers. If you are concidering an 3D printer, buy from Ultimaker, they are nice people.</p>
 		<h2>Source</h2>


### PR DESCRIPTION
The link to downloads is sorted by name, but due to inconsistent file naming across years, new versions are more difficult to find. Sort the list by last-modified time instead to force newer versions to appear first.