### PR TITLE
fix Bug: ship sticks to station instead of flying in formation

### DIFF
--- a/src/ai/ai.cpp
+++ b/src/ai/ai.cpp
@@ -531,6 +531,9 @@ void ShipAI::flyFormation(P<SpaceObject> target, sf::Vector2f offset)
 
     if (pathPlanner.route.size() == 1)
     {
+        if (owner->docking_state == DS_Docked)
+            owner->requestUndock();
+
         sf::Vector2f diff = target_position - owner->getPosition();
         float distance = sf::length(diff);
 


### PR DESCRIPTION
You can have a ship get "stuck" on a station after docking when you order it to fly in formation.

This snippet produces the bug for me reliably. Best watch it in GM screen.

    function init()
        station = SpaceStation():setTemplate("Medium Station"):setFaction("Independent"):setCallSign("Light")
        ship = CpuShip():setTemplate("Adder MK5"):setCallSign("Mama Moth"):setFaction("Independent"):setPosition(-1000, -1500):setHeading(0)
        wingman = CpuShip():setTemplate("Adder MK5"):setCallSign("Baby Moth"):setFaction("Independent"):setPosition(0, -1000):setHeading(0)
    
        ship:orderIdle()
        wingman:orderDock(station)
    end
    
    function update(delta)
        if wingman:isDocked(station) then
            wingman:orderFlyFormation(ship, 0, 1000)
        end
        local x, y = wingman:getPosition()
        if y <= -1200 then
            wingman:orderDock(station)
        end
    end

The ship docks and undocks correctly for the first time, but after docking the second time it sticks to the station and does not undock making it hard even for a GM to let it go.

The fix is as simple as making sure a ship is undocked if it is requested to fly in formation.