### PR TITLE
Fix hang on start tutorial with no tutorial selected

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -7,6 +7,9 @@ option(ENABLE_CRASH_LOGGER "Enable the drmingw crash logging facilities" OFF)
 if(NOT DEFINED SERIOUS_PROTON_DIR)
  message(FATAL_ERROR "SERIOUS_PROTON_DIR was not set. Unable to continue")
 endif(NOT DEFINED SERIOUS_PROTON_DIR)
+if(NOT IS_ABSOLUTE "${SERIOUS_PROTON_DIR}")
+  get_filename_component(SERIOUS_PROTON_DIR "${CMAKE_BINARY_DIR}/${SERIOUS_PROTON_DIR}" ABSOLUTE)
+endif()
 
 if(DEFINED ENABLE_CRASH_LOGGER)
  if(WIN32)
@@ -344,7 +347,7 @@ foreach(SP_SOURCE
 	src/lua/lgc.c
 	src/lua/lbitlib.c
 	)
-  	list(APPEND SOURCES ${SERIOUS_PROTON_DIR}${SP_SOURCE})
+	list(APPEND SOURCES ${SERIOUS_PROTON_DIR}/${SP_SOURCE})
 endforeach()
 
 add_definitions(-DWINDOW_TITLE="EmptyEpsilon")

--- a/src/menus/tutorialMenu.cpp
+++ b/src/menus/tutorialMenu.cpp
@@ -37,8 +37,6 @@ TutorialMenu::TutorialMenu()
         ScenarioInfo info(filename);
         tutorial_list->addEntry(info.name, filename);
     }
-    // Select the first scenario in the list by default.
-    tutorial_list->setSelectionIndex(0);
 
 
         // Show the scenario description text.
@@ -47,10 +45,11 @@ TutorialMenu::TutorialMenu()
     tutorial_description = new GuiScrollText(panel, "TUTORIAL_DESCRIPTION", "");
     tutorial_description->setTextSize(24)->setMargins(15)->setSize(GuiElement::GuiSizeMax, GuiElement::GuiSizeMax);
 
-    (new GuiButton(this, "START_TUTORIAL", "Start Tutorial", [this]() {
+    start_tutorial_button = new GuiButton(this, "START_TUTORIAL", "Start Tutorial", [this]() {
         destroy();
         new TutorialGame(false,selected_tutorial_filename);
-    }))->setPosition(0, -50, ABottomRight)->setSize(300, 50);
+    });
+    start_tutorial_button->setEnable(false)->setPosition(0, -50, ABottomRight)->setSize(300, 50);
     // Bottom GUI.
     // Back button.
     (new GuiButton(this, "BACK", "Back", [this]()
@@ -59,10 +58,17 @@ TutorialMenu::TutorialMenu()
         destroy();
         returnToMainMenu();
     }))->setPosition(50, -50, ABottomLeft)->setSize(300, 50);
+
+    // Select the first scenario in the list by default.
+    if (!tutorial_filenames.empty()) {
+        tutorial_list->setSelectionIndex(0);
+        selectTutorial(tutorial_filenames.front());
+    }
 }
 void TutorialMenu::selectTutorial(string filename)
 {
     selected_tutorial_filename = filename;
+    start_tutorial_button->setEnable(true);
     ScenarioInfo info(filename);
     tutorial_description->setText("");
     tutorial_description->setText(info.description);

--- a/src/menus/tutorialMenu.h
+++ b/src/menus/tutorialMenu.h
@@ -6,11 +6,13 @@
 class GuiSlider;
 class GuiLabel;
 class GuiScrollText;
+class GuiButton;
 
 class TutorialMenu : public GuiCanvas
 {
     string selected_tutorial_filename;
     GuiScrollText* tutorial_description;
+    GuiButton* start_tutorial_button;
 private:
 
     void selectTutorial(string filename);


### PR DESCRIPTION
The tutorial main screen selected the first entry without loading it nor
setting the filename. When the user pressed startTutorial the game would
hang.
Select the first tutorial entry if there is one and load the filename
and description, only then enable the start tutorial button.