### PR TITLE
Add sliders to GM-screen to control speed of combat maneuvers

### DIFF
--- a/src/screens/gm/tweak.cpp
+++ b/src/screens/gm/tweak.cpp
@@ -579,6 +579,19 @@ GuiShipTweakPlayer::GuiShipTweakPlayer(GuiContainer* owner)
     });
     energy_level_slider->addOverlay()->setSize(GuiElement::GuiSizeMax, 40);
 
+    // Display Boost/Strafe speed sliders
+    (new GuiLabel(left_col, "", "Boost Speed:", 30))->setSize(GuiElement::GuiSizeMax, 50);
+    combat_maneuver_boost_speed_slider = new GuiSlider(left_col, "", 0.0, 1000, 0.0, [this](float value) {
+        target->combat_maneuver_boost_speed = value;
+    });
+    combat_maneuver_boost_speed_slider->addOverlay()->setSize(GuiElement::GuiSizeMax, 40);
+
+    (new GuiLabel(left_col, "", "Strafe Speed:", 30))->setSize(GuiElement::GuiSizeMax, 50);
+    combat_maneuver_strafe_speed_slider = new GuiSlider(left_col, "", 0.0, 1000, 0.0, [this](float value) {
+        target->combat_maneuver_strafe_speed = value;
+    });
+    combat_maneuver_strafe_speed_slider->addOverlay()->setSize(GuiElement::GuiSizeMax, 40);
+
     // Right column
     // Count and list ship positions and whether they're occupied.
     position_count = new GuiLabel(right_col, "", "Positions occupied: ", 30);
@@ -633,6 +646,14 @@ void GuiShipTweakPlayer::open(P<SpaceObject> target)
     {
         // Read ship's control code.
         control_code->setText(player->control_code);
+
+        // Set and snap boost speed slider to current value
+        combat_maneuver_boost_speed_slider->setValue(player->combat_maneuver_boost_speed);
+        combat_maneuver_boost_speed_slider->clearSnapValues()->addSnapValue(player->combat_maneuver_boost_speed, 20.0f);
+
+        // Set and snap strafe speed slider to current value
+        combat_maneuver_strafe_speed_slider->setValue(player->combat_maneuver_strafe_speed);
+        combat_maneuver_strafe_speed_slider->clearSnapValues()->addSnapValue(player->combat_maneuver_strafe_speed, 20.0f);
     }
 }
 

--- a/src/screens/gm/tweak.h
+++ b/src/screens/gm/tweak.h
@@ -165,6 +165,8 @@ private:
     GuiSlider* reputation_point_slider;
     GuiSlider* energy_level_slider;
     GuiSlider* max_energy_level_slider;
+    GuiSlider* combat_maneuver_boost_speed_slider;
+    GuiSlider* combat_maneuver_strafe_speed_slider;
     GuiLabel* position_count;
     GuiKeyValueDisplay* position[max_crew_positions];
 public:


### PR DESCRIPTION
I've added two sliders to the Player-section of the GM-screen to control speed of combat maneuvers.