### PR TITLE
Added an faction aura in the radar, once we know what faction the ship is.

### DIFF
--- a/scripts/factionInfo.lua
+++ b/scripts/factionInfo.lua
@@ -3,7 +3,7 @@ neutral:setGMColor(128, 128, 128)
 neutral:setDescription([[Despite appearing as a faction, independents are distinguished primarily by having no strong affiliation with any faction at all. Most traders consider themselves independent, though certain voices have started to speak up about creating a merchant faction.]])
 
 human = FactionInfo():setName("Human Navy")
-human:setGMColor(255, 255, 255)
+human:setGMColor(128, 128, 255)
 human:setDescription([[The remnants of the human navy.
 
 While all other races were driven to the stars out of greed or scientific research, humans where the only race to start exploring the galaxy because their homeworld could no longer sustain their population. Some other races view humans as a sort of virus or plague due to the rate at which they can breed and spread.

--- a/scripts/factionInfo.lua
+++ b/scripts/factionInfo.lua
@@ -3,7 +3,7 @@ neutral:setGMColor(128, 128, 128)
 neutral:setDescription([[Despite appearing as a faction, independents are distinguished primarily by having no strong affiliation with any faction at all. Most traders consider themselves independent, though certain voices have started to speak up about creating a merchant faction.]])
 
 human = FactionInfo():setName("Human Navy")
-human:setGMColor(128, 128, 255)
+human:setGMColor(0, 255, 255)
 human:setDescription([[The remnants of the human navy.
 
 While all other races were driven to the stars out of greed or scientific research, humans where the only race to start exploring the galaxy because their homeworld could no longer sustain their population. Some other races view humans as a sort of virus or plague due to the rate at which they can breed and spread.

--- a/src/gameGlobalInfo.cpp
+++ b/src/gameGlobalInfo.cpp
@@ -33,7 +33,8 @@ GameGlobalInfo::GameGlobalInfo()
     use_system_damage = true;
     allow_main_screen_tactical_radar = true;
     allow_main_screen_long_range_radar = true;
-    
+    allow_faction_aura = true;
+
     intercept_all_comms_to_gm = false;
 
     registerMemberReplication(&scanning_complexity);
@@ -46,6 +47,7 @@ GameGlobalInfo::GameGlobalInfo()
     registerMemberReplication(&use_system_damage);
     registerMemberReplication(&allow_main_screen_tactical_radar);
     registerMemberReplication(&allow_main_screen_long_range_radar);
+    registerMemberReplication(&allow_faction_aura);
 
     for(unsigned int n=0; n<factionInfo.size(); n++)
         reputation_points.push_back(0);
@@ -318,7 +320,7 @@ public:
     : script_name(script_name), variation(variation)
     {
     }
-    
+
     virtual void update(float delta)
     {
         gameGlobalInfo->variation = variation;

--- a/src/gameGlobalInfo.h
+++ b/src/gameGlobalInfo.h
@@ -57,7 +57,7 @@ private:
 public:
     string global_message;
     float global_message_timeout;
-    
+
     string banner_string;
 
     std::vector<float> reputation_points;
@@ -72,6 +72,7 @@ public:
     bool use_system_damage;
     bool allow_main_screen_tactical_radar;
     bool allow_main_screen_long_range_radar;
+    bool allow_faction_aura;
     string variation = "None";
 
     //List of script functions that can be called from the GM interface (Server only!)

--- a/src/menus/serverCreationScreen.cpp
+++ b/src/menus/serverCreationScreen.cpp
@@ -31,6 +31,7 @@ ServerCreationScreen::ServerCreationScreen()
     gameGlobalInfo->use_system_damage = PreferencesManager::get("server_config_use_system_damage", "1").toInt();
     gameGlobalInfo->allow_main_screen_tactical_radar = PreferencesManager::get("server_config_allow_main_screen_tactical_radar", "1").toInt();
     gameGlobalInfo->allow_main_screen_long_range_radar = PreferencesManager::get("server_config_allow_main_screen_long_range_radar", "1").toInt();
+    gameGlobalInfo->allow_faction_aura = PreferencesManager::get("server_config_allow_faction_aura", "1").toInt();
 
     // Create a two-column layout.
     GuiElement* container = new GuiAutoLayout(this, "", GuiAutoLayout::ELayoutMode::LayoutVerticalColumns);
@@ -107,7 +108,9 @@ ServerCreationScreen::ServerCreationScreen()
     }))->setValue(gameGlobalInfo->allow_main_screen_tactical_radar)->setSize(275, GuiElement::GuiSizeMax)->setPosition(0, 0, ACenterLeft);
     (new GuiToggleButton(row, "MAIN_LONG_RANGE_TOGGLE", "Long range radar", [](bool value) {
         gameGlobalInfo->allow_main_screen_long_range_radar = value == 1;
-    }))->setValue(gameGlobalInfo->allow_main_screen_long_range_radar)->setSize(275, GuiElement::GuiSizeMax)->setPosition(0, 0, ACenterRight);
+    }))->setValue(gameGlobalInfo->allow_main_screen_long_range_radar)->setSize(275, GuiElement::GuiSizeMax)->setPosition(0, 0, ACenter);
+
+
 
     // Game rules section.
     (new GuiLabel(left_panel, "GAME_RULES_LABEL", "Game rules", 30))->addBackground()->setSize(GuiElement::GuiSizeMax, 50);
@@ -130,6 +133,14 @@ ServerCreationScreen::ServerCreationScreen()
     (new GuiToggleButton(row, "GAME_SYS_DAMAGE_TOGGLE", "Per-system damage", [](bool value) {
         gameGlobalInfo->use_system_damage = value == 1;
     }))->setValue(gameGlobalInfo->use_system_damage)->setSize(275, GuiElement::GuiSizeMax)->setPosition(0, 0, ACenterRight);
+
+    // Radar View mods
+    row = new GuiAutoLayout(left_panel, "", GuiAutoLayout::LayoutHorizontalLeftToRight);
+    row->setSize(GuiElement::GuiSizeMax, 50);
+    (new GuiToggleButton(row, "MAIN_FACTION_AURA_TOGGLE", "Faction Aura", [](bool value) {
+        gameGlobalInfo->allow_faction_aura = value == 1;
+    }))->setValue(gameGlobalInfo->allow_faction_aura)->setSize(275, GuiElement::GuiSizeMax)->setPosition(0, 0, ACenterRight);
+
 
     // Right column contents.
     // Scenario section.
@@ -218,7 +229,7 @@ void ServerCreationScreen::selectScenario(string filename)
         variation_names_list.push_back(variation.first);
         variation_descriptions_list.push_back(variation.second);
     }
-    
+
     variation_selection->setOptions(variation_names_list);
     // Show the variation information only if there's more than 1.
     variation_container->setVisible(variation_names_list.size() > 1);
@@ -234,6 +245,7 @@ void ServerCreationScreen::startScenario()
     PreferencesManager::set("server_config_use_system_damage", string(int(gameGlobalInfo->use_system_damage)));
     PreferencesManager::set("server_config_allow_main_screen_tactical_radar", string(int(gameGlobalInfo->allow_main_screen_tactical_radar)));
     PreferencesManager::set("server_config_allow_main_screen_long_range_radar", string(int(gameGlobalInfo->allow_main_screen_long_range_radar)));
+    PreferencesManager::set("server_config_allow_faction_aura", string(int(gameGlobalInfo->allow_faction_aura)));
 
     // Start the selected scenario.
     gameGlobalInfo->startScenario(selected_scenario_filename);

--- a/src/screenComponents/radarView.cpp
+++ b/src/screenComponents/radarView.cpp
@@ -513,7 +513,7 @@ void GuiRadarView::drawMissileTubes(sf::RenderTarget& window)
             sf::Vector2f fire_draw_position = radar_screen_center + (view_position - fire_position) * scale;
 
             float fire_angle = my_spaceship->getRotation() + my_spaceship->weapon_tube[n].getDirection();
-            
+
             a[n * 2].position = fire_draw_position;
             a[n * 2 + 1].position = fire_draw_position + (sf::vector2FromAngle(fire_angle) * 1000.0f) * scale;
             a[n * 2].color = sf::Color(128, 128, 128, 128);
@@ -586,6 +586,7 @@ void GuiRadarView::drawObjects(sf::RenderTarget& window_normal, sf::RenderTarget
             sf::RenderTarget* window = &window_normal;
             if (!obj->canHideInNebula())
                 window = &window_alpha;
+            if (gameGlobalInfo->allow_faction_aura) obj->drawFactionOnRadar(*window, object_position_on_screen, scale, long_range);
             obj->drawOnRadar(*window, object_position_on_screen, scale, long_range);
             if (show_callsigns && obj->getCallSign() != "")
                 drawText(*window, sf::FloatRect(object_position_on_screen.x, object_position_on_screen.y - 15, 0, 0), obj->getCallSign(), ACenter, 15, bold_font);
@@ -594,6 +595,7 @@ void GuiRadarView::drawObjects(sf::RenderTarget& window_normal, sf::RenderTarget
     if (my_spaceship)
     {
         sf::Vector2f object_position_on_screen = radar_screen_center + (my_spaceship->getPosition() - view_position) * scale;
+        if (gameGlobalInfo->allow_faction_aura) my_spaceship->drawFactionOnRadar(window_normal, object_position_on_screen, scale, long_range);
         my_spaceship->drawOnRadar(window_normal, object_position_on_screen, scale, long_range);
     }
 }

--- a/src/spaceObjects/spaceObject.cpp
+++ b/src/spaceObjects/spaceObject.cpp
@@ -128,6 +128,9 @@ void SpaceObject::draw3D()
     model_info.render(getPosition(), getRotation());
 }
 #endif//FEATURE_3D_RENDERING
+void SpaceObject::drawFactionOnRadar(sf::RenderTarget& window, sf::Vector2f position, float scale, bool longRange)
+{
+}
 
 void SpaceObject::drawOnRadar(sf::RenderTarget& window, sf::Vector2f position, float scale, bool longRange)
 {

--- a/src/spaceObjects/spaceObject.h
+++ b/src/spaceObjects/spaceObject.h
@@ -165,6 +165,7 @@ public:
     virtual void draw3D();
     virtual void draw3DTransparent() {}
 #endif//FEATURE_3D_RENDERING
+    virtual void drawFactionOnRadar(sf::RenderTarget& window, sf::Vector2f position, float scale, bool longRange);
     virtual void drawOnRadar(sf::RenderTarget& window, sf::Vector2f position, float scale, bool longRange);
     virtual void drawOnGMRadar(sf::RenderTarget& window, sf::Vector2f position, float scale, bool longRange);
     virtual void destroy();

--- a/src/spaceObjects/spaceStation.cpp
+++ b/src/spaceObjects/spaceStation.cpp
@@ -48,7 +48,7 @@ void SpaceStation::drawOnRadar(sf::RenderTarget& window, sf::Vector2f position, 
     if (my_spaceship)
     {
         sf::Color factionColor = factionInfo[getFactionId()]->gm_color;
-        sf::Color factionAuraColor (factionColor.r, factionColor.g, factionColor.b, 128);
+        sf::Color factionAuraColor (factionColor.r, factionColor.g, factionColor.b, 192);
         objectFactionAura.setColor( factionAuraColor);
 
         if (isEnemy(my_spaceship))

--- a/src/spaceObjects/spaceStation.cpp
+++ b/src/spaceObjects/spaceStation.cpp
@@ -24,16 +24,46 @@ SpaceStation::SpaceStation()
     callsign = "DS" + string(getMultiplayerId());
 }
 
-void SpaceStation::drawOnRadar(sf::RenderTarget& window, sf::Vector2f position, float scale, bool long_range)
+void SpaceStation::drawFactionOnRadar(sf::RenderTarget& window, sf::Vector2f position, float scale, bool long_range)
 {
-    sf::Sprite objectSprite;
     sf::Sprite objectFactionAura;
+
+    sf::Sprite objectSprite;
     textureManager.setTexture(objectSprite, radar_trace);
-    objectSprite.setPosition(position);
+
 
     textureManager.setTexture(objectFactionAura, "RadarBlip.png");
     objectFactionAura.setPosition (position);
     objectFactionAura.setColor( sf::Color::Transparent);
+
+    float sprite_scale = scale * 1.5 * getRadius() * 1.5 / objectSprite.getTextureRect().width;
+
+    if (!long_range)
+    {
+        sprite_scale *= 0.7;
+    }
+
+    sprite_scale = std::max(0.22f, sprite_scale);
+
+    objectFactionAura.setScale (sprite_scale, sprite_scale);
+
+    if (my_spaceship)
+    {
+        sf::Color factionColor = factionInfo[getFactionId()]->gm_color;
+        sf::Color factionAuraColor (factionColor.r, factionColor.g, factionColor.b, 192);
+        objectFactionAura.setColor( factionAuraColor);
+    }
+    window.draw(objectFactionAura);
+}
+
+void SpaceStation::drawOnRadar(sf::RenderTarget& window, sf::Vector2f position, float scale, bool long_range)
+{
+    sf::Sprite objectSprite;
+
+    textureManager.setTexture(objectSprite, radar_trace);
+    objectSprite.setPosition(position);
+
+
 
     float sprite_scale = scale * getRadius() * 1.5 / objectSprite.getTextureRect().width;
 
@@ -44,13 +74,9 @@ void SpaceStation::drawOnRadar(sf::RenderTarget& window, sf::Vector2f position, 
     }
     sprite_scale = std::max(0.15f, sprite_scale);
     objectSprite.setScale(sprite_scale, sprite_scale);
-    objectFactionAura.setScale (sprite_scale*1.5, sprite_scale*1.5);
+
     if (my_spaceship)
     {
-        sf::Color factionColor = factionInfo[getFactionId()]->gm_color;
-        sf::Color factionAuraColor (factionColor.r, factionColor.g, factionColor.b, 192);
-        objectFactionAura.setColor( factionAuraColor);
-
         if (isEnemy(my_spaceship))
             objectSprite.setColor(sf::Color::Red);
         else if (isFriendly(my_spaceship))
@@ -60,7 +86,7 @@ void SpaceStation::drawOnRadar(sf::RenderTarget& window, sf::Vector2f position, 
     }else{
         objectSprite.setColor(factionInfo[getFactionId()]->gm_color);
     }
-    window.draw(objectFactionAura);
+
     window.draw(objectSprite);
 }
 

--- a/src/spaceObjects/spaceStation.cpp
+++ b/src/spaceObjects/spaceStation.cpp
@@ -27,8 +27,14 @@ SpaceStation::SpaceStation()
 void SpaceStation::drawOnRadar(sf::RenderTarget& window, sf::Vector2f position, float scale, bool long_range)
 {
     sf::Sprite objectSprite;
+    sf::Sprite objectFactionAura;
     textureManager.setTexture(objectSprite, radar_trace);
     objectSprite.setPosition(position);
+
+    textureManager.setTexture(objectFactionAura, "RadarBlip.png");
+    objectFactionAura.setPosition (position);
+    objectFactionAura.setColor( sf::Color::Transparent);
+
     float sprite_scale = scale * getRadius() * 1.5 / objectSprite.getTextureRect().width;
 
     if (!long_range)
@@ -38,8 +44,13 @@ void SpaceStation::drawOnRadar(sf::RenderTarget& window, sf::Vector2f position, 
     }
     sprite_scale = std::max(0.15f, sprite_scale);
     objectSprite.setScale(sprite_scale, sprite_scale);
+    objectFactionAura.setScale (sprite_scale*1.5, sprite_scale*1.5);
     if (my_spaceship)
     {
+        sf::Color factionColor = factionInfo[getFactionId()]->gm_color;
+        sf::Color factionAuraColor (factionColor.r, factionColor.g, factionColor.b, 128);
+        objectFactionAura.setColor( factionAuraColor);
+
         if (isEnemy(my_spaceship))
             objectSprite.setColor(sf::Color::Red);
         else if (isFriendly(my_spaceship))
@@ -49,6 +60,7 @@ void SpaceStation::drawOnRadar(sf::RenderTarget& window, sf::Vector2f position, 
     }else{
         objectSprite.setColor(factionInfo[getFactionId()]->gm_color);
     }
+    window.draw(objectFactionAura);
     window.draw(objectSprite);
 }
 
@@ -62,7 +74,7 @@ void SpaceStation::destroyedByDamage(DamageInfo& info)
     ExplosionEffect* e = new ExplosionEffect();
     e->setSize(getRadius());
     e->setPosition(getPosition());
-    
+
     if (info.instigator)
     {
         float points = 0;

--- a/src/spaceObjects/spaceStation.h
+++ b/src/spaceObjects/spaceStation.h
@@ -7,8 +7,9 @@ class SpaceStation : public ShipTemplateBasedObject
 {
 public:
     SpaceStation();
-    
+
     virtual void drawOnRadar(sf::RenderTarget& window, sf::Vector2f position, float scale, bool long_range);
+    virtual void drawFactionOnRadar(sf::RenderTarget& window, sf::Vector2f position, float scale, bool long_range) override;
     virtual bool canBeDockedBy(P<SpaceObject> obj);
     virtual void destroyedByDamage(DamageInfo& info);
     virtual void applyTemplateValues();

--- a/src/spaceObjects/spaceship.cpp
+++ b/src/spaceObjects/spaceship.cpp
@@ -257,6 +257,39 @@ void SpaceShip::draw3DTransparent()
 }
 #endif//FEATURE_3D_RENDERING
 
+void SpaceShip::drawFactionOnRadar (sf::RenderTarget& window, sf::Vector2f position, float scale, bool long_range)
+{
+    sf::Sprite objectFactionAura;
+
+    textureManager.setTexture(objectFactionAura, "RadarBlip.png");
+    objectFactionAura.setPosition (position);
+    objectFactionAura.setColor( sf::Color::Transparent);
+
+    sf::Sprite objectSprite;
+    textureManager.setTexture(objectSprite, radar_trace);
+
+    float sprite_scale = 0.7f*1.5f;
+
+    if (!long_range)
+    {
+        sprite_scale*=1.5f;
+    }
+
+    objectFactionAura.setScale (sprite_scale, sprite_scale);
+
+    if (my_spaceship)
+    {
+        if (getScannedStateFor(my_spaceship) >= SS_SimpleScan)
+        {
+            sf::Color factionColor = factionInfo[getFactionId()]->gm_color;
+            sf::Color factionAuraColor (factionColor.r, factionColor.g, factionColor.b, 192);
+            objectFactionAura.setColor( factionAuraColor);
+        }
+    }
+
+    window.draw(objectFactionAura);
+}
+
 void SpaceShip::drawOnRadar(sf::RenderTarget& window, sf::Vector2f position, float scale, bool long_range)
 {
     // Draw beam arcs on short-range radar only, and only for fully scanned
@@ -371,11 +404,6 @@ void SpaceShip::drawOnRadar(sf::RenderTarget& window, sf::Vector2f position, flo
 
     // Set up the radar sprite for objects.
     sf::Sprite objectSprite;
-    sf::Sprite objectFactionAura;
-
-    textureManager.setTexture(objectFactionAura, "RadarBlip.png");
-    objectFactionAura.setPosition (position);
-    objectFactionAura.setColor( sf::Color::Transparent);
 
     // If the object is a ship that hasn't been scanned, draw the default icon.
     // Otherwise, draw the ship-specific icon.
@@ -395,10 +423,7 @@ void SpaceShip::drawOnRadar(sf::RenderTarget& window, sf::Vector2f position, flo
     {
         objectSprite.setScale(0.7, 0.7);
     }
-    else
-    {
-        objectFactionAura.setScale (1.5, 1.5);
-    }
+
     if (my_spaceship == this)
     {
         objectSprite.setColor(sf::Color(192, 192, 255));
@@ -416,16 +441,10 @@ void SpaceShip::drawOnRadar(sf::RenderTarget& window, sf::Vector2f position, flo
             objectSprite.setColor(sf::Color(192, 192, 192));
         }
 
-        if (getScannedStateFor(my_spaceship) >= SS_SimpleScan)
-        {
-            sf::Color factionColor = factionInfo[getFactionId()]->gm_color;
-            sf::Color factionAuraColor (factionColor.r, factionColor.g, factionColor.b, 192);
-            objectFactionAura.setColor( factionAuraColor);
-        }
     }else{
         objectSprite.setColor(factionInfo[getFactionId()]->gm_color);
     }
-    window.draw(objectFactionAura);
+
     window.draw(objectSprite);
 }
 

--- a/src/spaceObjects/spaceship.cpp
+++ b/src/spaceObjects/spaceship.cpp
@@ -371,12 +371,18 @@ void SpaceShip::drawOnRadar(sf::RenderTarget& window, sf::Vector2f position, flo
 
     // Set up the radar sprite for objects.
     sf::Sprite objectSprite;
+    sf::Sprite objectFactionAura;
+
+    textureManager.setTexture(objectFactionAura, "RadarBlip.png");
+    objectFactionAura.setPosition (position);
+    objectFactionAura.setColor( sf::Color::Transparent);
 
     // If the object is a ship that hasn't been scanned, draw the default icon.
     // Otherwise, draw the ship-specific icon.
     if (my_spaceship && (getScannedStateFor(my_spaceship) == SS_NotScanned || getScannedStateFor(my_spaceship) == SS_FriendOrFoeIdentified))
     {
         textureManager.setTexture(objectSprite, "RadarArrow.png");
+
     }
     else
     {
@@ -388,6 +394,10 @@ void SpaceShip::drawOnRadar(sf::RenderTarget& window, sf::Vector2f position, flo
     if (long_range)
     {
         objectSprite.setScale(0.7, 0.7);
+    }
+    else
+    {
+        objectFactionAura.setScale (1.5, 1.5);
     }
     if (my_spaceship == this)
     {
@@ -405,9 +415,17 @@ void SpaceShip::drawOnRadar(sf::RenderTarget& window, sf::Vector2f position, flo
         }else{
             objectSprite.setColor(sf::Color(192, 192, 192));
         }
+
+        if (getScannedStateFor(my_spaceship) >= SS_SimpleScan)
+        {
+            sf::Color factionColor = factionInfo[getFactionId()]->gm_color;
+            sf::Color factionAuraColor (factionColor.r, factionColor.g, factionColor.b, 128);
+            objectFactionAura.setColor( factionAuraColor);
+        }
     }else{
         objectSprite.setColor(factionInfo[getFactionId()]->gm_color);
     }
+    window.draw(objectFactionAura);
     window.draw(objectSprite);
 }
 

--- a/src/spaceObjects/spaceship.cpp
+++ b/src/spaceObjects/spaceship.cpp
@@ -419,7 +419,7 @@ void SpaceShip::drawOnRadar(sf::RenderTarget& window, sf::Vector2f position, flo
         if (getScannedStateFor(my_spaceship) >= SS_SimpleScan)
         {
             sf::Color factionColor = factionInfo[getFactionId()]->gm_color;
-            sf::Color factionAuraColor (factionColor.r, factionColor.g, factionColor.b, 128);
+            sf::Color factionAuraColor (factionColor.r, factionColor.g, factionColor.b, 192);
             objectFactionAura.setColor( factionAuraColor);
         }
     }else{

--- a/src/spaceObjects/spaceship.h
+++ b/src/spaceObjects/spaceship.h
@@ -176,6 +176,7 @@ public:
      * Draw this ship on the radar.
      */
     virtual void drawOnRadar(sf::RenderTarget& window, sf::Vector2f position, float scale, bool long_range) override;
+    virtual void drawFactionOnRadar(sf::RenderTarget& window, sf::Vector2f position, float scale, bool long_range) override;
     virtual void drawOnGMRadar(sf::RenderTarget& window, sf::Vector2f position, float scale, bool long_range) override;
 
     virtual void update(float delta) override;
@@ -327,7 +328,7 @@ public:
     float getBeamWeaponDirection(int index) { if (index < 0 || index >= max_beam_weapons) return 0.0; return beam_weapons[index].getDirection(); }
     float getBeamWeaponRange(int index) { if (index < 0 || index >= max_beam_weapons) return 0.0; return beam_weapons[index].getRange(); }
 
-    float getBeamWeaponTurretArc(int index) 
+    float getBeamWeaponTurretArc(int index)
     {
         if (index < 0 || index >= max_beam_weapons)
             return 0.0;


### PR DESCRIPTION
This adds a semi-transparent circle to ship (displayed under) and station of the color of the faction, so that they can be identified visually.

I also had to change the color of "Human Navy" faction has the aura was too hard to distinguished from the "Independent" faction