### PR TITLE
Feature/beam effects settings for lua

### DIFF
--- a/src/spaceObjects/beamEffect.cpp
+++ b/src/spaceObjects/beamEffect.cpp
@@ -10,6 +10,11 @@ REGISTER_SCRIPT_SUBCLASS(BeamEffect, SpaceObject)
 {
     REGISTER_SCRIPT_CLASS_FUNCTION(BeamEffect, setSource);
     REGISTER_SCRIPT_CLASS_FUNCTION(BeamEffect, setTarget);
+    REGISTER_SCRIPT_CLASS_FUNCTION(BeamEffect, setTexture);
+    REGISTER_SCRIPT_CLASS_FUNCTION(BeamEffect, setBeamFireSound);
+    REGISTER_SCRIPT_CLASS_FUNCTION(BeamEffect, setBeamFireSoundPower);
+    REGISTER_SCRIPT_CLASS_FUNCTION(BeamEffect, setDuration);
+
 }
 
 REGISTER_MULTIPLAYER_CLASS(BeamEffect, "BeamEffect");

--- a/src/spaceObjects/beamEffect.cpp
+++ b/src/spaceObjects/beamEffect.cpp
@@ -25,7 +25,9 @@ BeamEffect::BeamEffect()
     lifetime = 1.0;
     sourceId = -1;
     target_id = -1;
-
+    beam_texture = "beam_orange.png";
+    beam_fire_sound = "sfx/laser_fire.wav";
+    beam_fire_sound_power = 1;
     registerMemberReplication(&sourceId);
     registerMemberReplication(&target_id);
     registerMemberReplication(&sourceOffset);

--- a/src/spaceObjects/beamEffect.h
+++ b/src/spaceObjects/beamEffect.h
@@ -25,6 +25,15 @@ public:
 
     void setSource(P<SpaceObject> source, sf::Vector3f offset);
     void setTarget(P<SpaceObject> target, sf::Vector2f hitLocation);
+
+    ///Set the texture used for this beam. Options available by default take the form beam_color.png
+    void setTexture(string texture) {this->beam_texture = texture;}
+    ///Set the sound played when firing the beam. Included laser sound is laser.wav
+    void setBeamFireSound(string sound) {this->beam_fire_sound = sound;}
+    ///Control volume and pitch of firing sound
+    void setBeamFireSoundPower(float power) {this->beam_fire_sound_power = power;}
+    ///Control Duration of the beam. Default is 1 second
+    void setDuration(float duration) {this->lifetime = duration;}
 };
 
 #endif//BEAM_EFFECT_H

--- a/src/spaceObjects/beamEffect.h
+++ b/src/spaceObjects/beamEffect.h
@@ -26,11 +26,11 @@ public:
     void setSource(P<SpaceObject> source, sf::Vector3f offset);
     void setTarget(P<SpaceObject> target, sf::Vector2f hitLocation);
 
-    ///Set the texture used for this beam. Options available by default take the form beam_color.png
+    ///Set the texture used for this beam. Default is beam_orange.png
     void setTexture(string texture) {this->beam_texture = texture;}
-    ///Set the sound played when firing the beam. Included laser sound is laser.wav
+    ///Set the sound played when firing the beam. Default firing sound is sfx/laser_fire.wav
     void setBeamFireSound(string sound) {this->beam_fire_sound = sound;}
-    ///Control volume and pitch of firing sound
+    ///Control volume and pitch of firing sound. Default is 1.0, ships use beam damage/6
     void setBeamFireSoundPower(float power) {this->beam_fire_sound_power = power;}
     ///Control Duration of the beam. Default is 1 second
     void setDuration(float duration) {this->lifetime = duration;}


### PR DESCRIPTION
Exposes the beamEffects properties to lua and sets some defaults which are usually set via BeamTemplate or BeamWeapon, but uninitialized when a BeamEffect is produced by the script.

Question on the side: the default laser fire sound is sfx/laser_fire.wav. There is a similar-sounding laser.wav in the main resources directory that I could find no usage of. Is that leftover from something, or is my grep-fu just bad?