### PR TITLE
fix overlay in radar screen painting everything black in mac

### DIFF
--- a/src/screenComponents/radarView.cpp
+++ b/src/screenComponents/radarView.cpp
@@ -81,8 +81,7 @@ void GuiRadarView::onDraw(sf::RenderTarget& window)
     if (fog_style == NebulaFogOfWar || fog_style == FriendlysShortRangeFogOfWar)
     {
         drawRenderTexture(mask_texture, forground_texture, sf::Color::White, sf::BlendMode(
-            sf::BlendMode::Zero, sf::BlendMode::SrcColor, sf::BlendMode::Add,
-            sf::BlendMode::Zero, sf::BlendMode::SrcColor, sf::BlendMode::Add
+            sf::BlendMode::Zero, sf::BlendMode::SrcAlpha, sf::BlendMode::Add
         ));
     }
     //Post masking


### PR DESCRIPTION
this change should theoretically do nothing - it uses the mask's alpha channel instead of color (both of them are set to all 1's) for the BlendMode's destinationFactor. 
This fixes an issue in OSX that painted all the objects in black, with the price of not rendering the mask itself on the screen.
fixes #554 