### PR TITLE
Issue #624 - Remember last connection

### DIFF
--- a/src/menus/joinServerMenu.cpp
+++ b/src/menus/joinServerMenu.cpp
@@ -3,6 +3,7 @@
 #include "menus/joinServerMenu.h"
 #include "menus/serverBrowseMenu.h"
 #include "playerInfo.h"
+#include "preferenceManager.h"
 #include "gameGlobalInfo.h"
 #include "gui/gui2_label.h"
 #include "gui/gui2_panel.h"
@@ -61,6 +62,7 @@ void JoinServerScreen::update(float delta)
         new ServerBrowserMenu(this->source);
         break;
     case GameClient::Connected:
+        PreferencesManager::set("last_server", this->ip.toString());
         if (game_client->getClientId() > 0)
         {
             foreach(PlayerInfo, i, player_info_list)

--- a/src/menus/serverBrowseMenu.cpp
+++ b/src/menus/serverBrowseMenu.cpp
@@ -1,6 +1,7 @@
 #include "main.h"
 #include "serverBrowseMenu.h"
 #include "joinServerMenu.h"
+#include "preferenceManager.h"
 
 #include "gui/gui2_overlay.h"
 #include "gui/gui2_button.h"
@@ -44,10 +45,13 @@ ServerBrowserMenu::ServerBrowserMenu(SearchSource source)
         new JoinServerScreen(lan_internet_selector->getSelectionIndex() == 0 ? Local : Internet, sf::IpAddress(text));
         destroy();
     });
-    
     server_list = new GuiListbox(this, "SERVERS", [this](int index, string value) {
         manual_ip->setText(value);
     });
+    if (PreferencesManager::get("last_server", "") != "") {
+        server_list->addEntry("Last Session (" + PreferencesManager::get("last_server", "")  + ")",
+            PreferencesManager::get("last_server", ""));
+    }
     scanner->addCallbacks([this](sf::IpAddress address, string name) {
         //New server found
         server_list->addEntry(name + " (" + address.toString() + ")", address.toString());


### PR DESCRIPTION
In the event of rejoining a server, or getting disconnected, this will pre-populate one of the servers in the list with the last server you connected to. I didn't add a check to see if the server is still valid, just cache the IP.