### PR TITLE
Remove headings and callsigns from windowScreen

### DIFF
--- a/src/screens/windowScreen.cpp
+++ b/src/screens/windowScreen.cpp
@@ -12,7 +12,7 @@ WindowScreen::WindowScreen(float angle)
 : angle(angle)
 {
     viewport = new GuiViewport3D(this, "VIEWPORT");
-    viewport->showCallsigns()->showHeadings()->showSpacedust();
+    viewport->showSpacedust();
     viewport->setPosition(0, 0, ATopLeft)->setSize(GuiElement::GuiSizeMax, GuiElement::GuiSizeMax);
 
     new GuiShipDestroyedPopup(this);


### PR DESCRIPTION
So this lets the ship window look more like a window, as it removes the callsigns and headings.
I kept the spacedust though, while not really realistic it maintains a sense of movement. But of course this could be removed as well if you disagree here.
This replaces #617 - As without the options it's just a oneliner, doing a new PR was much easier than trying to reduce that other one.