### PR TITLE
Fixed E1.31 DMP layer packet octet 118 value to 0xa1

### DIFF
--- a/src/hardware/devices/sACNDMXDevice.cpp
+++ b/src/hardware/devices/sACNDMXDevice.cpp
@@ -96,7 +96,7 @@ void StreamingAcnDMXDevice::updateLoop()
         //DMP layer
         packet << uint16_t(0x7000 | (11 + channel_count)); //Flags and length
         packet << uint8_t(2);  //Vector, message is PDU
-        packet << uint8_t(0x1a);  //Format of address and data
+        packet << uint8_t(0xa1);  //Format of address and data
         packet << uint16_t(0x0000);  //First property address
         packet << uint16_t(0x0001);  //Address increments
         packet << uint16_t(1 + channel_count);  //Value count


### PR DESCRIPTION
It seems that there were small typo in E1.31 data packet format on DMP Layer. For reference please see http://tsp.esta.org/tsp/documents/docs/E1-31-2016.pdf page 5 which defines data packet format.