### PR TITLE
add eventListeners for shipTemplateBasedObjects and warpJammers being damaged or destroyed

### DIFF
--- a/src/spaceObjects/shipTemplateBasedObject.cpp
+++ b/src/spaceObjects/shipTemplateBasedObject.cpp
@@ -60,6 +60,12 @@ REGISTER_SCRIPT_SUBCLASS_NO_CREATE(ShipTemplateBasedObject, SpaceObject)
     REGISTER_SCRIPT_CLASS_FUNCTION(ShipTemplateBasedObject, setRearShield);
     /// [Depricated]
     REGISTER_SCRIPT_CLASS_FUNCTION(ShipTemplateBasedObject, setRearShieldMax);
+    /// Set a function that will be called if the object is taking damage.
+    /// First argument given to the function will be the object taking damage, the second the instigator SpaceObject (or nil).
+    REGISTER_SCRIPT_CLASS_FUNCTION(ShipTemplateBasedObject, onTakingDamage);
+    /// Set a function that will be called if the object is destroyed by taking damage.
+    /// First argument given to the function will be the object taking damage, the second the instigator SpaceObject that gave the final blow (or nil).
+    REGISTER_SCRIPT_CLASS_FUNCTION(ShipTemplateBasedObject, onDestruction);
 }
 
 ShipTemplateBasedObject::ShipTemplateBasedObject(float collision_range, string multiplayer_name, float multiplayer_significant_range)
@@ -260,6 +266,19 @@ void ShipTemplateBasedObject::takeDamage(float damage_amount, DamageInfo info)
     {
         takeHullDamage(damage_amount, info);
     }
+
+    if (hull_strength > 0)
+    {
+        if (on_taking_damage.isSet())
+        {
+            if (info.instigator)
+            {
+                on_taking_damage.call(P<ShipTemplateBasedObject>(this), P<SpaceObject>(info.instigator));
+            } else {
+                on_taking_damage.call(P<ShipTemplateBasedObject>(this));
+            }
+        }
+    }
 }
 
 void ShipTemplateBasedObject::takeHullDamage(float damage_amount, DamageInfo& info)
@@ -272,6 +291,15 @@ void ShipTemplateBasedObject::takeHullDamage(float damage_amount, DamageInfo& in
     if (hull_strength <= 0.0)
     {
         destroyedByDamage(info);
+        if (on_destruction.isSet())
+        {
+            if (info.instigator)
+            {
+                on_destruction.call(P<ShipTemplateBasedObject>(this), P<SpaceObject>(info.instigator));
+            } else {
+                on_destruction.call(P<ShipTemplateBasedObject>(this));
+            }
+        }
         destroy();
     }
 }
@@ -336,6 +364,16 @@ ESystem ShipTemplateBasedObject::getShieldSystemForShieldIndex(int index)
     if (std::abs(sf::angleDifference(angle, 0.0f)) < 90)
         return SYS_FrontShield;
     return SYS_RearShield;
+}
+
+void ShipTemplateBasedObject::onTakingDamage(ScriptSimpleCallback callback)
+{
+    this->on_taking_damage = callback;
+}
+
+void ShipTemplateBasedObject::onDestruction(ScriptSimpleCallback callback)
+{
+    this->on_destruction = callback;
 }
 
 string ShipTemplateBasedObject::getShieldDataString()

--- a/src/spaceObjects/shipTemplateBasedObject.h
+++ b/src/spaceObjects/shipTemplateBasedObject.h
@@ -30,6 +30,9 @@ public:
 
     bool shares_energy_with_docked;       //[config]
     bool repair_docked;                   //[config]
+
+    ScriptSimpleCallback on_destruction;
+    ScriptSimpleCallback on_taking_damage;
 public:
     ShipTemplateBasedObject(float collision_range, string multiplayer_name, float multiplayer_significant_range=-1);
 
@@ -91,7 +94,10 @@ public:
     void setSharesEnergyWithDocked(bool enabled) { shares_energy_with_docked = enabled; }
     bool getRepairDocked() { return repair_docked; }
     void setRepairDocked(bool enabled) { repair_docked = enabled; }
-    
+
+    void onTakingDamage(ScriptSimpleCallback callback);
+    void onDestruction(ScriptSimpleCallback callback);
+
     string getShieldDataString();
 };
 

--- a/src/spaceObjects/warpJammer.cpp
+++ b/src/spaceObjects/warpJammer.cpp
@@ -8,6 +8,12 @@
 REGISTER_SCRIPT_SUBCLASS(WarpJammer, SpaceObject)
 {
     REGISTER_SCRIPT_CLASS_FUNCTION(WarpJammer, setRange);
+    /// Set a function that will be called if the warp jammer is taking damage.
+    /// First argument given to the function will be the warp jammer, the second the instigator SpaceObject (or nil).
+    REGISTER_SCRIPT_CLASS_FUNCTION(WarpJammer, onTakingDamage);
+    /// Set a function that will be called if the warp jammer is destroyed by taking damage.
+    /// First argument given to the function will be the warp jammer, the second the instigator SpaceObject that gave the final blow (or nil).
+    REGISTER_SCRIPT_CLASS_FUNCTION(WarpJammer, onDestruction);
 }
 
 REGISTER_MULTIPLAYER_CLASS(WarpJammer, "WarpJammer");
@@ -64,7 +70,28 @@ void WarpJammer::takeDamage(float damage_amount, DamageInfo info)
         P<ExplosionEffect> e = new ExplosionEffect();
         e->setSize(getRadius());
         e->setPosition(getPosition());
+
+        if (on_destruction.isSet())
+        {
+            if (info.instigator)
+            {
+                on_destruction.call(P<WarpJammer>(this), P<SpaceObject>(info.instigator));
+            } else {
+                on_destruction.call(P<WarpJammer>(this));
+            }
+        }
+
         destroy();
+    } else {
+        if (on_taking_damage.isSet())
+        {
+            if (info.instigator)
+            {
+                on_taking_damage.call(P<WarpJammer>(this), P<SpaceObject>(info.instigator));
+            } else {
+                on_taking_damage.call(P<WarpJammer>(this));
+            }
+        }
     }
 }
 
@@ -106,4 +133,14 @@ sf::Vector2f WarpJammer::getFirstNoneJammedPosition(sf::Vector2f start, sf::Vect
 
     float d = sf::length(first_jammer_q - first_jammer->getPosition());
     return first_jammer_q + sf::normalize(start - end) * sqrtf(first_jammer->range * first_jammer->range - d * d);
+}
+
+void WarpJammer::onTakingDamage(ScriptSimpleCallback callback)
+{
+    this->on_taking_damage = callback;
+}
+
+void WarpJammer::onDestruction(ScriptSimpleCallback callback)
+{
+    this->on_destruction = callback;
 }

--- a/src/spaceObjects/warpJammer.h
+++ b/src/spaceObjects/warpJammer.h
@@ -9,6 +9,9 @@ class WarpJammer : public SpaceObject
 
     float range;
     float hull;
+
+    ScriptSimpleCallback on_destruction;
+    ScriptSimpleCallback on_taking_damage;
 public:
     WarpJammer();
     
@@ -21,6 +24,9 @@ public:
 
     static bool isWarpJammed(sf::Vector2f position);
     static sf::Vector2f getFirstNoneJammedPosition(sf::Vector2f start, sf::Vector2f end);
+
+    void onTakingDamage(ScriptSimpleCallback callback);
+    void onDestruction(ScriptSimpleCallback callback);
     
     virtual string getExportLine() { return "WarpJammer():setFaction(\"" + getFaction() + "\"):setPosition(" + string(getPosition().x, 0) + ", " + string(getPosition().y, 0) + ")"; }
 };


### PR DESCRIPTION
EventListeners for when a station/ship/player/warp jammer take damage or are destroyed by taking damage. #587 

`onDestruction` will intentionally not be triggered in cases where the ship is not destroyed by taking damage. This could be scripts calling `destroy` directly, the GM console or some quirks like black holes. The black hole behavior should probably be fixed and there might be other edge cases.

Would be happy for feedback if this behavior is expected by you or if a change is required. `onDestructionByDamage` would be probably be a more accurate name, but is very cumbersome.

Also currently there is no instigator given if the damage is caused by collision with an asteroid. This could be fixed in the future also.

Usage:

    function init()
        local kraylor, station, ship, player
    
        kraylor = CpuShip():setFaction("Kraylor"):setTemplate("Odin"):setCallSign("Odin"):setPosition(1000, 0):orderRoaming()
    
        local source = function(instigator)
            if type(instigator) == "table" and type(instigator.getCallSign) == "function" and instigator:getCallSign() ~= "" then
                return " by " .. instigator:getCallSign()
            elseif type(instigator) == "table" and type(instigator.type) == "string" then
                return " by a " .. instigator.type
            else
                return ""
            end
        end
    
        local onTakingDamage = function(self, instigator)
            print(self:getCallSign() .. " is taking damage" .. source(instigator))
        end
        local onDestruction = function(self, instigator)
            print(self:getCallSign() .. " was destroyed" .. source(instigator))
        end
    
        SpaceStation():
        setTemplate("Medium Station"):
        setCallSign("Dummy"):
        setFaction("Human Navy"):
        onTakingDamage(onTakingDamage):
        onDestruction(onDestruction)
    
        CpuShip():
        setTemplate("Adder MK4"):
        setCallSign("Ship"):
        setPosition(0, 1000):
        setFaction("Human Navy"):
        onTakingDamage(onTakingDamage):
        onDestruction(onDestruction):orderIdle()
    
        PlayerSpaceship():
        setTemplate("Flavia P.Falcon"):
        setCallSign("Player"):
        setPosition(0, -1000):
        setFaction("Human Navy"):
        onTakingDamage(onTakingDamage):
        onDestruction(onDestruction)
    
        WarpJammer():
        setCallSign("Jammer"):
        setPosition(0, -2000):
        setFaction("Human Navy"):
        onTakingDamage(onTakingDamage):
        onDestruction(onDestruction)
    
    end