### PR TITLE
Remove deprecated sf::Text::setColor calls

### DIFF
--- a/src/gui/debugRenderer.cpp
+++ b/src/gui/debugRenderer.cpp
@@ -80,10 +80,14 @@ void DebugRenderer::render(sf::RenderTarget& window)
         text_server_update.setPosition(0, window.getView().getSize().y - 18 * 3 - 170);
         text_collision.setPosition(0, window.getView().getSize().y - 18 * 2 - 170);
         text_render.setPosition(0, window.getView().getSize().y - 18 - 170);
-        text_update.setColor(sf::Color::Red);
-        text_server_update.setColor(sf::Color::Yellow);
-        text_collision.setColor(sf::Color::Cyan);
-        text_render.setColor(sf::Color::Green);
+        text_update.setFillColor(sf::Color::Red);
+        text_update.setOutlineColor(sf::Color::Red);
+        text_server_update.setFillColor(sf::Color::Yellow);
+        text_server_update.setOutlineColor(sf::Color::Yellow);
+        text_collision.setFillColor(sf::Color::Cyan);
+        text_collision.setOutlineColor(sf::Color::Cyan);
+        text_render.setFillColor(sf::Color::Green);
+        text_render.setOutlineColor(sf::Color::Green);
         window.draw(text_update);
         window.draw(text_server_update);
         window.draw(text_collision);

--- a/src/gui/gui2_element.cpp
+++ b/src/gui/gui2_element.cpp
@@ -375,7 +375,8 @@ void GuiElement::drawText(sf::RenderTarget& window, sf::FloatRect rect, string t
         break;
     }
     textElement.setPosition(x, y);
-    textElement.setColor(color);
+    textElement.setOutlineColor(color);
+    textElement.setFillColor(color);
     window.draw(textElement);
 }
 
@@ -405,7 +406,8 @@ void GuiElement::drawVerticalText(sf::RenderTarget& window, sf::FloatRect rect, 
         break;
     }
     textElement.setPosition(x, y);
-    textElement.setColor(color);
+    textElement.setOutlineColor(color);
+    textElement.setFillColor(color);
     window.draw(textElement);
 }
 

--- a/src/gui/scriptError.cpp
+++ b/src/gui/scriptError.cpp
@@ -19,7 +19,8 @@ void ScriptErrorRenderer::render(sf::RenderTarget& window)
     if (error != "")
     {
         sf::Text textElement(error, *bold_font, 25);
-        textElement.setColor(sf::Color::Red);
+        textElement.setOutlineColor(sf::Color::Red);
+        textElement.setFillColor(sf::Color::Red);
         textElement.setPosition(0, 0);
         window.draw(textElement);
     }

--- a/src/screenComponents/alertOverlay.cpp
+++ b/src/screenComponents/alertOverlay.cpp
@@ -39,7 +39,8 @@ void AlertLevelOverlay::onDraw(sf::RenderTarget& window)
     alert.setPosition(window.getView().getSize() / 2.0f);
     window.draw(alert);
     sf::Text alert_text(text, *main_font, text_size);
-    alert_text.setColor(color);
+    alert_text.setFillColor(color);
+    alert_text.setOutlineColor(color);
     alert_text.setOrigin(sf::Vector2f(alert_text.getLocalBounds().width / 2.0f, alert_text.getLocalBounds().height / 2.0f + alert_text.getLocalBounds().top));
     alert_text.setPosition(window.getView().getSize() / 2.0f - sf::Vector2f(0, 300));
     window.draw(alert_text);

--- a/src/spaceObjects/zone.cpp
+++ b/src/spaceObjects/zone.cpp
@@ -62,7 +62,8 @@ void Zone::drawOnRadar(sf::RenderTarget& window, sf::Vector2f position, float sc
         float y = position.y - font_size + font_size * 0.35;
 
         text_element.setPosition(x, y);
-        text_element.setColor(sf::Color(color.r, color.g, color.b, 128));
+        text_element.setFillColor(sf::Color(color.r, color.g, color.b, 128));
+        text_element.setOutlineColor(sf::Color(color.r, color.g, color.b, 128));
         window.draw(text_element);
     }
 }


### PR DESCRIPTION
[sf::Text::setColor](https://www.sfml-dev.org/documentation/2.5.0/classsf_1_1Text.php#afd1742fca1adb6b0ea98357250ffb634) was deprecated and causes compilation warnings (not failures). This replaces calls setFillColor and setOutlineColor instead to avoid the warnings

This seemed like the sanest approach, but it does duplicate lines, so I'm miffed. Figured I'd open as draft to get ideas.