### PR TITLE
Fix spelling of Birth of the Atlantis mission

### DIFF
--- a/scripts/scenario_08_atlantis.lua
+++ b/scripts/scenario_08_atlantis.lua
@@ -1,4 +1,4 @@
--- Name: Birth of the Altantis
+-- Name: Birth of the Atlantis
 -- Description: You are the first crew of a new and improved version of the Atlantis space explorer.
 --- Your mission will be to take it trough it's first tests and initial mission.
 -- Type: Mission


### PR DESCRIPTION
It's either "Atlantis" and just the title was wrong, or "Altantis" and the rest of the texts were wrong. Altantis would've been fun too, but I'm guessing the intention was Atlantis.