### PR TITLE
Config for joystick axes

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -163,6 +163,18 @@ int main(int argc, char** argv)
     colorConfig.load();
     hotkeys.load();
 
+    //set joystick defaults to formerly hardcoded settings
+    
+    if (PreferencesManager::get("joystick_combat_strafe").empty())
+        PreferencesManager::set("joystick_combat_strafe", "4");
+    if (PreferencesManager::get("joystick_combat_boost").empty())
+        PreferencesManager::set("joystick_combat_boost", "2");
+    if (PreferencesManager::get("joystick_rotate").empty())
+        PreferencesManager::set("joystick_rotate", "1");
+    if (PreferencesManager::get("joystick_impulse").empty())
+        PreferencesManager::set("joystick_impulse", "3");
+                
+    
     if (PreferencesManager::get("headless") == "")
     {
         //Setup the rendering layers.

--- a/src/preferenceManager.cpp
+++ b/src/preferenceManager.cpp
@@ -45,6 +45,8 @@ void PreferencesManager::save(string filename)
         fprintf(f, "# Empty Epsilon Settings\n# This file will be overwritten by EE.\n\n");
         fprintf(f, "# Include the following line to enable an experimental http server:\n# httpserver=8080\n\n");
         fprintf(f, "# For possible hotkey values check: http://www.sfml-dev.org/documentation/2.3.1/classsf_1_1Keyboard.php#acb4cacd7cc5802dec45724cf3314a142\n\n");
+        fprintf(f, "# To configure the joystick settings, assign the number of an axis (1-4) to an action. If you don't want to assign an axis, choose 0. e.g:\n# joystick_rotate=0\n\n");
+        
         std::vector<string> keys;
         for(std::unordered_map<string, string>::iterator i = preference.begin(); i != preference.end(); i++)
         {

--- a/src/screenComponents/radarView.cpp
+++ b/src/screenComponents/radarView.cpp
@@ -8,6 +8,7 @@
 #include "radarView.h"
 #include "missileTubeControls.h"
 #include "targetsContainer.h"
+#include "preferenceManager.h"
 
 GuiRadarView::GuiRadarView(GuiContainer* owner, string id, float distance, TargetsContainer* targets)
 : GuiElement(owner, id), next_ghost_dot_update(0.0), targets(targets), missile_tube_controls(nullptr), distance(distance), long_range(false), show_ghost_dots(false)
@@ -767,4 +768,54 @@ bool GuiRadarView::onJoystickRMove(float position)
     if (joystick_r_func)
         joystick_r_func(position);
     return true;
+}
+
+
+void GuiRadarView::joystickControl(float axis_position, int axis_number)
+{
+    if (PreferencesManager::get("joystick_rotate").toInt() == axis_number) {
+        if (my_spaceship)
+        {
+            float angle = my_spaceship->getRotation() + axis_position;
+            my_spaceship->commandTargetRotation(angle);
+        }
+    }
+    if (PreferencesManager::get("joystick_combat_boost").toInt() == axis_number) {
+        if (my_spaceship && (fabs(axis_position) > 20))
+        {
+            // Add some more hysteresis, since some axes can be hard to keep at 0
+            float value;
+            if (axis_position > 0)
+                value = (axis_position-20) * 1.25 / 100;
+            else
+                value = (axis_position+20) * 1.25 / 100;
+
+            my_spaceship->commandCombatManeuverBoost(-value);
+        }
+        else if (my_spaceship)
+        {
+            my_spaceship->commandCombatManeuverBoost(0.0);
+        }
+    }
+    if (PreferencesManager::get("joystick_impulse").toInt() == axis_number) {
+        if (my_spaceship)
+            my_spaceship->commandImpulse(-(axis_position / 100));
+    }
+    if (PreferencesManager::get("joystick_combat_strafe").toInt() == axis_number) {
+        if (my_spaceship && (fabs(axis_position) > 20))
+        {
+            // Add some more hysteresis, since some axes can be hard to keep at 0
+            float value;
+            if (axis_position > 0)
+                value = (axis_position-20) * 1.25 / 100;
+            else
+                value = (axis_position+20) * 1.25 / 100;
+
+            my_spaceship->commandCombatManeuverStrafe(value);
+        }
+        else if (my_spaceship)
+        {
+            my_spaceship->commandCombatManeuverStrafe(0.0);
+        }
+    }
 }

--- a/src/screenComponents/radarView.h
+++ b/src/screenComponents/radarView.h
@@ -108,6 +108,7 @@ public:
     virtual bool onJoystickXYMove(sf::Vector2f position);
     virtual bool onJoystickZMove(float position);
     virtual bool onJoystickRMove(float position);
+    void joystickControl(float axis_position, int axis_number);
 private:
     void updateGhostDots();
 

--- a/src/screens/crew1/singlePilotScreen.cpp
+++ b/src/screens/crew1/singlePilotScreen.cpp
@@ -72,37 +72,17 @@ SinglePilotScreen::SinglePilotScreen(GuiContainer* owner)
 
     // Joystick controls.
     radar->setJoystickCallbacks(
-        [this](float x_position) {
-            if (my_spaceship)
-            {
-                float angle = my_spaceship->getRotation() + x_position;
-                my_spaceship->commandTargetRotation(angle);
-            }
+        [this](float x_position) {            
+            radar->joystickControl(x_position,1);            
         },
         [this](float y_position) {
-            if (my_spaceship && (fabs(y_position) > 20))
-            {
-                // Add some more hysteresis, since y-axis can be hard to keep at 0
-                float value;
-                if (y_position > 0)
-                    value = (y_position-20) * 1.25 / 100;
-                else
-                    value = (y_position+20) * 1.25 / 100;
-
-                my_spaceship->commandCombatManeuverBoost(-value);
-            }
-            else if (my_spaceship)
-            {
-                my_spaceship->commandCombatManeuverBoost(0.0);
-            }
+            radar->joystickControl(y_position,2);
         },
         [this](float z_position) {
-            if (my_spaceship)
-                my_spaceship->commandImpulse(-(z_position / 100));
+            radar->joystickControl(z_position,3);
         },
         [this](float r_position) {
-            if (my_spaceship)
-                my_spaceship->commandCombatManeuverStrafe(r_position / 100);
+            radar->joystickControl(r_position,4);
         }
     );
 

--- a/src/screens/crew4/tacticalScreen.cpp
+++ b/src/screens/crew4/tacticalScreen.cpp
@@ -19,6 +19,7 @@
 
 #include "gui/gui2_keyvaluedisplay.h"
 #include "gui/gui2_rotationdial.h"
+//#include "preferenceManager.h"
 
 TacticalScreen::TacticalScreen(GuiContainer* owner)
 : GuiOverlay(owner, "TACTICAL_SCREEN", colorConfig.background)
@@ -59,37 +60,17 @@ TacticalScreen::TacticalScreen(GuiContainer* owner)
 
     // Joystick controls.
     radar->setJoystickCallbacks(
-        [this](float x_position) {
-            if (my_spaceship)
-            {
-                float angle = my_spaceship->getRotation() + x_position;
-                my_spaceship->commandTargetRotation(angle);
-            }
+        [this](float x_position) {            
+            radar->joystickControl(x_position,1);            
         },
         [this](float y_position) {
-            if (my_spaceship && (fabs(y_position) > 20))
-            {
-                // Add some more hysteresis, since y-axis can be hard to keep at 0
-                float value;
-                if (y_position > 0)
-                    value = (y_position-20) * 1.25 / 100;
-                else
-                    value = (y_position+20) * 1.25 / 100;
-
-                my_spaceship->commandCombatManeuverBoost(-value);
-            }
-            else if (my_spaceship)
-            {
-                my_spaceship->commandCombatManeuverBoost(0.0);
-            }
+            radar->joystickControl(y_position,2);
         },
         [this](float z_position) {
-            if (my_spaceship)
-                my_spaceship->commandImpulse(-(z_position / 100));
+            radar->joystickControl(z_position,3);
         },
         [this](float r_position) {
-            if (my_spaceship)
-                my_spaceship->commandCombatManeuverStrafe(r_position / 100);
+            radar->joystickControl(r_position,4);
         }
     );
 
@@ -145,6 +126,46 @@ void TacticalScreen::onDraw(sf::RenderTarget& window)
     }
     GuiOverlay::onDraw(window);
 }
+
+/*
+void TacticalScreen::joystickControl(float axis_position, int axis_number)
+{
+    if (PreferencesManager::get("joystick_rotate").toInt() == axis_number) {
+        if (my_spaceship)
+        {
+            float angle = my_spaceship->getRotation() + axis_position;
+            my_spaceship->commandTargetRotation(angle);
+        }
+    }
+    if (PreferencesManager::get("joystick_boost").toInt() == axis_number) {
+        if (my_spaceship && (fabs(axis_position) > 20))
+        {
+            // Add some more hysteresis, since y-axis can be hard to keep at 0
+            float value;
+            if (axis_position > 0)
+                value = (axis_position-20) * 1.25 / 100;
+            else
+                value = (axis_position+20) * 1.25 / 100;
+
+            my_spaceship->commandCombatManeuverBoost(-value);
+            //combat_maneuver->setBoostValue(fabs(value));
+        }
+        else if (my_spaceship)
+        {
+            my_spaceship->commandCombatManeuverBoost(0.0);
+        }
+    }
+    if (PreferencesManager::get("joystick_impulse").toInt() == axis_number) {
+        if (my_spaceship)
+            my_spaceship->commandImpulse(-(axis_position / 100));
+    }
+    if (PreferencesManager::get("joystick_strafe").toInt() == axis_number) {                    
+        if (my_spaceship)
+            my_spaceship->commandCombatManeuverStrafe(axis_position / 100);
+    }
+}
+
+*/
 
 void TacticalScreen::onHotkey(const HotkeyResult& key)
 {

--- a/src/screens/crew6/helmsScreen.cpp
+++ b/src/screens/crew6/helmsScreen.cpp
@@ -28,7 +28,7 @@ HelmsScreen::HelmsScreen(GuiContainer* owner)
     // Render the alert level color overlay.
     (new AlertLevelOverlay(this));
 
-    GuiRadarView* radar = new GuiRadarView(this, "HELMS_RADAR", 5000.0, nullptr);
+    radar = new GuiRadarView(this, "HELMS_RADAR", 5000.0, nullptr);
     
     combat_maneuver = new GuiCombatManeuver(this, "COMBAT_MANEUVER");
     combat_maneuver->setPosition(-20, -20, ABottomRight)->setSize(280, 215);
@@ -60,44 +60,22 @@ HelmsScreen::HelmsScreen(GuiContainer* owner)
         }
     );
     
+    // Joystick controls.
     radar->setJoystickCallbacks(
-        [this](float x_position) {
-            if (my_spaceship)
-            {
-                float angle = my_spaceship->getRotation() + x_position;
-                my_spaceship->commandTargetRotation(angle);
-            }
+        [this](float x_position) {            
+            radar->joystickControl(x_position,1);            
         },
         [this](float y_position) {
-            if (my_spaceship && (fabs(y_position) > 20))
-            {
-                // Add some more hysteresis, since y-axis can be hard to keep at 0
-                float value;
-                if (y_position > 0)
-                    value = (y_position-20)*1.25/100;
-                else
-                    value = (y_position+20)*1.25/100;
-                
-                my_spaceship->commandCombatManeuverBoost(-value);
-                combat_maneuver->setBoostValue(fabs(value));
-            }
-            else if (my_spaceship)
-            {
-                my_spaceship->commandCombatManeuverBoost(0.0);
-                combat_maneuver->setBoostValue(0.0);
-            }
+            radar->joystickControl(y_position,2);
         },
         [this](float z_position) {
-            if (my_spaceship)
-                my_spaceship->commandImpulse(-(z_position / 100));
+            radar->joystickControl(z_position,3);
         },
         [this](float r_position) {
-            if (my_spaceship)
-            {
-                my_spaceship->commandCombatManeuverStrafe(r_position/100);
-                combat_maneuver->setStrafeValue(r_position/100);
-            }
-        });
+            radar->joystickControl(r_position,4);
+        }
+    );    
+
     heading_hint = new GuiLabel(this, "HEADING_HINT", "", 30);
     heading_hint->setAlignment(ACenter)->setSize(0, 0);
 

--- a/src/screens/crew6/helmsScreen.h
+++ b/src/screens/crew6/helmsScreen.h
@@ -4,6 +4,7 @@
 #include "gui/gui2_overlay.h"
 #include "screenComponents/combatManeuver.h"
 
+class GuiRadarView;
 class GuiKeyValueDisplay;
 class GuiLabel;
 
@@ -18,6 +19,7 @@ private:
     GuiKeyValueDisplay* velocity_display;
     GuiElement* warp_controls;
     GuiElement* jump_controls;
+    GuiRadarView* radar;
     GuiLabel* heading_hint;
     GuiCombatManeuver* combat_maneuver;
 public:


### PR DESCRIPTION
This adds some configurability for the joystick axes. It is pretty simple, we still only have 4 axes and four actions, but now you can freely assign in options.ini which action will be triggered by which axis, or deactivate one if needed.

They are two minor drawbacks to keep this PR relatively simple:
- The deadzone that is currently in there for vertical combat maneuvers, will now also be used for horizontal ones.
- The handle in the combat maneuver box will not moved when the CM is made by joystick. This is already the case on singlepilot and tactical, and will now also be true on helm. But I think the moving joystick itself will be enough feedback anyway