### PR TITLE
Engineering quick-tweak function.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -191,6 +191,7 @@ set(SOURCES
 	src/gui/gui2_arrowbutton.cpp
 	src/gui/gui2_entrylist.cpp
 	src/gui/gui2_progressbar.cpp
+	src/gui/gui2_progressslider.cpp
 	src/gui/gui2_scrolltext.cpp
 	src/gui/gui2_advancedscrolltext.cpp
 	src/gui/gui2_button.cpp

--- a/src/gui/gui2_progressbar.cpp
+++ b/src/gui/gui2_progressbar.cpp
@@ -1,13 +1,13 @@
 #include "gui2_progressbar.h"
 
-GuiProgressbar::GuiProgressbar(GuiContainer* owner, string id, float min, float max, float value)
-: GuiElement(owner, id), min(min), max(max), value(value), color(sf::Color(255, 255, 255, 64)), drawBackground(true)
+GuiProgressbar::GuiProgressbar(GuiContainer* owner, string id, float min_value, float max_value, float value)
+: GuiElement(owner, id), min_value(min_value), max_value(max_value), value(value), color(sf::Color(255, 255, 255, 64)), drawBackground(true)
 {
 }
 
 void GuiProgressbar::onDraw(sf::RenderTarget& window)
 {
-    float f = (value - min) / (max - min);
+    float f = (value - min_value) / (max_value - min_value);
 
     if (drawBackground)
         drawStretched(window, rect, "gui/ProgressbarBackground");
@@ -33,10 +33,10 @@ GuiProgressbar* GuiProgressbar::setValue(float value)
     return this;
 }
 
-GuiProgressbar* GuiProgressbar::setRange(float min, float max)
+GuiProgressbar* GuiProgressbar::setRange(float min_value, float max_value)
 {
-    this->min = min;
-    this->max = max;
+    this->min_value = min_value;
+    this->max_value = max_value;
     return this;
 }
 

--- a/src/gui/gui2_progressbar.cpp
+++ b/src/gui/gui2_progressbar.cpp
@@ -1,7 +1,7 @@
 #include "gui2_progressbar.h"
 
-GuiProgressbar::GuiProgressbar(GuiContainer* owner, string id, float min_value, float max_value, float value)
-: GuiElement(owner, id), min_value(min_value), max_value(max_value), value(value), color(sf::Color(255, 255, 255, 64)), drawBackground(true)
+GuiProgressbar::GuiProgressbar(GuiContainer* owner, string id, float min_value, float max_value, float start_value)
+: GuiElement(owner, id), min_value(min_value), max_value(max_value), value(start_value), color(sf::Color(255, 255, 255, 64)), drawBackground(true)
 {
 }
 

--- a/src/gui/gui2_progressbar.h
+++ b/src/gui/gui2_progressbar.h
@@ -14,7 +14,7 @@ private:
 
     string text;
 public:
-    GuiProgressbar(GuiContainer* owner, string id, float min_value, float max_value, float value);
+    GuiProgressbar(GuiContainer* owner, string id, float min_value, float max_value, float start_value);
 
     virtual void onDraw(sf::RenderTarget& window);
 

--- a/src/gui/gui2_progressbar.h
+++ b/src/gui/gui2_progressbar.h
@@ -6,20 +6,20 @@
 class GuiProgressbar : public GuiElement
 {
 private:
-    float min;
-    float max;
+    float min_value;
+    float max_value;
     float value;
     sf::Color color;
     bool drawBackground;
 
     string text;
 public:
-    GuiProgressbar(GuiContainer* owner, string id, float min, float max, float value);
+    GuiProgressbar(GuiContainer* owner, string id, float min_value, float max_value, float value);
 
     virtual void onDraw(sf::RenderTarget& window);
 
     GuiProgressbar* setValue(float value);
-    GuiProgressbar* setRange(float min, float max);
+    GuiProgressbar* setRange(float min_value, float max_value);
     GuiProgressbar* setText(string text);
     GuiProgressbar* setColor(sf::Color color);
     GuiProgressbar* setDrawBackground(bool drawBackground);

--- a/src/gui/gui2_progressslider.cpp
+++ b/src/gui/gui2_progressslider.cpp
@@ -1,8 +1,7 @@
 #include "gui2_progressslider.h"
 
 GuiProgressSlider::GuiProgressSlider(GuiContainer* owner, string id, float min_value, float max_value, float start_value, func_t func)
-: GuiElement(owner, id), min_value(min_value), max_value(max_value), value(start_value), func(func), color(sf::Color(255, 255, 255, 64)), drawBackground(true)
-
+: GuiBasicSlider(owner, id, min_value, max_value, start_value, func), color(sf::Color(255, 255, 255, 64)), drawBackground(true)
 {
 }
 
@@ -85,36 +84,4 @@ void GuiProgressSlider::onMouseDrag(sf::Vector2f position)
 
 void GuiProgressSlider::onMouseUp(sf::Vector2f position)
 {
-}
-
-GuiProgressSlider* GuiProgressSlider::setValue(float value)
-{
-    if (min_value < max_value)
-    {
-        if (value < min_value)
-            value = min_value;
-        if (value > max_value)
-            value = max_value;
-    }else{
-        if (value > min_value)
-            value = min_value;
-        if (value < max_value)
-            value = max_value;
-    }
-    this->value = value;
-    return this;
-}
-
-GuiProgressSlider* GuiProgressSlider::setRange(float min, float max)
-{
-    this->min_value = min;
-    this->max_value = max;
-    setValue(this->value);
-    return this;
-}
-
-
-float GuiProgressSlider::getValue() const
-{
-    return value;
 }

--- a/src/gui/gui2_progressslider.cpp
+++ b/src/gui/gui2_progressslider.cpp
@@ -1,0 +1,120 @@
+#include "gui2_progressslider.h"
+
+GuiProgressSlider::GuiProgressSlider(GuiContainer* owner, string id, float min_value, float max_value, float start_value, func_t func)
+: GuiElement(owner, id), min_value(min_value), max_value(max_value), value(start_value), func(func), color(sf::Color(255, 255, 255, 64)), drawBackground(true)
+
+{
+}
+
+void GuiProgressSlider::onDraw(sf::RenderTarget& window)
+{
+    float f = (value - min_value) / (max_value - min_value);
+
+    if (drawBackground)
+        drawStretched(window, rect, "gui/ProgressbarBackground");
+
+    sf::FloatRect fill_rect = rect;
+    if (rect.width >= rect.height)
+    {
+        fill_rect.width *= f;
+        drawStretchedH(window, fill_rect, "gui/ProgressbarFill", color);
+    }
+    else
+    {
+        fill_rect.height *= f;
+        fill_rect.top = rect.top + rect.height - fill_rect.height;
+        drawStretchedV(window, fill_rect, "gui/ProgressbarFill", color);
+    }
+    drawText(window, rect, text, ACenter);
+}
+
+GuiProgressSlider* GuiProgressSlider::setText(string text)
+{
+    this->text = text;
+    return this;
+}
+
+GuiProgressSlider* GuiProgressSlider::setColor(sf::Color color)
+{
+    this->color = color;
+    return this;
+}
+
+GuiProgressSlider* GuiProgressSlider::setDrawBackground(bool drawBackground)
+{
+    this->drawBackground = drawBackground;
+    return this;
+}
+
+bool GuiProgressSlider::onMouseDown(sf::Vector2f position)
+{
+    onMouseDrag(position);
+    return true;
+}
+
+void GuiProgressSlider::onMouseDrag(sf::Vector2f position)
+{
+    float new_value;
+    if (rect.width > rect.height)
+        new_value = (position.x - rect.left+2) / (rect.width-4);
+    else
+        new_value = (position.y - rect.top+2) / (rect.height-4);
+    new_value = min_value + (max_value - min_value) * new_value;
+    if (min_value < max_value)
+    {
+        if (new_value < min_value)
+            new_value = min_value;
+        if (new_value > max_value)
+            new_value = max_value;
+    }else{
+        if (new_value > min_value)
+            new_value = min_value;
+        if (new_value < max_value)
+            new_value = max_value;
+    }
+    if (value != new_value)
+    {
+        value = new_value;
+        if (func)
+        {
+            func_t f = func;
+            f(value);
+        }
+    }
+}
+
+void GuiProgressSlider::onMouseUp(sf::Vector2f position)
+{
+}
+
+GuiProgressSlider* GuiProgressSlider::setValue(float value)
+{
+    if (min_value < max_value)
+    {
+        if (value < min_value)
+            value = min_value;
+        if (value > max_value)
+            value = max_value;
+    }else{
+        if (value > min_value)
+            value = min_value;
+        if (value < max_value)
+            value = max_value;
+    }
+    this->value = value;
+    return this;
+}
+
+GuiProgressSlider* GuiProgressSlider::setRange(float min, float max)
+{
+    this->min_value = min;
+    this->max_value = max;
+    setValue(this->value);
+    return this;
+}
+
+
+float GuiProgressSlider::getValue() const
+{
+    return value;
+}

--- a/src/gui/gui2_progressslider.h
+++ b/src/gui/gui2_progressslider.h
@@ -1,0 +1,39 @@
+#ifndef GUI2_PROGRESSSLIDER_H
+#define GUI2_PROGRESSSLIDER_H
+
+#include "gui2_element.h"
+
+class GuiProgressSlider : public GuiElement
+{
+public:
+    typedef std::function<void(float value)> func_t;
+private:
+    sf::Color color;
+    bool drawBackground;
+
+    string text;
+protected:
+    float min_value;
+    float max_value;
+    float value;
+    func_t func;
+public:
+    GuiProgressSlider(GuiContainer* owner, string id, float min_value, float max_value, float start_value, func_t func);
+
+    virtual void onDraw(sf::RenderTarget& window);
+    virtual bool onMouseDown(sf::Vector2f position);
+    virtual void onMouseDrag(sf::Vector2f position);
+    virtual void onMouseUp(sf::Vector2f position);
+    
+    GuiProgressSlider* setText(string text);
+    GuiProgressSlider* setColor(sf::Color color);
+    GuiProgressSlider* setDrawBackground(bool drawBackground);
+   
+    GuiProgressSlider* clearSnapValues();
+    GuiProgressSlider* addSnapValue(float value, float range);
+    GuiProgressSlider* setValue(float value);
+    GuiProgressSlider* setRange(float min, float max);
+    float getValue() const;
+};
+
+#endif//GUI2_PROGRESSSLIDER_H

--- a/src/gui/gui2_progressslider.h
+++ b/src/gui/gui2_progressslider.h
@@ -2,8 +2,9 @@
 #define GUI2_PROGRESSSLIDER_H
 
 #include "gui2_element.h"
+#include "gui2_slider.h"
 
-class GuiProgressSlider : public GuiElement
+class GuiProgressSlider : public GuiBasicSlider
 {
 public:
     typedef std::function<void(float value)> func_t;
@@ -12,11 +13,6 @@ private:
     bool drawBackground;
 
     string text;
-protected:
-    float min_value;
-    float max_value;
-    float value;
-    func_t func;
 public:
     GuiProgressSlider(GuiContainer* owner, string id, float min_value, float max_value, float start_value, func_t func);
 
@@ -28,12 +24,6 @@ public:
     GuiProgressSlider* setText(string text);
     GuiProgressSlider* setColor(sf::Color color);
     GuiProgressSlider* setDrawBackground(bool drawBackground);
-   
-    GuiProgressSlider* clearSnapValues();
-    GuiProgressSlider* addSnapValue(float value, float range);
-    GuiProgressSlider* setValue(float value);
-    GuiProgressSlider* setRange(float min, float max);
-    float getValue() const;
 };
 
 #endif//GUI2_PROGRESSSLIDER_H

--- a/src/gui/gui2_slider.cpp
+++ b/src/gui/gui2_slider.cpp
@@ -3,13 +3,12 @@
 #include "gui2_slider.h"
 #include "preferenceManager.h"
 
-GuiSlider::GuiSlider(GuiContainer* owner, string id, float min_value, float max_value, float start_value, func_t func)
+GuiBasicSlider::GuiBasicSlider(GuiContainer* owner, string id, float min_value, float max_value, float start_value, func_t func)
 : GuiElement(owner, id), min_value(min_value), max_value(max_value), value(start_value), func(func)
 {
-    overlay_label = nullptr;
 }
 
-void GuiSlider::onDraw(sf::RenderTarget& window)
+void GuiBasicSlider::onDraw(sf::RenderTarget& window)
 {
     drawStretched(window, rect, "gui/SliderBackground", selectColor(colorConfig.slider.background));
 
@@ -18,11 +17,128 @@ void GuiSlider::onDraw(sf::RenderTarget& window)
     if (rect.width > rect.height)
     {
         float x;
+        x = rect.left + (rect.width - rect.height) * (value - min_value) / (max_value - min_value);
 
+        sf::Sprite sprite;
+        textureManager.setTexture(sprite, "gui/SliderKnob");
+        sprite.setOrigin(0, 0);
+        sprite.setPosition(x, rect.top);
+        sprite.setScale(rect.height / sprite.getTextureRect().width, rect.height / sprite.getTextureRect().width);
+        sprite.setColor(color);
+        window.draw(sprite);
+    }else{
+        float y;
+        y = rect.top + (rect.height - rect.width) * (value - min_value) / (max_value - min_value);
+
+        sf::Sprite sprite;
+        textureManager.setTexture(sprite, "gui/SliderKnob");
+        sprite.setOrigin(0, 0);
+        sprite.setPosition(rect.left, y);
+        sprite.setScale(rect.width / sprite.getTextureRect().width, rect.width / sprite.getTextureRect().width);
+        sprite.setColor(color);
+        window.draw(sprite);
+    }
+}
+
+bool GuiBasicSlider::onMouseDown(sf::Vector2f position)
+{
+    onMouseDrag(position);
+    return true;
+}
+
+void GuiBasicSlider::onMouseDrag(sf::Vector2f position)
+{
+    float new_value;
+    if (rect.width > rect.height)
+        new_value = (position.x - rect.left - (rect.height / 2.0)) / (rect.width - rect.height);
+    else
+        new_value = (position.y - rect.top - (rect.width / 2.0)) / (rect.height - rect.width);
+    new_value = min_value + (max_value - min_value) * new_value;
+    if (min_value < max_value)
+    {
+        if (new_value < min_value)
+            new_value = min_value;
+        if (new_value > max_value)
+            new_value = max_value;
+    }else{
+        if (new_value > min_value)
+            new_value = min_value;
+        if (new_value < max_value)
+            new_value = max_value;
+    }
+    if (value != new_value)
+    {
+        value = new_value;
+        if (func)
+        {
+            func_t f = func;
+            f(value);
+        }
+    }
+}
+
+void GuiBasicSlider::onMouseUp(sf::Vector2f position)
+{
+}
+
+GuiBasicSlider* GuiBasicSlider::setValue(float value)
+{
+    if (min_value < max_value)
+    {
+        if (value < min_value)
+            value = min_value;
+        if (value > max_value)
+            value = max_value;
+    }else{
+        if (value > min_value)
+            value = min_value;
+        if (value < max_value)
+            value = max_value;
+    }
+    this->value = value;
+    return this;
+}
+
+GuiBasicSlider* GuiBasicSlider::setRange(float min, float max)
+{
+    this->min_value = min;
+    this->max_value = max;
+    setValue(this->value);
+    return this;
+}
+
+float GuiBasicSlider::getValue() const
+{
+    return value;
+}
+
+
+
+
+
+
+
+
+GuiSlider::GuiSlider(GuiContainer* owner, string id, float min_value, float max_value, float start_value, func_t func)
+: GuiBasicSlider(owner, id, min_value, max_value, start_value, func)
+{
+    overlay_label = nullptr;
+}
+
+void GuiSlider::onDraw(sf::RenderTarget& window)
+{
+    drawStretched(window, rect, "gui/SliderBackground", selectColor(colorConfig.slider.background));
+    
+    sf::Color color = selectColor(colorConfig.slider.forground);
+    
+    if (rect.width > rect.height)
+    {
+        float x;
+        
         for(TSnapPoint& point : snap_points)
         {
             x = rect.left + (rect.width - rect.height) * (point.value - min_value) / (max_value - min_value);
-
+            
             sf::Sprite snap_sprite;
             textureManager.setTexture(snap_sprite, "gui/SliderTick");
             snap_sprite.setRotation(90);
@@ -32,7 +148,7 @@ void GuiSlider::onDraw(sf::RenderTarget& window)
             window.draw(snap_sprite);
         }
         x = rect.left + (rect.width - rect.height) * (value - min_value) / (max_value - min_value);
-
+        
         sf::Sprite sprite;
         textureManager.setTexture(sprite, "gui/SliderKnob");
         sprite.setOrigin(0, 0);
@@ -45,7 +161,7 @@ void GuiSlider::onDraw(sf::RenderTarget& window)
         for(TSnapPoint& point : snap_points)
         {
             y = rect.top + (rect.height - rect.width) * (point.value - min_value) / (max_value - min_value);
-
+            
             sf::Sprite snap_sprite;
             textureManager.setTexture(snap_sprite, "gui/SliderTick");
             snap_sprite.setOrigin(0, 0);
@@ -55,7 +171,7 @@ void GuiSlider::onDraw(sf::RenderTarget& window)
             window.draw(snap_sprite);
         }
         y = rect.top + (rect.height - rect.width) * (value - min_value) / (max_value - min_value);
-
+        
         sf::Sprite sprite;
         textureManager.setTexture(sprite, "gui/SliderKnob");
         sprite.setOrigin(0, 0);
@@ -131,32 +247,6 @@ GuiSlider* GuiSlider::addSnapValue(float value, float range)
     return this;
 }
 
-GuiSlider* GuiSlider::setValue(float value)
-{
-    if (min_value < max_value)
-    {
-        if (value < min_value)
-            value = min_value;
-        if (value > max_value)
-            value = max_value;
-    }else{
-        if (value > min_value)
-            value = min_value;
-        if (value < max_value)
-            value = max_value;
-    }
-    this->value = value;
-    return this;
-}
-
-GuiSlider* GuiSlider::setRange(float min, float max)
-{
-    this->min_value = min;
-    this->max_value = max;
-    setValue(this->value);
-    return this;
-}
-
 GuiSlider* GuiSlider::addOverlay()
 {
     if (!overlay_label)
@@ -167,10 +257,13 @@ GuiSlider* GuiSlider::addOverlay()
     return this;
 }
 
-float GuiSlider::getValue() const
-{
-    return value;
-}
+
+
+
+
+
+
+
 
 GuiSlider2D::GuiSlider2D(GuiContainer* owner, string id, sf::Vector2f min_value, sf::Vector2f max_value, sf::Vector2f start_value, func_t func)
 : GuiElement(owner, id), min_value(min_value), max_value(max_value), value(start_value), func(func)

--- a/src/gui/gui2_slider.h
+++ b/src/gui/gui2_slider.h
@@ -4,7 +4,29 @@
 #include "gui2_element.h"
 #include "gui2_label.h"
 
-class GuiSlider : public GuiElement
+class GuiBasicSlider : public GuiElement
+{
+public:
+    typedef std::function<void(float value)> func_t;
+protected:
+    float min_value;
+    float max_value;
+    float value;
+    func_t func;
+public:
+    GuiBasicSlider(GuiContainer* owner, string id, float min_value, float max_value, float start_value, func_t func);
+
+    virtual void onDraw(sf::RenderTarget& window);
+    virtual bool onMouseDown(sf::Vector2f position);
+    virtual void onMouseDrag(sf::Vector2f position);
+    virtual void onMouseUp(sf::Vector2f position);
+    
+    GuiBasicSlider* setValue(float value);
+    GuiBasicSlider* setRange(float min, float max);
+    float getValue() const;
+};
+
+class GuiSlider : public GuiBasicSlider
 {
 public:
     typedef std::function<void(float value)> func_t;
@@ -14,11 +36,7 @@ protected:
         float value;
         float range;
     };
-    float min_value;
-    float max_value;
-    float value;
     std::vector<TSnapPoint> snap_points;
-    func_t func;
     GuiLabel* overlay_label;
 public:
     GuiSlider(GuiContainer* owner, string id, float min_value, float max_value, float start_value, func_t func);
@@ -28,12 +46,10 @@ public:
     virtual void onMouseDrag(sf::Vector2f position);
     virtual void onMouseUp(sf::Vector2f position);
     
+    GuiSlider* setValueSnapped(float value);
     GuiSlider* clearSnapValues();
     GuiSlider* addSnapValue(float value, float range);
-    GuiSlider* setValue(float value);
-    GuiSlider* setRange(float min, float max);
     GuiSlider* addOverlay();
-    float getValue() const;
 };
 
 class GuiSlider2D : public GuiElement

--- a/src/screens/crew6/engineeringScreen.cpp
+++ b/src/screens/crew6/engineeringScreen.cpp
@@ -12,6 +12,7 @@
 #include "gui/gui2_togglebutton.h"
 #include "gui/gui2_slider.h"
 #include "gui/gui2_progressbar.h"
+#include "gui/gui2_progressslider.h"
 #include "gui/gui2_arrow.h"
 #include "gui/gui2_image.h"
 #include "gui/gui2_panel.h"
@@ -63,9 +64,15 @@ EngineeringScreen::EngineeringScreen(GuiContainer* owner, ECrewPosition crew_pos
         info.heat_arrow->setSize(GuiElement::GuiSizeMax, GuiElement::GuiSizeMax);
         info.heat_icon = new GuiImage(info.heat_bar, "", "gui/icons/status_overheat");
         info.heat_icon->setColor(colorConfig.overlay_overheating)->setPosition(0, 0, ACenter)->setSize(GuiElement::GuiSizeMatchHeight, GuiElement::GuiSizeMax);
-        info.power_bar = new GuiProgressbar(info.layout, id + "_POWER", 0.0, 3.0, 0.0);
+        info.power_bar = new GuiProgressSlider(info.layout, id + "_POWER", 0.0, 3.0, 0.0, [this,n](float value){
+            if (my_spaceship)
+                my_spaceship->commandSetSystemPowerRequest(ESystem(n), value);
+        });
         info.power_bar->setColor(sf::Color(192, 192, 32, 128))->setSize(100, GuiElement::GuiSizeMax);
-        info.coolant_bar = new GuiProgressbar(info.layout, id + "_COOLANT", 0.0, 10.0, 0.0);
+        info.coolant_bar = new GuiProgressSlider(info.layout, id + "_COOLANT", 0.0, 10.0, 0.0, [this,n](float value){
+            if (my_spaceship)
+                my_spaceship->commandSetSystemCoolantRequest(ESystem(n), value);
+        });
         info.coolant_bar->setColor(sf::Color(32, 128, 128, 128))->setSize(100, GuiElement::GuiSizeMax);
         if (!gameGlobalInfo->use_system_damage){
             info.damage_bar->hide();

--- a/src/screens/crew6/engineeringScreen.h
+++ b/src/screens/crew6/engineeringScreen.h
@@ -13,6 +13,7 @@ class GuiImage;
 class GuiArrow;
 class GuiToggleButton;
 class GuiProgressbar;
+class GuiProgressSlider;
 
 class EngineeringScreen : public GuiOverlay
 {
@@ -39,8 +40,8 @@ private:
         GuiProgressbar* heat_bar;
         GuiArrow* heat_arrow;
         GuiImage* heat_icon;
-        GuiProgressbar* power_bar;
-        GuiProgressbar* coolant_bar;
+        GuiProgressSlider* power_bar;
+        GuiProgressSlider* coolant_bar;
     };
     std::vector<SystemRow> system_rows;
     GuiAutoLayout* system_effects_container;


### PR DESCRIPTION
I added the ability to click on the power level and coolant level "progress" bars in engineering to make quick adjustments to the systems.

Often times in engineering a lot of quick, rough adjustments are needed.  Clicking though each system to adjust the sliders is tedious and cannot be done quick.  Also keeping a mental understanding of the systems states is difficult when all the adjustments are done separate from the visual feedback.  Some might like this to add difficulty but I prefer the difficulty to be the game and communication with the other officers rather than the interface method with the computer.  When interfacing with the game is smooth and direct, so that mental thoughts translate subconsciously into the game, allowing me to do seemingly amazing things, have been some of the most satisfying experiences games have given me.

I know I will use this adjustment for myself and I hope you will accept it, when it is polished, upstream.  The code is perhaps a little rough still, but I would love to hear your thoughts on the concept.

Thanks!
