### PR TITLE
fix joystick rotation

### DIFF
--- a/src/screens/crew1/singlePilotScreen.cpp
+++ b/src/screens/crew1/singlePilotScreen.cpp
@@ -75,8 +75,7 @@ SinglePilotScreen::SinglePilotScreen(GuiContainer* owner)
         [this](float x_position) {
             if (my_spaceship)
             {
-                float angle = my_spaceship->getRotation() + x_position;
-                my_spaceship->commandTargetRotation(angle);
+                my_spaceship->commandTurnSpeed(x_position / 100);
             }
         },
         [this](float y_position) {

--- a/src/screens/crew4/tacticalScreen.cpp
+++ b/src/screens/crew4/tacticalScreen.cpp
@@ -62,8 +62,7 @@ TacticalScreen::TacticalScreen(GuiContainer* owner)
         [this](float x_position) {
             if (my_spaceship)
             {
-                float angle = my_spaceship->getRotation() + x_position;
-                my_spaceship->commandTargetRotation(angle);
+                my_spaceship->commandTurnSpeed(x_position / 100);
             }
         },
         [this](float y_position) {

--- a/src/screens/crew6/helmsScreen.cpp
+++ b/src/screens/crew6/helmsScreen.cpp
@@ -64,8 +64,7 @@ HelmsScreen::HelmsScreen(GuiContainer* owner)
         [this](float x_position) {
             if (my_spaceship)
             {
-                float angle = my_spaceship->getRotation() + x_position;
-                my_spaceship->commandTargetRotation(angle);
+                my_spaceship->commandTurnSpeed(x_position / 100);
             }
         },
         [this](float y_position) {

--- a/src/spaceObjects/playerSpaceship.cpp
+++ b/src/spaceObjects/playerSpaceship.cpp
@@ -1041,6 +1041,7 @@ void PlayerSpaceship::onReceiveClientCommand(int32_t client_id, sf::Packet& pack
     switch(command)
     {
     case CMD_TARGET_ROTATION:
+        turnSpeed = 0;
         packet >> target_rotation;
         break;
     case CMD_TURN_SPEED:

--- a/src/spaceObjects/playerSpaceship.cpp
+++ b/src/spaceObjects/playerSpaceship.cpp
@@ -173,6 +173,7 @@ static const int16_t CMD_ABORT_DOCK = 0x0026;
 static const int16_t CMD_SET_MAIN_SCREEN_OVERLAY = 0x0027;
 static const int16_t CMD_HACKING_FINISHED = 0x0028;
 static const int16_t CMD_CUSTOM_FUNCTION = 0x0029;
+static const int16_t CMD_TURN_SPEED = 0x002A;
 
 string alertLevelToString(EAlertLevel level)
 {
@@ -1042,6 +1043,10 @@ void PlayerSpaceship::onReceiveClientCommand(int32_t client_id, sf::Packet& pack
     case CMD_TARGET_ROTATION:
         packet >> target_rotation;
         break;
+    case CMD_TURN_SPEED:
+        target_rotation = getRotation();
+        packet >> turnSpeed;
+        break;
     case CMD_IMPULSE:
         packet >> impulse_request;
         break;
@@ -1485,6 +1490,13 @@ void PlayerSpaceship::commandTargetRotation(float target)
 {
     sf::Packet packet;
     packet << CMD_TARGET_ROTATION << target;
+    sendClientCommand(packet);
+}
+
+void PlayerSpaceship::commandTurnSpeed(float turnSpeed)
+{
+    sf::Packet packet;
+    packet << CMD_TURN_SPEED << turnSpeed;
     sendClientCommand(packet);
 }
 

--- a/src/spaceObjects/playerSpaceship.h
+++ b/src/spaceObjects/playerSpaceship.h
@@ -197,6 +197,7 @@ public:
     // Client command functions
     virtual void onReceiveClientCommand(int32_t client_id, sf::Packet& packet) override;
     void commandTargetRotation(float target);
+    void commandTurnSpeed(float turnSpeed);
     void commandImpulse(float target);
     void commandWarp(int8_t target);
     void commandJump(float distance);

--- a/src/spaceObjects/spaceship.cpp
+++ b/src/spaceObjects/spaceship.cpp
@@ -116,8 +116,10 @@ SpaceShip::SpaceShip(string multiplayerClassName, float multiplayer_significant_
     impulse_acceleration = 20.0;
     energy_level = 1000;
     max_energy_level = 1000;
+    turnSpeed = 0.0f;
 
     registerMemberReplication(&target_rotation, 1.5);
+    registerMemberReplication(&turnSpeed, 1.5);
     registerMemberReplication(&impulse_request, 0.1);
     registerMemberReplication(&current_impulse, 0.5);
     registerMemberReplication(&has_warp_drive);
@@ -466,7 +468,12 @@ void SpaceShip::update(float delta)
             warp_request = 0.0;
     }
 
-    float rotationDiff = sf::angleDifference(getRotation(), target_rotation);
+    float rotationDiff;
+    if (fabs(turnSpeed) < 0.0005f) {
+        rotationDiff = sf::angleDifference(getRotation(), target_rotation);
+    } else {
+        rotationDiff = turnSpeed;
+    }
 
     if (rotationDiff > 1.0)
         setAngularVelocity(turn_speed * getSystemEffectiveness(SYS_Maneuver));

--- a/src/spaceObjects/spaceship.h
+++ b/src/spaceObjects/spaceship.h
@@ -73,6 +73,11 @@ public:
      *[input] Ship will try to aim to this rotation. (degrees)
      */
     float target_rotation;
+    
+    /*!
+     *[input] Ship will rotate in this velocity. ([-1,1], overrides target_rotation)
+     */
+    float turnSpeed;
 
     /*!
      * [input] Amount of impulse requested from the user (-1.0 to 1.0)


### PR DESCRIPTION
currently the stick only increments ship's `targetRotation` when the axis value changes. so holding the stick steady at an angle does not translate to a continuous rotation. 
To continuously rotate using the stick, the pilot needs to jiggle the stick to create a stream of joystick events.

in this PR the joystick directly changes ship turn speed. feels much better IMO.
