### PR TITLE
add modifier keys to the GM screen

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@
 ### Added
 
 - Mission scripts can modify the total coolant available to engineering
+- GM screen allows modifier keys
+  - `Shift` adds objects to the current selection
+  - `Ctrl` only selects stations and ships
+  - `Alt` only selects objects from the same faction as the faction selector
 
 ### Changed
 

--- a/src/screenComponents/targetsContainer.cpp
+++ b/src/screenComponents/targetsContainer.cpp
@@ -16,7 +16,7 @@ void TargetsContainer::clear()
 
 void TargetsContainer::add(P<SpaceObject> obj)
 {
-    if (obj)
+    if (obj && !entries.has(obj))
         entries.push_back(obj);
 }
 

--- a/src/screens/gm/gameMasterScreen.cpp
+++ b/src/screens/gm/gameMasterScreen.cpp
@@ -445,6 +445,7 @@ void GameMasterScreen::onMouseUp(sf::Vector2f position)
     case CD_BoxSelect:
         {
             bool shift_down = InputHandler::keyboardIsDown(sf::Keyboard::LShift) || InputHandler::keyboardIsDown(sf::Keyboard::RShift);
+            //Using sf::Keyboard::isKeyPressed, as CTRL does not seem to generate keydown/key up events in SFML.
             bool ctrl_down = sf::Keyboard::isKeyPressed(sf::Keyboard::LControl) || sf::Keyboard::isKeyPressed(sf::Keyboard::RControl);
             bool alt_down = InputHandler::keyboardIsDown(sf::Keyboard::LAlt) || InputHandler::keyboardIsDown(sf::Keyboard::RAlt);
             PVector<Collisionable> objects = CollisionManager::queryArea(drag_start_position, position);

--- a/src/screens/gm/gameMasterScreen.cpp
+++ b/src/screens/gm/gameMasterScreen.cpp
@@ -444,14 +444,32 @@ void GameMasterScreen::onMouseUp(sf::Vector2f position)
         break;
     case CD_BoxSelect:
         {
+            bool shift_down = InputHandler::keyboardIsDown(sf::Keyboard::LShift) || InputHandler::keyboardIsDown(sf::Keyboard::RShift);
+            bool ctrl_down = sf::Keyboard::isKeyPressed(sf::Keyboard::LControl) || sf::Keyboard::isKeyPressed(sf::Keyboard::RControl);
+            bool alt_down = InputHandler::keyboardIsDown(sf::Keyboard::LAlt) || InputHandler::keyboardIsDown(sf::Keyboard::RAlt);
             PVector<Collisionable> objects = CollisionManager::queryArea(drag_start_position, position);
             PVector<SpaceObject> space_objects;
             foreach(Collisionable, c, objects)
             {
-                if (!P<Zone>(c))
-                    space_objects.push_back(c);
+                if (P<Zone>(c))
+                    continue;
+                if (ctrl_down && !P<ShipTemplateBasedObject>(c))
+                    continue;
+                if (alt_down && (!P<SpaceObject>(c) || (int)(P<SpaceObject>(c))->getFactionId() != faction_selector->getSelectionIndex()))
+                    continue;
+                space_objects.push_back(c);
             }
-            targets.set(space_objects);
+            if (shift_down)
+            {
+                foreach(SpaceObject, s, space_objects)
+                {
+                    targets.add(s);
+                }
+            } else {
+                targets.set(space_objects);
+            }
+
+
             if (space_objects.size() > 0)
                 faction_selector->setSelectionIndex(space_objects[0]->getFactionId());
         }


### PR DESCRIPTION
- `Shift` adds objects to the current selection
- `Ctrl` only selects stations and ships
- `Alt` only selects objects from the same faction as the faction selector