### PR TITLE
Redirect mouse clicks on main screen radar

### DIFF
--- a/src/screens/mainScreen.cpp
+++ b/src/screens/mainScreen.cpp
@@ -25,14 +25,18 @@ ScreenMainScreen::ScreenMainScreen()
     viewport->setPosition(0, 0, ATopLeft)->setSize(GuiElement::GuiSizeMax, GuiElement::GuiSizeMax);
     
     (new GuiRadarView(viewport, "VIEWPORT_RADAR", 5000.0f, nullptr))->setStyle(GuiRadarView::CircularMasked)->setSize(200, 200)->setPosition(-20, 20, ATopRight);
-    
+
     tactical_radar = new GuiRadarView(this, "TACTICAL", 5000.0f, nullptr);
     tactical_radar->setPosition(0, 0, ATopLeft)->setSize(GuiElement::GuiSizeMax, GuiElement::GuiSizeMax);
     tactical_radar->setRangeIndicatorStepSize(1000.0f)->shortRange()->enableCallsigns()->hide();
-    long_range_radar = new GuiRadarView(this, "TACTICAL", gameGlobalInfo->long_range_radar_range, nullptr);
+    tactical_radar->setCallbacks([this](sf::Vector2f position) {onClick(position);}, nullptr, nullptr);
+
+    long_range_radar = new GuiRadarView(this, "LONG_RANGE", gameGlobalInfo->long_range_radar_range, nullptr);
     long_range_radar->setPosition(0, 0, ATopLeft)->setSize(GuiElement::GuiSizeMax, GuiElement::GuiSizeMax);
     long_range_radar->setRangeIndicatorStepSize(5000.0f)->longRange()->enableCallsigns()->hide();
+    long_range_radar->setCallbacks([this](sf::Vector2f position) {onClick(position);}, nullptr, nullptr);
     long_range_radar->setFogOfWarStyle(GuiRadarView::NebulaFogOfWar);
+
     onscreen_comms = new GuiCommsOverlay(this);
     onscreen_comms->setSize(GuiElement::GuiSizeMax, GuiElement::GuiSizeMax)->setVisible(false);
 


### PR DESCRIPTION
When mouse clicks occurred on the GuiRadarView elements nothing was being done with them.  The user would have to verify that the mouse pointer was not on the element in order for the click event to be handled.