### PR TITLE
allow to configure a callback when an Artifact is picked up

### DIFF
--- a/src/spaceObjects/artifact.cpp
+++ b/src/spaceObjects/artifact.cpp
@@ -71,9 +71,7 @@ void Artifact::collide(Collisionable* target, float force)
     {
         if (on_pickup_callback.isSet())
         {
-            on_pickup_callback.addObjectArgument(player);
-            on_pickup_callback.addObjectArgument(this);
-            on_pickup_callback.call();
+            on_pickup_callback.call(player, P<Artifact>(this));
         }
         destroy();
     }

--- a/src/spaceObjects/artifact.cpp
+++ b/src/spaceObjects/artifact.cpp
@@ -18,6 +18,9 @@ REGISTER_SCRIPT_SUBCLASS(Artifact, SpaceObject)
     REGISTER_SCRIPT_CLASS_FUNCTION(Artifact, explode);
     /// Set if this artifact can be picked up or not. When it is picked up, this artifact will be destroyed.
     REGISTER_SCRIPT_CLASS_FUNCTION(Artifact, allowPickup);
+    /// Set a function that will be called if a player picks up the artifact.
+    /// First argument given to the function will be the playerSpaceShip, the second the artifact.
+    REGISTER_SCRIPT_CLASS_FUNCTION(Artifact, setPickUpCallback);
 }
 
 REGISTER_MULTIPLAYER_CLASS(Artifact, "Artifact");
@@ -63,8 +66,15 @@ void Artifact::collide(Collisionable* target, float force)
     if (!isServer() || !allow_pickup)
         return;
     P<SpaceObject> hit_object = P<Collisionable>(target);
-    if (P<PlayerSpaceship>(hit_object))
+    P<PlayerSpaceship> player = hit_object;
+    if (player)
     {
+        if (on_pickup_callback.isSet())
+        {
+            on_pickup_callback.addObjectArgument(player);
+            on_pickup_callback.addObjectArgument(this);
+            on_pickup_callback.call();
+        }
         destroy();
     }
 }
@@ -85,6 +95,12 @@ void Artifact::explode()
 void Artifact::allowPickup(bool allow)
 {
     allow_pickup = allow;
+}
+
+void Artifact::setPickUpCallback(ScriptSimpleCallback callback)
+{
+    this->allow_pickup = 1;
+    this->on_pickup_callback = callback;
 }
 
 string Artifact::getExportLine()

--- a/src/spaceObjects/artifact.h
+++ b/src/spaceObjects/artifact.h
@@ -9,6 +9,7 @@ private:
     string current_model_data_name;
     string model_data_name;
     bool allow_pickup;
+    ScriptSimpleCallback on_pickup_callback;
 public:
     Artifact();
 
@@ -23,6 +24,7 @@ public:
     void allowPickup(bool allow);
     
     virtual string getExportLine();
+    void setPickUpCallback(ScriptSimpleCallback callback);
 };
 
 #endif//ARTIFACT_H


### PR DESCRIPTION
Because it was mentioned in the forums recently and it is also on my wishlist I had a look how it was possible to have a callback function if an `Artifact` is picked up.

This pull request depends on [SeriousProton:#23](https://github.com/daid/SeriousProton/pull/23). But if both are approved I think there are lot more places to utilize this pattern – like when a ship is destroyed, docks or undocks a station etc.

Here is how it could be used:

    function init()
        PlayerSpaceship():
            setTemplate("Piranha"):
            setFaction("Human Navy"):
            setCallSign("Thief")
        Artifact():
            setCallSign("Stack of Gold"):
            setPickUpCallback(function(foo, bar)
                print(foo:getCallSign() .. " picked up " .. bar:getCallSign())
            end)
    end