### PR TITLE
updates to CMakeLists.txt to make it more manageable 

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,8 +3,6 @@ cmake_minimum_required(VERSION 2.8.12)
 
 option(ENABLE_CRASH_LOGGER "Enable the drmingw crash logging facilities" OFF)
 message(STATUS "ENABLE_CRASH_LOGGER is " ${ENABLE_CRASH_LOGGER})
-option(COMPILE_DEV_HELPER "Compile with the 'DEBUG' fpreprocessor flag" OFF)
-message(STATUS "COMPILE_DEV_HELPER is " ${COMPILE_DEV_HELPER})
 
 # Check if serious proton dir is set.
 if(NOT DEFINED SERIOUS_PROTON_DIR)
@@ -14,9 +12,9 @@ if(NOT IS_ABSOLUTE "${SERIOUS_PROTON_DIR}")
   get_filename_component(SERIOUS_PROTON_DIR "${CMAKE_BINARY_DIR}/${SERIOUS_PROTON_DIR}" ABSOLUTE)
 endif()
 
-if(COMPILE_DEV_HELPER)
+if(CMAKE_BUILD_TYPE MATCHES Debug)
 	add_compile_definitions(DEBUG)
-endif(COMPILE_DEV_HELPER)
+endif(CMAKE_BUILD_TYPE MATCHES Debug)
 
 if(ENABLE_CRASH_LOGGER)
  if(WIN32)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,6 +2,9 @@ project(EmptyEpsilon)
 cmake_minimum_required(VERSION 2.8.12)
 
 option(ENABLE_CRASH_LOGGER "Enable the drmingw crash logging facilities" OFF)
+message(STATUS "ENABLE_CRASH_LOGGER is " ${ENABLE_CRASH_LOGGER})
+option(COMPILE_DEV_HELPER "Compile with the 'DEBUG' fpreprocessor flag" OFF)
+message(STATUS "COMPILE_DEV_HELPER is " ${COMPILE_DEV_HELPER})
 
 # Check if serious proton dir is set.
 if(NOT DEFINED SERIOUS_PROTON_DIR)
@@ -11,13 +14,17 @@ if(NOT IS_ABSOLUTE "${SERIOUS_PROTON_DIR}")
   get_filename_component(SERIOUS_PROTON_DIR "${CMAKE_BINARY_DIR}/${SERIOUS_PROTON_DIR}" ABSOLUTE)
 endif()
 
-if(DEFINED ENABLE_CRASH_LOGGER)
+if(COMPILE_DEV_HELPER)
+	add_compile_definitions(DEBUG)
+endif(COMPILE_DEV_HELPER)
+
+if(ENABLE_CRASH_LOGGER)
  if(WIN32)
   if(NOT DEFINED DRMINGW_ROOT)
    message(FATAL_ERROR "DRMINGW_ROOT was not set. Unable to continue")
   endif(NOT DEFINED DRMINGW_ROOT)
  endif(WIN32)
-endif(DEFINED ENABLE_CRASH_LOGGER)
+endif(ENABLE_CRASH_LOGGER)
 
 if(NOT DEFINED CPACK_PACKAGE_VERSION_MAJOR)
  string(TIMESTAMP CPACK_PACKAGE_VERSION_MAJOR "%Y")


### PR DESCRIPTION
These changes allow working on EmptyEpsilon from [vscode](https://code.visualstudio.com/). It's a very smooth dev environment.
I've made a [guide and some configuration files](https://gist.github.com/amir-arad/169993b47e97034277e0e5dfe18b1397) in how to set up the environment, there's feature in that setup that depends on the changes in this PR.
the changes for CMake are minor:
* add `COMPILE_DEV_HELPER` option to set the `DEBUG` preprocessor value (opt in)
* add messages to print the value of options 
* fix a bug where `DRMINGW_ROOT` is required even when `ENABLE_CRASH_LOGGER` was not defined by the user