### PR TITLE
Fix the mod option

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -120,11 +120,11 @@ int main(int argc, char** argv)
         string mod = PreferencesManager::get("mod");
         if (getenv("HOME"))
         {
-            new DirectoryResourceProvider(string(getenv("HOME")) + "/.emptyepsilon/resources/mods/" + mod);
-            PackResourceProvider::addPackResourcesForDirectory(string(getenv("HOME")) + "/.emptyepsilon/resources/mods/" + mod);
+            new DirectoryResourceProvider(string(getenv("HOME")) + "/.emptyepsilon/resources/mods/" + mod + "/");
+            PackResourceProvider::addPackResourcesForDirectory(string(getenv("HOME")) + "/.emptyepsilon/resources/mods/" + mod + "/");
         }
-        new DirectoryResourceProvider("resources/mods/" + mod);
-        PackResourceProvider::addPackResourcesForDirectory("resources/mods/" + mod);
+        new DirectoryResourceProvider("resources/mods/" + mod + "/");
+        PackResourceProvider::addPackResourcesForDirectory("resources/mods/" + mod + "/");
     }
 
 #ifdef RESOURCE_BASE_DIR

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -120,11 +120,13 @@ int main(int argc, char** argv)
         string mod = PreferencesManager::get("mod");
         if (getenv("HOME"))
         {
-            new DirectoryResourceProvider(string(getenv("HOME")) + "/.emptyepsilon/resources/mods/" + mod + "/");
-            PackResourceProvider::addPackResourcesForDirectory(string(getenv("HOME")) + "/.emptyepsilon/resources/mods/" + mod + "/");
+            new DirectoryResourceProvider(string(getenv("HOME")) + "/.emptyepsilon/resources/mods/" + mod + "/resources/");
+            new DirectoryResourceProvider(string(getenv("HOME")) + "/.emptyepsilon/resources/mods/" + mod + "/scripts/");
+            PackResourceProvider::addPackResourcesForDirectory(string(getenv("HOME")) + "/.emptyepsilon/resources/mods/" + mod + "/packs/");
         }
-        new DirectoryResourceProvider("resources/mods/" + mod + "/");
-        PackResourceProvider::addPackResourcesForDirectory("resources/mods/" + mod + "/");
+        new DirectoryResourceProvider("resources/mods/" + mod + "/resources/");
+        new DirectoryResourceProvider("resources/mods/" + mod + "/scripts/");
+        PackResourceProvider::addPackResourcesForDirectory("resources/mods/" + mod + "/packs/");
     }
 
 #ifdef RESOURCE_BASE_DIR

--- a/src/scenarioInfo.cpp
+++ b/src/scenarioInfo.cpp
@@ -7,7 +7,11 @@ ScenarioInfo::ScenarioInfo(string filename)
     name = filename.substr(9, -4);
 
     P<ResourceStream> stream = getResourceStream(filename);
-    if (!stream) return;
+    if (!stream)
+    {
+        LOG(ERROR) << "Scenario not found: " << filename;
+        return;
+    }
 
     string key;
     string value;


### PR DESCRIPTION
The `mod` option did not work as I was expecting it. Starting EE like

    ./EmptyEpsilon mod=my_mod

did not use any files from the mod. And even though scenarios from the mod where found they could not be started. The simple bugfix to restore that functionality is in comit f5cc8a5.

I think that this resulted in the mod feature not being used by anyone<sup>[citation needed]</sup>. So I thought of forcing the `script`, `resources` and `packs` directories to the mods too. This would be a breaking change, but I'm not sure if anyone would be affected by it. But I do not see why scripts and models should be stored in the same folder for mods. This is the second commit 29ad5ec.