### PR TITLE
CMake: setable version number and config dir

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -16,9 +16,11 @@ if(DEFINED ENABLE_CRASH_LOGGER)
  endif(WIN32)
 endif(DEFINED ENABLE_CRASH_LOGGER)
 
-string(TIMESTAMP CPACK_PACKAGE_VERSION_MAJOR "%Y")
-string(TIMESTAMP CPACK_PACKAGE_VERSION_MINOR "%m")
-string(TIMESTAMP CPACK_PACKAGE_VERSION_PATCH "%d")
+if(NOT DEFINED CPACK_PACKAGE_VERSION_MAJOR)
+ string(TIMESTAMP CPACK_PACKAGE_VERSION_MAJOR "%Y")
+ string(TIMESTAMP CPACK_PACKAGE_VERSION_MINOR "%m")
+ string(TIMESTAMP CPACK_PACKAGE_VERSION_PATCH "%d")
+endif(NOT DEFINED CPACK_PACKAGE_VERSION_MAJOR)
 
 set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Wall")
 set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall")
@@ -29,6 +31,12 @@ set(CMAKE_INSTALL_PREFIX "./")
 elseif(UNIX)
 # Set RESOURCE_BASE_DIR on Unix so the built binary is able to find resources
 add_definitions(-DRESOURCE_BASE_DIR="${CMAKE_INSTALL_PREFIX}/share/emptyepsilon/")
+endif()
+
+if(CONFIG_DIR)
+    add_definitions(-DCONFIG_DIR="${CONFIG_DIR}")
+elseif(UNIX)
+    add_definitions(-DCONFIG_DIR="${CMAKE_INSTALL_PREFIX}/share/emptyepsilon/")
 endif()
 
 ## ensure c++11 is used

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -97,8 +97,8 @@ int main(int argc, char** argv)
 #if defined(__WIN32__) && !defined(DEBUG)
     Logging::setLogFile("EmptyEpsilon.log");
 #endif
-#ifdef RESOURCE_BASE_DIR
-    PreferencesManager::load(RESOURCE_BASE_DIR "options.ini");
+#ifdef CONFIG_DIR
+    PreferencesManager::load(CONFIG_DIR "options.ini");
 #endif
     if (getenv("HOME"))
         PreferencesManager::load(string(getenv("HOME")) + "/.emptyepsilon/options.ini");
@@ -262,8 +262,8 @@ int main(int argc, char** argv)
     }
 
     P<HardwareController> hardware_controller = new HardwareController();
-#ifdef RESOURCE_BASE_DIR
-    hardware_controller->loadConfiguration(RESOURCE_BASE_DIR "hardware.ini");
+#ifdef CONFIG_DIR
+    hardware_controller->loadConfiguration(CONFIG_DIR "hardware.ini");
 #endif
     if (getenv("HOME"))
         hardware_controller->loadConfiguration(string(getenv("HOME")) + "/.emptyepsilon/hardware.ini");


### PR DESCRIPTION
Added variables into cmake to allow packaging for linux distributions.
Without defined variables, behavior of cmake should not be changed.
New variables allow:
* set version number (to rebuild old package with original version number)
* to store options.ini/hardware.ini files in /etc instead of /usr

Example of using:
```
cmake .. \
  -DSERIOUS_PROTON_DIR=%{_builddir}/SeriousProton-EE-%{version}/ \
  -DCPACK_PACKAGE_VERSION_MAJOR=%{version_major} \
  -DCPACK_PACKAGE_VERSION_MINOR=%{version_minor} \
  -DCPACK_PACKAGE_VERSION_PATCH=%{version_patch} \
  -DCONFIG_DIR=%{_sysconfdir}/emptyepsilon/ \
  -DCMAKE_INSTALL_PREFIX=%{_prefix}
make
make DESTDIR=%{buildroot} install
```
Patch already used for new Fedora package (in review):
https://bugzilla.redhat.com/show_bug.cgi?id=1422931
I believe it will be useful in upstream too.