### PR TITLE
do not crash when isEnemy or isFriendly is called with destroyed ship

### DIFF
--- a/src/spaceObjects/spaceObject.cpp
+++ b/src/spaceObjects/spaceObject.cpp
@@ -274,12 +274,22 @@ void SpaceObject::setScanningParameters(int complexity, int depth)
 
 bool SpaceObject::isEnemy(P<SpaceObject> obj)
 {
-    return factionInfo[faction_id]->states[obj->faction_id] == FVF_Enemy;
+    if (obj)
+    {
+        return factionInfo[faction_id]->states[obj->faction_id] == FVF_Enemy;
+    } else {
+        return false;
+    }
 }
 
 bool SpaceObject::isFriendly(P<SpaceObject> obj)
 {
-    return factionInfo[faction_id]->states[obj->faction_id] == FVF_Friendly;
+    if (obj)
+    {
+        return factionInfo[faction_id]->states[obj->faction_id] == FVF_Friendly;
+    } else {
+        return false;
+    }
 }
 
 void SpaceObject::damageArea(sf::Vector2f position, float blast_range, float min_damage, float max_damage, DamageInfo info, float min_range)


### PR DESCRIPTION
Another non-friendly `SEGFAULT` is approaching our sector. Destroy it!

    local one = CpuShip():setTemplate("Adder MK5")
    local two = CpuShip():setTemplate("Adder MK5")
    two:destroy()

    print(one:isFriendly(two)) -- <-- boom
    print(one:isEnemy(two)) -- <-- double boom