### PR TITLE
Add ship info to science

### DIFF
--- a/src/menus/autoConnectScreen.cpp
+++ b/src/menus/autoConnectScreen.cpp
@@ -39,7 +39,7 @@ AutoConnectScreen::AutoConnectScreen(ECrewPosition crew_position, bool control_m
         LOG(INFO) << "Auto connect filter: " << key << " = " << ship_filters[key];
     }
 
-    if (!PreferencesManager::get("instance_name").compare(""))
+    if (PreferencesManager::get("instance_name") != "")
     {
         (new GuiLabel(this, "", PreferencesManager::get("instance_name"), 25))->setAlignment(ACenterLeft)->setPosition(20, 20, ATopLeft)->setSize(0, 18);
     }
@@ -124,7 +124,7 @@ bool AutoConnectScreen::isValidShip(int index)
 
     for(auto it : ship_filters)
     {
-        if (it.first.compare("solo"))
+        if (it.first == "solo")
         {
             int crew_at_position = 0;
             foreach(PlayerInfo, i, player_info_list)
@@ -138,19 +138,19 @@ bool AutoConnectScreen::isValidShip(int index)
             if (crew_at_position > 0)
                 return false;
         }
-        else if (it.first.compare("faction"))
+        else if (it.first == "faction")
         {
             if (ship->getFactionId() != FactionInfo::findFactionId(it.second))
                 return false;
         }
-        else if (it.first.compare("callsign"))
+        else if (it.first == "callsign")
         {
-            if (!ship->getCallSign().lower().compare(it.second.lower()))
+            if (ship->getCallSign().lower() != it.second.lower())
                 return false;
         }
-        else if (it.first.compare("type"))
+        else if (it.first == "type")
         {
-            if (!ship->getTypeName().lower().compare(it.second.lower()))
+            if (ship->getTypeName().lower() != it.second.lower())
                 return false;
         }
         else

--- a/src/menus/autoConnectScreen.cpp
+++ b/src/menus/autoConnectScreen.cpp
@@ -39,7 +39,7 @@ AutoConnectScreen::AutoConnectScreen(ECrewPosition crew_position, bool control_m
         LOG(INFO) << "Auto connect filter: " << key << " = " << ship_filters[key];
     }
 
-    if (PreferencesManager::get("instance_name") != "")
+    if (!PreferencesManager::get("instance_name").compare(""))
     {
         (new GuiLabel(this, "", PreferencesManager::get("instance_name"), 25))->setAlignment(ACenterLeft)->setPosition(20, 20, ATopLeft)->setSize(0, 18);
     }
@@ -124,7 +124,7 @@ bool AutoConnectScreen::isValidShip(int index)
 
     for(auto it : ship_filters)
     {
-        if (it.first == "solo")
+        if (it.first.compare("solo"))
         {
             int crew_at_position = 0;
             foreach(PlayerInfo, i, player_info_list)
@@ -138,19 +138,19 @@ bool AutoConnectScreen::isValidShip(int index)
             if (crew_at_position > 0)
                 return false;
         }
-        else if (it.first == "faction")
+        else if (it.first.compare("faction"))
         {
             if (ship->getFactionId() != FactionInfo::findFactionId(it.second))
                 return false;
         }
-        else if (it.first == "callsign")
+        else if (it.first.compare("callsign"))
         {
-            if (ship->getCallSign().lower() != it.second.lower())
+            if (!ship->getCallSign().lower().compare(it.second.lower()))
                 return false;
         }
-        else if (it.first == "type")
+        else if (it.first.compare("type"))
         {
-            if (ship->getTypeName().lower() != it.second.lower())
+            if (!ship->getTypeName().lower().compare(it.second.lower()))
                 return false;
         }
         else

--- a/src/screens/crew6/scienceScreen.cpp
+++ b/src/screens/crew6/scienceScreen.cpp
@@ -309,7 +309,7 @@ void ScienceScreen::onDraw(sf::RenderTarget& window)
         string description = obj->getDescription();
         string sidebar_pager_selection = sidebar_pager->getSelectionValue();
 
-        addDescriptionBox(description, description.size() > 0)
+        addDescriptionBox(description, description.size() > 0);
 
         // If the target is a ship, show information about the ship based on how
         // deeply we've scanned it.
@@ -354,10 +354,10 @@ void ScienceScreen::onDraw(sf::RenderTarget& window)
                 {
                     if (description_scanned.size() > 0)
                     {
-                        desc = "Special Intel:\n" + description_scanned
+                        desc = "Special Intel:\n" + description_scanned;
                     }
                 }
-                addDescriptionBox(desc, description.size() > 0 || description_scanned.size() > 0)
+                addDescriptionBox(desc, description.size() > 0 || description_scanned.size() > 0);
                 sidebar_pager->setVisible(sidebar_pager->entryCount() > 1);
 
                 // Check sidebar pager state.

--- a/src/screens/crew6/scienceScreen.cpp
+++ b/src/screens/crew6/scienceScreen.cpp
@@ -309,24 +309,19 @@ void ScienceScreen::onDraw(sf::RenderTarget& window)
         string description = obj->getDescription();
         string sidebar_pager_selection = sidebar_pager->getSelectionValue();
 
-        if (description.size() > 0)
-        {
-            info_description->setText(description)->show();
-
-            if (!sidebar_pager->indexByValue("Description"))
-            {
-                sidebar_pager->addEntry("Description", "Description");
-            }
-        }
-        else
-        {
-            sidebar_pager->removeEntry(sidebar_pager->indexByValue("Description"));
-        }
+        addDescriptionBox(description, description.size() > 0)
 
         // If the target is a ship, show information about the ship based on how
         // deeply we've scanned it.
         if (ship)
         {
+            string description_scanned = ship->getDescriptionScanned();
+            if (ship->getScannedStateFor(my_spaceship) < SS_SimpleScan)
+            {
+                sidebar_pager->removeEntry(sidebar_pager->indexByValue("Description"));
+                info_description->hide();
+            }
+
             // On a simple scan or deeper, show the faction, ship type, shields,
             // hull integrity, and database reference button.
             if (ship->getScannedStateFor(my_spaceship) >= SS_SimpleScan)
@@ -336,12 +331,33 @@ void ScienceScreen::onDraw(sf::RenderTarget& window)
                 info_type_button->show();
                 info_shields->setValue(ship->getShieldDataString());
                 info_hull->setValue(int(ship->getHull()));
+                addDescriptionBox(description, description.size() > 0);
             }
 
             // On a full scan, show tactical and systems data (if any), and its
             // description (if one is set).
             if (ship->getScannedStateFor(my_spaceship) >= SS_FullScan)
             {
+                string desc = "";
+                if (description.size() > 0)
+                {
+                    if (description_scanned.size() > 0)
+                    {
+                        desc = description + "\nSpecial Intel:\n" + description_scanned;
+                    }
+                    else
+                    {
+                        desc = description;
+                    }
+                }
+                else
+                {
+                    if (description_scanned.size() > 0)
+                    {
+                        desc = "Special Intel:\n" + description_scanned
+                    }
+                }
+                addDescriptionBox(desc, description.size() > 0 || description_scanned.size() > 0)
                 sidebar_pager->setVisible(sidebar_pager->entryCount() > 1);
 
                 // Check sidebar pager state.
@@ -438,5 +454,21 @@ void ScienceScreen::onDraw(sf::RenderTarget& window)
         info_distance->setValue(string(distance / 1000.0f, 1) + DISTANCE_UNIT_1K);
         info_heading->setValue(string(int(heading)));
         info_relspeed->setValue(string(rel_velocity / 1000.0f * 60.0f, 1) + DISTANCE_UNIT_1K + "/min");
+    }
+}
+
+void ScienceScreen::addDescriptionBox(const string &description, bool condition) const {
+    if (condition)
+    {
+        info_description->setText(description)->show();
+
+        if (!sidebar_pager->indexByValue("Description"))
+        {
+            sidebar_pager->addEntry("Description", "Description");
+        }
+    }
+    else
+    {
+        sidebar_pager->removeEntry(sidebar_pager->indexByValue("Description"));
     }
 }

--- a/src/screens/crew6/scienceScreen.h
+++ b/src/screens/crew6/scienceScreen.h
@@ -62,6 +62,9 @@ public:
     ScienceScreen(GuiContainer* owner);
 
     virtual void onDraw(sf::RenderTarget& window);
+
+private:
+    void addDescriptionBox(const string &description, bool condition) const;
 };
 
 #endif//SCIENCE_SCREEN_H

--- a/src/spaceObjects/spaceship.cpp
+++ b/src/spaceObjects/spaceship.cpp
@@ -149,6 +149,7 @@ SpaceShip::SpaceShip(string multiplayerClassName, float multiplayer_significant_
     registerMemberReplication(&combat_maneuver_boost_speed);
     registerMemberReplication(&combat_maneuver_strafe_speed);
     registerMemberReplication(&radar_trace);
+    registerMemberReplication(&object_description_scanned);
 
     for(int n=0; n<SYS_COUNT; n++)
     {

--- a/src/spaceObjects/spaceship.cpp
+++ b/src/spaceObjects/spaceship.cpp
@@ -77,6 +77,9 @@ REGISTER_SCRIPT_SUBCLASS_NO_CREATE(SpaceShip, ShipTemplateBasedObject)
     REGISTER_SCRIPT_CLASS_FUNCTION(SpaceShip, setRadarTrace);
 
     REGISTER_SCRIPT_CLASS_FUNCTION(SpaceShip, addBroadcast);
+
+    REGISTER_SCRIPT_CLASS_FUNCTION(SpaceShip, setDescriptionScanned);
+    REGISTER_SCRIPT_CLASS_FUNCTION(SpaceShip, getDescriptionScanned);
 }
 
 SpaceShip::SpaceShip(string multiplayerClassName, float multiplayer_significant_range)

--- a/src/spaceObjects/spaceship.h
+++ b/src/spaceObjects/spaceship.h
@@ -167,6 +167,11 @@ public:
     P<SpaceObject> docking_target; //Server only
     sf::Vector2f docking_offset; //Server only
 
+    /**
+     * An additional descrption only revealed on deep scan
+     */
+    string object_description_scanned;
+
     SpaceShip(string multiplayerClassName, float multiplayer_significant_range=-1);
 
 #if FEATURE_3D_RENDERING
@@ -397,6 +402,9 @@ public:
     void setRadarTrace(string trace) { radar_trace = trace; }
 
     void addBroadcast(int threshold, string message);
+
+    string getDescriptionScanned() { return object_description_scanned; }
+    void setDescriptionScanned(string description) { object_description_scanned = description; }
 
     //Return a string that can be appended to an object create function in the lua scripting.
     // This function is used in getScriptExport calls to adjust for tweaks done in the GM screen.


### PR DESCRIPTION
Make a ship description only visible when scanned. Also added another description property to ships which only appears if the ship is deep scanned. This is currently only possible for ships. Maybe this should be extended to ships and stations. For other objects it is maybe worthwhile that the description can be seen all the time.