### PR TITLE
Fix bug: add missing cpp file to cmake

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -70,6 +70,7 @@ set(SOURCES
 	src/menus/serverBrowseMenu.cpp
 	src/menus/mainMenus.cpp
 	src/menus/serverCreationScreen.cpp
+	src/menus/tutorialMenu.cpp
 	src/menus/optionsMenu.cpp
 	src/menus/shipSelectionScreen.cpp
 	src/menus/autoConnectScreen.cpp


### PR DESCRIPTION
The tutorialMenu.cpp file was missing in cmake so there was a linker error.