### PR TITLE
Feature/updatable custom infos

### DIFF
--- a/src/screenComponents/customShipFunctions.cpp
+++ b/src/screenComponents/customShipFunctions.cpp
@@ -32,7 +32,14 @@ void GuiCustomShipFunctions::checkEntries()
         }
         else if (entries[n].element->getText() != my_spaceship->custom_functions[n].caption)
         {
-            entries[n].element->setText(my_spaceship->custom_functions[n].caption)
+            if (my_spaceship->custom_functions[n].type == PlayerSpaceship::CustomShipFunction::Type::Button)
+            {
+              ((GuiButton*) entries[n].element)->setText(my_spaceship->custom_functions[n].caption);
+            }
+            else if (my_spaceship->custom_functions[n].type == PlayerSpaceship::CustomShipFunction::Type::Info)
+            {
+              ((GuiButton*) entries[n].element)->setText(my_spaceship->custom_functions[n].caption);
+            }
         }
     }
 }

--- a/src/screenComponents/customShipFunctions.cpp
+++ b/src/screenComponents/customShipFunctions.cpp
@@ -25,6 +25,7 @@ void GuiCustomShipFunctions::checkEntries()
     }
     for(unsigned int n=0; n<entries.size(); n++)
     {
+        string caption = my_spaceship->custom_functions[n].caption;
         if (entries[n].name != my_spaceship->custom_functions[n].name)
         {
             createEntries();
@@ -32,18 +33,18 @@ void GuiCustomShipFunctions::checkEntries()
         }
         else if (my_spaceship->custom_functions[n].type == PlayerSpaceship::CustomShipFunction::Type::Button)
         {
-            GuiButton* button = (GuiButton*) entries[n].element;
-            if (button->getText() != my_spaceship->custom_functions[n].caption)
+            GuiButton* button = (GuiButton*) (entries[n].element);
+            if (button->getText() != caption)
             {
-              button->setText(my_spaceship->custom_functions[n].caption);
+                button->setText(caption);
             }
         }
         else if (my_spaceship->custom_functions[n].type == PlayerSpaceship::CustomShipFunction::Type::Info)
         {
-            GuiLabel* label = (GuiLabel*) entries[n].element;
-            if (label->getText() != my_spaceship->custom_functions[n].caption)
+            GuiLabel* label = (GuiLabel*) (entries[n].element);
+            if (label->getText() != caption)
             {
-              label->setText(my_spaceship->custom_functions[n].caption);
+                label->setText(caption);
             }
         }
     }

--- a/src/screenComponents/customShipFunctions.cpp
+++ b/src/screenComponents/customShipFunctions.cpp
@@ -30,6 +30,10 @@ void GuiCustomShipFunctions::checkEntries()
             createEntries();
             return;
         }
+        else if (entries[n].element->getText() != my_spaceship->custom_functions[n].caption)
+        {
+            entries[n].element->setText(my_spaceship->custom_functions[n].caption)
+        }
     }
 }
 

--- a/src/screenComponents/customShipFunctions.cpp
+++ b/src/screenComponents/customShipFunctions.cpp
@@ -30,15 +30,20 @@ void GuiCustomShipFunctions::checkEntries()
             createEntries();
             return;
         }
-        else if (entries[n].element->getText() != my_spaceship->custom_functions[n].caption)
+        else if (my_spaceship->custom_functions[n].type == PlayerSpaceship::CustomShipFunction::Type::Button)
         {
-            if (my_spaceship->custom_functions[n].type == PlayerSpaceship::CustomShipFunction::Type::Button)
+            GuiButton* button = (GuiButton*) entries[n].element;
+            if (button->getText() != my_spaceship->custom_functions[n].caption)
             {
-              ((GuiButton*) entries[n].element)->setText(my_spaceship->custom_functions[n].caption);
+              button->setText(my_spaceship->custom_functions[n].caption);
             }
-            else if (my_spaceship->custom_functions[n].type == PlayerSpaceship::CustomShipFunction::Type::Info)
+        }
+        else if (my_spaceship->custom_functions[n].type == PlayerSpaceship::CustomShipFunction::Type::Info)
+        {
+            GuiLabel* label = (GuiLabel*) entries[n].element;
+            if (label->getText() != my_spaceship->custom_functions[n].caption)
             {
-              ((GuiButton*) entries[n].element)->setText(my_spaceship->custom_functions[n].caption);
+              label->setText(my_spaceship->custom_functions[n].caption);
             }
         }
     }

--- a/src/screenComponents/customShipFunctions.cpp
+++ b/src/screenComponents/customShipFunctions.cpp
@@ -33,16 +33,16 @@ void GuiCustomShipFunctions::checkEntries()
         }
         else if (my_spaceship->custom_functions[n].type == PlayerSpaceship::CustomShipFunction::Type::Button)
         {
-            GuiButton* button = (GuiButton*) (entries[n].element);
-            if (button->getText() != caption)
+            GuiButton* button = dynamic_cast<GuiButton*>(entries[n].element);
+            if (button && button->getText() != caption)
             {
                 button->setText(caption);
             }
         }
         else if (my_spaceship->custom_functions[n].type == PlayerSpaceship::CustomShipFunction::Type::Info)
         {
-            GuiLabel* label = (GuiLabel*) (entries[n].element);
-            if (label->getText() != caption)
+            GuiLabel* label = dynamic_cast<GuiLabel*>(entries[n].element);
+            if (label && label->getText() != caption)
             {
                 label->setText(caption);
             }


### PR DESCRIPTION
When scripting a new Scenario, I noticed that while you can add custom Infos and Buttons to Screens, you can't update them once they are there. The PlayerInfo object has the updated values, but they don't get passed to the GUI if the name of the element doesnt change. If you want the value to change, you currently have to remove the customInfo/customButton, wait until a point where you are sure the player has been forced to draw the Element, and then re-add the element.

This PR deals with that by not only checking that the element exists, but that it has the correct text, and changes it if not.

This makes it possible to add things like timers to the screens.