### PR TITLE
Issue 629 - Don't timeout connections while waiting for auth

### DIFF
--- a/src/menus/joinServerMenu.cpp
+++ b/src/menus/joinServerMenu.cpp
@@ -14,7 +14,7 @@ JoinServerScreen::JoinServerScreen(ServerBrowserMenu::SearchSource source, sf::I
 : ip(ip)
 {
     this->source = source;
-    
+
     status_label = new GuiLabel(this, "STATUS", "Connecting...", 30);
     status_label->setPosition(0, 300, ATopCenter)->setSize(0, 50);
     (new GuiButton(this, "BTN_CANCEL", "Cancel", [this]() {
@@ -22,7 +22,7 @@ JoinServerScreen::JoinServerScreen(ServerBrowserMenu::SearchSource source, sf::I
         disconnectFromServer();
         new ServerBrowserMenu(this->source);
     }))->setPosition(50, -50, ABottomLeft)->setSize(300, 50);
-    
+
     password_entry_box = new GuiPanel(this, "PASSWORD_ENTRY_BOX");
     password_entry_box->setPosition(0, 350, ATopCenter)->setSize(600, 100);
     password_entry_box->hide();
@@ -48,6 +48,10 @@ void JoinServerScreen::update(float delta)
         //If we are still trying to connect, do nothing.
         break;
     case GameClient::WaitingForPassword:
+        if (keep_alive_timer.getElapsedTime().asSeconds() > 10) {
+            keep_alive_timer.restart();
+            game_client->keepAlive();
+        }
         status_label->setText("Please enter the server password:");
         password_entry_box->show();
         if (!password_focused)

--- a/src/menus/joinServerMenu.h
+++ b/src/menus/joinServerMenu.h
@@ -15,6 +15,7 @@ class JoinServerScreen : public GuiCanvas, public Updatable
     GuiPanel* password_entry_box;
     GuiTextEntry* password_entry;
     bool password_focused = false;
+    sf::Clock keep_alive_timer;
     
     ServerBrowserMenu::SearchSource source;
 public:


### PR DESCRIPTION
Previously, during server auth, there are no packets sent back and forth between the client and server, which causes the client to timeout after 20 seconds (assuming this is in case the server has shutdown/crashed/etc). As reported in issue 629, this may not be long enough. So combined with https://github.com/daid/SeriousProton/pull/37, this will send keep alives to the server (which will re-request auth) to ensure the connection stays alive. This implementation has the client act as the initiator of the keep alive, not the server. This prevents adding extra load to the server.