### PR TITLE
read beam settings in lua scripts

### DIFF
--- a/src/spaceObjects/playerSpaceship.cpp
+++ b/src/spaceObjects/playerSpaceship.cpp
@@ -68,7 +68,6 @@ REGISTER_SCRIPT_SUBCLASS(PlayerSpaceship, SpaceShip)
     REGISTER_SCRIPT_CLASS_FUNCTION(PlayerSpaceship, addCustomMessageWithCallback);
     REGISTER_SCRIPT_CLASS_FUNCTION(PlayerSpaceship, removeCustom);
     
-    REGISTER_SCRIPT_CLASS_FUNCTION(PlayerSpaceship, getBeamFrequency);
     REGISTER_SCRIPT_CLASS_FUNCTION(PlayerSpaceship, getBeamSystemTarget);
     /// Gets the name of the target system, instead of the ID
     REGISTER_SCRIPT_CLASS_FUNCTION(PlayerSpaceship, getBeamSystemTargetName);

--- a/src/spaceObjects/playerSpaceship.cpp
+++ b/src/spaceObjects/playerSpaceship.cpp
@@ -70,6 +70,8 @@ REGISTER_SCRIPT_SUBCLASS(PlayerSpaceship, SpaceShip)
     
     REGISTER_SCRIPT_CLASS_FUNCTION(PlayerSpaceship, getBeamFrequency);
     REGISTER_SCRIPT_CLASS_FUNCTION(PlayerSpaceship, getBeamSystemTarget);
+    /// Gets the name of the target system, instead of the ID
+    REGISTER_SCRIPT_CLASS_FUNCTION(PlayerSpaceship, getBeamSystemTargetName);
 
     // Command functions
     REGISTER_SCRIPT_CLASS_FUNCTION(PlayerSpaceship, commandTargetRotation);

--- a/src/spaceObjects/playerSpaceship.cpp
+++ b/src/spaceObjects/playerSpaceship.cpp
@@ -67,6 +67,9 @@ REGISTER_SCRIPT_SUBCLASS(PlayerSpaceship, SpaceShip)
     REGISTER_SCRIPT_CLASS_FUNCTION(PlayerSpaceship, addCustomMessage);
     REGISTER_SCRIPT_CLASS_FUNCTION(PlayerSpaceship, addCustomMessageWithCallback);
     REGISTER_SCRIPT_CLASS_FUNCTION(PlayerSpaceship, removeCustom);
+    
+    REGISTER_SCRIPT_CLASS_FUNCTION(PlayerSpaceship, getBeamFrequency);
+    REGISTER_SCRIPT_CLASS_FUNCTION(PlayerSpaceship, getBeamSystemTarget);
 
     // Command functions
     REGISTER_SCRIPT_CLASS_FUNCTION(PlayerSpaceship, commandTargetRotation);

--- a/src/spaceObjects/playerSpaceship.h
+++ b/src/spaceObjects/playerSpaceship.h
@@ -195,7 +195,6 @@ public:
     void addCustomMessageWithCallback(ECrewPosition position, string name, string caption, ScriptSimpleCallback callback);
     void removeCustom(string name);
 
-    int getBeamFrequency(){ return beam_frequency; }
     ESystem getBeamSystemTarget(){ return beam_system_target; }
     string getBeamSystemTargetName(){ return getSystemName(beam_system_target); }
     // Client command functions

--- a/src/spaceObjects/playerSpaceship.h
+++ b/src/spaceObjects/playerSpaceship.h
@@ -197,7 +197,7 @@ public:
 
     int getBeamFrequency(){ return beam_frequency; }
     ESystem getBeamSystemTarget(){ return beam_system_target; }
-
+    string getBeamSystemTargetName(){ return getSystemName(beam_system_target); }
     // Client command functions
     virtual void onReceiveClientCommand(int32_t client_id, sf::Packet& packet) override;
     void commandTargetRotation(float target);

--- a/src/spaceObjects/playerSpaceship.h
+++ b/src/spaceObjects/playerSpaceship.h
@@ -195,6 +195,9 @@ public:
     void addCustomMessageWithCallback(ECrewPosition position, string name, string caption, ScriptSimpleCallback callback);
     void removeCustom(string name);
 
+    int getBeamFrequency(){ return beam_frequency; }
+    ESystem getBeamSystemTarget(){ return beam_system_target; }
+
     // Client command functions
     virtual void onReceiveClientCommand(int32_t client_id, sf::Packet& packet) override;
     void commandTargetRotation(float target);

--- a/src/spaceObjects/spaceship.cpp
+++ b/src/spaceObjects/spaceship.cpp
@@ -28,6 +28,7 @@ REGISTER_SCRIPT_SUBCLASS_NO_CREATE(SpaceShip, ShipTemplateBasedObject)
     REGISTER_SCRIPT_CLASS_FUNCTION(SpaceShip, setWeaponStorageMax);
     REGISTER_SCRIPT_CLASS_FUNCTION(SpaceShip, getShieldsFrequency);
     REGISTER_SCRIPT_CLASS_FUNCTION(SpaceShip, setShieldsFrequency);
+    REGISTER_SCRIPT_CLASS_FUNCTION(SpaceShip, getBeamFrequency);
     REGISTER_SCRIPT_CLASS_FUNCTION(SpaceShip, getMaxEnergy);
     REGISTER_SCRIPT_CLASS_FUNCTION(SpaceShip, setMaxEnergy);
     REGISTER_SCRIPT_CLASS_FUNCTION(SpaceShip, getEnergy);

--- a/src/spaceObjects/spaceship.h
+++ b/src/spaceObjects/spaceship.h
@@ -356,6 +356,8 @@ public:
     int getShieldsFrequency(void){ return shield_frequency; }
     void setShieldsFrequency(float freq) { if ((freq > SpaceShip::max_frequency) || (freq < 0)) return; shield_frequency = freq;}
 
+    int getBeamFrequency(){ return beam_frequency; }
+
     void setBeamWeapon(int index, float arc, float direction, float range, float cycle_time, float damage)
     {
         if (index < 0 || index >= max_beam_weapons)


### PR DESCRIPTION
Right now, you can only set the beam frequency and target systems in lua, but not read them. This PR closes that gap, including a function to also get the name of the target system.