### PR TITLE
eventListener when a SpaceObject uses a WormHole

### DIFF
--- a/src/spaceObjects/wormHole.cpp
+++ b/src/spaceObjects/wormHole.cpp
@@ -19,6 +19,9 @@ REGISTER_SCRIPT_SUBCLASS(WormHole, SpaceObject)
     /// Set the target of this wormhole
     REGISTER_SCRIPT_CLASS_FUNCTION(WormHole, setTargetPosition);
     REGISTER_SCRIPT_CLASS_FUNCTION(WormHole, getTargetPosition);
+    /// Set a function that will be called if a SpaceObject is teleported.
+    /// First argument given to the function will be the WormHole, the second the SpaceObject that has been teleported.
+    REGISTER_SCRIPT_CLASS_FUNCTION(WormHole, onTeleportation);
 }
 
 REGISTER_MULTIPLAYER_CLASS(WormHole, "WormHole");
@@ -132,8 +135,14 @@ void WormHole::collide(Collisionable* target, float collision_force)
             target->setPosition( (target_position + 
                                   sf::Vector2f(random(-TARGET_SPREAD, TARGET_SPREAD), 
                                                random(-TARGET_SPREAD, TARGET_SPREAD))));
-            if (obj)
-                obj->wormhole_alpha = 0.0;
+        if (obj)
+        {
+            obj->wormhole_alpha = 0.0;
+            if (on_teleportation.isSet())
+            {
+                on_teleportation.call(P<WormHole>(this), obj);
+            }
+        }
     }
     
     // Warp postprocessor-alpha is calculated using alpha = (1 - (delay/10))
@@ -152,4 +161,9 @@ void WormHole::setTargetPosition(sf::Vector2f v)
 sf::Vector2f WormHole::getTargetPosition()
 {
     return target_position;
+}
+
+void WormHole::onTeleportation(ScriptSimpleCallback callback)
+{
+    this->on_teleportation = callback;
 }

--- a/src/spaceObjects/wormHole.h
+++ b/src/spaceObjects/wormHole.h
@@ -15,6 +15,7 @@ class WormHole : public SpaceObject, public Updatable
     static const int cloud_count = 5;
     NebulaCloud clouds[cloud_count];
 
+    ScriptSimpleCallback on_teleportation;
 public:
     WormHole();
 
@@ -28,7 +29,8 @@ public:
     
     void setTargetPosition(sf::Vector2f v);   /* Where to jump to */
     sf::Vector2f getTargetPosition();
-    
+    void onTeleportation(ScriptSimpleCallback callback);
+
     virtual string getExportLine() { return "WormHole():setPosition(" + string(getPosition().x, 0) + ", " + string(getPosition().y, 0) + "):setTargetPosition(" + string(target_position.x, 0) + ", " + string(target_position.y, 0) + ")"; }
 };
 


### PR DESCRIPTION
see #587

Usage:

    function init()
        PlayerSpaceship():
        setTemplate("Flavia P.Falcon"):
        setCallSign("Player"):
        setPosition(0, 2000):
        setFaction("Human Navy")
    
        WormHole():setPosition(0, 0):setTargetPosition(9999, 0):onTeleportation(function(self, ship)
            ship:setSystemHealth("reactor", -1)
            ship:addToShipLog("Your reactor broke while jumping.", "white")
    
            print(ship:getCallSign() .. " jumped")
        end)
    end