### PR TITLE
Philips Hue connection port

### DIFF
--- a/src/hardware/devices/philipsHueDevice.cpp
+++ b/src/hardware/devices/philipsHueDevice.cpp
@@ -35,6 +35,11 @@ bool PhilipsHueDevice::configure(std::unordered_map<string, string> settings)
         userfile = settings["userfile"];
     }
 
+    if (settings.find("port") != settings.end())
+    {
+        port = settings["port"].toInt();
+    }
+
     //If no user name set, try to read it from the userfile.
     if (username == "")
     {
@@ -48,12 +53,14 @@ bool PhilipsHueDevice::configure(std::unordered_map<string, string> settings)
         }
     }
 
+    LOG(INFO) << "Attempting to connect to Hue bridge " << ip_address << " on port " << port;
+
     //If no username was set, or no username was read from the userfile, then we need to request one from the philips hue bridge.
     int retry_counter = 120 / 5;
     while(username == "")
     {
-        sf::Http http(ip_address);
-        
+        sf::Http http(ip_address,port);
+
         LOG(INFO) << "No philips hue username. Going to request one. Be sure to press the button on the hue bridge.";
         sf::Http::Response response = http.sendRequest(sf::Http::Request("/api", sf::Http::Request::Post, "{\"devicetype\":\"EmptyEpsilon#EmptyEpsilon\"}"));
         if (response.getStatus() == sf::Http::Response::Ok)
@@ -105,7 +112,7 @@ bool PhilipsHueDevice::configure(std::unordered_map<string, string> settings)
     
     if (username != "")
     {
-        sf::Http http(ip_address);
+        sf::Http http(ip_address,port);
         sf::Http::Response response = http.sendRequest(sf::Http::Request("/api/" + username + "/lights"));
         if (response.getStatus() != sf::Http::Response::Ok)
         {
@@ -168,8 +175,8 @@ int PhilipsHueDevice::getChannelCount()
 
 void PhilipsHueDevice::updateLoop()
 {
-    sf::Http http(ip_address);
-    
+    sf::Http http(ip_address,port);
+
     while(run_thread)
     {
         for(int n=0; n<light_count; n++)

--- a/src/hardware/devices/philipsHueDevice.h
+++ b/src/hardware/devices/philipsHueDevice.h
@@ -54,6 +54,7 @@ private:
     void updateLoop();
     
     string ip_address;
+    int port = 80;
     string username;
     string userfile;
     int light_count;


### PR DESCRIPTION
Allows user to specify the port on which to connect to the Hue bridge. 

For my purposes, this allows EmptyEpsilon to more easily connect to emulated Hue bridges instead of physical ones, which lets me have an even more complicated bridge setup. I'm hoping it'll be useful to others as well.