### PR TITLE
rename onPickUp callback for Artifact and add it for SupplyDrop

### DIFF
--- a/src/spaceObjects/artifact.cpp
+++ b/src/spaceObjects/artifact.cpp
@@ -19,8 +19,8 @@ REGISTER_SCRIPT_SUBCLASS(Artifact, SpaceObject)
     /// Set if this artifact can be picked up or not. When it is picked up, this artifact will be destroyed.
     REGISTER_SCRIPT_CLASS_FUNCTION(Artifact, allowPickup);
     /// Set a function that will be called if a player picks up the artifact.
-    /// First argument given to the function will be the playerSpaceShip, the second the artifact.
-    REGISTER_SCRIPT_CLASS_FUNCTION(Artifact, setPickUpCallback);
+    /// First argument given to the function will be the artifact, the second the player.
+    REGISTER_SCRIPT_CLASS_FUNCTION(Artifact, onPickUp);
 }
 
 REGISTER_MULTIPLAYER_CLASS(Artifact, "Artifact");
@@ -71,7 +71,7 @@ void Artifact::collide(Collisionable* target, float force)
     {
         if (on_pickup_callback.isSet())
         {
-            on_pickup_callback.call(player, P<Artifact>(this));
+            on_pickup_callback.call(P<Artifact>(this), player);
         }
         destroy();
     }
@@ -95,7 +95,7 @@ void Artifact::allowPickup(bool allow)
     allow_pickup = allow;
 }
 
-void Artifact::setPickUpCallback(ScriptSimpleCallback callback)
+void Artifact::onPickUp(ScriptSimpleCallback callback)
 {
     this->allow_pickup = 1;
     this->on_pickup_callback = callback;

--- a/src/spaceObjects/artifact.h
+++ b/src/spaceObjects/artifact.h
@@ -24,7 +24,7 @@ public:
     void allowPickup(bool allow);
     
     virtual string getExportLine();
-    void setPickUpCallback(ScriptSimpleCallback callback);
+    void onPickUp(ScriptSimpleCallback callback);
 };
 
 #endif//ARTIFACT_H

--- a/src/spaceObjects/supplyDrop.cpp
+++ b/src/spaceObjects/supplyDrop.cpp
@@ -9,6 +9,9 @@ REGISTER_SCRIPT_SUBCLASS(SupplyDrop, SpaceObject)
 {
     REGISTER_SCRIPT_CLASS_FUNCTION(SupplyDrop, setEnergy);
     REGISTER_SCRIPT_CLASS_FUNCTION(SupplyDrop, setWeaponStorage);
+    /// Set a function that will be called if a player picks up the supply drop.
+    /// First argument given to the function will be the supply drop, the second the player.
+    REGISTER_SCRIPT_CLASS_FUNCTION(SupplyDrop, onPickUp);
 }
 
 REGISTER_MULTIPLAYER_CLASS(SupplyDrop, "SupplyDrop");
@@ -62,10 +65,20 @@ void SupplyDrop::collide(Collisionable* target, float force)
                 picked_up = true;
             }
         }
+        if (on_pickup_callback.isSet())
+        {
+            on_pickup_callback.call(P<SupplyDrop>(this), player);
+            picked_up = true;
+        }
 
         if (picked_up)
             destroy();
     }
+}
+
+void SupplyDrop::onPickUp(ScriptSimpleCallback callback)
+{
+    this->on_pickup_callback = callback;
 }
 
 string SupplyDrop::getExportLine()

--- a/src/spaceObjects/supplyDrop.h
+++ b/src/spaceObjects/supplyDrop.h
@@ -6,6 +6,8 @@
 
 class SupplyDrop : public SpaceObject
 {
+private:
+    ScriptSimpleCallback on_pickup_callback;
 public:
     int8_t weapon_storage[MW_Count];
     float energy;
@@ -18,7 +20,9 @@ public:
 
     void setEnergy(float amount) { energy = amount; }
     void setWeaponStorage(EMissileWeapons weapon, int amount) { if (weapon != MW_None) weapon_storage[weapon] = amount; }
-    
+
+    void onPickUp(ScriptSimpleCallback callback);
+
     virtual string getExportLine();
 };
 


### PR DESCRIPTION
I renamed the callback function for Artifact pickup to have a consistent naming as described in #587 and switched the parameter order. I found this more intuitive as lua functions usually have `self` as the _first_ argument. So this is a *breaking change*, but it should not have any real impact as the function was only introduced recently and is not used yet in any official missions.

This commit also adds the same functionality for SupplyDrops.
    
Usage:

    function init()
        PlayerSpaceship():
            setTemplate("Piranha"):
            setFaction("Human Navy"):
            setCallSign("Thief")
        Artifact():
            setCallSign("Stack of Gold"):
            onPickUp(function(foo, bar)
                print(bar:getCallSign() .. " picked up " .. foo:getCallSign())
            end)
        SupplyDrop():
            setCallSign("Ammo Crate"):
            setFaction("Human Navy"):
            onPickUp(function(foo, bar)
                print(bar:getCallSign() .. " picked up " .. foo:getCallSign())
            end)
    end