### PR TITLE
HotKey Menu for User settings

### DIFF
--- a/src/gui/hotkeyConfig.cpp
+++ b/src/gui/hotkeyConfig.cpp
@@ -6,6 +6,12 @@ HotkeyConfig hotkeys;
 
 HotkeyConfig::HotkeyConfig()
 {  // this list includes all Hotkeys and their standard configuration
+    newCategory("BASIC", "basic"); // these Items should all have predefined values
+    newKey("PAUSE", std::make_tuple("Pause game", "P"));
+    newKey("HELP", std::make_tuple("Show in-game help", "F1"));
+    newKey("ESCAPE", std::make_tuple("Return to ship options menu", "Escape"));
+    newKey("HOME", std::make_tuple("Return to ship options menu", "Home"));  // Remove this item as it does the same as Escape?
+
     newCategory("GENERAL", "General");
     newKey("NEXT_STATION", std::make_tuple("Switch to next crew station", ""));
     newKey("PREV_STATION", std::make_tuple("Switch to previous crew station", ""));
@@ -274,6 +280,24 @@ std::vector<std::pair<string, string>> HotkeyConfig::listHotkeysByCategory(strin
     return ret;
 }
 
+std::vector<std::pair<string, string>> HotkeyConfig::listAllHotkeysByCategory(string hotkey_category)
+{
+    std::vector<std::pair<string, string>> ret;
+
+    for(HotkeyConfigCategory& cat : categories)
+    {
+        if (cat.name == hotkey_category)
+        {
+            for(HotkeyConfigItem& item : cat.hotkeys)
+            {
+                ret.push_back({std::get<0>(item.value), std::get<1>(item.value)});
+            }
+        }
+    }
+
+    return ret;
+}
+
 HotkeyConfigItem::HotkeyConfigItem(string key, std::tuple<string, string> value)
 {
     this->key = key;
@@ -309,4 +333,31 @@ void HotkeyConfigItem::load(string key_config)
             }
         }
     }
+}
+
+void HotkeyConfig::setHotKey(std::string work_cat, std::pair<string,string> key, std::string new_value)
+{
+
+    for(HotkeyConfigCategory& cat : categories)
+    {
+        if (cat.name == work_cat)
+        {
+            int i = 0;
+            for(HotkeyConfigItem& item : cat.hotkeys)
+            {
+                if (key.first == std::get<0>(item.value)) {
+
+                    cat.hotkeys.emplace_back(item.key, std::make_tuple(key.first, new_value));
+                    PreferencesManager::set(std::string("HOTKEY.") + cat.key + "." + item.key, new_value);
+
+                    // erase last, as pointer will show different information afterwards
+                    cat.hotkeys.erase(cat.hotkeys.begin()+i);
+
+                    // needs test if new_value is part of the sfml_list
+                }
+                i++;
+            }
+        }
+    }
+
 }

--- a/src/gui/hotkeyConfig.h
+++ b/src/gui/hotkeyConfig.h
@@ -41,8 +41,10 @@ public:
     void load();
     std::vector<string> getCategories();
     std::vector<std::pair<string, string>> listHotkeysByCategory(string hotkey_category);
-    
+    std::vector<std::pair<string, string>> listAllHotkeysByCategory(string hotkey_category);
+
     std::vector<HotkeyResult> getHotkey(sf::Event::KeyEvent key);
+    void setHotKey(std::string work_cat, std::pair<string,string> key, std::string new_value);
 private:
     std::vector<HotkeyConfigCategory> categories;
     

--- a/src/gui/hotkeyConfig.h
+++ b/src/gui/hotkeyConfig.h
@@ -44,7 +44,7 @@ public:
     std::vector<std::pair<string, string>> listAllHotkeysByCategory(string hotkey_category);
 
     std::vector<HotkeyResult> getHotkey(sf::Event::KeyEvent key);
-    void setHotKey(std::string work_cat, std::pair<string,string> key, std::string new_value);
+    bool setHotKey(std::string work_cat, std::pair<string,string> key, std::string new_value);
 private:
     std::vector<HotkeyConfigCategory> categories;
     

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -11,6 +11,7 @@
 #include "menus/mainMenus.h"
 #include "menus/autoConnectScreen.h"
 #include "menus/shipSelectionScreen.h"
+#include "menus/optionsMenu.h"
 #include "mouseCalibrator.h"
 #include "factionInfo.h"
 #include "gameGlobalInfo.h"
@@ -358,4 +359,9 @@ void returnToShipSelection()
     {
         new ShipSelectionScreen();
     }
+}
+
+void returnToOptionMenu()
+{
+    new OptionsMenu();
 }

--- a/src/main.h
+++ b/src/main.h
@@ -22,5 +22,6 @@ extern PostProcessor* warpPostProcessor;
 
 void returnToMainMenu();
 void returnToShipSelection();
+void returnToOptionMenu();
 
 #endif//MAIN_H

--- a/src/menus/HotKeyMenu.cpp
+++ b/src/menus/HotKeyMenu.cpp
@@ -1,0 +1,133 @@
+#include "engine.h"
+#include "HotKeyMenu.h"
+#include "main.h"
+#include "preferenceManager.h"
+#include "gui/gui2_element.h"
+#include "gui/gui2_selector.h"
+#include "gui/gui2_overlay.h"
+#include "gui/gui2_autolayout.h"
+#include "gui/gui2_textentry.h"
+#include "gui/gui2_panel.h"
+#include "gui/gui2_label.h"
+#include "gui/gui2_scrollbar.h"
+
+HotKeyMenu::HotKeyMenu()
+{
+    P<WindowManager> windowManager = engine->getObject("windowManager");
+
+    new GuiOverlay(this, "", colorConfig.background);
+    (new GuiOverlay(this, "", sf::Color::White))->setTextureTiled("gui/BackgroundCrosses");
+
+    // Left column, manual layout. Draw first element at 50px from top.
+    int top = 50;
+    (new GuiLabel(this, "HOTKEY_OPTIONS_LABEL", "HOTKEYS", 30))->addBackground()->setPosition(50, top, ATopLeft)->setSize(500, 50);
+
+    // Category selector.
+    top += 50;
+    CategoryList = hotkeys.getCategories();
+    (new GuiSelector(this, "Category", [this](int index, string value)
+    {
+        HotKeyMenu::setCategory(index);
+    }))->setOptions(CategoryList)->setSelectionIndex(cat_index)->setPosition(50, top, ATopLeft)->setSize(500, 50);
+
+    // frame with keys
+    top += 60;
+    frame = new GuiPanel(this, "HELP_FRAME");
+    frame->setPosition(50, top, ATopLeft)->setSize(600, 600);
+
+    Cat_label = new GuiLabel(frame, "Category_Label", category, 30);
+    Cat_label->addBackground()->setPosition(50, 10, ATopLeft)->setSize(500, 50);
+
+    // initial category listing
+    HotKeyMenu::setCategory(1);
+
+    // Bottom GUI.
+    // Back button.
+    (new GuiButton(this, "BACK", "Back", [this]()
+    {
+        // Close this menu, stop the music, and return to the main menu.
+        destroy();
+        soundManager->stopMusic();
+        returnToOptionMenu();
+    }))->setPosition(50, -50, ABottomLeft)->setSize(300, 50);
+
+    // Update Hotkey Values
+    (new GuiButton(this, "UPDATE", "Set Hotkeys", [this]()
+    {
+        HotKeyMenu::updateHotKeys();
+    }))->setPosition(400, -50, ABottomLeft)->setSize(300, 50);
+}
+
+void HotKeyMenu::onKey(sf::Event::KeyEvent key, int unicode)
+{
+    switch(key.code)
+    {
+        //TODO: This is more generic code and is duplicated.
+        case sf::Keyboard::Escape:
+        case sf::Keyboard::Home:
+            destroy();
+            returnToOptionMenu();
+            break;
+        default:
+            break;
+    }
+}
+
+void HotKeyMenu::setCategory(int cat)
+{
+    // remove old entries
+    for (GuiTextEntry* text : text_entries){
+        text->destroy();
+    }
+    text_entries.clear();
+    for (GuiLabel* label : label_entries){
+        label->destroy();
+    }
+    label_entries.clear();
+
+    // reset help frame size
+    int frame_width = 600;
+    frame->setSize(frame_width, 600);
+
+    // get chosen category
+    cat_index = cat;
+    category = CategoryList[cat];
+
+    int top = 70;
+
+    HotKeyList = hotkeys.listAllHotkeysByCategory(category);
+
+    // begin filling of Hotkey listing for category
+    Cat_label->setText(category);
+    int left = 50;
+    for (std::pair<string,string> item : HotKeyList) {
+
+        label_entries.push_back(new GuiLabel(frame, "NAME_LABEL", item.first.append(" = "), 30));
+        label_entries.back()->setPosition(left, top, ATopLeft)->setSize(300, 50);
+
+        text_entries.push_back(new GuiTextEntry(frame, "HotKey_Entry", item.second));
+        text_entries.back()->setTextSize(30)->setPosition(left+300, top, ATopLeft)->setSize(200, 50);
+        top += 50;
+
+        if (top>550){
+            left = left + 550;
+            top = 60;
+            frame_width = frame_width + 600;
+            frame->setSize(frame_width, 600);
+        }
+    }
+}
+
+void HotKeyMenu::updateHotKeys()
+{
+    int i = 0;
+    std::string text = "";
+
+    // read in all TextEntry values and update hotkeys
+    for (std::pair<string,string> item : HotKeyList) {
+
+        text = text_entries[i]->getText();
+        hotkeys.setHotKey(category, item, text);
+        i++;
+    }
+}

--- a/src/menus/HotKeyMenu.cpp
+++ b/src/menus/HotKeyMenu.cpp
@@ -122,12 +122,26 @@ void HotKeyMenu::updateHotKeys()
 {
     int i = 0;
     std::string text = "";
+    bool hotkey_exists = false;
 
     // read in all TextEntry values and update hotkeys
     for (std::pair<string,string> item : HotKeyList) {
 
         text = text_entries[i]->getText();
-        hotkeys.setHotKey(category, item, text);
+        hotkey_exists = hotkeys.setHotKey(category, item, text);
+
+        if (!hotkey_exists){
+            text_entries[i]->setText("");
+            error_window = new GuiOverlay(this, "KEY_ERROR_OVERLAY", sf::Color::Black);
+            error_window->setPosition(0, -100, ACenter)->setSize(500, 200)->setVisible(true);
+            (new GuiLabel(error_window, "ERROR_LABEL", text.append(" -> this sfml key does not exist"), 30))->setPosition(0, 50, ATopCenter)->setSize(300, 50);
+            (new GuiButton(error_window, "ERROR_OK", "OK", [this]()
+            {
+                // Close this window
+                error_window->destroy();
+            }))->setPosition(0, -10, ABottomCenter)->setSize(200, 50);
+            return;
+        }
         i++;
     }
 }

--- a/src/menus/HotKeyMenu.h
+++ b/src/menus/HotKeyMenu.h
@@ -5,6 +5,7 @@
 #include "gui/gui2_canvas.h"
 #include "gui/gui2_scrollbar.h"
 
+class GuiOverlay;
 class GuiSlider;
 class GuiLabel;
 class GuiCanvas;
@@ -18,6 +19,7 @@ private:
     std::vector<GuiTextEntry*> text_entries;
     std::vector<GuiLabel*> label_entries;
     GuiLabel* Cat_label;
+    GuiOverlay* error_window;
 
     string category = "";
     int    cat_index = 1;

--- a/src/menus/HotKeyMenu.h
+++ b/src/menus/HotKeyMenu.h
@@ -1,0 +1,36 @@
+#ifndef EMPTYEPSILON_HOTKEYMENU_H
+#define EMPTYEPSILON_HOTKEYMENU_H
+
+#include <gui/gui2_entrylist.h>
+#include "gui/gui2_canvas.h"
+#include "gui/gui2_scrollbar.h"
+
+class GuiSlider;
+class GuiLabel;
+class GuiCanvas;
+class GuiPanel;
+class GuiScrollText;
+class GuiTextEntry;
+
+class HotKeyMenu : public GuiCanvas
+{
+private:
+    std::vector<GuiTextEntry*> text_entries;
+    std::vector<GuiLabel*> label_entries;
+    GuiLabel* Cat_label;
+
+    string category = "";
+    int    cat_index = 1;
+    std::vector<string> CategoryList;
+    std::vector<std::pair<string, string>> HotKeyList;
+
+    void setCategory(int cat);
+    void updateHotKeys();
+public:
+    HotKeyMenu();
+    GuiPanel* frame;
+
+    void onKey(sf::Event::KeyEvent key, int unicode);
+};
+
+#endif //EMPTYEPSILON_HOTKEYMENU_H

--- a/src/menus/optionsMenu.cpp
+++ b/src/menus/optionsMenu.cpp
@@ -10,9 +10,9 @@
 #include "gui/gui2_slider.h"
 #include "gui/gui2_listbox.h"
 #include "gui/gui2_keyvaluedisplay.h"
+#include "HotKeyMenu.h"
 
-OptionsMenu::OptionsMenu()
-{
+OptionsMenu::OptionsMenu() {
     P<WindowManager> windowManager = engine->getObject("windowManager");
 
     new GuiOverlay(this, "", colorConfig.background);
@@ -100,7 +100,7 @@ OptionsMenu::OptionsMenu()
     }))->setOptions({"Disabled", "Enabled", "Main Screen only"})->setSelectionIndex(music_enabled_index)->setPosition(50, top, ATopLeft)->setSize(300, 50);
 
     // Hotkey Options: set Keys
-    top += 50;
+    top += 60;
     (new GuiLabel(this, "HELP_KEY_OPTIONS_LABEL", "Help Key Options", 30))->addBackground()->setPosition(50, top, ATopLeft)->setSize(300, 50);
 
     top += 50;

--- a/src/menus/optionsMenu.cpp
+++ b/src/menus/optionsMenu.cpp
@@ -99,6 +99,16 @@ OptionsMenu::OptionsMenu()
         PreferencesManager::set("music_enabled", string(index));
     }))->setOptions({"Disabled", "Enabled", "Main Screen only"})->setSelectionIndex(music_enabled_index)->setPosition(50, top, ATopLeft)->setSize(300, 50);
 
+    // Hotkey Options: set Keys
+    top += 50;
+    (new GuiLabel(this, "HELP_KEY_OPTIONS_LABEL", "Help Key Options", 30))->addBackground()->setPosition(50, top, ATopLeft)->setSize(300, 50);
+
+    top += 50;
+    (new GuiButton(this, "SET_HOTKEYS", " HotKeys Menu", [this]() {
+        new HotKeyMenu();
+        destroy();
+    }))->setPosition(50, top , ATopLeft)->setSize(300, 50);
+
     // Right column, manual layout. Draw first element 50px from top.
     top = 50;
 

--- a/src/menus/optionsMenu.h
+++ b/src/menus/optionsMenu.h
@@ -13,6 +13,8 @@ private:
     GuiSlider* music_volume_slider;
     GuiLabel* sound_volume_overlay_label;
     GuiLabel* music_volume_overlay_label;
+
+    std::vector<string> HotKeyCategories;
 public:
     OptionsMenu();
 


### PR DESCRIPTION
Additional menu point in Options is a Hotkey Menu. 
Hotkeys can be viewed and changed for any category. For categories with a lot of entries this might be a problem, as I not yet have limited the window width.
There is a check if user set SFML key exist and also the key names are made case insensitive.
This menu might in future also allow for Joystick SFML commands to be set by user.