### PR TITLE
Correct the compilation warning: 'setParameter' is deprecated

### DIFF
--- a/src/modelData.cpp
+++ b/src/modelData.cpp
@@ -205,11 +205,11 @@ void ModelData::render()
 
     glScalef(scale, scale, scale);
     glTranslatef(mesh_offset.x, mesh_offset.y, mesh_offset.z);
-    shader->setParameter("baseMap", *texture);
+    shader->setUniform("baseMap", *texture);
     if (specular_texture)
-        shader->setParameter("specularMap", *specular_texture);
+        shader->setUniform("specularMap", *specular_texture);
     if (illumination_texture)
-        shader->setParameter("illuminationMap", *illumination_texture);
+        shader->setUniform("illuminationMap", *illumination_texture);
     sf::Shader::bind(shader);
     mesh->render();
 

--- a/src/modelInfo.cpp
+++ b/src/modelInfo.cpp
@@ -73,7 +73,7 @@ void ModelInfo::renderOverlay(sf::Texture* texture, float alpha)
     glTranslatef(data->mesh_offset.x, data->mesh_offset.y, data->mesh_offset.z);
     glDepthFunc(GL_EQUAL);
     glColor4f(alpha, alpha, alpha, 1);
-    ShaderManager::getShader("basicShader")->setParameter("textureMap", *texture);
+    ShaderManager::getShader("basicShader")->setUniform("textureMap", *texture);
     sf::Shader::bind(ShaderManager::getShader("basicShader"));
     data->mesh->render();
     glDepthFunc(GL_LESS);
@@ -85,7 +85,7 @@ void ModelInfo::renderOverlay(sf::Texture* texture, float alpha)
 void ModelInfo::renderShield(float alpha)
 {
 #if FEATURE_3D_RENDERING
-    ShaderManager::getShader("basicShader")->setParameter("textureMap", *textureManager.getTexture("shield_hit_effect.png"));
+    ShaderManager::getShader("basicShader")->setUniform("textureMap", *textureManager.getTexture("shield_hit_effect.png"));
     sf::Shader::bind(ShaderManager::getShader("basicShader"));
 
     glPushMatrix();
@@ -103,7 +103,7 @@ void ModelInfo::renderShield(float alpha, float angle)
 #if FEATURE_3D_RENDERING
     if (!data) return;
 
-    ShaderManager::getShader("basicShader")->setParameter("textureMap", *textureManager.getTexture("shield_hit_effect.png"));
+    ShaderManager::getShader("basicShader")->setUniform("textureMap", *textureManager.getTexture("shield_hit_effect.png"));
     sf::Shader::bind(ShaderManager::getShader("basicShader"));
 
     glPushMatrix();

--- a/src/particleEffect.cpp
+++ b/src/particleEffect.cpp
@@ -9,7 +9,7 @@ std::vector<Particle> ParticleEngine::particles;
 void ParticleEngine::render()
 {
 #if FEATURE_3D_RENDERING
-    ShaderManager::getShader("billboardShader")->setParameter("textureMap", *textureManager.getTexture("particle.png"));
+    ShaderManager::getShader("billboardShader")->setUniform("textureMap", *textureManager.getTexture("particle.png"));
     sf::Shader::bind(ShaderManager::getShader("billboardShader"));
     glBegin(GL_QUADS);
     for(unsigned int n=0; n<particles.size(); n++)

--- a/src/screenComponents/viewport3d.cpp
+++ b/src/screenComponents/viewport3d.cpp
@@ -37,7 +37,7 @@ void GuiViewport3D::onDraw(sf::RenderTarget& window)
         soundManager->setListenerPosition(sf::Vector2f(camera_position.x, camera_position.y), camera_yaw);
     window.popGLStates();
 
-    ShaderManager::getShader("billboardShader")->setParameter("camera_position", camera_position);
+    ShaderManager::getShader("billboardShader")->setUniform("camera_position", camera_position);
 
     float camera_fov = 60.0f;
     float sx = window.getSize().x * window.getView().getViewport().width / window.getView().getSize().x;
@@ -260,7 +260,7 @@ void GuiViewport3D::onDraw(sf::RenderTarget& window)
         glTranslatef(-camera_position.x,-camera_position.y, -camera_position.z);
         glTranslatef(target->getPosition().x, target->getPosition().y, 0);
 
-        ShaderManager::getShader("billboardShader")->setParameter("textureMap", *textureManager.getTexture("redicule2.png"));
+        ShaderManager::getShader("billboardShader")->setUniform("textureMap", *textureManager.getTexture("redicule2.png"));
         sf::Shader::bind(ShaderManager::getShader("billboardShader"));
         glColor4f(0.5, 0.5, 0.5, target->getRadius() * 2.5);
         glBegin(GL_QUADS);

--- a/src/spaceObjects/asteroid.cpp
+++ b/src/spaceObjects/asteroid.cpp
@@ -40,8 +40,8 @@ void Asteroid::draw3D()
     glRotatef(engine->getElapsedTime() * rotation_speed, 0, 0, 1);
     glScalef(getRadius(), getRadius(), getRadius());
     sf::Shader* shader = ShaderManager::getShader("objectShaderBS");
-    shader->setParameter("baseMap", *textureManager.getTexture("Astroid_" + string(model_number) + "_d.png"));
-    shader->setParameter("specularMap", *textureManager.getTexture("Astroid_" + string(model_number) + "_s.png"));
+    shader->setUniform("baseMap", *textureManager.getTexture("Astroid_" + string(model_number) + "_d.png"));
+    shader->setUniform("specularMap", *textureManager.getTexture("Astroid_" + string(model_number) + "_s.png"));
     sf::Shader::bind(shader);
     Mesh* m = Mesh::getMesh("Astroid_" + string(model_number) + ".model");
     m->render();
@@ -121,8 +121,8 @@ void VisualAsteroid::draw3D()
     glRotatef(engine->getElapsedTime() * rotation_speed, 0, 0, 1);
     glScalef(getRadius(), getRadius(), getRadius());
     sf::Shader* shader = ShaderManager::getShader("objectShaderBS");
-    shader->setParameter("baseMap", *textureManager.getTexture("Astroid_" + string(model_number) + "_d.png"));
-    shader->setParameter("specularMap", *textureManager.getTexture("Astroid_" + string(model_number) + "_s.png"));
+    shader->setUniform("baseMap", *textureManager.getTexture("Astroid_" + string(model_number) + "_d.png"));
+    shader->setUniform("specularMap", *textureManager.getTexture("Astroid_" + string(model_number) + "_s.png"));
     sf::Shader::bind(shader);
     Mesh* m = Mesh::getMesh("Astroid_" + string(model_number) + ".model");
     m->render();

--- a/src/spaceObjects/beamEffect.cpp
+++ b/src/spaceObjects/beamEffect.cpp
@@ -32,7 +32,7 @@ void BeamEffect::draw3DTransparent()
     sf::Vector3f endPoint(targetLocation.x, targetLocation.y, targetOffset.z);
     sf::Vector3f eyeNormal = sf::normalize(sf::cross(camera_position - startPoint, endPoint - startPoint));
 
-    ShaderManager::getShader("basicShader")->setParameter("textureMap", *textureManager.getTexture(beam_texture));
+    ShaderManager::getShader("basicShader")->setUniform("textureMap", *textureManager.getTexture(beam_texture));
     sf::Shader::bind(ShaderManager::getShader("basicShader"));
     glColor3f(lifetime, lifetime, lifetime);
     {
@@ -63,7 +63,7 @@ void BeamEffect::draw3DTransparent()
     sf::Vector3f v3 = v0 - side * ring_size - up * ring_size;
     sf::Vector3f v4 = v0 + side * ring_size - up * ring_size;
 
-    ShaderManager::getShader("basicShader")->setParameter("textureMap", *textureManager.getTexture("fire_ring.png"));
+    ShaderManager::getShader("basicShader")->setUniform("textureMap", *textureManager.getTexture("fire_ring.png"));
     sf::Shader::bind(ShaderManager::getShader("basicShader"));
     glBegin(GL_QUADS);
     glTexCoord2f(0, 0);

--- a/src/spaceObjects/blackHole.cpp
+++ b/src/spaceObjects/blackHole.cpp
@@ -31,7 +31,7 @@ void BlackHole::draw3DTransparent()
     float distance = sf::length(camera_position - sf::Vector3f(getPosition().x, getPosition().y, 0));
 
     glBlendFunc(GL_SRC_ALPHA, GL_ONE_MINUS_SRC_ALPHA);
-    ShaderManager::getShader("billboardShader")->setParameter("textureMap", *textureManager.getTexture("blackHole3d.png"));
+    ShaderManager::getShader("billboardShader")->setUniform("textureMap", *textureManager.getTexture("blackHole3d.png"));
     sf::Shader::bind(ShaderManager::getShader("billboardShader"));
     glColor4f(1, 1, 1, 5000.0);
     glBegin(GL_QUADS);

--- a/src/spaceObjects/electricExplosionEffect.cpp
+++ b/src/spaceObjects/electricExplosionEffect.cpp
@@ -43,7 +43,7 @@ void ElectricExplosionEffect::draw3DTransparent()
     glScalef(scale * size, scale * size, scale * size);
     glColor3f(alpha, alpha, alpha);
     
-    ShaderManager::getShader("basicShader")->setParameter("textureMap", *textureManager.getTexture("electric_sphere_texture.png"));
+    ShaderManager::getShader("basicShader")->setUniform("textureMap", *textureManager.getTexture("electric_sphere_texture.png"));
     sf::Shader::bind(ShaderManager::getShader("basicShader"));
     Mesh* m = Mesh::getMesh("sphere.obj");
     m->render();
@@ -51,7 +51,7 @@ void ElectricExplosionEffect::draw3DTransparent()
     m->render();
     glPopMatrix();
     
-    ShaderManager::getShader("billboardShader")->setParameter("textureMap", *textureManager.getTexture("particle.png"));
+    ShaderManager::getShader("billboardShader")->setUniform("textureMap", *textureManager.getTexture("particle.png"));
     sf::Shader::bind(ShaderManager::getShader("billboardShader"));
     scale = Tween<float>::easeInCubic(f, 0.0, 1.0, 0.3f, 3.0f);
     float r = Tween<float>::easeOutQuad(f, 0.0, 1.0, 1.0f, 0.0f);

--- a/src/spaceObjects/explosionEffect.cpp
+++ b/src/spaceObjects/explosionEffect.cpp
@@ -48,12 +48,12 @@ void ExplosionEffect::draw3DTransparent()
     sf::Vector3f v3 = sf::Vector3f( 1,  1, 0);
     sf::Vector3f v4 = sf::Vector3f(-1,  1, 0);
 
-    ShaderManager::getShader("basicShader")->setParameter("textureMap", *textureManager.getTexture("fire_sphere_texture.png"));
+    ShaderManager::getShader("basicShader")->setUniform("textureMap", *textureManager.getTexture("fire_sphere_texture.png"));
     sf::Shader::bind(ShaderManager::getShader("basicShader"));
     Mesh* m = Mesh::getMesh("sphere.obj");
     m->render();
 
-    ShaderManager::getShader("basicShader")->setParameter("textureMap", *textureManager.getTexture("fire_ring.png"));
+    ShaderManager::getShader("basicShader")->setUniform("textureMap", *textureManager.getTexture("fire_ring.png"));
     sf::Shader::bind(ShaderManager::getShader("basicShader"));
     glScalef(1.5, 1.5, 1.5);
     glBegin(GL_QUADS);
@@ -69,7 +69,7 @@ void ExplosionEffect::draw3DTransparent()
     glPopMatrix();
     
     
-    ShaderManager::getShader("billboardShader")->setParameter("textureMap", *textureManager.getTexture("particle.png"));
+    ShaderManager::getShader("billboardShader")->setUniform("textureMap", *textureManager.getTexture("particle.png"));
     sf::Shader::bind(ShaderManager::getShader("billboardShader"));
     scale = Tween<float>::easeInCubic(f, 0.0, 1.0, 0.3f, 5.0f);
     float r = Tween<float>::easeInQuad(f, 0.0, 1.0, 1.0f, 0.0f);

--- a/src/spaceObjects/nebula.cpp
+++ b/src/spaceObjects/nebula.cpp
@@ -55,7 +55,7 @@ void Nebula::draw3DTransparent()
         if (alpha < 0.0)
             continue;
 
-        ShaderManager::getShader("billboardShader")->setParameter("textureMap", *textureManager.getTexture("Nebula" + string(cloud.texture) + ".png"));
+        ShaderManager::getShader("billboardShader")->setUniform("textureMap", *textureManager.getTexture("Nebula" + string(cloud.texture) + ".png"));
         sf::Shader::bind(ShaderManager::getShader("billboardShader"));
         glBegin(GL_QUADS);
         glColor4f(alpha * 0.8, alpha * 0.8, alpha * 0.8, size);

--- a/src/spaceObjects/planet.cpp
+++ b/src/spaceObjects/planet.cpp
@@ -12,21 +12,21 @@ class PlanetMeshGenerator
 public:
     std::vector<MeshVertex> vertices;
     int max_iterations;
-    
+
     PlanetMeshGenerator(int iterations)
     {
         max_iterations = iterations;
-        
+
         createFace(0, sf::Vector3f(0, 0, 1), sf::Vector3f(0, 1, 0), sf::Vector3f(1, 0, 0), sf::Vector2f(0, 0), sf::Vector2f(0, 0.5), sf::Vector2f(0.25, 0.5));
         createFace(0, sf::Vector3f(0, 0, 1), sf::Vector3f(1, 0, 0), sf::Vector3f(0,-1, 0), sf::Vector2f(0.25, 0), sf::Vector2f(0.25, 0.5), sf::Vector2f(0.5, 0.5));
         createFace(0, sf::Vector3f(0, 0, 1), sf::Vector3f(0,-1, 0), sf::Vector3f(-1, 0, 0), sf::Vector2f(0.5, 0), sf::Vector2f(0.5, 0.5), sf::Vector2f(0.75, 0.5));
         createFace(0, sf::Vector3f(0, 0, 1), sf::Vector3f(-1, 0, 0), sf::Vector3f(0, 1, 0), sf::Vector2f(0.75, 0), sf::Vector2f(0.75, 0.5), sf::Vector2f(1.0, 0.5));
-        
+
         createFace(0, sf::Vector3f(0, 0,-1), sf::Vector3f(1, 0, 0), sf::Vector3f(0, 1, 0), sf::Vector2f(0, 1.0), sf::Vector2f(0.25, 0.5), sf::Vector2f(0.0, 0.5));
         createFace(0, sf::Vector3f(0, 0,-1), sf::Vector3f(0,-1, 0), sf::Vector3f(1, 0, 0), sf::Vector2f(0.25, 1.0), sf::Vector2f(0.5, 0.5), sf::Vector2f(0.25, 0.5));
         createFace(0, sf::Vector3f(0, 0,-1), sf::Vector3f(-1, 0, 0), sf::Vector3f(0,-1, 0), sf::Vector2f(0.5, 1.0), sf::Vector2f(0.75, 0.5), sf::Vector2f(0.5, 0.5));
         createFace(0, sf::Vector3f(0, 0,-1), sf::Vector3f(0,1, 0), sf::Vector3f(-1, 0, 0), sf::Vector2f(0.75, 1.0), sf::Vector2f(1.0, 0.5), sf::Vector2f(0.75, 0.5));
-        
+
         for(unsigned int n=0; n<vertices.size(); n++)
         {
             float u = sf::vector2ToAngle(sf::Vector2f(vertices[n].position[1], vertices[n].position[0])) / 360.0f;
@@ -38,7 +38,7 @@ public:
             vertices[n].uv[1] = 0.5 + sf::vector2ToAngle(sf::Vector2f(sf::length(sf::Vector2f(vertices[n].position[0], vertices[n].position[1])), vertices[n].position[2])) / 180.0f;
         }
     }
-    
+
     void createFace(int iteration, sf::Vector3f v0, sf::Vector3f v1, sf::Vector3f v2, sf::Vector2f uv0, sf::Vector2f uv1, sf::Vector2f uv2)
     {
         if (iteration < max_iterations)
@@ -123,7 +123,7 @@ Planet::Planet()
     collision_size = -2.0f;
 
     setRadarSignatureInfo(0.5, 0, 0);
-    
+
     registerMemberReplication(&planet_size);
     registerMemberReplication(&cloud_size);
     registerMemberReplication(&planet_texture);
@@ -198,7 +198,7 @@ void Planet::update(float delta)
         if (collision_size > 0.0)
             PathPlannerManager::getInstance()->addAvoidObject(this, collision_size);
     }
-    
+
     if (orbit_distance > 0.0f)
     {
         P<SpaceObject> orbit_target;
@@ -213,7 +213,7 @@ void Planet::update(float delta)
             setPosition(orbit_target->getPosition() + sf::vector2FromAngle(angle) * orbit_distance);
         }
     }
-    
+
     if (axial_rotation_time != 0.0f)
         setRotation(getRotation() + delta / axial_rotation_time * 360.0f);
 }
@@ -222,7 +222,7 @@ void Planet::update(float delta)
 void Planet::draw3D()
 {
     float distance = sf::length(camera_position - sf::Vector3f(getPosition().x, getPosition().y, distance_from_movement_plane));
-    
+
     //view_scale ~= about the size the planet is on the screen.
     float view_scale = planet_size / distance;
     int level_of_detail = 4;
@@ -243,8 +243,8 @@ void Planet::draw3D()
             planet_mesh[level_of_detail] = new Mesh(planet_mesh_generator.vertices);
         }
         sf::Shader* shader = ShaderManager::getShader("planetShader");
-        shader->setParameter("baseMap", *textureManager.getTexture(planet_texture));
-        shader->setParameter("atmosphereColor", atmosphere_color);
+        shader->setUniform("baseMap", *textureManager.getTexture(planet_texture));
+        shader->setUniform("atmosphereColor", (sf::Glsl::Vec4)atmosphere_color);
         sf::Shader::bind(shader);
         planet_mesh[level_of_detail]->render();
     }
@@ -253,7 +253,7 @@ void Planet::draw3D()
 void Planet::draw3DTransparent()
 {
     float distance = sf::length(camera_position - sf::Vector3f(getPosition().x, getPosition().y, distance_from_movement_plane));
-    
+
     //view_scale ~= about the size the planet is on the screen.
     float view_scale = planet_size / distance;
     int level_of_detail = 4;
@@ -276,15 +276,15 @@ void Planet::draw3DTransparent()
             planet_mesh[level_of_detail] = new Mesh(planet_mesh_generator.vertices);
         }
         sf::Shader* shader = ShaderManager::getShader("planetShader");
-        shader->setParameter("baseMap", *textureManager.getTexture(cloud_texture));
-        shader->setParameter("atmosphereColor", sf::Color(0,0,0));
+        shader->setUniform("baseMap", *textureManager.getTexture(cloud_texture));
+        shader->setUniform("atmosphereColor", (sf::Glsl::Vec4)sf::Color(0,0,0));
         sf::Shader::bind(shader);
         planet_mesh[level_of_detail]->render();
         glPopMatrix();
     }
     if (atmosphere_texture != "" && atmosphere_size > 0)
     {
-        ShaderManager::getShader("billboardShader")->setParameter("textureMap", *textureManager.getTexture(atmosphere_texture));
+        ShaderManager::getShader("billboardShader")->setUniform("textureMap", *textureManager.getTexture(atmosphere_texture));
         sf::Shader::bind(ShaderManager::getShader("billboardShader"));
         glColor4f(atmosphere_color.r / 255.0f, atmosphere_color.g / 255.0f, atmosphere_color.b / 255.0f, atmosphere_size * 2.0f);
         glBegin(GL_QUADS);

--- a/src/spaceObjects/wormHole.cpp
+++ b/src/spaceObjects/wormHole.cpp
@@ -63,7 +63,7 @@ void WormHole::draw3DTransparent()
         if (alpha < 0.0)
             continue;
 
-        ShaderManager::getShader("billboardShader")->setParameter("textureMap", *textureManager.getTexture("wormHole" + string(cloud.texture) + ".png"));
+        ShaderManager::getShader("billboardShader")->setUniform("textureMap", *textureManager.getTexture("wormHole" + string(cloud.texture) + ".png"));
         sf::Shader::bind(ShaderManager::getShader("billboardShader"));
         glBegin(GL_QUADS);
         glColor4f(alpha * 0.8, alpha * 0.8, alpha * 0.8, size);


### PR DESCRIPTION
Replaced with setUniform()
Avoid error at compilation because of implicit color conversion not working with setUniform()
Explicit conversion: (sf::Glsl::Vec4)color to convert color to 4D float vector