### PR TITLE
Fix bug for TOGGLE_AIM_LOCK

### DIFF
--- a/src/screenComponents/aimLock.cpp
+++ b/src/screenComponents/aimLock.cpp
@@ -26,14 +26,17 @@ void AimLockButton::onHotkey(const HotkeyResult& key)
         if (key.hotkey == "TOGGLE_AIM_LOCK")
         {
             setAimLock(!getValue());
+            setValue(!getValue());
         }
         if (key.hotkey == "ENABLE_AIM_LOCK")
         {
             setAimLock(true);
+            setValue(true);
         }
         if (key.hotkey == "DISABLE_AIM_LOCK")
         {
             setAimLock(false);
+            setValue(false);
         }
     }
 }


### PR DESCRIPTION
The hotkey for toggling the aim lock did not work correctly, because the toggle code read the state of the lock button, but the hotkeys only changed the state of the aim lock, but not the state of the button.
