### PR TITLE
(mostly) Refactor gm screen

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,3 +35,8 @@ thumbs.db
 *.swp
 
 options.ini
+
+
+.vscode
+logs
+*.log

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -88,6 +88,7 @@ set(SOURCES
 	src/commsScriptInterface.cpp
 	src/modelData.cpp
 	src/gameGlobalInfo.cpp
+	src/GMActions.cpp
 	src/script.cpp
 	src/playerInfo.cpp
 	src/gameStateLogger.cpp

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -127,6 +127,7 @@ set(SOURCES
 	src/screens/extra/databaseScreen.cpp
 	src/screens/extra/shipLogScreen.cpp
 	src/screens/gm/gameMasterScreen.cpp
+	src/screens/gm/objectCreationView.cpp
 	src/screens/gm/chatDialog.cpp
 	src/screens/gm/tweak.cpp
 	src/screenComponents/aimLock.cpp

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -128,6 +128,7 @@ set(SOURCES
 	src/screens/extra/shipLogScreen.cpp
 	src/screens/gm/gameMasterScreen.cpp
 	src/screens/gm/objectCreationView.cpp
+	src/screens/gm/globalMessageEntryView.cpp
 	src/screens/gm/chatDialog.cpp
 	src/screens/gm/tweak.cpp
 	src/screenComponents/aimLock.cpp

--- a/src/GMActions.cpp
+++ b/src/GMActions.cpp
@@ -1,0 +1,62 @@
+#include "GMActions.h"
+
+#include "engine.h"
+#include "gameGlobalInfo.h"
+
+const static int16_t CMD_RUN_SCRIPT = 0x0000;
+const static int16_t CMD_SEND_GLOBAL_MESSAGE = 0x0001;
+
+P<GameMasterActions> gameMasterActions;
+
+REGISTER_MULTIPLAYER_CLASS(GameMasterActions, "GameMasterActions")
+GameMasterActions::GameMasterActions()
+: MultiplayerObject("GameMasterActions")
+{
+    assert(!gameMasterActions);
+    gameMasterActions = this;
+}
+
+void GameMasterActions::onReceiveClientCommand(int32_t client_id, sf::Packet& packet)
+{
+    int16_t command;
+    packet >> command;
+    switch(command)
+    {
+    case CMD_RUN_SCRIPT:
+        {
+            string code;
+            packet >> code;
+            if (code.length() > 0)
+            {
+                P<ScriptObject> so = new ScriptObject();
+                so->runCode(code);
+                so->destroy();
+            }
+        }
+        break;
+    case CMD_SEND_GLOBAL_MESSAGE:
+        {
+            string message;
+            packet >> message;
+            if (message.length() > 0)
+            {
+                gameGlobalInfo->global_message = message;
+                gameGlobalInfo->global_message_timeout = 5.0;
+            }
+        }
+        break;
+    }
+}
+
+void GameMasterActions::commandRunScript(string code)
+{
+    sf::Packet packet;
+    packet << CMD_RUN_SCRIPT << code;
+    sendClientCommand(packet);
+}
+void GameMasterActions::commandSendGlobalMessage(string message)
+{
+    sf::Packet packet;
+    packet << CMD_SEND_GLOBAL_MESSAGE << message;
+    sendClientCommand(packet);
+}

--- a/src/GMActions.h
+++ b/src/GMActions.h
@@ -1,0 +1,22 @@
+#ifndef GM_ACTIONS
+#define GM_ACTIONS
+
+#include "engine.h"
+
+
+class GameMasterActions;
+extern P<GameMasterActions> gameMasterActions;
+
+class GameMasterActions : public MultiplayerObject
+{
+
+public:
+
+    GameMasterActions();
+
+    void commandRunScript(string code);
+    void commandSendGlobalMessage(string message);
+    virtual void onReceiveClientCommand(int32_t client_id, sf::Packet& packet);
+};
+
+#endif//GM_ACTIONS

--- a/src/epsilonServer.cpp
+++ b/src/epsilonServer.cpp
@@ -1,12 +1,14 @@
 #include "epsilonServer.h"
 #include "playerInfo.h"
 #include "gameGlobalInfo.h"
+#include "GMActions.h"
 #include "main.h"
 
 EpsilonServer::EpsilonServer()
 : GameServer("Server", VERSION_NUMBER)
 {
     new GameGlobalInfo();
+    new GameMasterActions();
     PlayerInfo* info = new PlayerInfo();
     info->client_id = 0;
     my_player_info = info;
@@ -45,6 +47,8 @@ void disconnectFromServer()
         game_server->destroy();
     if (gameGlobalInfo)
         gameGlobalInfo->destroy();
+    if (gameMasterActions)
+        gameMasterActions->destroy();
     foreach(PlayerInfo, i, player_info_list)
         i->destroy();
     if (my_player_info)

--- a/src/screens/gm/gameMasterScreen.cpp
+++ b/src/screens/gm/gameMasterScreen.cpp
@@ -1,6 +1,7 @@
 #include "main.h"
 #include "gameGlobalInfo.h"
 #include "gameMasterScreen.h"
+#include "objectCreationView.h"
 #include "tweak.h"
 #include "chatDialog.h"
 #include "spaceObjects/cpuShip.h"
@@ -70,7 +71,7 @@ GameMasterScreen::GameMasterScreen()
     player_ship_selector->setPosition(270, -20, ABottomLeft)->setSize(350, 50);
 
     create_button = new GuiButton(this, "CREATE_OBJECT_BUTTON", "Create...", [this]() {
-        object_creation_screen->show();
+        object_creation_view->show();
     });
     create_button->setPosition(20, -70, ABottomLeft)->setSize(250, 50);
 
@@ -185,8 +186,12 @@ GameMasterScreen::GameMasterScreen()
 
     global_message_entry = new GuiGlobalMessageEntry(this);
     global_message_entry->hide();
-    object_creation_screen = new GuiObjectCreationScreen(this);
-    object_creation_screen->hide();
+    object_creation_view = new GuiObjectCreationView(this, [this](){
+        create_button->hide();
+        cancel_create_button->show();
+        object_creation_view->hide();
+    });
+    object_creation_view->hide();
 }
 
 void GameMasterScreen::update(float delta)
@@ -325,7 +330,7 @@ void GameMasterScreen::onMouseDown(sf::Vector2f position)
     {
         if (cancel_create_button->isVisible())
         {
-            object_creation_screen->createObject(position);
+            object_creation_view->createObject(position);
         }else{
             click_and_drag_state = CD_BoxSelect;
             
@@ -541,100 +546,4 @@ GuiGlobalMessageEntry::GuiGlobalMessageEntry(GuiContainer* owner)
 bool GuiGlobalMessageEntry::onMouseDown(sf::Vector2f position)
 {   //Catch clicks.
     return true;
-}
-
-GuiObjectCreationScreen::GuiObjectCreationScreen(GameMasterScreen* gm_screen)
-: GuiOverlay(gm_screen, "OBJECT_CREATE_SCREEN", sf::Color(0, 0, 0, 128))
-{
-    this->gm_screen = gm_screen;
-    
-    GuiPanel* box = new GuiPanel(this, "FRAME");
-    box->setPosition(0, 0, ACenter)->setSize(1000, 500);
-
-    faction_selector = new GuiSelector(box, "FACTION_SELECTOR", nullptr);
-    for(P<FactionInfo> info : factionInfo)
-        faction_selector->addEntry(info->getName(), info->getName());
-    faction_selector->setSelectionIndex(0);
-    faction_selector->setPosition(20, 20, ATopLeft)->setSize(300, 50);
-    
-    float y = 20;
-    std::vector<string> template_names = ShipTemplate::getTemplateNameList(ShipTemplate::Station);
-    std::sort(template_names.begin(), template_names.end());
-    for(string template_name : template_names)
-    {
-        (new GuiButton(box, "CREATE_STATION_" + template_name, template_name, [this, template_name]() {
-            setCreateScript("SpaceStation():setRotation(random(0, 360)):setFactionId(" + string(faction_selector->getSelectionIndex()) + "):setTemplate(\"" + template_name + "\")");
-        }))->setTextSize(20)->setPosition(-350, y, ATopRight)->setSize(300, 30);
-        y += 30;
-    }
-    
-    (new GuiButton(box, "CREATE_WARP_JAMMER", "Warp Jammer", [this]() {
-        setCreateScript("WarpJammer():setRotation(random(0, 360)):setFactionId(" + string(faction_selector->getSelectionIndex()) + ")");
-    }))->setTextSize(20)->setPosition(-350, y, ATopRight)->setSize(300, 30);
-    y += 30;
-    (new GuiButton(box, "CREATE_MINE", "Mine", [this]() {
-        setCreateScript("Mine():setFactionId(" + string(faction_selector->getSelectionIndex()) + ")");
-    }))->setTextSize(20)->setPosition(-350, y, ATopRight)->setSize(300, 30);
-    y += 30;
-    // Default supply drop values copied from scripts/supply_drop.lua
-    (new GuiButton(box, "CREATE_SUPPLY_DROP", "Supply Drop", [this]() {
-        setCreateScript("SupplyDrop():setFactionId(" + string(faction_selector->getSelectionIndex()) + "):setEnergy(500):setWeaponStorage('Nuke', 1):setWeaponStorage('Homing', 4):setWeaponStorage('Mine', 2):setWeaponStorage('EMP', 1)");
-    }))->setTextSize(20)->setPosition(-350, y, ATopRight)->setSize(300, 30);
-    y += 30;
-    (new GuiButton(box, "CREATE_ASTEROID", "Asteroid", [this]() {
-        setCreateScript("Asteroid()");
-    }))->setTextSize(20)->setPosition(-350, y, ATopRight)->setSize(300, 30);
-    y += 30;
-    (new GuiButton(box, "CREATE_BLACKHOLE", "BlackHole", [this]() {
-        setCreateScript("BlackHole()");
-    }))->setTextSize(20)->setPosition(-350, y, ATopRight)->setSize(300, 30);
-    y += 30;
-    (new GuiButton(box, "CREATE_NEBULA", "Nebula", [this]() {
-        setCreateScript("Nebula()");
-    }))->setTextSize(20)->setPosition(-350, y, ATopRight)->setSize(300, 30);
-    y += 30;
-    (new GuiButton(box, "CREATE_WORMHOLE", "Worm Hole", [this]() {
-        setCreateScript("WormHole()");
-    }))->setTextSize(20)->setPosition(-350, y, ATopRight)->setSize(300, 30);
-    y += 30;
-    y = 20;
-    template_names = ShipTemplate::getTemplateNameList(ShipTemplate::Ship);
-    std::sort(template_names.begin(), template_names.end());
-    GuiListbox* listbox = new GuiListbox(box, "CREATE_SHIPS", [this](int index, string value)
-    {
-        setCreateScript("CpuShip():setRotation(random(0, 360)):setFactionId(" + string(faction_selector->getSelectionIndex()) + "):setTemplate(\"" + value + "\"):orderRoaming()");
-    });
-    listbox->setTextSize(20)->setButtonHeight(30)->setPosition(-20, 20, ATopRight)->setSize(300, 460);
-    for(string template_name : template_names)
-    {
-        listbox->addEntry(template_name, template_name);
-    }
-    
-    (new GuiButton(box, "CLOSE_BUTTON", "Cancel", [this]() {
-        create_script = "";
-        this->hide();
-    }))->setPosition(20, -20, ABottomLeft)->setSize(300, 50);
-}
-
-bool GuiObjectCreationScreen::onMouseDown(sf::Vector2f position)
-{   //Catch clicks.
-    return true;
-}
-
-void GuiObjectCreationScreen::setCreateScript(string script)
-{
-    create_script = script;
-    gm_screen->create_button->hide();
-    gm_screen->cancel_create_button->show();
-    hide();
-}
-
-void GuiObjectCreationScreen::createObject(sf::Vector2f position)
-{
-    if (create_script == "")
-        return;
-    
-    P<ScriptObject> so = new ScriptObject();
-    so->runCode(create_script + ":setPosition("+string(position.x)+","+string(position.y)+")");
-    so->destroy();
 }

--- a/src/screens/gm/gameMasterScreen.cpp
+++ b/src/screens/gm/gameMasterScreen.cpp
@@ -2,6 +2,7 @@
 #include "gameGlobalInfo.h"
 #include "gameMasterScreen.h"
 #include "objectCreationView.h"
+#include "globalMessageEntryView.h"
 #include "tweak.h"
 #include "chatDialog.h"
 #include "spaceObjects/cpuShip.h"
@@ -184,7 +185,7 @@ GameMasterScreen::GameMasterScreen()
     object_tweak_dialog = new GuiObjectTweak(this, TW_Object);
     object_tweak_dialog->hide();
 
-    global_message_entry = new GuiGlobalMessageEntry(this);
+    global_message_entry = new GuiGlobalMessageEntryView(this);
     global_message_entry->hide();
     object_creation_view = new GuiObjectCreationView(this, [this](){
         create_button->hide();
@@ -517,33 +518,4 @@ string GameMasterScreen::getScriptExport(bool selected_only)
         output += "    " + line + "\n";
     }
     return output;
-}
-
-GuiGlobalMessageEntry::GuiGlobalMessageEntry(GuiContainer* owner)
-: GuiOverlay(owner, "GLOBAL_MESSAGE_ENTRY", sf::Color(0, 0, 0, 128))
-{
-    GuiPanel* box = new GuiPanel(this, "FRAME");
-    box->setPosition(0, 0, ACenter)->setSize(800, 150);
-    
-    message_entry = new GuiTextEntry(box, "MESSAGE_ENTRY", "");
-    message_entry->setPosition(0, 20, ATopCenter)->setSize(700, 50);
-    
-    (new GuiButton(box, "CLOSE_BUTTON", "Cancel", [this]() {
-        this->hide();
-    }))->setPosition(20, -20, ABottomLeft)->setSize(300, 50);
-
-    (new GuiButton(box, "SEND_BUTTON", "Send", [this]() {
-        string message = message_entry->getText();
-        if (message.length() > 0)
-        {
-            gameGlobalInfo->global_message = message;
-            gameGlobalInfo->global_message_timeout = 5.0;
-        }
-        this->hide();
-    }))->setPosition(-20, -20, ABottomRight)->setSize(300, 50);
-}
-
-bool GuiGlobalMessageEntry::onMouseDown(sf::Vector2f position)
-{   //Catch clicks.
-    return true;
 }

--- a/src/screens/gm/gameMasterScreen.h
+++ b/src/screens/gm/gameMasterScreen.h
@@ -20,6 +20,7 @@ class GuiToggleButton;
 class GuiTextEntry;
 class GameMasterChatDialog;
 class GuiObjectCreationView;
+class GuiGlobalMessageEntryView;
 class GameMasterScreen : public GuiCanvas, public Updatable
 {
 private:
@@ -31,7 +32,7 @@ private:
     
     GuiElement* chat_layer;
     std::vector<GameMasterChatDialog*> chat_dialog_per_ship;
-    GuiGlobalMessageEntry* global_message_entry;
+    GuiGlobalMessageEntryView* global_message_entry;
     GuiObjectCreationView* object_creation_view;
     GuiObjectTweak* player_tweak_dialog;
     GuiObjectTweak* ship_tweak_dialog;
@@ -79,14 +80,5 @@ public:
     string getScriptExport(bool selected_only);
 };
 
-class GuiGlobalMessageEntry : public GuiOverlay
-{
-private:
-    GuiTextEntry* message_entry;
-public:
-    GuiGlobalMessageEntry(GuiContainer* owner);
-    
-    virtual bool onMouseDown(sf::Vector2f position);
-};
 
 #endif//GAME_MASTER_SCREEN_H

--- a/src/screens/gm/gameMasterScreen.h
+++ b/src/screens/gm/gameMasterScreen.h
@@ -19,7 +19,7 @@ class GuiButton;
 class GuiToggleButton;
 class GuiTextEntry;
 class GameMasterChatDialog;
-
+class GuiObjectCreationView;
 class GameMasterScreen : public GuiCanvas, public Updatable
 {
 private:
@@ -32,7 +32,7 @@ private:
     GuiElement* chat_layer;
     std::vector<GameMasterChatDialog*> chat_dialog_per_ship;
     GuiGlobalMessageEntry* global_message_entry;
-    GuiObjectCreationScreen* object_creation_screen;
+    GuiObjectCreationView* object_creation_view;
     GuiObjectTweak* player_tweak_dialog;
     GuiObjectTweak* ship_tweak_dialog;
     GuiObjectTweak* object_tweak_dialog;
@@ -87,22 +87,6 @@ public:
     GuiGlobalMessageEntry(GuiContainer* owner);
     
     virtual bool onMouseDown(sf::Vector2f position);
-};
-
-class GuiObjectCreationScreen : public GuiOverlay
-{
-private:
-    string create_script;
-    GuiSelector* faction_selector;
-    GameMasterScreen* gm_screen;
-public:
-    GuiObjectCreationScreen(GameMasterScreen* gm_screen);
-    
-    virtual bool onMouseDown(sf::Vector2f position);
-    
-    void setCreateScript(string script);
-    
-    void createObject(sf::Vector2f position);
 };
 
 #endif//GAME_MASTER_SCREEN_H

--- a/src/screens/gm/globalMessageEntryView.cpp
+++ b/src/screens/gm/globalMessageEntryView.cpp
@@ -1,5 +1,5 @@
 #include "globalMessageEntryView.h"
-#include "gameGlobalInfo.h"
+#include "GMActions.h"
 
 #include "gui/gui2_panel.h"
 #include "gui/gui2_textentry.h"
@@ -20,11 +20,7 @@ GuiGlobalMessageEntryView::GuiGlobalMessageEntryView(GuiContainer* owner)
 
     (new GuiButton(box, "SEND_BUTTON", "Send", [this]() {
         string message = message_entry->getText();
-        if (message.length() > 0)
-        {
-            gameGlobalInfo->global_message = message;
-            gameGlobalInfo->global_message_timeout = 5.0;
-        }
+        gameMasterActions->commandSendGlobalMessage(message);
         this->hide();
     }))->setPosition(-20, -20, ABottomRight)->setSize(300, 50);
 }

--- a/src/screens/gm/globalMessageEntryView.cpp
+++ b/src/screens/gm/globalMessageEntryView.cpp
@@ -1,0 +1,35 @@
+#include "globalMessageEntryView.h"
+#include "gameGlobalInfo.h"
+
+#include "gui/gui2_panel.h"
+#include "gui/gui2_textentry.h"
+#include "gui/gui2_button.h"
+
+GuiGlobalMessageEntryView::GuiGlobalMessageEntryView(GuiContainer* owner)
+: GuiOverlay(owner, "GLOBAL_MESSAGE_ENTRY", sf::Color(0, 0, 0, 128))
+{
+    GuiPanel* box = new GuiPanel(this, "FRAME");
+    box->setPosition(0, 0, ACenter)->setSize(800, 150);
+    
+    message_entry = new GuiTextEntry(box, "MESSAGE_ENTRY", "");
+    message_entry->setPosition(0, 20, ATopCenter)->setSize(700, 50);
+    
+    (new GuiButton(box, "CLOSE_BUTTON", "Cancel", [this]() {
+        this->hide();
+    }))->setPosition(20, -20, ABottomLeft)->setSize(300, 50);
+
+    (new GuiButton(box, "SEND_BUTTON", "Send", [this]() {
+        string message = message_entry->getText();
+        if (message.length() > 0)
+        {
+            gameGlobalInfo->global_message = message;
+            gameGlobalInfo->global_message_timeout = 5.0;
+        }
+        this->hide();
+    }))->setPosition(-20, -20, ABottomRight)->setSize(300, 50);
+}
+
+bool GuiGlobalMessageEntryView::onMouseDown(sf::Vector2f position)
+{   //Catch clicks.
+    return true;
+}

--- a/src/screens/gm/globalMessageEntryView.h
+++ b/src/screens/gm/globalMessageEntryView.h
@@ -1,0 +1,20 @@
+
+#ifndef GLOBAL_MESSAGE_ENTRY_VIEW
+#define GLOBAL_MESSAGE_ENTRY_VIEW
+
+#include "gui/gui2_overlay.h"
+
+class GuiTextEntry;
+class GuiContainer;
+
+class GuiGlobalMessageEntryView : public GuiOverlay
+{
+private:
+    GuiTextEntry* message_entry;
+public:
+    GuiGlobalMessageEntryView(GuiContainer* owner);
+    
+    virtual bool onMouseDown(sf::Vector2f position);
+};
+
+#endif//GLOBAL_MESSAGE_ENTRY_VIEW

--- a/src/screens/gm/objectCreationView.cpp
+++ b/src/screens/gm/objectCreationView.cpp
@@ -1,5 +1,5 @@
 #include "objectCreationView.h"
-#include "engine.h"
+#include "GMActions.h"
 #include "factionInfo.h"
 #include "shipTemplate.h"
 #include "gui/gui2_panel.h"
@@ -93,8 +93,5 @@ void GuiObjectCreationView::createObject(sf::Vector2f position)
 {
     if (create_script == "")
         return;
-    
-    P<ScriptObject> so = new ScriptObject();
-    so->runCode(create_script + ":setPosition("+string(position.x)+","+string(position.y)+")");
-    so->destroy();
+    gameMasterActions->commandRunScript(create_script + ":setPosition("+string(position.x)+","+string(position.y)+")");
 }

--- a/src/screens/gm/objectCreationView.cpp
+++ b/src/screens/gm/objectCreationView.cpp
@@ -1,0 +1,100 @@
+#include "objectCreationView.h"
+#include "engine.h"
+#include "factionInfo.h"
+#include "shipTemplate.h"
+#include "gui/gui2_panel.h"
+#include "gui/gui2_selector.h"
+#include "gui/gui2_listbox.h"
+
+
+GuiObjectCreationView::GuiObjectCreationView(GuiContainer* owner, func_t enterCreateMode)
+: GuiOverlay(owner, "OBJECT_CREATE_SCREEN", sf::Color(0, 0, 0, 128)), enterCreateMode(enterCreateMode)
+{
+    GuiPanel* box = new GuiPanel(this, "FRAME");
+    box->setPosition(0, 0, ACenter)->setSize(1000, 500);
+
+    faction_selector = new GuiSelector(box, "FACTION_SELECTOR", nullptr);
+    for(P<FactionInfo> info : factionInfo)
+        faction_selector->addEntry(info->getName(), info->getName());
+    faction_selector->setSelectionIndex(0);
+    faction_selector->setPosition(20, 20, ATopLeft)->setSize(300, 50);
+    
+    float y = 20;
+    std::vector<string> template_names = ShipTemplate::getTemplateNameList(ShipTemplate::Station);
+    std::sort(template_names.begin(), template_names.end());
+    for(string template_name : template_names)
+    {
+        (new GuiButton(box, "CREATE_STATION_" + template_name, template_name, [this, template_name]() {
+            setCreateScript("SpaceStation():setRotation(random(0, 360)):setFactionId(" + string(faction_selector->getSelectionIndex()) + "):setTemplate(\"" + template_name + "\")");
+        }))->setTextSize(20)->setPosition(-350, y, ATopRight)->setSize(300, 30);
+        y += 30;
+    }
+    
+    (new GuiButton(box, "CREATE_WARP_JAMMER", "Warp Jammer", [this]() {
+        setCreateScript("WarpJammer():setRotation(random(0, 360)):setFactionId(" + string(faction_selector->getSelectionIndex()) + ")");
+    }))->setTextSize(20)->setPosition(-350, y, ATopRight)->setSize(300, 30);
+    y += 30;
+    (new GuiButton(box, "CREATE_MINE", "Mine", [this]() {
+        setCreateScript("Mine():setFactionId(" + string(faction_selector->getSelectionIndex()) + ")");
+    }))->setTextSize(20)->setPosition(-350, y, ATopRight)->setSize(300, 30);
+    y += 30;
+    // Default supply drop values copied from scripts/supply_drop.lua
+    (new GuiButton(box, "CREATE_SUPPLY_DROP", "Supply Drop", [this]() {
+        setCreateScript("SupplyDrop():setFactionId(" + string(faction_selector->getSelectionIndex()) + "):setEnergy(500):setWeaponStorage('Nuke', 1):setWeaponStorage('Homing', 4):setWeaponStorage('Mine', 2):setWeaponStorage('EMP', 1)");
+    }))->setTextSize(20)->setPosition(-350, y, ATopRight)->setSize(300, 30);
+    y += 30;
+    (new GuiButton(box, "CREATE_ASTEROID", "Asteroid", [this]() {
+        setCreateScript("Asteroid()");
+    }))->setTextSize(20)->setPosition(-350, y, ATopRight)->setSize(300, 30);
+    y += 30;
+    (new GuiButton(box, "CREATE_BLACKHOLE", "BlackHole", [this]() {
+        setCreateScript("BlackHole()");
+    }))->setTextSize(20)->setPosition(-350, y, ATopRight)->setSize(300, 30);
+    y += 30;
+    (new GuiButton(box, "CREATE_NEBULA", "Nebula", [this]() {
+        setCreateScript("Nebula()");
+    }))->setTextSize(20)->setPosition(-350, y, ATopRight)->setSize(300, 30);
+    y += 30;
+    (new GuiButton(box, "CREATE_WORMHOLE", "Worm Hole", [this]() {
+        setCreateScript("WormHole()");
+    }))->setTextSize(20)->setPosition(-350, y, ATopRight)->setSize(300, 30);
+    y += 30;
+    y = 20;
+    template_names = ShipTemplate::getTemplateNameList(ShipTemplate::Ship);
+    std::sort(template_names.begin(), template_names.end());
+    GuiListbox* listbox = new GuiListbox(box, "CREATE_SHIPS", [this](int index, string value)
+    {
+        setCreateScript("CpuShip():setRotation(random(0, 360)):setFactionId(" + string(faction_selector->getSelectionIndex()) + "):setTemplate(\"" + value + "\"):orderRoaming()");
+    });
+    listbox->setTextSize(20)->setButtonHeight(30)->setPosition(-20, 20, ATopRight)->setSize(300, 460);
+    for(string template_name : template_names)
+    {
+        listbox->addEntry(template_name, template_name);
+    }
+    
+    (new GuiButton(box, "CLOSE_BUTTON", "Cancel", [this]() {
+        create_script = "";
+        this->hide();
+    }))->setPosition(20, -20, ABottomLeft)->setSize(300, 50);
+}
+
+bool GuiObjectCreationView::onMouseDown(sf::Vector2f position)
+{   //Catch clicks.
+    return true;
+}
+
+void GuiObjectCreationView::setCreateScript(string script)
+{
+    create_script = script;
+    enterCreateMode();
+}
+
+void GuiObjectCreationView::createObject(sf::Vector2f position)
+{
+    if (create_script == "")
+        return;
+    
+    P<ScriptObject> so = new ScriptObject();
+    so->runCode(create_script + ":setPosition("+string(position.x)+","+string(position.y)+")");
+    so->destroy();
+}

--- a/src/screens/gm/objectCreationView.h
+++ b/src/screens/gm/objectCreationView.h
@@ -1,0 +1,26 @@
+#ifndef OBJECT_CREATION_VIEW_H
+#define OBJECT_CREATION_VIEW_H
+
+#include "gui/gui2_overlay.h"
+
+class GuiSelector;
+class GuiContainer;
+
+class GuiObjectCreationView : public GuiOverlay
+{
+    typedef std::function<void()> func_t;
+private:
+    string create_script;
+    GuiSelector* faction_selector;
+    func_t enterCreateMode;
+public:
+    GuiObjectCreationView(GuiContainer* owner, func_t enterCreateMode);
+    
+    virtual bool onMouseDown(sf::Vector2f position);
+    
+    void setCreateScript(string script);
+    
+    void createObject(sf::Vector2f position);
+};
+
+#endif//OBJECT_CREATION_VIEW_H


### PR DESCRIPTION
This is a refactor of the GM screen - extract inner components `GuiObjectCreationView` and `GuiGlobalMessageEntryView` into their own files (and cut circular dependency  of `GMScreen` and `ObjectCreation` using callback)
In addition, the last commit introduced a GM actions executor singleton. its purpose is to allow remote / multiple GM stations (#543) , by sending GM commands to the server instead of running them locally.