### PR TITLE
Bugfix: Don't look for another button if the clicked button has been found

### DIFF
--- a/src/spaceObjects/playerSpaceship.cpp
+++ b/src/spaceObjects/playerSpaceship.cpp
@@ -1471,8 +1471,8 @@ void PlayerSpaceship::onReceiveClientCommand(int32_t client_id, sf::Packet& pack
                     if (csf.type == CustomShipFunction::Type::Message)
                     {
                         removeCustom(name);
-                        break;
                     }
+                    break;
                 }
             }
         }


### PR DESCRIPTION
I am currently adding a lib to have buttons behave as menus (see [here](https://github.com/czenker/lively-epsilon/blob/master/test/domain/trait/player/menus_spec.lua) and [here](https://github.com/czenker/lively-epsilon/blob/master/test/domain/trait/player/power_presets_spec.lua) if you are curios).

But regularily there were Segmantation Faults when clicking on the menu items – especially after reloading the scenario. I traced it down to the following point

    #0  0x00007ffff6236243 in std::string::size() const () from /usr/lib/x86_64-linux-gnu/libstdc++.so.6
    #1  0x00000000005ee86a in std::operator==<char> (__lhs=<error reading variable: Cannot access memory at address 0xffffffffffffffe8>, __rhs="science_station_3") at /usr/include/c++/4.9/bits/basic_string.h:2514
    #2  0x000000000079331c in PlayerSpaceship::onReceiveClientCommand (this=0x26b8e10, client_id=0, packet=...) at EmptyEpsilon/src/spaceObjects/playerSpaceship.cpp:1465
    #3  0x000000000082072f in MultiplayerObject::sendClientCommand (this=0x26b8e28, packet=...) at SeriousProton/src/multiplayer.cpp:188
    #4  0x0000000000795142 in PlayerSpaceship::commandCustomFunction (this=0x26b8e10, name=...) at EmptyEpsilon/src/spaceObjects/playerSpaceship.cpp:1789
    #5  0x0000000000723068 in GuiCustomShipFunctions::<lambda()>::operator()(void) const (__closure=0x21aaac0) at EmptyEpsilon/src/screenComponents/customShipFunctions.cpp:69
    #6  0x0000000000723671 in std::_Function_handler<void(), GuiCustomShipFunctions::createEntries()::<lambda()> >::_M_invoke(const std::_Any_data &) (__functor=...) at /usr/include/c++/4.9/functional:2039
    #7  0x00000000005f1de4 in std::function<void ()>::operator()() const (this=0x7fffffffc920) at /usr/include/c++/4.9/functional:2439
    #8  0x0000000000749558 in GuiButton::onMouseUp (this=0x28378b0, position=...) at EmptyEpsilon/src/gui/gui2_button.cpp:69
    #9  0x000000000074182f in GuiCanvas::render (this=0x2824b70, window=...) at EmptyEpsilon/src/gui/gui2_canvas.cpp:54
    #10 0x00000000007f8d2f in RenderLayer::render (this=0x19a7520, window=...) at SeriousProton/src/Renderable.cpp:21
    #11 0x00000000007f8ce8 in RenderLayer::render (this=0x19a5e30, window=...) at SeriousProton/src/Renderable.cpp:18
    #12 0x00000000007f8ce8 in RenderLayer::render (this=0x19a5df0, window=...) at SeriousProton/src/Renderable.cpp:18
    #13 0x00000000007f8ce8 in RenderLayer::render (this=0x19a71e0, window=...) at SeriousProton/src/Renderable.cpp:18
    #14 0x00000000007e3ed4 in PostProcessor::render (this=0x19a7870, window=...) at SeriousProton/src/postProcessManager.cpp:42
    #15 0x00000000007e3ed4 in PostProcessor::render (this=0x19a95c0, window=...) at SeriousProton/src/postProcessManager.cpp:42
    #16 0x000000000085e9b2 in WindowManager::render (this=0x19a9860) at SeriousProton/src/windowManager.cpp:31
    #17 0x000000000085ca6f in Engine::runMainLoop (this=0x15fd640) at SeriousProton/src/engine.cpp:141
    #18 0x00000000005eb5ad in main (argc=1, argv=0x7fffffffdd28) at EmptyEpsilon/src/main.cpp:274

Turns out that the code tries to access a `CustomShipFunction` at a point where none exists. My guess is that `std::vector` has an issue with being modified while iterating over it – as implementations in most other programming languages do.

So the solution is to just stop looking for another `CustomShipFunction` once the right one has been found. I guess having two buttons with the same name was never considered a feature, was it?

At least this fixes the Segmentation Faults for me.