### PR TITLE
make maximum coolant available to a crew configurable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 ## [Unreleased]
 
+### Added
+
+- Mission scripts can modify the total coolant available to engineering
+
+### Changed
+
 - Nothing
 
 ## [2018-02-15]

--- a/src/screens/crew6/engineeringScreen.cpp
+++ b/src/screens/crew6/engineeringScreen.cpp
@@ -117,6 +117,8 @@ EngineeringScreen::EngineeringScreen(GuiContainer* owner, ECrewPosition crew_pos
     power_label->setVertical()->setAlignment(ACenterLeft)->setPosition(20, 20, ATopLeft)->setSize(30, 360);
     coolant_label = new GuiLabel(box, "COOLANT_LABEL", "Coolant", 30);
     coolant_label->setVertical()->setAlignment(ACenterLeft)->setPosition(110, 20, ATopLeft)->setSize(30, 360);
+    total_coolant_label = new GuiLabel(box, "TOTAL_COOLANT_LABEL", "Total Coolant", 30);
+    total_coolant_label->setVertical()->setAlignment(ACenterLeft)->setPosition(200, 20, ATopLeft)->setSize(30, 360);
 
     power_slider = new GuiSlider(box, "POWER_SLIDER", 3.0, 0.0, 1.0, [this](float value) {
         if (my_spaceship && selected_system != SYS_None)
@@ -179,6 +181,7 @@ void EngineeringScreen::onDraw(sf::RenderTarget& window)
         front_shield_display->setValue(string(my_spaceship->getShieldPercentage(0)) + "%");
         rear_shield_display->setValue(string(my_spaceship->getShieldPercentage(1)) + "%");
 
+        float total_coolant = 0.0f;
         for(int n=0; n<SYS_COUNT; n++)
         {
             SystemRow info = system_rows[n];
@@ -207,13 +210,19 @@ void EngineeringScreen::onDraw(sf::RenderTarget& window)
 
             info.power_bar->setValue(my_spaceship->systems[n].power_level);
             info.coolant_bar->setValue(my_spaceship->systems[n].coolant_level);
+
+            total_coolant += my_spaceship->systems[n].coolant_level;
         }
+
+        total_coolant_label->setText("Total Coolant: " + string(int(total_coolant / PlayerSpaceship::max_coolant_per_system * 100)) + "/" + string(int(my_spaceship->max_coolant / PlayerSpaceship::max_coolant_per_system * 100)));
+
         if (selected_system != SYS_None)
         {
             ShipSystem& system = my_spaceship->systems[selected_system];
             power_label->setText("Power: " + string(int(system.power_level * 100)) + "%/" + string(int(system.power_request * 100)) + "%");
-            coolant_label->setText("Coolant: " + string(int(system.coolant_level / PlayerSpaceship::max_coolant * 100)) + "%/" + string(int(system.coolant_request / PlayerSpaceship::max_coolant * 100)) + "%");
+            coolant_label->setText("Coolant: " + string(int(system.coolant_level / PlayerSpaceship::max_coolant_per_system * 100)) + "/" + string(int(std::min(system.coolant_request, my_spaceship->max_coolant) / PlayerSpaceship::max_coolant_per_system * 100)));
             coolant_slider->setEnable(!my_spaceship->auto_coolant_enabled);
+            coolant_slider->setValue(std::min(system.coolant_request, my_spaceship->max_coolant));
 
             system_effects_index = 0;
             float effectiveness = my_spaceship->getSystemEffectiveness(selected_system);

--- a/src/screens/crew6/engineeringScreen.cpp
+++ b/src/screens/crew6/engineeringScreen.cpp
@@ -35,8 +35,10 @@ EngineeringScreen::EngineeringScreen(GuiContainer* owner, ECrewPosition crew_pos
     front_shield_display->setIcon("gui/icons/shields-fore")->setTextSize(20)->setPosition(20, 180, ATopLeft)->setSize(240, 40);
     rear_shield_display = new GuiKeyValueDisplay(this, "SHIELDS_DISPLAY", 0.45, "Rear", "");
     rear_shield_display->setIcon("gui/icons/shields-aft")->setTextSize(20)->setPosition(20, 220, ATopLeft)->setSize(240, 40);
+    coolant_display = new GuiKeyValueDisplay(this, "COOLANT_DISPLAY", 0.45, "Coolant", "");
+    coolant_display->setIcon("gui/icons/coolant")->setTextSize(20)->setPosition(20, 260, ATopLeft)->setSize(240, 40);
 
-    (new GuiSelfDestructButton(this, "SELF_DESTRUCT"))->setPosition(20, 260, ATopLeft)->setSize(240, 100);
+    (new GuiSelfDestructButton(this, "SELF_DESTRUCT"))->setPosition(20, 300, ATopLeft)->setSize(240, 100);
 
     GuiElement* system_config_container = new GuiElement(this, "");
     system_config_container->setPosition(0, -20, ABottomCenter)->setSize(750 + 300, GuiElement::GuiSizeMax);
@@ -117,8 +119,6 @@ EngineeringScreen::EngineeringScreen(GuiContainer* owner, ECrewPosition crew_pos
     power_label->setVertical()->setAlignment(ACenterLeft)->setPosition(20, 20, ATopLeft)->setSize(30, 360);
     coolant_label = new GuiLabel(box, "COOLANT_LABEL", "Coolant", 30);
     coolant_label->setVertical()->setAlignment(ACenterLeft)->setPosition(110, 20, ATopLeft)->setSize(30, 360);
-    total_coolant_label = new GuiLabel(box, "TOTAL_COOLANT_LABEL", "Total Coolant", 30);
-    total_coolant_label->setVertical()->setAlignment(ACenterLeft)->setPosition(200, 20, ATopLeft)->setSize(30, 360);
 
     power_slider = new GuiSlider(box, "POWER_SLIDER", 3.0, 0.0, 1.0, [this](float value) {
         if (my_spaceship && selected_system != SYS_None)
@@ -180,8 +180,8 @@ void EngineeringScreen::onDraw(sf::RenderTarget& window)
             hull_display->setColor(sf::Color::White);
         front_shield_display->setValue(string(my_spaceship->getShieldPercentage(0)) + "%");
         rear_shield_display->setValue(string(my_spaceship->getShieldPercentage(1)) + "%");
+        coolant_display->setValue(string(int(my_spaceship->max_coolant * 10)) + "%");
 
-        float total_coolant = 0.0f;
         for(int n=0; n<SYS_COUNT; n++)
         {
             SystemRow info = system_rows[n];
@@ -210,17 +210,13 @@ void EngineeringScreen::onDraw(sf::RenderTarget& window)
 
             info.power_bar->setValue(my_spaceship->systems[n].power_level);
             info.coolant_bar->setValue(my_spaceship->systems[n].coolant_level);
-
-            total_coolant += my_spaceship->systems[n].coolant_level;
         }
-
-        total_coolant_label->setText("Total Coolant: " + string(int(total_coolant / PlayerSpaceship::max_coolant_per_system * 100)) + "/" + string(int(my_spaceship->max_coolant / PlayerSpaceship::max_coolant_per_system * 100)));
 
         if (selected_system != SYS_None)
         {
             ShipSystem& system = my_spaceship->systems[selected_system];
             power_label->setText("Power: " + string(int(system.power_level * 100)) + "%/" + string(int(system.power_request * 100)) + "%");
-            coolant_label->setText("Coolant: " + string(int(system.coolant_level / PlayerSpaceship::max_coolant_per_system * 100)) + "/" + string(int(std::min(system.coolant_request, my_spaceship->max_coolant) / PlayerSpaceship::max_coolant_per_system * 100)));
+            coolant_label->setText("Coolant: " + string(int(system.coolant_level / PlayerSpaceship::max_coolant_per_system * 100)) + "%/" + string(int(std::min(system.coolant_request, my_spaceship->max_coolant) / PlayerSpaceship::max_coolant_per_system * 100)) + "%");
             coolant_slider->setEnable(!my_spaceship->auto_coolant_enabled);
             coolant_slider->setValue(std::min(system.coolant_request, my_spaceship->max_coolant));
 

--- a/src/screens/crew6/engineeringScreen.h
+++ b/src/screens/crew6/engineeringScreen.h
@@ -29,6 +29,7 @@ private:
     GuiSlider* power_slider;
     GuiLabel* coolant_label;
     GuiSlider* coolant_slider;
+    GuiLabel* total_coolant_label;
     
     class SystemRow
     {

--- a/src/screens/crew6/engineeringScreen.h
+++ b/src/screens/crew6/engineeringScreen.h
@@ -25,12 +25,12 @@ private:
     GuiKeyValueDisplay* hull_display;
     GuiKeyValueDisplay* front_shield_display;
     GuiKeyValueDisplay* rear_shield_display;
+    GuiKeyValueDisplay* coolant_display;
     GuiLabel* power_label;
     GuiSlider* power_slider;
     GuiLabel* coolant_label;
     GuiSlider* coolant_slider;
-    GuiLabel* total_coolant_label;
-    
+
     class SystemRow
     {
     public:

--- a/src/screens/extra/powerManagement.cpp
+++ b/src/screens/extra/powerManagement.cpp
@@ -67,7 +67,7 @@ void PowerManagementScreen::onDraw(sf::RenderTarget& window)
         {
             systems[n].box->setVisible(my_spaceship->hasSystem(ESystem(n)));
             systems[n].power_slider->setValue(my_spaceship->systems[n].power_request);
-            systems[n].coolant_slider->setValue(my_spaceship->systems[n].coolant_request);
+            systems[n].coolant_slider->setValue(std::min(my_spaceship->systems[n].coolant_request, my_spaceship->max_coolant));
 
             float heat = my_spaceship->systems[n].heat_level;
             float power = my_spaceship->systems[n].power_level;

--- a/src/screens/extra/powerManagement.cpp
+++ b/src/screens/extra/powerManagement.cpp
@@ -9,12 +9,17 @@
 #include "gui/gui2_label.h"
 #include "gui/gui2_slider.h"
 #include "gui/gui2_progressbar.h"
+#include "gui/gui2_keyvaluedisplay.h"
 
 PowerManagementScreen::PowerManagementScreen(GuiContainer* owner)
 : GuiOverlay(owner, "POWER_MANAGEMENT_SCREEN", colorConfig.background)
 {
+    energy_display = new GuiKeyValueDisplay(this, "ENERGY_DISPLAY", 0.45, "Energy", "");
+    energy_display->setIcon("gui/icons/energy")->setTextSize(20)->setPosition(20, 20, ATopLeft)->setSize(285, 40);
+    coolant_display = new GuiKeyValueDisplay(this, "COOLANT_DISPLAY", 0.45, "Coolant", "");
+    coolant_display->setIcon("gui/icons/coolant")->setTextSize(20)->setPosition(315, 20, ATopLeft)->setSize(280, 40);
     GuiAutoLayout* layout = new GuiAutoLayout(this, "", GuiAutoLayout::LayoutHorizontalLeftToRight);
-    layout->setPosition(20, 50, ATopLeft)->setSize(GuiElement::GuiSizeMax, 400);
+    layout->setPosition(20, 60, ATopLeft)->setSize(GuiElement::GuiSizeMax, 400);
     for(int n=0; n<SYS_COUNT; n++)
     {
         if (n == 4)
@@ -56,6 +61,10 @@ PowerManagementScreen::PowerManagementScreen(GuiContainer* owner)
     }
 
     (new GuiCustomShipFunctions(this, powerManagement, ""))->setPosition(-20, 120, ATopRight)->setSize(250, GuiElement::GuiSizeMax);
+
+    previous_energy_level = 0.0;
+    average_energy_delta = 0.0;
+    previous_energy_measurement = 0.0;
 }
 
 void PowerManagementScreen::onDraw(sf::RenderTarget& window)
@@ -63,6 +72,26 @@ void PowerManagementScreen::onDraw(sf::RenderTarget& window)
     GuiOverlay::onDraw(window);
     if (my_spaceship)
     {
+        //Update the energy usage.
+        if (previous_energy_measurement == 0.0)
+        {
+            previous_energy_level = my_spaceship->energy_level;
+            previous_energy_measurement = engine->getElapsedTime();
+        }else{
+            if (previous_energy_measurement != engine->getElapsedTime())
+            {
+                float delta_t = engine->getElapsedTime() - previous_energy_measurement;
+                float delta_e = my_spaceship->energy_level - previous_energy_level;
+                float delta_e_per_second = delta_e / delta_t;
+                average_energy_delta = average_energy_delta * 0.99 + delta_e_per_second * 0.01;
+
+                previous_energy_level = my_spaceship->energy_level;
+                previous_energy_measurement = engine->getElapsedTime();
+            }
+        }
+        energy_display->setValue(string(int(my_spaceship->energy_level)) + " (" + string(int(average_energy_delta * 60.0f)) + "/m)");
+        coolant_display->setValue(string(int(my_spaceship->max_coolant * 10)) + "%");
+
         for(int n=0; n<SYS_COUNT; n++)
         {
             systems[n].box->setVisible(my_spaceship->hasSystem(ESystem(n)));

--- a/src/screens/extra/powerManagement.h
+++ b/src/screens/extra/powerManagement.h
@@ -7,10 +7,18 @@
 class GuiPanel;
 class GuiSlider;
 class GuiProgressbar;
+class GuiKeyValueDisplay;
 
 class PowerManagementScreen : public GuiOverlay
 {
 private:
+    GuiKeyValueDisplay* energy_display;
+    GuiKeyValueDisplay* coolant_display;
+
+    float previous_energy_measurement;
+    float previous_energy_level;
+    float average_energy_delta;
+
     class SystemRow
     {
     public:

--- a/src/spaceObjects/playerSpaceship.cpp
+++ b/src/spaceObjects/playerSpaceship.cpp
@@ -52,7 +52,11 @@ REGISTER_SCRIPT_SUBCLASS(PlayerSpaceship, SpaceShip)
     REGISTER_SCRIPT_CLASS_FUNCTION(PlayerSpaceship, setEnergyLevelMax);
     REGISTER_SCRIPT_CLASS_FUNCTION(PlayerSpaceship, getEnergyLevel);
     REGISTER_SCRIPT_CLASS_FUNCTION(PlayerSpaceship, getEnergyLevelMax);
-    
+
+    /// Set the maximum coolant available to engineering. Default is 10.
+    REGISTER_SCRIPT_CLASS_FUNCTION(PlayerSpaceship, setMaxCoolant);
+    REGISTER_SCRIPT_CLASS_FUNCTION(PlayerSpaceship, getMaxCoolant);
+
     REGISTER_SCRIPT_CLASS_FUNCTION(PlayerSpaceship, setScanProbeCount);
     REGISTER_SCRIPT_CLASS_FUNCTION(PlayerSpaceship, getScanProbeCount);
     REGISTER_SCRIPT_CLASS_FUNCTION(PlayerSpaceship, setMaxScanProbeCount);
@@ -205,6 +209,7 @@ PlayerSpaceship::PlayerSpaceship()
     shield_calibration_delay = 0.0;
     auto_repair_enabled = false;
     auto_coolant_enabled = false;
+    max_coolant = max_coolant_per_system;
     activate_self_destruct = false;
     self_destruct_countdown = 0.0;
     scanning_delay = 0.0;
@@ -236,6 +241,7 @@ PlayerSpaceship::PlayerSpaceship()
     registerMemberReplication(&shields_active);
     registerMemberReplication(&shield_calibration_delay, 0.5);
     registerMemberReplication(&auto_repair_enabled);
+    registerMemberReplication(&max_coolant);
     registerMemberReplication(&auto_coolant_enabled);
     registerMemberReplication(&beam_system_target);
     registerMemberReplication(&comms_state);
@@ -632,8 +638,41 @@ void PlayerSpaceship::takeHullDamage(float damage_amount, DamageInfo& info)
     SpaceShip::takeHullDamage(damage_amount, info);
 }
 
+void PlayerSpaceship::setMaxCoolant(float coolant)
+{
+    max_coolant = std::max(coolant, 0.0f);
+    float total_coolant = 0;
+
+    for(int n = 0; n < SYS_COUNT; n++)
+    {
+        if (!hasSystem(ESystem(n))) continue;
+
+        total_coolant += systems[n].coolant_request;
+    }
+
+    if (total_coolant > max_coolant)
+    {
+        for(int n = 0; n < SYS_COUNT; n++)
+        {
+            if (!hasSystem(ESystem(n))) continue;
+
+            systems[n].coolant_request *= max_coolant / total_coolant;
+        }
+    } else {
+        if (total_coolant > 0)
+        {
+            for(int n = 0; n < SYS_COUNT; n++)
+            {
+                if (!hasSystem(ESystem(n))) continue;
+                systems[n].coolant_request = std::min(systems[n].coolant_request * max_coolant / total_coolant, (float) max_coolant_per_system);
+            }
+        }
+    }
+}
+
 void PlayerSpaceship::setSystemCoolantRequest(ESystem system, float request)
 {
+    request = std::max(0.0f, std::min(request, std::min((float) max_coolant_per_system, max_coolant)));
     // Set coolant levels on a system.
     float total_coolant = 0;
     int cnt = 0;
@@ -662,7 +701,7 @@ void PlayerSpaceship::setSystemCoolantRequest(ESystem system, float request)
                 if (!hasSystem(ESystem(n))) continue;
                 if (n == system) continue;
 
-                systems[n].coolant_request *= (max_coolant - request) / total_coolant;
+                systems[n].coolant_request = std::min(systems[n].coolant_request * (max_coolant - request) / total_coolant, (float) max_coolant_per_system);
             }
         }
     }

--- a/src/spaceObjects/playerSpaceship.h
+++ b/src/spaceObjects/playerSpaceship.h
@@ -39,7 +39,8 @@ public:
     // Coolant change rate
     constexpr static float system_coolant_level_change_per_second = 1.2;
     // Total coolant
-    constexpr static float max_coolant = 10.0;
+    constexpr static float max_coolant_per_system = 10.0f;
+    float max_coolant;
     // Overheat subsystem damage rate
     constexpr static float damage_per_second_on_overheat = 0.08f;
     // Base time it takes to perform an action
@@ -248,6 +249,8 @@ public:
     virtual void executeJump(float distance) override;
     virtual void takeHullDamage(float damage_amount, DamageInfo& info) override;
     void setSystemCoolantRequest(ESystem system, float request);
+    void setMaxCoolant(float coolant);
+    float getMaxCoolant() { return max_coolant; }
     void setAutoCoolant(bool active) { auto_coolant_enabled = active; }
     int getRepairCrewCount();
     void setRepairCrewCount(int amount);


### PR DESCRIPTION
I think adding different coolant levels might make some missions more interesting:

* @TolotosRhodan created a [mission](https://github.com/TolotosRhodan/EE-MotU) where you can dispose of some coolant in order to create a temporary nebula to escape like a ninja
* decreasing coolant would force a crew to play more strategic and turn systems off more often
* scenarios could add a mechanic where coolant has to be refilled regularly or can be earned as reward
* "sabotage" the players by draining their coolant and have them improvise

![EmptyEpsilon_015](https://user-images.githubusercontent.com/264799/61749434-111e8c80-ada3-11e9-9e0e-7ac914ee4db7.png)
![EmptyEpsilon_016](https://user-images.githubusercontent.com/264799/61749440-14197d00-ada3-11e9-9f37-08964d0c632a.png)

---

Im currently having a problem with linking. The compiler runs fine, but the linker seems not to be able to find the reference to `max_coolant_per_system`. I spend over an hour trying to figure out what the problem is, but I am out of ideas.

`playerSpaceship.cpp:(.text+0x5876): undefined reference to 
 PlayerSpaceship::max_coolant_per_system'`

Maybe someone can give it a try. It could be an issue with my setup or it is just my missing C++ knowledge or some weird foo... :-/ 

@daid to the rescue!