### PR TITLE
Hotkeys for crew4 and crew1 screens

### DIFF
--- a/src/gui/hotkeyConfig.cpp
+++ b/src/gui/hotkeyConfig.cpp
@@ -7,7 +7,7 @@ HotkeyConfig hotkeys;
 HotkeyConfig::HotkeyConfig()
 {  // this list includes all Hotkeys and their standard configuration
     newCategory("GENERAL", "General");
-    newKey("NEXT_STATION", std::make_tuple("Switch to next crew station", ""));
+    newKey("NEXT_STATION", std::make_tuple("Switch to next crew station", "Tab"));
     newKey("PREV_STATION", std::make_tuple("Switch to previous crew station", ""));
     newKey("STATION_HELMS", std::make_tuple("Switch to helms station", "F2"));
     newKey("STATION_WEAPONS", std::make_tuple("Switch to weapons station", "F3"));

--- a/src/screens/crew1/singlePilotScreen.cpp
+++ b/src/screens/crew1/singlePilotScreen.cpp
@@ -163,3 +163,14 @@ void SinglePilotScreen::onDraw(sf::RenderTarget& window)
         camera_yaw += sf::angleDifference(camera_yaw, target_camera_yaw) * 0.1f;
     }
 }
+
+void SinglePilotScreen::onHotkey(const HotkeyResult& key)
+{
+    if (key.category == "HELMS" && my_spaceship)
+    {
+        if (key.hotkey == "TURN_LEFT")
+            my_spaceship->commandTargetRotation(my_spaceship->getRotation() - 5.0f);
+        else if (key.hotkey == "TURN_RIGHT")
+            my_spaceship->commandTargetRotation(my_spaceship->getRotation() + 5.0f);
+    }
+}

--- a/src/screens/crew1/singlePilotScreen.h
+++ b/src/screens/crew1/singlePilotScreen.h
@@ -36,6 +36,7 @@ public:
     SinglePilotScreen(GuiContainer* owner);
     
     virtual void onDraw(sf::RenderTarget& window);
+    virtual void onHotkey(const HotkeyResult& key) override;
 };
 
 #endif//SINGLE_PILOT_SCREEN_H

--- a/src/screens/crew4/tacticalScreen.cpp
+++ b/src/screens/crew4/tacticalScreen.cpp
@@ -142,3 +142,14 @@ void TacticalScreen::onDraw(sf::RenderTarget& window)
     }
     GuiOverlay::onDraw(window);
 }
+
+void TacticalScreen::onHotkey(const HotkeyResult& key)
+{
+    if (key.category == "HELMS" && my_spaceship)
+    {
+        if (key.hotkey == "TURN_LEFT")
+            my_spaceship->commandTargetRotation(my_spaceship->getRotation() - 5.0f);
+        else if (key.hotkey == "TURN_RIGHT")
+            my_spaceship->commandTargetRotation(my_spaceship->getRotation() + 5.0f);
+    }
+}

--- a/src/screens/crew4/tacticalScreen.h
+++ b/src/screens/crew4/tacticalScreen.h
@@ -32,6 +32,7 @@ public:
     TacticalScreen(GuiContainer* owner);
     
     virtual void onDraw(sf::RenderTarget& window);
+    virtual void onHotkey(const HotkeyResult& key) override;
 };
 
 #endif//TACTICAL_SCREEN_H

--- a/src/screens/crewStationScreen.cpp
+++ b/src/screens/crewStationScreen.cpp
@@ -255,8 +255,13 @@ GuiElement* CrewStationScreen::findTab(string name)
 string CrewStationScreen::listHotkeysLimited(string station)
 {	
 	string ret = "";
+	keyboard_general = "";
+	for (std::pair<string, string> shortcut : hotkeys.listHotkeysByCategory("General"))
+		if (shortcut.first == "Switch to next crew station" || shortcut.first =="Switch to previous crew station") 				
+			keyboard_general += shortcut.second + ":\t" + shortcut.first + "\n";
 	if (station == "Tactical")
-	{
+	{	
+		
 		for (std::pair<string, string> shortcut : hotkeys.listHotkeysByCategory("Helms"))
             ret += shortcut.second + ":\t" + shortcut.first + "\n";
 		for (std::pair<string, string> shortcut : hotkeys.listHotkeysByCategory("Weapons"))

--- a/src/screens/crewStationScreen.cpp
+++ b/src/screens/crewStationScreen.cpp
@@ -92,6 +92,8 @@ void CrewStationScreen::addStationTab(GuiElement* element, ECrewPosition positio
 
         for (std::pair<string, string> shortcut : hotkeys.listHotkeysByCategory(info.button->getText()))
             keyboard_category += shortcut.second + ":\t" + shortcut.first + "\n";
+        if (keyboard_category == "")	// special hotkey combination for crew1 and crew4 screens
+            keyboard_category = listHotkeysLimited(info.button->getText());
 
         keyboard_help->setText(keyboard_general + keyboard_category);
     }else{
@@ -228,6 +230,8 @@ void CrewStationScreen::showTab(GuiElement* element)
 
             for (std::pair<string, string> shortcut : hotkeys.listHotkeysByCategory(info.button->getText()))
                 keyboard_category += shortcut.second + ":\t" + shortcut.first + "\n";
+			if (keyboard_category == "")	// special hotkey combination for crew1 and crew4 screens
+				keyboard_category = listHotkeysLimited(info.button->getText());               
 
             keyboard_help->setText(keyboard_general + keyboard_category);
         }else{
@@ -246,4 +250,43 @@ GuiElement* CrewStationScreen::findTab(string name)
     }
 
     return nullptr;
+}
+
+string CrewStationScreen::listHotkeysLimited(string station)
+{	
+	string ret = "";
+	if (station == "Tactical")
+	{
+		for (std::pair<string, string> shortcut : hotkeys.listHotkeysByCategory("Helms"))
+            ret += shortcut.second + ":\t" + shortcut.first + "\n";
+		for (std::pair<string, string> shortcut : hotkeys.listHotkeysByCategory("Weapons"))
+		{
+			if (shortcut.first != "Toggle shields") 
+				ret += shortcut.second + ":\t" + shortcut.first + "\n";
+		}
+	}
+	else if (station == "Engineering+")
+	{
+		for (std::pair<string, string> shortcut : hotkeys.listHotkeysByCategory("Engineering"))
+            ret += shortcut.second + ":\t" + shortcut.first + "\n";
+        for (std::pair<string, string> shortcut : hotkeys.listHotkeysByCategory("Weapons"))
+        {
+            if (shortcut.first == "Toggle shields") 
+				ret += shortcut.second + ":\t" + shortcut.first + "\n";
+		}
+	}
+
+//	-- not yet used --
+//	else if (station == "Operations") 
+//		return ret;
+//	----
+
+	else if (station == "Single Pilot")
+	{
+		for (std::pair<string, string> shortcut : hotkeys.listHotkeysByCategory("Helms"))
+            ret += shortcut.second + ":\t" + shortcut.first + "\n";
+		for (std::pair<string, string> shortcut : hotkeys.listHotkeysByCategory("Weapons"))
+			ret += shortcut.second + ":\t" + shortcut.first + "\n";
+	}
+    return ret;
 }

--- a/src/screens/crewStationScreen.h
+++ b/src/screens/crewStationScreen.h
@@ -45,7 +45,10 @@ private:
     string keyboard_general = "";
     void showNextTab(int offset=1);
     void showTab(GuiElement* element);
+
     GuiElement* findTab(string name);
+    
+    string listHotkeysLimited(string station);
 };
 
 #endif//CREW_STATION_SCREEN_H


### PR DESCRIPTION
This modifies the hotkey help screen to show the proper keys for screens of the 3/4 crew and 1 crew/extras setup. It also will add some additional hotkey support for those screens.

- Added hotkey support for turning left and right for tactical and single pilot
- Help screen shows the appropriate hotkey for 1crew and 4crew setups
- Preset for next station hotkey (as there is no equivalent hotkey for switching to a distinct station on non-6crew-screens)

