### PR TITLE
Possible fix for #628.

### DIFF
--- a/src/menus/joinServerMenu.cpp
+++ b/src/menus/joinServerMenu.cpp
@@ -30,7 +30,7 @@ JoinServerScreen::JoinServerScreen(ServerBrowserMenu::SearchSource source, sf::I
     (new GuiButton(password_entry_box, "PASSWORD_ENTRY_OK", "Ok", [this]()
     {
         password_entry_box->hide();
-        game_client->sendPassword(password_entry->getText());
+        game_client->sendPassword(password_entry->getText().upper());
     }))->setPosition(420, 0, ACenterLeft)->setSize(160, 50);
     
     new GameClient(VERSION_NUMBER, ip);

--- a/src/menus/serverCreationScreen.cpp
+++ b/src/menus/serverCreationScreen.cpp
@@ -58,7 +58,7 @@ ServerCreationScreen::ServerCreationScreen()
     row = new GuiAutoLayout(left_panel, "", GuiAutoLayout::LayoutHorizontalLeftToRight);
     row->setSize(GuiElement::GuiSizeMax, 50);
     (new GuiLabel(row, "PASSWORD_LABEL", "Server password: ", 30))->setAlignment(ACenterRight)->setSize(250, GuiElement::GuiSizeMax);
-    (new GuiTextEntry(row, "SERVER_PASSWORD", ""))->callback([](string text){game_server->setPassword(text);})->setSize(GuiElement::GuiSizeMax, GuiElement::GuiSizeMax);
+    (new GuiTextEntry(row, "SERVER_PASSWORD", ""))->callback([](string text){game_server->setPassword(text.upper());})->setSize(GuiElement::GuiSizeMax, GuiElement::GuiSizeMax);
 
     // Server IP row.
     row = new GuiAutoLayout(left_panel, "", GuiAutoLayout::LayoutHorizontalLeftToRight);


### PR DESCRIPTION
Since the font used in Empty Epsilon always shows uppercase, I made it so the password is always uppercase/case-insensitive.

Is this an appropriate fix for #628?