### PR TITLE
toggle between simple and complex radar signatures

### DIFF
--- a/src/gameGlobalInfo.cpp
+++ b/src/gameGlobalInfo.cpp
@@ -31,6 +31,7 @@ GameGlobalInfo::GameGlobalInfo()
     long_range_radar_range = 30000;
     use_beam_shield_frequencies = true;
     use_system_damage = true;
+    use_complex_radar_signatures = true;
     allow_main_screen_tactical_radar = true;
     allow_main_screen_long_range_radar = true;
     
@@ -44,6 +45,7 @@ GameGlobalInfo::GameGlobalInfo()
     registerMemberReplication(&long_range_radar_range);
     registerMemberReplication(&use_beam_shield_frequencies);
     registerMemberReplication(&use_system_damage);
+    registerMemberReplication(&use_complex_radar_signatures);
     registerMemberReplication(&allow_main_screen_tactical_radar);
     registerMemberReplication(&allow_main_screen_long_range_radar);
 

--- a/src/gameGlobalInfo.h
+++ b/src/gameGlobalInfo.h
@@ -70,6 +70,7 @@ public:
     float long_range_radar_range;
     bool use_beam_shield_frequencies;
     bool use_system_damage;
+    bool use_complex_radar_signatures;
     bool allow_main_screen_tactical_radar;
     bool allow_main_screen_long_range_radar;
     string variation = "None";

--- a/src/menus/serverCreationScreen.cpp
+++ b/src/menus/serverCreationScreen.cpp
@@ -29,6 +29,7 @@ ServerCreationScreen::ServerCreationScreen()
     gameGlobalInfo->scanning_complexity = EScanningComplexity(PreferencesManager::get("server_config_scanning_complexity", "2").toInt());
     gameGlobalInfo->use_beam_shield_frequencies = PreferencesManager::get("server_config_use_beam_shield_frequencies", "1").toInt();
     gameGlobalInfo->use_system_damage = PreferencesManager::get("server_config_use_system_damage", "1").toInt();
+    gameGlobalInfo->use_complex_radar_signatures = PreferencesManager::get("server_config_use_complex_radar_signatures", "1").toInt();
     gameGlobalInfo->allow_main_screen_tactical_radar = PreferencesManager::get("server_config_allow_main_screen_tactical_radar", "1").toInt();
     gameGlobalInfo->allow_main_screen_long_range_radar = PreferencesManager::get("server_config_allow_main_screen_long_range_radar", "1").toInt();
 
@@ -131,6 +132,13 @@ ServerCreationScreen::ServerCreationScreen()
         gameGlobalInfo->use_system_damage = value == 1;
     }))->setValue(gameGlobalInfo->use_system_damage)->setSize(275, GuiElement::GuiSizeMax)->setPosition(0, 0, ACenterRight);
 
+    row = new GuiAutoLayout(left_panel, "", GuiAutoLayout::LayoutHorizontalLeftToRight);
+    row->setSize(GuiElement::GuiSizeMax, 50);
+
+    (new GuiToggleButton(row, "GAME_SYS_RADAR_TOGGLE", "Complex Radar Lines", [](bool value) {
+        gameGlobalInfo->use_complex_radar_signatures = value == 1;
+    }))->setValue(gameGlobalInfo->use_complex_radar_signatures)->setSize(275, GuiElement::GuiSizeMax)->setPosition(0, 0, ACenterRight);
+
     // Right column contents.
     // Scenario section.
     (new GuiLabel(right_panel, "SCENARIO_LABEL", "Scenario", 30))->addBackground()->setSize(GuiElement::GuiSizeMax, 50);
@@ -232,6 +240,7 @@ void ServerCreationScreen::startScenario()
     PreferencesManager::set("server_config_scanning_complexity", string(int(gameGlobalInfo->scanning_complexity)));
     PreferencesManager::set("server_config_use_beam_shield_frequencies", string(int(gameGlobalInfo->use_beam_shield_frequencies)));
     PreferencesManager::set("server_config_use_system_damage", string(int(gameGlobalInfo->use_system_damage)));
+    PreferencesManager::set("server_config_use_complex_radar_signatures", string(int(gameGlobalInfo->use_complex_radar_signatures)));
     PreferencesManager::set("server_config_allow_main_screen_tactical_radar", string(int(gameGlobalInfo->allow_main_screen_tactical_radar)));
     PreferencesManager::set("server_config_allow_main_screen_long_range_radar", string(int(gameGlobalInfo->allow_main_screen_long_range_radar)));
 

--- a/src/screenComponents/rawScannerDataRadarOverlay.cpp
+++ b/src/screenComponents/rawScannerDataRadarOverlay.cpp
@@ -1,4 +1,5 @@
 #include "rawScannerDataRadarOverlay.h"
+#include "gameGlobalInfo.h"
 #include "radarView.h"
 #include "playerInfo.h"
 #include "spaceObjects/playerSpaceship.h"
@@ -89,20 +90,28 @@ void RawScannerDataRadarOverlay::onDraw(sf::RenderTarget& window)
         float g = random(-1, 1);
         float b = random(-1, 1);
 
-        // ... and then modify the bands' values based on the object's signature.
-        // Biological signatures amplify the red and green bands.
-        r += signatures[n].biological * 30;
-        g += signatures[n].biological * 30;
+        if (gameGlobalInfo->use_complex_radar_signatures)
+        {
 
-        // Electrical signatures amplify the red and blue bands.
-        r += random(-20, 20) * signatures[n].electrical;
-        b += random(-20, 20) * signatures[n].electrical;
+            // ... and then modify the bands' values based on the object's signature.
+            // Biological signatures amplify the red and green bands.
+            r += signatures[n].biological * 30;
+            g += signatures[n].biological * 30;
 
-        // Gravitational signatures amplify all bands, but especially modify
-        // the green and blue bands.
-        r = r * (1.0f - signatures[n].gravity);
-        g = g * (1.0f - signatures[n].gravity) + 40 * signatures[n].gravity;
-        b = b * (1.0f - signatures[n].gravity) + 40 * signatures[n].gravity;
+            // Electrical signatures amplify the red and blue bands.
+            r += random(-20, 20) * signatures[n].electrical;
+            b += random(-20, 20) * signatures[n].electrical;
+
+            // Gravitational signatures amplify all bands, but especially modify
+            // the green and blue bands.
+            r = r * (1.0f - signatures[n].gravity);
+            g = g * (1.0f - signatures[n].gravity) + 40 * signatures[n].gravity;
+            b = b * (1.0f - signatures[n].gravity) + 40 * signatures[n].gravity;
+        } else {
+            r += signatures[n].gravity * 40;
+            g += signatures[n].biological * 30;
+            b += random(-20, 20) * signatures[n].electrical;
+        }
 
         // Apply the values to the radar bands.
         amp_r[n] = r;


### PR DESCRIPTION
This commit adds a toggle to the server creation screen that can simplify the radar signatures.

The default mode mixes gravitational, bio signs and electronic signatures into all of the three radar signatures. This is not intuitive for new players. To make the science screen more accessible the simple mode only shows one dimension for each radar signature:
 * red shows gravitation
 * green shows bio signs
 * blue shows electronic signatures