### PR TITLE
Enable to select selectable objects in Operations

### DIFF
--- a/src/screens/crew4/operationsScreen.cpp
+++ b/src/screens/crew4/operationsScreen.cpp
@@ -44,7 +44,7 @@ OperationScreen::OperationScreen(GuiContainer* owner)
             switch(mode)
             {
             case TargetSelection:
-                science->targets.setToClosestTo(position, 1000.0, TargetsContainer::Targetable);
+                science->targets.setToClosestTo(position, 1000.0, TargetsContainer::Selectable);
                 break;
             case WaypointPlacement:
                 if (my_spaceship)


### PR DESCRIPTION
Like in the science station, all selectable objects now can be selected from operations and will show their description, not just those that are "targetable".