### PR TITLE
add and expose Wormhole:getTargetPosition to scripts

### DIFF
--- a/src/spaceObjects/wormHole.cpp
+++ b/src/spaceObjects/wormHole.cpp
@@ -18,6 +18,7 @@ REGISTER_SCRIPT_SUBCLASS(WormHole, SpaceObject)
 {
     /// Set the target of this wormhole
     REGISTER_SCRIPT_CLASS_FUNCTION(WormHole, setTargetPosition);
+    REGISTER_SCRIPT_CLASS_FUNCTION(WormHole, getTargetPosition);
 }
 
 REGISTER_MULTIPLAYER_CLASS(WormHole, "WormHole");
@@ -146,4 +147,9 @@ void WormHole::collide(Collisionable* target, float collision_force)
 void WormHole::setTargetPosition(sf::Vector2f v)
 {
     target_position = v;
+}
+
+sf::Vector2f WormHole::getTargetPosition()
+{
+    return target_position;
 }

--- a/src/spaceObjects/wormHole.h
+++ b/src/spaceObjects/wormHole.h
@@ -27,6 +27,7 @@ public:
     virtual void collide(Collisionable* target, float force) override;
     
     void setTargetPosition(sf::Vector2f v);   /* Where to jump to */
+    sf::Vector2f getTargetPosition();
     
     virtual string getExportLine() { return "WormHole():setPosition(" + string(getPosition().x, 0) + ", " + string(getPosition().y, 0) + "):setTargetPosition(" + string(target_position.x, 0) + ", " + string(target_position.y, 0) + ")"; }
 };


### PR DESCRIPTION
Writing the `targetPosition` is – as the wormhole itself – a one-way street. This commit adds a getter.

Usage:

    local wormhole = WormHole():setPosition(0, 0):setTargetPosition(20000, 10000)
    print(wormhole:getTargetPosition())