### PR TITLE
Philips Hue Light Count

### DIFF
--- a/EmptyEpsilon.cbp
+++ b/EmptyEpsilon.cbp
@@ -297,6 +297,8 @@
 		<Unit filename="../SeriousProton/src/httpServer.h" />
 		<Unit filename="../SeriousProton/src/input.cpp" />
 		<Unit filename="../SeriousProton/src/input.h" />
+		<Unit filename="../SeriousProton/src/json11/json11.hpp" />
+		<Unit filename="../SeriousProton/src/json11/json11.cpp" />
 		<Unit filename="../SeriousProton/src/logging.cpp" />
 		<Unit filename="../SeriousProton/src/logging.h" />
 		<Unit filename="../SeriousProton/src/lua/lapi.c">

--- a/src/hardware/devices/philipsHueDevice.cpp
+++ b/src/hardware/devices/philipsHueDevice.cpp
@@ -130,7 +130,7 @@ bool PhilipsHueDevice::configure(std::unordered_map<string, string> settings)
             //Count the number of { and } brackets and when they're equal and there's a quotation mark, look for a number.
 
             int bracket_counter = -1;
-            int int_builder = 0;
+            int int_builder = -1;
             light_count = 0;
             for ( unsigned int i = 0; i < body.size(); i++ )
             {

--- a/src/hardware/devices/philipsHueDevice.cpp
+++ b/src/hardware/devices/philipsHueDevice.cpp
@@ -134,10 +134,9 @@ bool PhilipsHueDevice::configure(std::unordered_map<string, string> settings)
             light_count = 0;
             for ( unsigned int i = 0; i < body.size(); i++ )
             {
-                if ( int_builder != 0 )
+                if ( int_builder != -1 )
                 {
                     //The int builder process consumes digits after a " until a non-numeric char is found.
-                    if ( int_builder == -1 ) { int_builder = 0; }
                     if ( std::isdigit(body[i]) )
                     {
                         int this_digit = body[i] - '0'; //Char to int
@@ -148,7 +147,7 @@ bool PhilipsHueDevice::configure(std::unordered_map<string, string> settings)
                     {
                         LOG(DEBUG) << "Found light ID " << int_builder << " in Hue response.";
                         if( int_builder > light_count ) { light_count = int_builder; }
-                        int_builder = 0;
+                        int_builder = -1;
                     }
                 }
 
@@ -161,7 +160,7 @@ bool PhilipsHueDevice::configure(std::unordered_map<string, string> settings)
                         bracket_counter--;
                         break;
                     case '"':
-                        if(bracket_counter == 0) { int_builder = -1; }
+                        if(bracket_counter == 0) { int_builder = 0; }
                         break;
                 }
             }


### PR DESCRIPTION
One of the listed "TODOs" in philipsHueDevice was to determine how many lights were returned in the JSON response.

- I implemented this as a standalone string parser instead of adding a JSON parsing library, as I'm not sure on this project's stance on adding additional libraries. If adding a library for this purpose makes sense at this time, I'd be happy to do that instead.
- The code does not count the lights returned by the Hue. Instead, it finds the highest light index and returns that value. This is specifically  because other parts of the code (setChannelData for one) depend on the light_count being greater than or equal to than the light index - otherwise the light won't update.