### PR TITLE
add message overlay for game master screen

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -100,6 +100,7 @@ set(SOURCES
 	src/scenarioInfo.cpp
 	src/repairCrew.cpp
 	src/GMScriptCallback.cpp
+	src/GMMessage.cpp
 	src/tutorialGame.cpp
 	src/menus/joinServerMenu.cpp
 	src/menus/serverBrowseMenu.cpp

--- a/src/GMMessage.cpp
+++ b/src/GMMessage.cpp
@@ -1,0 +1,20 @@
+#include "GMMessage.h"
+#include "gameGlobalInfo.h"
+
+GMMessage::GMMessage(string text)
+: text(text)
+{
+}
+
+static int addGMMessage(lua_State* L)
+{
+    string text = luaL_checkstring(L, 1);
+
+    gameGlobalInfo->gm_messages.emplace_back(text);
+
+    return 0;
+}
+
+/// addGMMessage(message)
+/// shows a message on the GM screen
+REGISTER_SCRIPT_FUNCTION(addGMMessage);

--- a/src/GMMessage.h
+++ b/src/GMMessage.h
@@ -1,0 +1,14 @@
+#ifndef GM_MESSAGE_H
+#define GM_MESSAGE_H
+
+#include "engine.h"
+
+class GMMessage
+{
+public:
+    string text;
+
+    GMMessage(string text);
+};
+
+#endif//GM_MESSAGE_H

--- a/src/gameGlobalInfo.h
+++ b/src/gameGlobalInfo.h
@@ -4,6 +4,7 @@
 #include "spaceObjects/playerSpaceship.h"
 #include "script.h"
 #include "GMScriptCallback.h"
+#include "GMMessage.h"
 #include "gameStateLogger.h"
 
 class GameStateLogger;
@@ -76,6 +77,7 @@ public:
 
     //List of script functions that can be called from the GM interface (Server only!)
     std::list<GMScriptCallback> gm_callback_functions;
+    std::list<GMMessage> gm_messages;
     //When active, all comms request goto the GM as chat, and normal scripted converstations are disabled. This does not disallow player<->player ship comms.
     bool intercept_all_comms_to_gm;
 

--- a/src/screens/gm/gameMasterScreen.cpp
+++ b/src/screens/gm/gameMasterScreen.cpp
@@ -193,6 +193,20 @@ GameMasterScreen::GameMasterScreen()
         object_creation_view->hide();
     });
     object_creation_view->hide();
+
+    message_frame = new GuiPanel(this, "");
+    message_frame->setPosition(0, 0, ATopCenter)->setSize(900, 230)->hide();
+
+    message_text = new GuiScrollText(message_frame, "", "");
+    message_text->setTextSize(20)->setPosition(20, 20, ATopLeft)->setSize(900 - 40, 200 - 40);
+    message_close_button = new GuiButton(message_frame, "", "Close", [this]() {
+        if (!gameGlobalInfo->gm_messages.empty())
+        {
+            gameGlobalInfo->gm_messages.pop_front();
+        }
+
+    });
+    message_close_button->setTextSize(30)->setPosition(-20, -20, ABottomRight)->setSize(300, 30);
 }
 
 void GameMasterScreen::update(float delta)
@@ -315,6 +329,15 @@ void GameMasterScreen::update(float delta)
         {
             gm_script_options->addEntry(callback.name, callback.name);
         }
+    }
+
+    if (!gameGlobalInfo->gm_messages.empty())
+    {
+        GMMessage* message = &gameGlobalInfo->gm_messages.front();
+        message_text->setText(message->text);
+        message_frame->show();
+    } else {
+        message_frame->hide();
     }
 }
 

--- a/src/screens/gm/gameMasterScreen.h
+++ b/src/screens/gm/gameMasterScreen.h
@@ -2,6 +2,8 @@
 #define GAME_MASTER_SCREEN_H
 
 #include "engine.h"
+#include "gui/gui2_panel.h"
+#include "gui/gui2_scrolltext.h"
 #include "gui/gui2_canvas.h"
 #include "gui/gui2_overlay.h"
 #include "screenComponents/targetsContainer.h"
@@ -50,6 +52,10 @@ private:
     GuiButton* copy_scenario_button;
     GuiButton* copy_selected_button;
     GuiSelector* player_ship_selector;
+
+    GuiPanel* message_frame;
+    GuiScrollText* message_text;
+    GuiButton* message_close_button;
     
     enum EClickAndDragState
     {


### PR DESCRIPTION
Added the possibility to show a message on the GM screen as it is possible on all stations.

I found it limiting to have no space to display longer texts to the GM during a scenario or inform them that the players have achieved a significant milestone.

It looks identical to the overlay on the stations (probably because I copied most of the code from there :smiley: )

![EmptyEpsilon_022](https://user-images.githubusercontent.com/264799/62976629-4f94ed80-be1d-11e9-8c0a-dd134dfeb468.png)
