### PR TITLE
extract ShipFilter from AutoConnectScreen

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -92,6 +92,7 @@ set(SOURCES
 	src/script.cpp
 	src/playerInfo.cpp
 	src/gameStateLogger.cpp
+	src/shipFilter.cpp
 	src/shipTemplate.cpp
 	src/beamTemplate.cpp
 	src/missileWeaponData.cpp

--- a/src/menus/autoConnectScreen.h
+++ b/src/menus/autoConnectScreen.h
@@ -3,6 +3,7 @@
 
 #include "gui/gui2_canvas.h"
 #include "playerInfo.h"
+#include "shipFilter.h"
 
 class GuiLabel;
 
@@ -12,7 +13,7 @@ class AutoConnectScreen : public GuiCanvas, public Updatable
     sf::IpAddress connect_to_address;
     ECrewPosition crew_position;
     bool control_main_screen;
-    std::map<string, string> ship_filters;
+    ShipFilter filter;
     
     GuiLabel* status_label;
 public:
@@ -22,8 +23,7 @@ public:
     virtual void update(float delta);
 
 private:
-    bool isValidShip(int index);
-    void connectToShip(int index);
+    void connectToShip(P<PlayerSpaceship> ship);
 };
 
 #endif//AUTO_CONNECT_SCREEN_H

--- a/src/shipFilter.cpp
+++ b/src/shipFilter.cpp
@@ -1,0 +1,83 @@
+#include "shipFilter.h"
+#include "gameGlobalInfo.h"
+
+ShipFilter::ShipFilter(string ship_filter, ECrewPosition crew_position) : crew_position(crew_position)
+{
+    for (string filter : ship_filter.split(";"))
+    {
+        std::vector<string> key_value = filter.split("=", 1);
+        string key = key_value[0].strip().lower();
+        if (key.length() < 1)
+            continue;
+
+        if (key_value.size() == 1)
+            ship_filters[key] = "1";
+        else if (key_value.size() == 2)
+            ship_filters[key] = key_value[1].strip();
+    }
+}
+
+void ShipFilter::log()
+{
+    for (auto& entry : ship_filters) 
+    {
+        LOG(INFO) << "Auto connect filter: " << entry.first << " = " << entry.second;
+    }
+}
+
+P<PlayerSpaceship> ShipFilter::findValidShip()
+{
+    for (int n = 0; n < GameGlobalInfo::max_player_ships; n++)
+    {
+        P<PlayerSpaceship> ship = gameGlobalInfo->getPlayerShip(n);
+        if (isValidShip(ship))
+        {
+            return ship;
+        }
+    }
+    return nullptr;
+}
+
+bool ShipFilter::isValidShip(P<PlayerSpaceship> ship)
+{
+    if (!ship || !ship->ship_template)
+        return false;
+
+    for (auto it : ship_filters)
+    {
+        if (it.first == "solo")
+        {
+            int crew_at_position = 0;
+            foreach (PlayerInfo, i, player_info_list)
+            {
+                if (i->ship_id == ship->getMultiplayerId())
+                {
+                    if (crew_position != max_crew_positions && i->crew_position[crew_position])
+                        crew_at_position++;
+                }
+            }
+            if (crew_at_position > 0)
+                return false;
+        }
+        else if (it.first == "faction")
+        {
+            if (ship->getFactionId() != FactionInfo::findFactionId(it.second))
+                return false;
+        }
+        else if (it.first == "callsign")
+        {
+            if (ship->getCallSign().lower() != it.second.lower())
+                return false;
+        }
+        else if (it.first == "type")
+        {
+            if (ship->getTypeName().lower() != it.second.lower())
+                return false;
+        }
+        else
+        {
+            LOG(WARNING) << "Unknown ship filter: " << it.first << " = " << it.second;
+        }
+    }
+    return true;
+}

--- a/src/shipFilter.h
+++ b/src/shipFilter.h
@@ -1,0 +1,19 @@
+#ifndef SHIP_FILTER_H
+#define SHIP_FILTER_H
+
+#include "playerInfo.h"
+
+
+class ShipFilter 
+{
+    std::map<string, string> ship_filters;
+    ECrewPosition crew_position;
+public:
+    ShipFilter(string ship_filter, ECrewPosition crew_position = max_crew_positions);
+    P<PlayerSpaceship> findValidShip();
+    void log();
+private:
+    bool isValidShip(P<PlayerSpaceship> index);
+};
+
+#endif//SHIP_FILTER_H


### PR DESCRIPTION
a small refactor to extract a potentially reusable ship filter from auto-connect.

My next goal would be extending hardware.ini to support more than one ship (following [this](http://bridgesim.net/discussion/422/dmx-on-multiple-bridges-setup) thread)