### PR TITLE
F1 now shows Shift, Alt etc.

### DIFF
--- a/src/gui/hotkeyConfig.cpp
+++ b/src/gui/hotkeyConfig.cpp
@@ -264,9 +264,18 @@ std::vector<std::pair<string, string>> HotkeyConfig::listHotkeysByCategory(strin
             {
                 for(auto key_name : sfml_key_names)
                 {
-                    if (key_name.second == item.hotkey.code)
-                        ret.push_back({std::get<0>(item.value), key_name.first});
-                }
+                    if (key_name.second == item.hotkey.code){
+			string keyModifier = "";
+			if (item.hotkey.shift) {
+				keyModifier = "Shift+";
+			} else if (item.hotkey.control) {
+				keyModifier = "Ctrl+";
+			} else if (item.hotkey.alt){
+				keyModifier = "Alt+";
+			}
+                        ret.push_back({std::get<0>(item.value), keyModifier + key_name.first});
+                    }
+		}
             }
         }
     }


### PR DESCRIPTION
changed listHotkeysByCategorie function to show hotkeyModifiers (Shift, alt etc) for F1 helpoverlay.

When using [shift]Tab as a hotkey in options.ini, it wouldnt show correctly in the F1 Help overlay.
I fixed that. 

Regards Jan 