### PR TITLE
Custom captions for windowscreen via options.ini

### DIFF
--- a/src/menus/shipSelectionScreen.cpp
+++ b/src/menus/shipSelectionScreen.cpp
@@ -475,8 +475,8 @@ void ShipSelectionScreen::onReadyClick()
     }else if (window_button->getValue())
     {
         destroy();
-        uint8_t window_caption = PreferencesManager::get("ship_window_caption","1").toInt();
-        new WindowScreen(int(window_angle->getValue()), window_caption);
+        uint8_t window_flags = PreferencesManager::get("ship_window_flags","1").toInt();
+        new WindowScreen(int(window_angle->getValue()), window_flags);
     }else if(topdown_button->getValue())
     {
         my_player_info->commandSetShipId(-1);

--- a/src/menus/shipSelectionScreen.cpp
+++ b/src/menus/shipSelectionScreen.cpp
@@ -18,6 +18,7 @@
 #include "gui/gui2_slider.h"
 #include "gui/gui2_textentry.h"
 #include "gui/gui2_togglebutton.h"
+#include "preferenceManager.h"
 
 ShipSelectionScreen::ShipSelectionScreen()
 {
@@ -474,7 +475,8 @@ void ShipSelectionScreen::onReadyClick()
     }else if (window_button->getValue())
     {
         destroy();
-        new WindowScreen(int(window_angle->getValue()));
+        uint8_t window_caption = PreferencesManager::get("ship_window_caption","1").toInt();
+        new WindowScreen(int(window_angle->getValue()), window_caption);
     }else if(topdown_button->getValue())
     {
         my_player_info->commandSetShipId(-1);

--- a/src/preferenceManager.cpp
+++ b/src/preferenceManager.cpp
@@ -45,7 +45,7 @@ void PreferencesManager::save(string filename)
         fprintf(f, "# Empty Epsilon Settings\n# This file will be overwritten by EE.\n\n");
         fprintf(f, "# Include the following line to enable an experimental http server:\n# httpserver=8080\n\n");
         fprintf(f, "# For possible hotkey values check: http://www.sfml-dev.org/documentation/2.3.1/classsf_1_1Keyboard.php#acb4cacd7cc5802dec45724cf3314a142\n\n");
-        fprintf(f, "# Values for ship_window_caption are: spacedust:1, headings:2, callsigns:4 \n# Add them for any combination. Example: ship_window_caption=7 for all three\n\n");
+        fprintf(f, "# Values for ship_window_flags are: spacedust:1, headings:2, callsigns:4 \n# Add them for any combination. Example: ship_window_caption=7 for all three\n\n");
         std::vector<string> keys;
         for(std::unordered_map<string, string>::iterator i = preference.begin(); i != preference.end(); i++)
         {

--- a/src/preferenceManager.cpp
+++ b/src/preferenceManager.cpp
@@ -45,6 +45,7 @@ void PreferencesManager::save(string filename)
         fprintf(f, "# Empty Epsilon Settings\n# This file will be overwritten by EE.\n\n");
         fprintf(f, "# Include the following line to enable an experimental http server:\n# httpserver=8080\n\n");
         fprintf(f, "# For possible hotkey values check: http://www.sfml-dev.org/documentation/2.3.1/classsf_1_1Keyboard.php#acb4cacd7cc5802dec45724cf3314a142\n\n");
+        fprintf(f, "# Values for ship_window_caption are: spacedust:1, headings:2, callsigns:4 \n# Add them for any combination. Example: ship_window_caption=7 for all three\n\n");
         std::vector<string> keys;
         for(std::unordered_map<string, string>::iterator i = preference.begin(); i != preference.end(); i++)
         {

--- a/src/screens/windowScreen.cpp
+++ b/src/screens/windowScreen.cpp
@@ -8,11 +8,16 @@
 #include "screenComponents/indicatorOverlays.h"
 #include "screenComponents/shipDestroyedPopup.h"
 
-WindowScreen::WindowScreen(float angle)
+WindowScreen::WindowScreen(float angle, uint8_t caption)
 : angle(angle)
 {
     viewport = new GuiViewport3D(this, "VIEWPORT");
-    viewport->showSpacedust();
+    if (flag_callsigns & caption)
+      viewport->showCallsigns();
+    if (flag_headings & caption)
+      viewport->showHeadings();
+    if (flag_spacedust & caption)
+      viewport-> showSpacedust();
     viewport->setPosition(0, 0, ATopLeft)->setSize(GuiElement::GuiSizeMax, GuiElement::GuiSizeMax);
 
     new GuiShipDestroyedPopup(this);

--- a/src/screens/windowScreen.cpp
+++ b/src/screens/windowScreen.cpp
@@ -8,16 +8,16 @@
 #include "screenComponents/indicatorOverlays.h"
 #include "screenComponents/shipDestroyedPopup.h"
 
-WindowScreen::WindowScreen(float angle, uint8_t caption)
+WindowScreen::WindowScreen(float angle, uint8_t flags)
 : angle(angle)
 {
     viewport = new GuiViewport3D(this, "VIEWPORT");
-    if (flag_callsigns & caption)
+    if (flags & flag_callsigns)
       viewport->showCallsigns();
-    if (flag_headings & caption)
+    if (flags & flag_headings)
       viewport->showHeadings();
-    if (flag_spacedust & caption)
-      viewport-> showSpacedust();
+    if (flags & flag_spacedust)
+      viewport->showSpacedust();
     viewport->setPosition(0, 0, ATopLeft)->setSize(GuiElement::GuiSizeMax, GuiElement::GuiSizeMax);
 
     new GuiShipDestroyedPopup(this);

--- a/src/screens/windowScreen.h
+++ b/src/screens/windowScreen.h
@@ -12,11 +12,16 @@ private:
     GuiViewport3D* viewport;
     float angle;
 public:
-    WindowScreen(float angle);
+    WindowScreen(float angle, uint8_t caption = 0x00);
     
     virtual void update(float delta) override;
 
     virtual void onKey(sf::Event::KeyEvent key, int unicode) override;
+    
+    constexpr static uint8_t flag_callsigns = 0x04;
+    constexpr static uint8_t flag_headings  = 0x02;
+    constexpr static uint8_t flag_spacedust = 0x01;
+    
 };
 
 #endif//WINDOW_SCREEN_H

--- a/src/screens/windowScreen.h
+++ b/src/screens/windowScreen.h
@@ -12,7 +12,7 @@ private:
     GuiViewport3D* viewport;
     float angle;
 public:
-    WindowScreen(float angle, uint8_t caption = 0x00);
+    WindowScreen(float angle, uint8_t flags = 0x01);
     
     virtual void update(float delta) override;
 


### PR DESCRIPTION
This is a compromise between #617  and #621,  
It turned out that for some scenarios, a window screen with callsigns and headings is needed. For example, @PlanetariumWSD uses it to have multiple angled ship windows to combine into a huge first-person mainscreen that is projected onto a planetarium dome.
This PR is much simpler than #617 and uses an options.ini value instead of a menu.