### PR TITLE
Ability to turn beam fire ring off per script

### DIFF
--- a/src/spaceObjects/beamEffect.cpp
+++ b/src/spaceObjects/beamEffect.cpp
@@ -30,6 +30,7 @@ BeamEffect::BeamEffect()
     beam_fire_sound = "sfx/laser_fire.wav";
     beam_fire_sound_power = 1;
     fire_ring = true;
+    registerMemberReplication(&lifetime);
     registerMemberReplication(&sourceId);
     registerMemberReplication(&target_id);
     registerMemberReplication(&sourceOffset);
@@ -39,6 +40,8 @@ BeamEffect::BeamEffect()
     registerMemberReplication(&beam_texture);
     registerMemberReplication(&beam_fire_sound);
     registerMemberReplication(&beam_fire_sound_power);
+    registerMemberReplication(&fire_ring);
+    
 }
 
 #if FEATURE_3D_RENDERING

--- a/src/spaceObjects/beamEffect.cpp
+++ b/src/spaceObjects/beamEffect.cpp
@@ -30,7 +30,7 @@ BeamEffect::BeamEffect()
     beam_fire_sound = "sfx/laser_fire.wav";
     beam_fire_sound_power = 1;
     fire_ring = true;
-    registerMemberReplication(&lifetime);
+    registerMemberReplication(&lifetime, 0.1);
     registerMemberReplication(&sourceId);
     registerMemberReplication(&target_id);
     registerMemberReplication(&sourceOffset);

--- a/src/spaceObjects/beamEffect.cpp
+++ b/src/spaceObjects/beamEffect.cpp
@@ -14,6 +14,7 @@ REGISTER_SCRIPT_SUBCLASS(BeamEffect, SpaceObject)
     REGISTER_SCRIPT_CLASS_FUNCTION(BeamEffect, setBeamFireSound);
     REGISTER_SCRIPT_CLASS_FUNCTION(BeamEffect, setBeamFireSoundPower);
     REGISTER_SCRIPT_CLASS_FUNCTION(BeamEffect, setDuration);
+    REGISTER_SCRIPT_CLASS_FUNCTION(BeamEffect, setRing);
 
 }
 
@@ -28,6 +29,7 @@ BeamEffect::BeamEffect()
     beam_texture = "beam_orange.png";
     beam_fire_sound = "sfx/laser_fire.wav";
     beam_fire_sound_power = 1;
+    fire_ring = true;
     registerMemberReplication(&sourceId);
     registerMemberReplication(&target_id);
     registerMemberReplication(&sourceOffset);
@@ -67,29 +69,32 @@ void BeamEffect::draw3DTransparent()
         glEnd();
     }
 
-    sf::Vector3f side = sf::cross(hitNormal, sf::Vector3f(0, 0, 1));
-    sf::Vector3f up = sf::cross(side, hitNormal);
+    if (fire_ring)
+    {
+        sf::Vector3f side = sf::cross(hitNormal, sf::Vector3f(0, 0, 1));
+        sf::Vector3f up = sf::cross(side, hitNormal);
 
-    sf::Vector3f v0(targetLocation.x, targetLocation.y, targetOffset.z);
+        sf::Vector3f v0(targetLocation.x, targetLocation.y, targetOffset.z);
 
-    float ring_size = Tween<float>::easeOutCubic(lifetime, 1.0, 0.0, 10.0f, 80.0f);
-    sf::Vector3f v1 = v0 + side * ring_size + up * ring_size;
-    sf::Vector3f v2 = v0 - side * ring_size + up * ring_size;
-    sf::Vector3f v3 = v0 - side * ring_size - up * ring_size;
-    sf::Vector3f v4 = v0 + side * ring_size - up * ring_size;
+        float ring_size = Tween<float>::easeOutCubic(lifetime, 1.0, 0.0, 10.0f, 80.0f);
+        sf::Vector3f v1 = v0 + side * ring_size + up * ring_size;
+        sf::Vector3f v2 = v0 - side * ring_size + up * ring_size;
+        sf::Vector3f v3 = v0 - side * ring_size - up * ring_size;
+        sf::Vector3f v4 = v0 + side * ring_size - up * ring_size;
 
-    ShaderManager::getShader("basicShader")->setUniform("textureMap", *textureManager.getTexture("fire_ring.png"));
-    sf::Shader::bind(ShaderManager::getShader("basicShader"));
-    glBegin(GL_QUADS);
-    glTexCoord2f(0, 0);
-    glVertex3f(v1.x, v1.y, v1.z);
-    glTexCoord2f(1, 0);
-    glVertex3f(v2.x, v2.y, v2.z);
-    glTexCoord2f(1, 1);
-    glVertex3f(v3.x, v3.y, v3.z);
-    glTexCoord2f(0, 1);
-    glVertex3f(v4.x, v4.y, v4.z);
-    glEnd();
+        ShaderManager::getShader("basicShader")->setUniform("textureMap", *textureManager.getTexture("fire_ring.png"));
+        sf::Shader::bind(ShaderManager::getShader("basicShader"));
+        glBegin(GL_QUADS);
+        glTexCoord2f(0, 0);
+        glVertex3f(v1.x, v1.y, v1.z);
+        glTexCoord2f(1, 0);
+        glVertex3f(v2.x, v2.y, v2.z);
+        glTexCoord2f(1, 1);
+        glVertex3f(v3.x, v3.y, v3.z);
+        glTexCoord2f(0, 1);
+        glVertex3f(v4.x, v4.y, v4.z);
+        glEnd();
+    }
 }
 #endif//FEATURE_3D_RENDERING
 

--- a/src/spaceObjects/beamEffect.h
+++ b/src/spaceObjects/beamEffect.h
@@ -13,6 +13,7 @@ class BeamEffect : public SpaceObject, public Updatable
     sf::Vector2f targetLocation;
     sf::Vector3f hitNormal;
 public:
+    bool fire_ring;
     string beam_texture;
     string beam_fire_sound;
     float beam_fire_sound_power;
@@ -34,6 +35,7 @@ public:
     void setBeamFireSoundPower(float power) {this->beam_fire_sound_power = power;}
     ///Control Duration of the beam. Default is 1 second
     void setDuration(float duration) {this->lifetime = duration;}
+    void setRing(bool ring) {this->fire_ring = ring;}
 };
 
 #endif//BEAM_EFFECT_H


### PR DESCRIPTION
This is basically a small addition to #686
The effect features are great, however, "setDuration" is not much useful, as bigger values also make the fire ring (much) bigger and therefore looking out of place.
That's why I added a new method "setRing", wich can turn the fire ring off. This will also create additional use cases for the beam effect, like tractor beams, communication beams, mining lasers, etc.