### PR TITLE
Update Borderline Fever Scenario

### DIFF
--- a/scripts/scenario_59_border.lua
+++ b/scripts/scenario_59_border.lua
@@ -1,19 +1,17 @@
 -- Name: Borderline Fever
 -- Description: War temperature rises along the border between Human Navy space and Kraylor space. The treaty holds for now, but the diplomats and intelligence operatives fear the Kraylors are about to break the treaty. We must maintain the treaty despite provocation until war is formally declared.
 ---
---- Version 0
+--- Version 2 updated to take advantage of some recently released features such as coolant adjustments and friendlier custom info widgets
 -- Type: Replayable Mission
 -- Variation[Easy]: Easy goals and/or enemies
 -- Variation[Hard]: Hard goals and/or enemies
--- Variation[Timed]: Victory if all human navy stations and player ships survive for 30 minutes
--- Variation[Timed Easy]: Victory if all human navy stations and player ships survive for 30 minutes, Easy goals and/or enemies
--- Variation[Timed Hard]: Victory if all human navy stations and player ships survive for 30 minutes, Hard goals and/or enemies
-
+-- Variation[Timed]: Victory if some human navy stations and player ships survive for 30 minutes
+-- Variation[Timed Easy]: Victory if some human navy stations and player ships survive for 30 minutes, Easy goals and/or enemies
+-- Variation[Timed Hard]: Victory if some human navy stations and player ships survive for 30 minutes, Hard goals and/or enemies
 
 -- to do items:
 
 -- Station warning of enemies in area (helpful warnings - shuffle stations)
--- Kraylor ship names for freighters and warships; Human navy ship names for freighters and warships
 
 require("utils.lua")
 
@@ -25,6 +23,8 @@ function init()
 	defaultGameTimeLimitInMinutes = 30	--final: 30 (lowered for test)
 	rawKraylorShipStrength = 0
 	rawHumanShipStrength = 0
+	prefix_length = 0
+	suffix_index = 0
 	--These random range values are in seconds, not minutes
 	--Place in variables to facilitate testing and tinkering
 	--random range 1 final: 120, 300 (lowered for test) initial attack, pincer attack, vengence
@@ -59,32 +59,36 @@ function init()
 	setVariations()
 	initDiagnostic = false
 	diagnostic = false
+	muckDiagnostic = false
+	stationCommsDiagnostic = false
+	shipCommsDiagnostic = false
 	optionalMissionDiagnostic = false
-	paDiagnostic = true
+	paDiagnostic = false
 	plot3diagnostic = false
 	plot1Diagnostic = false
 	updateDiagnostic = false
 	healthDiagnostic = false
 	plot2diagnostic = false
-	endStatDiagnostic = true
+	endStatDiagnostic = false
 	printDetailedStats = true
 	setConstants()	--missle type names, template names and scores, deployment directions, player ship names, etc.
 	repeat
 		setGossipSnippets()
-		setGoodsList()
 		setListOfStations()
-		setBorderZones()
-		buildStationsPlus()
+		setBorderZones()	--establish neutral border zone and other zones
+		buildStationsPlus()	--put stations and other things in and out of the neutral border zone
 		if initDiagnostic then print("weird zone adjustment count: " .. wzac) end
+		--be sure initial spawn point (0,0) is inside the inner zone defining human territory
 		spawnInInnerZone = false
 		spawnMarker = VisualAsteroid():setPosition(0,0)
 		spawnInInnerZone = innerZone:isInside(spawnMarker)
 		spawnMarker:destroy()
+		--be sure each side has at least a minimal number of stations
 		if wzac > 0 or #kraylorStationList < 5 or #humanStationList < 5 or not spawnInInnerZone then
 			resetStationsPlus()
 		end
 	until(wzac < 1 and #kraylorStationList >= 5 and #humanStationList >= 5 and spawnInInnerZone)
-	if not diagnostic then
+	if not diagnostic then	--get rid of temporary set up zones
 		for i=1,#innerZoneList do
 			innerZoneList[i]:destroy()
 		end
@@ -92,22 +96,24 @@ function init()
 			outerZoneList[i]:destroy()
 		end
 	end
-	setFleets()
-	setEnemyStationDefenses()
-	setOptionalMissions()
-	setCharacterNames()
-	plot1 = treatyHolds
+	setFleets()						--give each side some ships
+	setEnemyStationDefenses()		--give enemy stations defensive mechanisms
+	setOptionalMissions()			--scatter upgrade missions around the stations
+	setCharacterNames()				--add decoy character names to stations
+	plot1 = treatyHolds				--start main plot with the treaty in place
 	treaty = true
 	initialAssetsEvaluated = false
-	plotC = autoCoolant		--enable buttons for turning on and off automated cooling
-	plotCI = cargoInventory
-	plotH = healthCheck		--Damage to ship can kill repair crew members
+	plotC = autoCoolant				--enable buttons for turning on and off automated cooling
+	plotCI = cargoInventory			--manage button on relay/operations to show cargo inventory
+	plotH = healthCheck				--Damage to ship can kill repair crew members
 	healthCheckTimer = 5
 	healthCheckTimerInterval = 5
-	plotPB = playerBorderCheck
-	plotPWC = playerWarCrimeCheck
-	plotED = enemyDefenseCheck
+	plotPB = playerBorderCheck		--monitor players positions relative to neutral border zone
+	plotPWC = playerWarCrimeCheck	--be sure players do not commit war crimes
+	plotED = enemyDefenseCheck		
 	plotEB = enemyBorderCheck
+	plotER = enemyReinforcements
+	plotMF = muckAndFlies
 	enemyEverDetected = false
 	enemyBorderCheckInterval = 3
 	enemyBorderCheckTimer = enemyBorderCheckInterval
@@ -125,6 +131,7 @@ function init()
 	endWarTimer = endWarTimerInterval
 	plotDGM = dynamicGameMasterButtons
 	plotPA = personalAmbush
+	plotCN = coolantNebulae
 	enemyVesselDestroyedNameList = {}
 	enemyVesselDestroyedType = {}
 	enemyVesselDestroyedValue = {}
@@ -140,23 +147,37 @@ function init()
 	primaryOrders = ""
 	secondaryOrders = ""
 	optionalOrders = ""
+	addGMFunction("Narsil",createPlayerShipNarsil)
+	addGMFunction("Headhunter",createPlayerShipHeadhunter)
+	addGMFunction("Blazon",createPlayerShipBlazon)
+	addGMFunction("Sting",createPlayerShipSting)
+	addGMFunction("Spyder",createPlayerShipSpyder)
 end
 function setVariations()
 	if string.find(getScenarioVariation(),"Easy") then
 		difficulty = .5
 		adverseEffect = .999
+		coolant_loss = .99999
+		coolant_gain = .01
+		ersAdj = 10
 		enemyDestructionVictoryCondition = enemyDestructionVictoryCondition*1.1
 		friendlyDestructionDefeatCondition = friendlyDestructionDefeatCondition*.9
 		destructionDifferenceEndCondition = destructionDifferenceEndCondition*1.1
 	elseif string.find(getScenarioVariation(),"Hard") then
 		difficulty = 2
 		adverseEffect = .99
+		coolant_loss = .9999
+		coolant_gain = .0001
+		ersAdj = -5
 		enemyDestructionVictoryCondition = enemyDestructionVictoryCondition*.9
 		friendlyDestructionDefeatCondition = friendlyDestructionDefeatCondition*1.1
 		destructionDifferenceEndCondition = destructionDifferenceEndCondition*.9
 	else
 		difficulty = 1		--default (normal)
 		adverseEffect = .995
+		coolant_loss = .99995
+		coolant_gain = .001
+		ersAdj = 0
 	end
 	if string.find(getScenarioVariation(),"Timed") then
 		playWithTimeLimit = true
@@ -167,6 +188,144 @@ function setVariations()
 		playWithTimeLimit = false
 	end
 end
+--      New player ship types via GM button
+function createPlayerShipNarsil()
+	playerNarsil = PlayerSpaceship():setTemplate("Atlantis"):setFaction("Human Navy"):setCallSign("Narsil")
+	playerNarsil:setTypeName("Proto-Atlantis")
+	playerNarsil:setRepairCrewCount(4)					--more repair crew (vs 3)
+	playerNarsil:setImpulseMaxSpeed(70)					--slower impulse max (vs 90)
+	playerNarsil:setRotationMaxSpeed(14)				--faster spin (vs 10)
+	playerNarsil:setJumpDrive(false)					--no Jump
+	playerNarsil:setWarpDrive(true)						--add warp
+	playerNarsil:setHullMax(200)						--weaker hull (vs 250)
+	playerNarsil:setHull(200)							
+	playerNarsil:setShieldsMax(150,150)					--weaker shields (vs 200)
+	playerNarsil:setShields(150,150)
+	playerNarsil:setWeaponTubeCount(6)					--one more forward tube, less flexible ordnance
+	playerNarsil:setWeaponTubeDirection(0,0)			--front facing
+	playerNarsil:setWeaponTubeExclusiveFor(0,"HVLI")	--HVLI only
+	playerNarsil:setWeaponTubeDirection(1,-90)			--left facing
+	playerNarsil:weaponTubeDisallowMissle(1,"Mine")		--all but mine
+	playerNarsil:setWeaponTubeDirection(2,-90)			--left facing
+	playerNarsil:setWeaponTubeExclusiveFor(2,"HVLI")	--HVLI only
+	playerNarsil:setWeaponTubeDirection(3,90)			--right facing
+	playerNarsil:weaponTubeDisallowMissle(3,"Mine")		--all but mine
+	playerNarsil:setWeaponTubeDirection(4,90)			--right facing
+	playerNarsil:setWeaponTubeExclusiveFor(4,"HVLI")	--HVLI only
+	playerNarsil:setWeaponTubeDirection(5,180)			--rear facing
+	playerNarsil:setWeaponTubeExclusiveFor(5,"Mine")	--Mine only
+	playerNarsil:addReputationPoints(50)
+	removeGMFunction("Narsil")
+end
+function createPlayerShipHeadhunter()
+	playerHeadhunter = PlayerSpaceship():setTemplate("Piranha"):setFaction("Human Navy"):setCallSign("Headhunter")
+	playerHeadhunter:setTypeName("Redhook")
+	playerHeadhunter:setRepairCrewCount(4)						--more repair crew (vs 2)
+	playerHeadhunter:setJumpDriveRange(2000,25000)				--shorter jump drive range (vs 5-50)
+	playerHeadhunter:setHullMax(140)							--stronger hull (vs 120)
+	playerHeadhunter:setHull(140)
+	playerHeadhunter:setShieldsMax(100, 100)					--stronger shields (vs 70, 70)
+	playerHeadhunter:setShields(100, 100)
+	playerHeadhunter:setBeamWeapon(0, 10, 0, 1200.0, 4.0, 4)	--one beam (vs 0)
+	playerHeadhunter:setBeamWeaponTurret(0, 80, 0, 1)			--slow turret 
+	playerHeadhunter:setWeaponTubeCount(7)						--one fewer mine tube, but EMPs added
+	playerHeadhunter:setWeaponTubeDirection(6, 180)				--mine tube points straight back
+	playerHeadhunter:setWeaponTubeExclusiveFor(0,"HVLI")
+	playerHeadhunter:setWeaponTubeExclusiveFor(1,"HVLI")
+	playerHeadhunter:setWeaponTubeExclusiveFor(2,"HVLI")
+	playerHeadhunter:setWeaponTubeExclusiveFor(3,"HVLI")
+	playerHeadhunter:setWeaponTubeExclusiveFor(4,"HVLI")
+	playerHeadhunter:setWeaponTubeExclusiveFor(5,"HVLI")
+	playerHeadhunter:setWeaponTubeExclusiveFor(6,"Mine")
+	playerHeadhunter:weaponTubeAllowMissle(1,"Homing")
+	playerHeadhunter:weaponTubeAllowMissle(1,"EMP")
+	playerHeadhunter:weaponTubeAllowMissle(1,"Nuke")
+	playerHeadhunter:weaponTubeAllowMissle(4,"Homing")
+	playerHeadhunter:weaponTubeAllowMissle(4,"EMP")
+	playerHeadhunter:weaponTubeAllowMissle(4,"Nuke")
+	playerHeadhunter:setWeaponStorageMax("Mine",4)				--fewer mines (vs 8)
+	playerHeadhunter:setWeaponStorage("Mine", 4)				
+	playerHeadhunter:setWeaponStorageMax("EMP",4)				--more EMPs (vs 0)
+	playerHeadhunter:setWeaponStorage("EMP", 4)					
+	playerHeadhunter:setWeaponStorageMax("Nuke",4)				--fewer Nukes (vs 6)
+	playerHeadhunter:setWeaponStorage("Nuke", 4)				
+	playerHeadhunter:addReputationPoints(50)
+	removeGMFunction("Headhunter")
+end
+function createPlayerShipBlazon()
+	playerBlazon = PlayerSpaceship():setTemplate("Striker"):setFaction("Human Navy"):setCallSign("Blazon")
+	playerBlazon:setTypeName("Stricken")
+	playerBlazon:setRepairCrewCount(2)				
+	playerBlazon:setImpulseMaxSpeed(105)			--vs 45		
+	playerBlazon:setRotationMaxSpeed(35)			--vs 15
+	playerBlazon:setShieldsMax(80,50)				--vs 50,30
+	playerBlazon:setShields(80,50)
+	playerBlazon:setBeamWeaponTurret(0,60,-15,2)	--vs arc width of 100 & turret speed of 6
+	playerBlazon:setBeamWeaponTurret(1,60, 15,2)
+	playerBlazon:setBeamWeapon(2,20,0,1200,6,5)		--vs only 2 turret beams (this is a 3rd beam)
+	playerBlazon:setWeaponTubeCount(3)				--vs no tubes
+	playerBlazon:setWeaponTubeDirection(0,-60)
+	playerBlazon:setWeaponTubeDirection(1,60)
+	playerBlazon:setWeaponTubeDirection(2,180)
+	playerBlazon:weaponTubeDisallowMissle(0,"Mine")
+	playerBlazon:weaponTubeDisallowMissle(1,"Mine")
+	playerBlazon:setWeaponTubeExclusiveFor(2,"Mine")
+	playerBlazon:setWeaponStorageMax("Homing",6)
+	playerBlazon:setWeaponStorage("Homing",6)
+	playerBlazon:setWeaponStorageMax("EMP",2)
+	playerBlazon:setWeaponStorage("EMP",2)
+	playerBlazon:setWeaponStorageMax("Nuke",2)
+	playerBlazon:setWeaponStorage("Nuke",2)
+	playerBlazon:setWeaponStorageMax("Mine",4)
+	playerBlazon:setWeaponStorage("Mine",4)
+	playerBlazon:addReputationPoints(50)
+	removeGMFunction("Blazon")
+end
+function createPlayerShipSting()
+	playerSting = PlayerSpaceship():setTemplate("Hathcock"):setFaction("Human Navy"):setCallSign("Sting")
+	playerSting:setTypeName("Surkov")
+	playerSting:setRepairCrewCount(3)	--more repair crew (vs 2)
+	playerSting:setImpulseMaxSpeed(60)	--faster impulse max (vs 50)
+	playerSting:setJumpDrive(false)		--no jump
+	playerSting:setWarpDrive(true)		--add warp
+	playerSting:setWeaponTubeCount(3)	--one more tube for mines, no heavy ordnance
+	playerSting:setWeaponTubeDirection(0, -90)
+	playerSting:weaponTubeDisallowMissle(0,"Mine")
+	playerSting:weaponTubeDisallowMissle(0,"Nuke")
+	playerSting:weaponTubeDisallowMissle(0,"EMP")
+	playerSting:setWeaponStorageMax("Mine",3)
+	playerSting:setWeaponStorage("Mine",3)
+	playerSting:setWeaponStorageMax("Nuke",0)
+	playerSting:setWeaponStorage("Nuke",0)
+	playerSting:setWeaponStorageMax("EMP",0)
+	playerSting:setWeaponStorage("EMP",0)
+	playerSting:setWeaponTubeDirection(1, 90)
+	playerSting:weaponTubeDisallowMissle(1,"Mine")
+	playerSting:weaponTubeDisallowMissle(1,"Nuke")
+	playerSting:weaponTubeDisallowMissle(1,"EMP")
+	playerSting:setWeaponTubeDirection(2,180)
+	playerSting:setWeaponTubeExclusiveFor(2,"Mine")
+	playerSting:addReputationPoints(50)
+	removeGMFunction("Sting")
+end
+function createPlayerShipSpyder()
+	playerSpyder = PlayerSpaceship():setTemplate("Atlantis"):setFaction("Human Navy"):setCallSign("Spyder")
+	playerSpyder:setTypeName("Atlantis II")
+	playerSpyder:setRepairCrewCount(4)					--more repair crew (vs 3)
+	playerSpyder:setImpulseMaxSpeed(80)					--slower impulse max (vs 90)
+	playerSpyder:setWeaponTubeCount(6)					--one more tube
+	playerSpyder:setWeaponTubeDirection(5,0)			--front facing
+	playerSpyder:weaponTubeDisallowMissle(5,"Mine")		--no Mine
+	playerSpyder:weaponTubeDisallowMissle(5,"EMP")		--no EMP
+	playerSpyder:weaponTubeDisallowMissle(5,"Nuke")		--no Nuke
+	playerSpyder:setWeaponTubeDirection(0,-60)			--left front facing
+	playerSpyder:setWeaponTubeDirection(1,-120)			--left rear facing
+	playerSpyder:setWeaponTubeDirection(2,60)			--right front facing
+	playerSpyder:setWeaponTubeDirection(3,120)			--right rear facing
+	playerSpyder:addReputationPoints(50)
+	removeGMFunction("Spyder")
+end
+
 function setConstants()
 	missile_types = {'Homing', 'Nuke', 'Mine', 'EMP', 'HVLI'}
 	--Ship Template Name List
@@ -174,11 +333,57 @@ function setConstants()
 	--Ship Template Score List
 	stsl = {5            ,5            ,7          ,6          ,7            ,8          ,15         ,16         ,15          ,15           ,25       ,20           ,25          ,25          ,50            ,70             ,250   ,6        ,18       ,14               ,30          ,27            ,80           ,100            ,65               ,6                ,45               ,40              ,4              ,48              ,8              ,50                 ,22}
 	-- square grid deployment
-	fleetPosDelta1x = {0,1,0,-1, 0,1,-1, 1,-1,2,0,-2, 0,2,-2, 2,-2,2, 2,-2,-2,1,-1, 1,-1}
-	fleetPosDelta1y = {0,0,1, 0,-1,1,-1,-1, 1,0,2, 0,-2,2,-2,-2, 2,1,-1, 1,-1,2, 2,-2,-2}
+	fleetPosDelta1x = {0,1,0,-1, 0,1,-1, 1,-1,2,0,-2, 0,2,-2, 2,-2,2, 2,-2,-2,1,-1, 1,-1,0, 0,3,-3,1, 1,3,-3,-1,-1, 3,-3,2, 2,3,-3,-2,-2, 3,-3,3, 3,-3,-3,4,0,-4, 0,4,-4, 4,-4,-4,-4,-4,-4,-4,-4,4, 4,4, 4,4, 4, 1,-1, 2,-2, 3,-3,1,-1,2,-2,3,-3,5,-5,0, 0,5, 5,-5,-5,-5,-5,-5,-5,-5,-5,-5,-5,5, 5,5, 5,5, 5,5, 5, 1,-1, 2,-2, 3,-3, 4,-4,1,-1,2,-2,3,-3,4,-4}
+	fleetPosDelta1y = {0,0,1, 0,-1,1,-1,-1, 1,0,2, 0,-2,2,-2,-2, 2,1,-1, 1,-1,2, 2,-2,-2,3,-3,0, 0,3,-3,1, 1, 3,-3,-1,-1,3,-3,2, 2, 3,-3,-2,-2,3,-3, 3,-3,0,4, 0,-4,4,-4,-4, 4, 1,-1, 2,-2, 3,-3,1,-1,2,-2,3,-3,-4,-4,-4,-4,-4,-4,4, 4,4, 4,4, 4,0, 0,5,-5,5,-5, 5,-5, 1,-1, 2,-2, 3,-3, 4,-4,1,-1,2,-2,3,-3,4,-4,-5,-5,-5,-5,-5,-5,-5,-5,5, 5,5, 5,5, 5,5, 5}
 	-- rough hexagonal deployment
-	fleetPosDelta2x = {0,2,-2,1,-1, 1, 1,4,-4,0, 0,2,-2,-2, 2,3,-3, 3,-3,6,-6,1,-1, 1,-1,3,-3, 3,-3,4,-4, 4,-4,5,-5, 5,-5}
-	fleetPosDelta2y = {0,0, 0,1, 1,-1,-1,0, 0,2,-2,2,-2, 2,-2,1,-1,-1, 1,0, 0,3, 3,-3,-3,3,-3,-3, 3,2,-2,-2, 2,1,-1,-1, 1}
+	fleetPosDelta2x = {0,2,-2,1,-1, 1,-1,4,-4,0, 0,2,-2,-2, 2,3,-3, 3,-3,6,-6,1,-1, 1,-1,3,-3, 3,-3,4,-4, 4,-4,5,-5, 5,-5,8,-8,4,-4, 4,-4,5,5 ,-5,-5,2, 2,-2,-2,0, 0,6, 6,-6,-6,7, 7,-7,-7,10,-10,5, 5,-5,-5,6, 6,-6,-6,7, 7,-7,-7,8, 8,-8,-8,9, 9,-9,-9,3, 3,-3,-3,1, 1,-1,-1,12,-12,6,-6, 6,-6,7,-7, 7,-7,8,-8, 8,-8,9,-9, 9,-9,10,-10,10,-10,11,-11,11,-11,4,-4, 4,-4,2,-2, 2,-2,0, 0}
+	fleetPosDelta2y = {0,0, 0,1, 1,-1,-1,0, 0,2,-2,2,-2, 2,-2,1,-1,-1, 1,0, 0,3, 3,-3,-3,3,-3,-3, 3,2,-2,-2, 2,1,-1,-1, 1,0, 0,4,-4,-4, 4,3,-3, 3,-3,4,-4, 4,-4,4,-4,2,-2, 2,-2,1,-1, 1,-1, 0,  0,5,-5, 5,-5,4,-4, 4,-4,3,-3, 3,-7,2,-2, 2,-2,1,-1, 1,-1,5,-5, 5,-5,5,-5, 5,-5, 0,  0,6, 6,-6,-6,5, 5,-5,-5,4, 4,-4,-4,3, 3,-3,-3, 2,  2,-2, -2, 1,  1,-1, -1,6, 6,-6,-6,6, 6,-6,-6,6,-6}
+	--						Template, 					strength
+	playerShipStrength = {	["MP52 Hornet"] =			7,
+							["Piranha"] = 				16,
+							["Flavia P.Falcon"] =		13,
+							["Phobos M3P"] =			19,
+							["Atlantis"] =				52,
+							["Player Cruiser"] =		40,
+							["Player Missile Cr."] =	45,
+							["Player Fighter"] =		7,
+							["Benedict"] =				10,
+							["Kiriya"] =				10,
+							["Striker"] =				8,
+							["ZX-Lindworm"] =			8,
+							["Repulse"] =				14,
+							["Ender"] =					100,
+							["Nautilus"] =				12,
+							["Hathcock"] =				30,
+							["Maverick"] =				45,
+							["Proto-Atlantis"] =		40,
+							["Surkov"] =				35,
+							["Stricken"] =				40,
+							["Atlantis II"] =			60,
+							["Redhook"] =				18	}
+	--						Template				maximum cargo space
+	playerShipCargo = 	{	["MP52 Hornet"] =			3,
+							["Piranha"] = 				8,
+							["Flavia P.Falcon"] =		15,
+							["Phobos M3P"] =			10,
+							["Atlantis"] =				6,
+							["Player Cruiser"] =		6,
+							["Player Missile Cr."] =	8,
+							["Player Fighter"] =		3,
+							["Benedict"] =				9,
+							["Kiriya"] =				9,
+							["Striker"] =				4,
+							["ZX-Lindworm"] =			3,
+							["Repulse"] =				12,
+							["Ender"] =					20,
+							["Nautilus"] =				7,
+							["Hathcock"] =				6,
+							["Maverick"] =				5,
+							["Proto-Atlantis"] =		4,
+							["Surkov"] =				6,
+							["Stricken"] =				4,
+							["Atlantis II"] =			5,
+							["Redhook"] =				8	}
 	--Player ship name lists to supplant standard randomized call sign generation
 	playerShipNamesForMP52Hornet = {"Dragonfly","Scarab","Mantis","Yellow Jacket","Jimminy","Flik","Thorny","Buzz"}
 	playerShipNamesForPiranha = {"Razor","Biter","Ripper","Voracious","Carnivorous","Characid","Vulture","Predator"}
@@ -196,7 +401,15 @@ function setConstants()
 	playerShipNamesForEnder = {"Mongo","Godzilla","Leviathan","Kraken","Jupiter","Saturn"}
 	playerShipNamesForNautilus = {"October", "Abdiel", "Manxman", "Newcon", "Nusret", "Pluton", "Amiral", "Amur", "Heinkel", "Dornier"}
 	playerShipNamesForHathcock = {"Hayha", "Waldron", "Plunkett", "Mawhinney", "Furlong", "Zaytsev", "Pavlichenko", "Pegahmagabow", "Fett", "Hawkeye", "Hanzo"}
+	playerShipNamesForProtoAtlantis = {"Narsil", "Blade", "Decapitator", "Trisect", "Sabre"}
+	playerShipNamesForSurkov = {"Sting", "Sneak", "Bingo", "Thrill", "Vivisect"}
+	playerShipNamesForStricken = {"Blazon", "Streaker", "Pinto", "Spear", "Javelin"}
+	playerShipNamesForAtlantisII = {"Spyder", "Shelob", "Tarantula", "Aragog", "Charlotte"}
+	playerShipNamesForRedhook = {"Headhunter", "Thud", "Troll", "Scalper", "Shark"}
 	playerShipNamesForLeftovers = {"Foregone","Righteous","Masher"}
+	commonGoods = {"food","medicine","nickel","platinum","gold","dilithium","tritanium","luxury","cobalt","impulse","warp","shield","tractor","repulsor","beam","optic","robotic","filament","transporter","sensor","communication","autodoc","lifter","android","nanites","software","circuit","battery"}
+	componentGoods = {"impulse","warp","shield","tractor","repulsor","beam","optic","robotic","filament","transporter","sensor","communication","autodoc","lifter","android","nanites","software","circuit","battery"}
+	mineralGoods = {"nickel","platinum","gold","dilithium","tritanium","cobalt"}
 	characterNames = {"Frank Brown",
 					  "Joyce Miller",
 					  "Harry Jones",
@@ -290,6 +503,34 @@ function setConstants()
 		{"reactor","maneuver","frontshield"},
 		{"reactor","maneuver","rearshield"}
 	}
+	--minutes and danger
+	enemyReinforcementSchedule = {
+		{30, 1},
+		{20, 1},
+		{15, 2},
+		{12, 2},
+		{15, 3},
+		{15, 3},
+		{20, 4}
+	}
+	cargoInventoryList = {}
+	table.insert(cargoInventoryList,cargoInventory1)
+	table.insert(cargoInventoryList,cargoInventory2)
+	table.insert(cargoInventoryList,cargoInventory3)
+	table.insert(cargoInventoryList,cargoInventory4)
+	table.insert(cargoInventoryList,cargoInventory5)
+	table.insert(cargoInventoryList,cargoInventory6)
+	table.insert(cargoInventoryList,cargoInventory7)
+	table.insert(cargoInventoryList,cargoInventory8)
+	get_coolant_function = {}
+	table.insert(get_coolant_function,getCoolant1)
+	table.insert(get_coolant_function,getCoolant2)
+	table.insert(get_coolant_function,getCoolant3)
+	table.insert(get_coolant_function,getCoolant4)
+	table.insert(get_coolant_function,getCoolant5)
+	table.insert(get_coolant_function,getCoolant6)
+	table.insert(get_coolant_function,getCoolant7)
+	table.insert(get_coolant_function,getCoolant8)
 end
 function setGossipSnippets()
 	gossipSnippets = {}
@@ -308,44 +549,43 @@ end
 function setCharacterNames()
 	for i=1,#humanStationList do
 		curStation = humanStationList[i]
-		if curStation.character == nil then
+		if curStation.comms_data.character == nil then
 			if #characterNames > 0 then
 				nameChoice = math.random(1,#characterNames)
-				curStation.character = characterNames[nameChoice]
+				curStation.comms_data.character = characterNames[nameChoice]
 				table.remove(characterNames,nameChoice)
 			end
 		end
 	end
 end
 function setBorderZones()
-	sx, sy = vectorFromAngle(random(0,360),random(20000,30000))
-	borderStartAngle = random(0,360)
-	borderStartX, borderStartY = vectorFromAngle(borderStartAngle,random(3500,4900))
-	halfLength = random(8000,15000)
-	zoneLimit = 150000
+	local borderStartAngle = random(0,360)	--gross orientation of default spawn point to neutral border zone
+	local borderStartX, borderStartY = vectorFromAngle(borderStartAngle,random(3500,4900))
+	local halfLength = random(8000,15000)
+	local zoneLimit = 150000
 	borderZone = {}
 	innerZoneList = {}
 	outerZoneList = {}
-	bzi = 1		--border zone index
-	--Note: "left" and "right" refer to someone standing on the 2D board at the spawn point looking at the zones being added;
+	local bzi = 1		--border zone index
+	--Note: "left" and "right" refer to someone standing on the 2D board at the spawn point (0,0) looking at the zones being added;
 	--		"inner" means closer to the spawn point, "outer" means further away from the spawn point
-	borderZoneLeftInnerX = {}
-	borderZoneLeftInnerY = {}
-	borderZoneRightInnerX = {}
-	borderZoneRightInnerY = {}
-	borderZoneLeftOuterX = {}
-	borderZoneLeftOuterY = {}
-	borderZoneRightOuterX = {}
-	borderZoneRightOuterY = {}
-	bzsx, bzsy = vectorFromAngle(borderStartAngle+270,halfLength)	--border zone start x and y coordinates
+	local borderZoneLeftInnerX = {}
+	local borderZoneLeftInnerY = {}
+	local borderZoneRightInnerX = {}
+	local borderZoneRightInnerY = {}
+	local borderZoneLeftOuterX = {}
+	local borderZoneLeftOuterY = {}
+	local borderZoneRightOuterX = {}
+	local borderZoneRightOuterY = {}
+	local bzsx, bzsy = vectorFromAngle(borderStartAngle+270,halfLength)	--border zone start x and y coordinates
 	table.insert(borderZoneLeftInnerX, borderStartX+bzsx)
 	table.insert(borderZoneLeftInnerY, borderStartY+bzsy)
 	bzsx, bzsy = vectorFromAngle(borderStartAngle+90,halfLength)	--border sone start x and y coordinates
 	table.insert(borderZoneRightInnerX, borderStartX+bzsx)
 	table.insert(borderZoneRightInnerY, borderStartY+bzsy)
-	bendAngle = random(1,30)
-	negativeBendCount = 0
-	positiveBendCount = 0
+	local bendAngle = random(1,30)	--inner and outer edges are parallel, connecting edges are bent
+	local negativeBendCount = 0
+	local positiveBendCount = 0
 	if random(1,100) < 50 then
 		negativeBendCount = negativeBendCount + bendAngle
 		bendAngle = -1*bendAngle
@@ -356,30 +596,34 @@ function setBorderZones()
 	if bendAngle < 0 then
 		bendAngle = bendAngle + 360
 	end
-	borderZoneWidth = random(10000,15000)
+	local borderZoneWidth = random(10000,15000)
 	bzsx, bzsy = vectorFromAngle(bendAngle,borderZoneWidth)		--border zone start x and y coordinates
 	table.insert(borderZoneLeftOuterX,borderZoneLeftInnerX[bzi]+bzsx)
 	table.insert(borderZoneLeftOuterY,borderZoneLeftInnerY[bzi]+bzsy)
 	table.insert(borderZoneRightOuterX,borderZoneRightInnerX[bzi]+bzsx)
 	table.insert(borderZoneRightOuterY,borderZoneRightInnerY[bzi]+bzsy)
-	cbz = Zone():setPoints(borderZoneLeftInnerX[bzi],borderZoneLeftInnerY[bzi],		--current border zone
+	local cbz = Zone():setPoints(borderZoneLeftInnerX[bzi],borderZoneLeftInnerY[bzi],		--current border zone
 						   borderZoneLeftOuterX[bzi],borderZoneLeftOuterY[bzi],
 						   borderZoneRightOuterX[bzi],borderZoneRightOuterY[bzi],
 						   borderZoneRightInnerX[bzi],borderZoneRightInnerY[bzi])
 		cbz:setColor(0,0,255)
 	cbz.detect = 0
 	table.insert(borderZone,cbz)
-	ilx, ily = vectorFromAngle(borderStartAngle+210,zoneLimit)		--inner left x and y coordinates
-	irx, iry = vectorFromAngle(borderStartAngle+150,zoneLimit)		--inner right x and y coordinates
-	ciz = Zone():setPoints(borderZoneLeftInnerX[bzi],borderZoneLeftInnerY[bzi],		--current inner zone
+	intelGatherArtifacts = {}
+	local igax, igay = vectorFromAngle(borderStartAngle+180,borderZoneWidth*2+random(1,30000))
+	local iga = Artifact():setPosition(borderStartX+igax,borderStartY+igay):setScanningParameters(difficulty*2,difficulty*2):setRadarSignatureInfo(random(0,1),random(0,1),random(0,1)):setModel("SensorBuoyMKIII"):setCallSign("Sensor Buoy"):setFaction("Human Navy")
+	table.insert(intelGatherArtifacts,iga)
+	local ilx, ily = vectorFromAngle(borderStartAngle+210,zoneLimit)		--inner left x and y coordinates
+	local irx, iry = vectorFromAngle(borderStartAngle+150,zoneLimit)		--inner right x and y coordinates
+	local ciz = Zone():setPoints(borderZoneLeftInnerX[bzi],borderZoneLeftInnerY[bzi],		--current inner zone
 						   borderZoneRightInnerX[bzi],borderZoneRightInnerY[bzi],
 						   borderZoneRightInnerX[bzi]+irx,borderZoneRightInnerY[bzi]+iry,
 						   borderZoneLeftInnerX[bzi]+ilx,borderZoneLeftInnerY[bzi]+ily)
 	if initDiagnostic then ciz:setColor(50,50,50) end
 	table.insert(innerZoneList,ciz)
-	olx, oly = vectorFromAngle(borderStartAngle+330,zoneLimit)		--outer left x and y coordinates
-	orx, ory = vectorFromAngle(borderStartAngle+30,zoneLimit)		--outer right x and y coordinates
-	coz = Zone():setPoints(borderZoneRightOuterX[bzi],borderZoneRightOuterY[bzi],	--current outer zone
+	local olx, oly = vectorFromAngle(borderStartAngle+330,zoneLimit)		--outer left x and y coordinates
+	local orx, ory = vectorFromAngle(borderStartAngle+30,zoneLimit)		--outer right x and y coordinates
+	local coz = Zone():setPoints(borderZoneRightOuterX[bzi],borderZoneRightOuterY[bzi],	--current outer zone
 						   borderZoneLeftOuterX[bzi],borderZoneLeftOuterY[bzi],
 						   borderZoneLeftOuterX[bzi]+olx,borderZoneLeftOuterY[bzi]+oly,
 						   borderZoneRightOuterX[bzi]+orx,borderZoneRightOuterY[bzi]+ory)
@@ -391,12 +635,12 @@ function setBorderZones()
 	table.insert(borderZoneRightInnerY,borderZoneLeftInnerY[bzi-1])
 	table.insert(borderZoneRightOuterX,borderZoneLeftOuterX[bzi-1])
 	table.insert(borderZoneRightOuterY,borderZoneLeftOuterY[bzi-1])
-	bzx, bzy = vectorFromAngle(bendAngle+270,random(20000,30000))		--border zone x and y corrdinates
+	local bzx, bzy = vectorFromAngle(bendAngle+270,random(20000,30000))		--border zone x and y corrdinates
 	table.insert(borderZoneLeftInnerX,borderZoneRightInnerX[bzi]+bzx)
 	table.insert(borderZoneLeftInnerY,borderZoneRightInnerY[bzi]+bzy)
-	upBound = 2 + negativeBendCount + positiveBendCount
-	cutOff = math.min(positiveBendCount,negativeBendCount)
-	newBend = random(1,30)
+	local upBound = 2 + negativeBendCount + positiveBendCount
+	local cutOff = math.min(positiveBendCount,negativeBendCount)
+	local newBend = random(1,30)
 	if negativeBendCount < positiveBendCount then
 		if random(1,upBound) <= cutOff then
 			negativeBendCount = negativeBendCount + newBend
@@ -438,6 +682,9 @@ function setBorderZones()
 		cbz:setColor(0,0,255)
 	cbz.detect = 0
 	table.insert(borderZone,cbz)
+	igax, igay = vectorFromAngle(bendAngle+180,borderZoneWidth*2+random(1,30000))
+	iga = Artifact():setPosition((borderZoneLeftInnerX[2]+borderZoneRightInnerX[2])/2+igax,(borderZoneLeftInnerY[2]+borderZoneRightInnerY[2])/2+igay):setScanningParameters(difficulty*2,difficulty*2):setRadarSignatureInfo(random(0,1),random(0,1),random(0,1)):setModel("SensorBuoyMKIII"):setCallSign("Sensor Buoy"):setFaction("Human Navy")
+	table.insert(intelGatherArtifacts,iga)
 	ilx, ily = vectorFromAngle(bendAngle+210,zoneLimit)
 	irx, iry = vectorFromAngle(bendAngle+150,zoneLimit)
 	ciz = Zone():setPoints(borderZoneLeftInnerX[bzi],borderZoneLeftInnerY[bzi],
@@ -462,6 +709,9 @@ function setBorderZones()
 		cbz:setColor(0,0,255)
 	cbz.detect = 0
 	table.insert(borderZone,cbz)
+	igax, igay = vectorFromAngle(bendAngle+180,borderZoneWidth*2+random(1,30000))
+	iga = Artifact():setPosition((borderZoneLeftInnerX[3]+borderZoneRightInnerX[3])/2+igax,(borderZoneLeftInnerY[3]+borderZoneRightInnerY[3])/2+igay):setScanningParameters(difficulty*2,difficulty*2):setRadarSignatureInfo(random(0,1),random(0,1),random(0,1)):setModel("SensorBuoyMKIII"):setCallSign("Sensor Buoy"):setFaction("Human Navy")
+	table.insert(intelGatherArtifacts,iga)
 	ilx, ily = vectorFromAngle(bendAngle+210,zoneLimit)
 	irx, iry = vectorFromAngle(bendAngle+150,zoneLimit)
 	ciz = Zone():setPoints(borderZoneLeftInnerX[bzi],borderZoneLeftInnerY[bzi],
@@ -523,6 +773,16 @@ function setBorderZones()
 		cbz:setColor(0,0,255)
 		cbz.detect = 0
 		table.insert(borderZone,cbz)
+		if i == 1 then
+			igax, igay = vectorFromAngle(bendAngle+180,borderZoneWidth*2+random(1,30000))
+			iga = Artifact():setPosition((borderZoneLeftInnerX[4]+borderZoneRightInnerX[4])/2+igax,(borderZoneLeftInnerY[4]+borderZoneRightInnerY[4])/2+igay):setScanningParameters(difficulty*2,difficulty*2):setRadarSignatureInfo(random(0,1),random(0,1),random(0,1)):setModel("SensorBuoyMKIII"):setCallSign("Sensor Buoy"):setFaction("Human Navy")
+			table.insert(intelGatherArtifacts,iga)
+		end
+		if i == 2 then
+			igax, igay = vectorFromAngle(bendAngle+180,borderZoneWidth*2+random(1,30000))
+			iga = Artifact():setPosition((borderZoneLeftInnerX[5]+borderZoneRightInnerX[5])/2+igax,(borderZoneLeftInnerY[5]+borderZoneRightInnerY[5])/2+igay):setScanningParameters(difficulty*2,difficulty*2):setRadarSignatureInfo(random(0,1),random(0,1),random(0,1)):setModel("SensorBuoyMKIII"):setCallSign("Sensor Buoy"):setFaction("Human Navy")
+			table.insert(intelGatherArtifacts,iga)
+		end
 		if i < 3 then
 			ilx, ily = vectorFromAngle(bendAngle+210,100000)
 			irx, iry = vectorFromAngle(bendAngle+150,100000)
@@ -580,8 +840,8 @@ function setBorderZones()
 		end
 	end
 	if initDiagnostic then print(string.format("border zones created: %i",bzi)) end
-	bzlx, bzly = vectorFromAngle(borderStartAngle+225,900000)
-	bzrx, bzry = vectorFromAngle(borderStartAngle+135,900000)
+	local bzlx, bzly = vectorFromAngle(borderStartAngle+225,900000)
+	local bzrx, bzry = vectorFromAngle(borderStartAngle+135,900000)
 	innerZone = Zone():setPoints(borderZoneLeftInnerX[1],borderZoneLeftInnerY[1],
 								 borderZoneRightInnerX[1],borderZoneRightInnerY[1],
 								 borderZoneRightInnerX[3],borderZoneRightInnerY[3],
@@ -678,41 +938,6 @@ function setBorderZones()
 								 borderZoneRightOuterX[3],borderZoneRightOuterY[3],
 								 borderZoneRightOuterX[1],borderZoneRightOuterY[1])
 	if initDiagnostic then outerZone:setColor(255,165,0) end
-end
-function setGoodsList()
-	--list of goods available to buy, sell or trade (sell still under development)
-	goodsList = {	{"food",0},
-					{"medicine",0},
-					{"nickel",0},
-					{"platinum",0},
-					{"gold",0},
-					{"dilithium",0},
-					{"tritanium",0},
-					{"luxury",0},
-					{"cobalt",0},
-					{"impulse",0},
-					{"warp",0},
-					{"shield",0},
-					{"tractor",0},
-					{"repulsor",0},
-					{"beam",0},
-					{"optic",0},
-					{"robotic",0},
-					{"filament",0},
-					{"transporter",0},
-					{"sensor",0},
-					{"communication",0},
-					{"autodoc",0},
-					{"lifter",0},
-					{"android",0},
-					{"nanites",0},
-					{"software",0},
-					{"circuit",0},
-					{"battery",0}	}
-	goods = {}					--overall tracking of goods
-	tradeFood = {}				--stations that will trade food for other goods
-	tradeLuxury = {}			--stations that will trade luxury for other goods
-	tradeMedicine = {}			--stations that will trade medicine for other goods
 end
 function setListOfStations()
 	--array of functions to facilitate randomized station placement (friendly and neutral)
@@ -838,10 +1063,10 @@ function buildStationsPlus()
 	gSize = random(6000,8000)	--grid cell size in positional units
 	adjList = {}				--adjacent space on grid location list
 	wzac = 0	--weird zone adjustment count
-	planet1 = false
-	blackHole1 = false
-	planet2 = false
-	blackHole2 = false
+	local planet1 = false
+	local blackHole1 = false
+	local planet2 = false
+	local blackHole2 = false
 	humanStationStrength = 0
 	kraylorStationStrength = 0
 	neutralStationStrength = 0
@@ -864,14 +1089,14 @@ function buildStationsPlus()
 		end
 		tSize = math.random(2,5)	--tack on to region size (3-6 since first is outside loop)
 		grid[gx][gy] = gp			--set current grid location to grid position list index
-		gRegion = {}				--grow region
+		local gRegion = {}			--grow region
 		table.insert(gRegion,{gx,gy})
 		for i=1,tSize do
 			adjList = getAdjacentGridLocations(gx,gy)
 			if #adjList < 1 then	--exit loop if there are no more adjacent spaces available
 				break
 			end
-			rd = math.random(1,#adjList)	--random direction to grow from adjacent list
+			local rd = math.random(1,#adjList)	--random direction to grow from adjacent list
 			grid[adjList[rd][1]][adjList[rd][2]] = gp
 			table.insert(gRegion,{adjList[rd][1],adjList[rd][2]})
 		end
@@ -884,10 +1109,10 @@ function buildStationsPlus()
 				adjList = getAllAdjacentGridLocations(gx,gy)
 			end
 		end
-		sri = math.random(1,#gRegion)				--select station random region index
+		local sri = math.random(1,#gRegion)				--select station random region index
 		psx = (gRegion[sri][1] - (gbHigh/2))*gSize + random(-gSize/2*.95,gSize/2*.95)	--place station x coordinate
 		psy = (gRegion[sri][2] - (gbHigh/2))*gSize + random(-gSize/2*.95,gSize/2*.95)	--place station y coordinate
-		ta = VisualAsteroid():setPosition(psx,psy)
+		local ta = VisualAsteroid():setPosition(psx,psy)
 		inBorderZone = false
 		bzPosCount = 0
 		for i=1,#borderZone do
@@ -953,31 +1178,48 @@ function buildStationsPlus()
 		if #gossipSnippets > 0 and stationFaction == "Human Navy" and pStation ~= nil then
 			if gp % 2 == 0 then
 				ni = math.random(1,#gossipSnippets)
-				pStation.gossip = gossipSnippets[ni]
+				pStation.comms_data.gossip = gossipSnippets[ni]
 				table.remove(gossipSnippets,ni)
 			end
 		end
 		gp = gp + 1						--set next station number
-		rn = math.random(1,#adjList)	--random next station start location
+		local rn = math.random(1,#adjList)	--random next station start location
 		gx = adjList[rn][1]
 		gy = adjList[rn][2]
 	until(not neutralStationsRemain or not humanStationsRemain or not kraylorStationsRemain)
 	if diagnostic then print(string.format("Human stations: %i, Kraylor stations: %i, Neutral stations: %i",#humanStationList,#kraylorStationList,#neutralStationList)) end
 	if not diagnostic then
-		placeRandomAroundPoint(Nebula,math.random(7,25),1,150000,0,0)
+		local nebula_count = math.random(7,25)
+		local nebula_list = placeRandomListAroundPoint(Nebula,nebula_count,1,150000,0,0)
+		local nebula_index = 0
+		for i=1,#nebula_list do
+			nebula_list[i].lose = false
+			nebula_list[i].gain = false
+		end
+		coolant_nebula = {}
+		for i=1,math.random(math.floor(nebula_count/2)) do
+			nebula_index = math.random(1,#nebula_list)
+			table.insert(coolant_nebula,nebula_list[nebula_index])
+			table.remove(nebula_list,nebula_index)
+			if math.random(1,100) < 50 then
+				coolant_nebula[#coolant_nebula].lose = true
+			else
+				coolant_nebula[#coolant_nebula].gain = true
+			end
+		end
 	end
 end
 function insertPlanet1()
-	tSize = 15
+	local tSize = 15
 	grid[gx][gy] = gp
-	gRegion = {}
+	local gRegion = {}
 	table.insert(gRegion,{gx,gy})
 	for i=1,tSize do
 		adjList = getAdjacentGridLocations(gx,gy)
 		if #adjList < 1 then
 			break
 		end
-		rd = math.random(1,#adjList)
+		local rd = math.random(1,#adjList)
 		grid[adjList[rd][1]][adjList[rd][2]] = gp
 		table.insert(gRegion,{adjList[rd][1],adjList[rd][2]})
 	end
@@ -985,27 +1227,27 @@ function insertPlanet1()
 	if #adjList < 1 then
 		adjList = getAllAdjacentGridLocations(gx,gy)	
 	end
-	sri = math.random(1,#gRegion)
-	bwx = (gRegion[sri][1] - (gbHigh/2))*gSize
-	bwy = (gRegion[sri][2] - (gbHigh/2))*gSize
+	local sri = math.random(1,#gRegion)
+	local bwx = (gRegion[sri][1] - (gbHigh/2))*gSize
+	local bwy = (gRegion[sri][2] - (gbHigh/2))*gSize
 	planetBespin = Planet():setPosition(bwx,bwy):setPlanetRadius(3000):setDistanceFromMovementPlane(-2000):setCallSign("Bespin")
 	planetBespin:setPlanetSurfaceTexture("planets/gas-1.png"):setAxialRotationTime(300):setDescription("Mining and Gambling")
 	gp = gp + 1
-	rn = math.random(1,#adjList)
+	local rn = math.random(1,#adjList)
 	gx = adjList[rn][1]
 	gy = adjList[rn][2]
 end
 function insertPlanet2()
-	tSize = 15
+	local tSize = 15
 	grid[gx][gy] = gp
-	gRegion = {}
+	local gRegion = {}
 	table.insert(gRegion,{gx,gy})
 	for i=1,tSize do
 		adjList = getAdjacentGridLocations(gx,gy)
 		if #adjList < 1 then
 			break
 		end
-		rd = math.random(1,#adjList)
+		local rd = math.random(1,#adjList)
 		grid[adjList[rd][1]][adjList[rd][2]] = gp
 		table.insert(gRegion,{adjList[rd][1],adjList[rd][2]})
 	end
@@ -1013,29 +1255,29 @@ function insertPlanet2()
 	if #adjList < 1 then
 		adjList = getAllAdjacentGridLocations(gx,gy)	
 	end
-	sri = math.random(1,#gRegion)
-	msx = (gRegion[sri][1] - (gbHigh/2))*gSize
-	msy = (gRegion[sri][2] - (gbHigh/2))*gSize
+	local sri = math.random(1,#gRegion)
+	local msx = (gRegion[sri][1] - (gbHigh/2))*gSize
+	local msy = (gRegion[sri][2] - (gbHigh/2))*gSize
 	planetHel = Planet():setPosition(msx,msy):setPlanetRadius(3000):setDistanceFromMovementPlane(-2000):setCallSign("Helicon")
 	planetHel:setPlanetSurfaceTexture("planets/planet-1.png"):setPlanetCloudTexture("planets/clouds-1.png")
 	planetHel:setPlanetAtmosphereTexture("planets/atmosphere.png"):setPlanetAtmosphereColor(0.2,0.2,1.0)
 	planetHel:setAxialRotationTime(400.0):setDescription("M class planet")
 	gp = gp + 1
-	rn = math.random(1,#adjList)
+	local rn = math.random(1,#adjList)
 	gx = adjList[rn][1]
 	gy = adjList[rn][2]
 end
 function insertBlackHole()
-	tSize = 22
+	local tSize = 22
 	grid[gx][gy] = gp
-	gRegion = {}
+	local gRegion = {}
 	table.insert(gRegion,{gx,gy})
 	for i=1,tSize do
 		adjList = getAdjacentGridLocations(gx,gy)
 		if #adjList < 1 then
 			break
 		end
-		rd = math.random(1,#adjList)
+		local rd = math.random(1,#adjList)
 		grid[adjList[rd][1]][adjList[rd][2]] = gp
 		table.insert(gRegion,{adjList[rd][1],adjList[rd][2]})
 	end
@@ -1047,12 +1289,12 @@ function insertBlackHole()
 			adjList = getAllAdjacentGridLocations(gx,gy)
 		end
 	end
-	sri = math.random(1,#gRegion)
-	bhx = (gRegion[sri][1] - (gbHigh/2))*gSize
-	bhy = (gRegion[sri][2] - (gbHigh/2))*gSize
+	local sri = math.random(1,#gRegion)
+	local bhx = (gRegion[sri][1] - (gbHigh/2))*gSize
+	local bhy = (gRegion[sri][2] - (gbHigh/2))*gSize
 	BlackHole():setPosition(bhx,bhy)
 	gp = gp + 1
-	rn = math.random(1,#adjList)
+	local rn = math.random(1,#adjList)
 	gx = adjList[rn][1]
 	gy = adjList[rn][2]
 end
@@ -1061,6 +1303,7 @@ function placeInner()
 		fb = gp									--set faction boundary
 	end
 	stationFaction = "Human Navy"				--set station faction
+	local si = 0
 	if #placeStation > 0 then
 		si = math.random(1,#placeStation)			--station index
 		pStation = placeStation[si]()				--place selected station
@@ -1096,6 +1339,7 @@ function placeOuter()
 		fb = gp									--set faction boundary
 	end
 	stationFaction = "Kraylor"
+	local si = 0
 	if #placeEnemyStation > 0 then
 		si = math.random(1,#placeEnemyStation)		--station index
 		pStation = placeEnemyStation[si]()			--place selected station
@@ -1131,6 +1375,7 @@ function placeBorder()
 		fb = gp									--set faction boundary
 	end
 	stationFaction = "Independent"				--set station faction
+	local si = 0
 	if #placeStation > 0 then
 		si = math.random(1,#placeStation)			--station index
 		pStation = placeStation[si]()				--place selected station
@@ -1161,8 +1406,8 @@ function placeBorder()
 		table.insert(neutralStationList,pStation)	--save station in neutral station list
 	end
 end
---adjacent empty grid locations around the grid locations of the currently building faction
 function getFactionAdjacentGridLocations(lx,ly)
+--adjacent empty grid locations around the grid locations of the currently building faction
 	tempGrid = {}
 	for i=gbLow,gbHigh do
 		tempGrid[i] = {}
@@ -1219,8 +1464,8 @@ function getFactionAdjacentGridLocations(lx,ly)
 	end
 	return ol
 end
---adjacent empty grid locations around the grid locations of the currently building faction, skip check as requested
 function getFactionAdjacentGridLocationsSkip(dSkip,lx,ly)
+--adjacent empty grid locations around the grid locations of the currently building faction, skip check as requested
 	tempGrid[lx][ly] = 1
 	if dSkip ~= 3 then
 		--check left
@@ -1279,8 +1524,8 @@ function getFactionAdjacentGridLocationsSkip(dSkip,lx,ly)
 		end
 	end
 end
---adjacent empty grid locations around all occupied locations
 function getAllAdjacentGridLocations(lx,ly)
+--adjacent empty grid locations around all occupied locations
 	tempGrid = {}
 	for i=gbLow,gbHigh do
 		tempGrid[i] = {}
@@ -1337,8 +1582,8 @@ function getAllAdjacentGridLocations(lx,ly)
 	end
 	return ol
 end
---adjacent empty grid locations around all occupied locations, skip as requested
 function getAllAdjacentGridLocationsSkip(dSkip,lx,ly)
+--adjacent empty grid locations around all occupied locations, skip as requested
 	tempGrid[lx][ly] = 1
 	if dSkip ~= 3 then
 		--check left
@@ -1397,8 +1642,8 @@ function getAllAdjacentGridLocationsSkip(dSkip,lx,ly)
 		end
 	end
 end
---adjacent empty grid locations around the most recently placed item
 function getAdjacentGridLocations(lx,ly)
+--adjacent empty grid locations around the most recently placed item
 	tempGrid = {}
 	for i=gbLow,gbHigh do
 		tempGrid[i] = {}
@@ -1455,8 +1700,8 @@ function getAdjacentGridLocations(lx,ly)
 	end
 	return ol
 end
---adjacent empty grid locations around the most recently placed item, skip as requested
 function getAdjacentGridLocationsSkip(dSkip,lx,ly)
+--adjacent empty grid locations around the most recently placed item, skip as requested
 	tempGrid[lx][ly] = 1
 	if dSkip ~= 3 then
 		--check left
@@ -1515,8 +1760,8 @@ function getAdjacentGridLocationsSkip(dSkip,lx,ly)
 		end
 	end
 end
---Randomly choose station size template
 function szt()
+--Randomly choose station size template
 	stationSizeRandom = random(1,100)
 	if stationSizeRandom <= 8 then
 		sizeTemplate = "Huge Station"		-- 8 percent huge
@@ -1529,6 +1774,28 @@ function szt()
 	end
 	return sizeTemplate
 end
+function randomMineral(exclude)
+	local good = mineralGoods[math.random(1,#mineralGoods)]
+	if exclude == nil then
+		return good
+	else
+		repeat
+			good = mineralGoods[math.random(1,#mineralGoods)]
+		until(good ~= exclude)
+		return good
+	end
+end
+function randomComponent(exclude)
+	local good = componentGoods[math.random(1,#componentGoods)]
+	if exclude == nil then
+		return good
+	else
+		repeat
+			good = componentGoods[math.random(1,#componentGoods)]
+		until(good ~= exclude)
+		return good
+	end
+end
 --[[-------------------------------------------------------------------
 	Human and neutral stations to be placed (all need some kind of goods)
 --]]-------------------------------------------------------------------
@@ -1536,187 +1803,273 @@ function placeAlcaleica()
 	--Alcaleica
 	stationAlcaleica = SpaceStation():setTemplate(szt()):setFaction(stationFaction):setCommsScript(""):setCommsFunction(commsStation)
 	stationAlcaleica:setPosition(psx,psy):setCallSign("Alcaleica"):setDescription("Optical Components")
+    stationAlcaleica.comms_data = {
+    	friendlyness = random(0,100),
+        weapons = 			{Homing = "neutral",					HVLI = "neutral", 						Mine = "neutral",						Nuke = "friend", 						EMP = "friend"},
+        weapon_available = 	{Homing = random(1,10)<=(8-difficulty),	HVLI = random(1,10)<=(9-difficulty),	Mine = random(1,10)<=(7-difficulty),	Nuke = random(1,10)<=(5-difficulty),	EMP = random(1,10)<=(6-difficulty)},
+        service_cost = 		{supplydrop = math.random(80,120), reinforcements = math.random(125,175)},
+        reputation_cost_multipliers = {friend = 1.0, neutral = 3.0},
+        max_weapon_refill_amount = {friend = 1.0, neutral = 0.5 },
+        goods = {	optic = {quantity = 5,	cost = 66} },
+        trade = {	food = false, medicine = false, luxury = false },
+		buy =	{	[randomMineral()] = math.random(40,200)	},
+        public_relations = true,
+        general_information = "We make and supply optic components for various station and ship systems",
+    	history = "This station continues the businesses from Earth based on the merging of several companies including Leica from Switzerland, the lens manufacturer and the Japanese advanced low carbon (ALCA) electronic and optic research and development company"
+	}
 	if stationFaction == "Human Navy" then
+		stationAlcaleica.comms_data.goods.food = {quantity = math.random(5,10), cost = 1}
 		if random(1,5) <= 1 then
-			goods[stationAlcaleica] = {{"food",math.random(5,10),1},{"medicine",5,5},{"optic",5,66}}
+			stationAlcaleica.comms_data.goods.medicine = {quantity = 5, cost = 5}
 		else
-			goods[stationAlcaleica] = {{"food",math.random(5,10),1},{"optic",5,66}}
-			tradeMedicine[stationAlcaleica] = true
+			stationAlcaleica.comms_data.trade.medicine = true
 		end
 	else
-		goods[stationAlcaleica] = {{"optic",5,66}}
-		tradeFood[stationAlcaleica] = true
-		tradeMedicine[stationAlcaleica] = true
+		stationAlcaleica.comms_data.trade.medicine = true
+		stationAlcaleica.comms_data.trade.food = true
 	end
-	stationAlcaleica.publicRelations = true
-	stationAlcaleica.generalInformation = "We make and supply optic components for various station and ship systems"
-	stationAlcaleica.stationHistory = "This station continues the businesses from Earth based on the merging of several companies including Leica from Switzerland, the lens manufacturer and the Japanese advanced low carbon electronic and optic company"
 	return stationAlcaleica
 end
 function placeAnderson()
 	--Anderson 
 	stationAnderson = SpaceStation():setTemplate(szt()):setFaction(stationFaction):setCommsScript(""):setCommsFunction(commsStation)
 	stationAnderson:setPosition(psx,psy):setCallSign("Anderson"):setDescription("Battery and software engineering")
+    stationAnderson.comms_data = {
+    	friendlyness = random(0,100),
+        weapons = 			{Homing = "neutral",					HVLI = "neutral", 						Mine = "neutral",						Nuke = "friend", 						EMP = "friend"},
+        weapon_available = 	{Homing = random(1,10)<=(8-difficulty),	HVLI = random(1,10)<=(9-difficulty),	Mine = random(1,10)<=(7-difficulty),	Nuke = random(1,10)<=(5-difficulty),	EMP = random(1,10)<=(6-difficulty)},
+        service_cost = 		{supplydrop = math.random(80,120), reinforcements = math.random(125,175)},
+        reputation_cost_multipliers = {friend = 1.0, neutral = 3.0},
+        max_weapon_refill_amount = {friend = 1.0, neutral = 0.5 },
+        goods = {	battery =	{quantity = 5,	cost = 66},
+        			software =	{quantity = 5,	cost = 115} },
+        trade = {	food = false, medicine = false, luxury = true },
+        public_relations = true,
+        general_information = "We provide high quality high capacity batteries and specialized software for all shipboard systems",
+    	history = "The station is named after a fictional software engineer in a late 20th century movie depicting humanity unknowingly conquered by aliens and kept docile by software generated illusion"
+	}
 	if stationFaction == "Human Navy" then
+		stationAnderson.comms_data.goods.food = {quantity = math.random(5,10), cost = 1}
 		if random(1,5) <= 1 then
-			goods[stationAnderson] = {{"food",math.random(5,10),1},{"medicine",5,5},{"battery",5,65},{"software",5,115}}
-		else
-			goods[stationAnderson] = {{"food",math.random(5,10),1},{"battery",5,65},{"software",5,115}}
+			stationAnderson.comms_data.goods.medicine = {quantity = 5, cost = 5}
 		end
-	else
-		goods[stationAnderson] = {{"battery",5,65},{"software",5,115}}
 	end
-	tradeLuxury[stationAnderson] = true
-	stationAnderson.publicRelations = true
-	stationAnderson.generalInformation = "We provide high quality high capacity batteries and specialized software for all shipboard systems"
-	stationAnderson.stationHistory = "The station is named after a fictional software engineer in a late 20th century movie depicting humanity unknowingly conquered by aliens and kept docile by software generated illusion"
 	return stationAnderson
 end
 function placeArcher()
 	--Archer 
 	stationArcher = SpaceStation():setTemplate(szt()):setFaction(stationFaction):setCommsScript(""):setCommsFunction(commsStation)
 	stationArcher:setPosition(psx,psy):setCallSign("Archer"):setDescription("Shield and Armor Research")
+    stationArcher.comms_data = {
+    	friendlyness = random(0,100),
+        weapons = 			{Homing = "neutral",					HVLI = "neutral", 						Mine = "neutral",						Nuke = "friend", 						EMP = "friend"},
+        weapon_available = 	{Homing = random(1,10)<=(8-difficulty),	HVLI = random(1,10)<=(9-difficulty),	Mine = random(1,10)<=(7-difficulty),	Nuke = random(1,10)<=(5-difficulty),	EMP = random(1,10)<=(6-difficulty)},
+        service_cost = 		{supplydrop = math.random(80,120), reinforcements = math.random(125,175)},
+        reputation_cost_multipliers = {friend = 1.0, neutral = 3.0},
+        max_weapon_refill_amount = {friend = 1.0, neutral = 0.5 },
+        goods = {	shield =	{quantity = 5,	cost = 90} },
+        trade = {	food = false, medicine = false, luxury = true },
+		buy =	{	[randomMineral()] = math.random(40,200)	},
+        public_relations = true,
+        general_information = "The finest shield and armor manufacturer in the quadrant",
+    	history = "We named this station for the pioneering spirit of the 22nd century Starfleet explorer, Captain Jonathan Archer"
+	}
 	if stationFaction == "Human Navy" then
+		stationArcher.comms_data.goods.food = {quantity = math.random(5,10), cost = 1}
 		if random(1,5) <= 1 then
-			goods[stationArcher] = {{"food",math.random(5,10),1},{"medicine",5,5},{"shield",5,90}}
+			stationArcher.comms_data.goods.medicine = {quantity = 5, cost = 5}
 		else
-			goods[stationArcher] = {{"food",math.random(5,10),1},{"shield",5,90}}
-			tradeMedicine[stationArcher] = true
+			stationArcher.comms_data.trade.medicine = true
 		end
 	else
-		goods[stationArcher] = {{"shield",5,90}}
-		tradeMedicine[stationArcher] = true
+		stationArcher.comms_data.trade.medicine = true
 	end
-	tradeLuxury[stationArcher] = true
-	stationArcher.publicRelations = true
-	stationArcher.generalInformation = "The finest shield and armor manufacturer in the quadrant"
-	stationArcher.stationHistory = "We named this station for the pioneering spirit of the 22nd century Starfleet explorer, Captain Jonathan Archer"
 	return stationArcher
 end
 function placeArchimedes()
 	--Archimedes
 	stationArchimedes = SpaceStation():setTemplate(szt()):setFaction(stationFaction):setCommsScript(""):setCommsFunction(commsStation)
 	stationArchimedes:setPosition(psx,psy):setCallSign("Archimedes"):setDescription("Energy and particle beam components")
+    stationArchimedes.comms_data = {
+    	friendlyness = random(0,100),
+        weapons = 			{Homing = "neutral",					HVLI = "neutral", 						Mine = "neutral",						Nuke = "friend", 						EMP = "friend"},
+        weapon_available = 	{Homing = random(1,10)<=(8-difficulty),	HVLI = random(1,10)<=(9-difficulty),	Mine = random(1,10)<=(7-difficulty),	Nuke = random(1,10)<=(5-difficulty),	EMP = random(1,10)<=(6-difficulty)},
+        service_cost = 		{supplydrop = math.random(80,120), reinforcements = math.random(125,175)},
+        reputation_cost_multipliers = {friend = 1.0, neutral = 3.0},
+        max_weapon_refill_amount = {friend = 1.0, neutral = 0.5 },
+        goods = {	beam =	{quantity = 5,	cost = 80} },
+        trade = {	food = false, medicine = false, luxury = true },
+        public_relations = true,
+        general_information = "We fabricate general and specialized components for ship beam systems",
+    	history = "This station was named after Archimedes who, according to legend, used a series of adjustable focal length mirrors to focus sunlight on a Roman naval fleet invading Syracuse, setting fire to it"
+	}
 	if stationFaction == "Human Navy" then
+		stationArchimedes.comms_data.goods.food = {quantity = math.random(5,10), cost = 1}
 		if random(1,5) <= 1 then
-			goods[stationArchimedes] = {{"food",math.random(5,10),1},{"medicine",5,5},{"beam",5,80}}
+			stationArchimedes.comms_data.goods.medicine = {quantity = 5, cost = 5}
 		else
-			goods[stationArchimedes] = {{"food",math.random(5,10),1},{"beam",5,80}}
-			tradeMedicine[stationArchimedes] = true
+			stationArchimedes.comms_data.trade.medicine = true
 		end
 	else
-		goods[stationArchimedes] = {{"beam",5,80}}
-		tradeFood[stationArchimedes] = true
+		stationArchimedes.comms_data.trade.food = true
 	end
-	tradeLuxury[stationArchimedes] = true
-	stationArchimedes.publicRelations = true
-	stationArchimedes.generalInformation = "We fabricate general and specialized components for ship beam systems"
-	stationArchimedes.stationHistory = "This station was named after Archimedes who, according to legend, used a series of adjustable focal length mirrors to focus sunlight on a Roman naval fleet invading Syracuse, setting fire to it"
 	return stationArchimedes
 end
 function placeArmstrong()
 	--Armstrong
 	stationArmstrong = SpaceStation():setTemplate(szt()):setFaction(stationFaction):setCommsScript(""):setCommsFunction(commsStation)
 	stationArmstrong:setPosition(psx,psy):setCallSign("Armstrong"):setDescription("Warp and Impulse engine manufacturing")
+    stationArmstrong.comms_data = {
+    	friendlyness = random(0,100),
+        weapons = 			{Homing = "neutral",					HVLI = "neutral", 						Mine = "neutral",						Nuke = "friend", 						EMP = "friend"},
+        weapon_available = 	{Homing = random(1,10)<=(8-difficulty),	HVLI = random(1,10)<=(9-difficulty),	Mine = random(1,10)<=(7-difficulty),	Nuke = random(1,10)<=(5-difficulty),	EMP = random(1,10)<=(6-difficulty)},
+        service_cost = 		{supplydrop = math.random(80,120), reinforcements = math.random(125,175)},
+        reputation_cost_multipliers = {friend = 1.0, neutral = 3.0},
+        max_weapon_refill_amount = {friend = 1.0, neutral = 0.5 },
+        goods = {	warp =		{quantity = 5,	cost = 77},
+        			repulsor =	{quantity = 5,	cost = 62} },
+        trade = {	food = false, medicine = false, luxury = false },
+		buy =	{	[randomMineral()] = math.random(40,200)	},
+        public_relations = true,
+        general_information = "We manufacture warp, impulse and jump engines for the human navy fleet as well as other independent clients on a contract basis",
+    	history = "The station is named after the late 19th century astronaut as well as the fictionlized stations that followed. The station initially constructed entire space worthy vessels. In time, it transitioned into specializeing in propulsion systems."
+	}
 	if stationFaction == "Human Navy" then
+		stationArmstrong.comms_data.goods.food = {quantity = math.random(5,10), cost = 1}
 		if random(1,5) <= 1 then
-			goods[stationArmstrong] = {{"food",math.random(5,10),1},{"medicine",5,5},{"repulsor",5,62}}
-		else
-			goods[stationArmstrong] = {{"food",math.random(5,10),1},{"repulsor",5,62}}
+			stationArmstrong.comms_data.goods.medicine = {quantity = 5, cost = 5}
 		end
-	else
-		goods[stationArmstrong] = {{"repulsor",5,62}}
 	end
---	table.insert(goods[stationArmstrong],{"warp",5,77})
-	stationArmstrong.publicRelations = true
-	stationArmstrong.generalInformation = "We manufacture warp, impulse and jump engines for the human navy fleet as well as other independent clients on a contract basis"
-	stationArmstrong.stationHistory = "The station is named after the late 19th century astronaut as well as the fictionlized stations that followed. The station initially constructed entire space worthy vessels. In time, it transitioned into specializeing in propulsion systems."
 	return stationArmstrong
 end
 function placeAsimov()
 	--Asimov
 	stationAsimov = SpaceStation():setTemplate(szt()):setFaction(stationFaction):setCommsScript(""):setCommsFunction(commsStation)
 	stationAsimov:setCallSign("Asimov"):setDescription("Training and Coordination"):setPosition(psx,psy)
+    stationAsimov.comms_data = {
+    	friendlyness = random(0,100),
+        weapons = 			{Homing = "neutral",					HVLI = "neutral", 						Mine = "neutral",						Nuke = "friend", 						EMP = "friend"},
+        weapon_available = 	{Homing = random(1,10)<=(8-difficulty),	HVLI = random(1,10)<=(9-difficulty),	Mine = random(1,10)<=(7-difficulty),	Nuke = random(1,10)<=(5-difficulty),	EMP = random(1,10)<=(6-difficulty)},
+        service_cost = 		{supplydrop = math.random(80,120), reinforcements = math.random(125,175)},
+        reputation_cost_multipliers = {friend = 1.0, neutral = 3.0},
+        max_weapon_refill_amount = {friend = 1.0, neutral = 0.5 },
+        goods = {	tractor =	{quantity = 5,	cost = 48} },
+        trade = {	food = false, medicine = false, luxury = false },
+        public_relations = true,
+        general_information = "We train naval cadets in routine and specialized functions aboard space vessels and coordinate naval activity throughout the sector",
+    	history = "The original station builders were fans of the late 20th century scientist and author Isaac Asimov. The station was initially named Foundation, but was later changed simply to Asimov. It started off as a stellar observatory, then became a supply stop and as it has grown has become an educational and coordination hub for the region"
+	}
 	if stationFaction == "Human Navy" then
+		stationAsimov.comms_data.goods.food = {quantity = math.random(5,10), cost = 1}
 		if random(1,5) <= 1 then
-			goods[stationAsimov] = {{"food",math.random(5,10),1},{"medicine",5,5},{"tractor",5,48}}
-		else
-			goods[stationAsimov] = {{"food",math.random(5,10),1},{"tractor",5,48}}		
+			stationAsimov.comms_data.goods.medicine = {quantity = 5, cost = 5}
 		end
-	else
-		goods[stationAsimov] = {{"tractor",5,48}}
 	end
-	stationAsimov.publicRelations = true
-	stationAsimov.generalInformation = "We train naval cadets in routine and specialized functions aboard space vessels and coordinate naval activity throughout the sector"
-	stationAsimov.stationHistory = "The original station builders were fans of the late 20th century scientist and author Isaac Asimov. The station was initially named Foundation, but was later changed simply to Asimov. It started off as a stellar observatory, then became a supply stop and as it has grown has become an educational and coordination hub for the region"
 	return stationAsimov
 end
 function placeBarclay()
 	--Barclay
 	stationBarclay = SpaceStation():setTemplate(szt()):setFaction(stationFaction):setCommsScript(""):setCommsFunction(commsStation)
 	stationBarclay:setPosition(psx,psy):setCallSign("Barclay"):setDescription("Communication components")
+    stationBarclay.comms_data = {
+    	friendlyness = random(0,100),
+        weapons = 			{Homing = "neutral",					HVLI = "neutral", 						Mine = "neutral",						Nuke = "friend", 						EMP = "friend"},
+        weapon_available = 	{Homing = random(1,10)<=(8-difficulty),	HVLI = random(1,10)<=(9-difficulty),	Mine = random(1,10)<=(7-difficulty),	Nuke = random(1,10)<=(5-difficulty),	EMP = random(1,10)<=(6-difficulty)},
+        service_cost = 		{supplydrop = math.random(80,120), reinforcements = math.random(125,175)},
+        reputation_cost_multipliers = {friend = 1.0, neutral = 3.0},
+        max_weapon_refill_amount = {friend = 1.0, neutral = 0.5 },
+        goods = {	communication =	{quantity = 5,	cost = 58} },
+        trade = {	food = false, medicine = false, luxury = false },
+		buy =	{	[randomMineral()] = math.random(40,200)	},
+        public_relations = true,
+        general_information = "We provide a range of communication equipment and software for use aboard ships",
+    	history = "The station is named after Reginald Barclay who established the first transgalactic com link through the creative application of a quantum singularity. Station personnel often refer to the station as the Broccoli station"
+	}
 	if stationFaction == "Human Navy" then
+		stationBarclay.comms_data.goods.food = {quantity = math.random(5,10), cost = 1}
 		if random(1,5) <= 1 then
-			goods[stationBarclay] = {{"food",math.random(5,10),1},{"medicine",5,5},{"communication",5,58}}
+			stationBarclay.comms_data.goods.medicine = {quantity = 5, cost = 5}
 		else
-			goods[stationBarclay] = {{"food",math.random(5,10),1},{"communication",5,58}}
-			tradeMedicine[stationBarclay] = true
+			stationBarclay.comms_data.trade.medicine = true
 		end
 	else
-		goods[stationBarclay] = {{"communication",5,58}}
-		tradeMedicine[stationBarclay] = true
+		stationBarclay.comms_data.trade.medicine = true
 	end
-	stationBarclay.publicRelations = true
-	stationBarclay.generalInformation = "We provide a range of communication equipment and software for use aboard ships"
-	stationBarclay.stationHistory = "The station is named after Reginald Barclay who established the first transgalactic com link through the creative application of a quantum singularity. Station personnel often refer to the station as the Broccoli station"
 	return stationBarclay
 end
 function placeBethesda()
 	--Bethesda 
 	stationBethesda = SpaceStation():setTemplate(szt()):setFaction(stationFaction):setCommsScript(""):setCommsFunction(commsStation)
 	stationBethesda:setPosition(psx,psy):setCallSign("Bethesda"):setDescription("Medical research")
-	goods[stationBethesda] = {{"food",math.random(5,10),1},{"medicine",5,5},{"autodoc",5,36}}
-	stationBethesda.publicRelations = true
-	stationBethesda.generalInformation = "We research and treat exotic medical conditions"
-	stationBethesda.stationHistory = "The station is named after the United States national medical research center based in Bethesda, Maryland on earth which was established in the mid 20th century"
+    stationBethesda.comms_data = {
+    	friendlyness = random(0,100),
+        weapons = 			{Homing = "neutral",					HVLI = "neutral", 						Mine = "neutral",						Nuke = "friend", 						EMP = "friend"},
+        weapon_available = 	{Homing = random(1,10)<=(8-difficulty),	HVLI = random(1,10)<=(9-difficulty),	Mine = random(1,10)<=(7-difficulty),	Nuke = random(1,10)<=(5-difficulty),	EMP = random(1,10)<=(6-difficulty)},
+        service_cost = 		{supplydrop = math.random(80,120), reinforcements = math.random(125,175)},
+        reputation_cost_multipliers = {friend = 1.0, neutral = 3.0},
+        max_weapon_refill_amount = {friend = 1.0, neutral = 0.5 },
+        goods = {	autodoc =	{quantity = 5,					cost = 36},
+        			medicine =	{quantity = 5,					cost = 5},
+        			food =		{quantity = math.random(5,10),	cost = 1} },
+        trade = {	food = false, medicine = false, luxury = false },
+        public_relations = true,
+        general_information = "We research and treat exotic medical conditions",
+    	history = "The station is named after the United States national medical research center based in Bethesda, Maryland on earth which was established in the mid 20th century"
+	}
 	return stationBethesda
 end
 function placeBroeck()
 	--Broeck
 	stationBroeck = SpaceStation():setTemplate(szt()):setFaction(stationFaction):setCommsScript(""):setCommsFunction(commsStation)
 	stationBroeck:setPosition(psx,psy):setCallSign("Broeck"):setDescription("Warp drive components")
+    stationBroeck.comms_data = {
+    	friendlyness = random(0,100),
+        weapons = 			{Homing = "neutral",					HVLI = "neutral", 						Mine = "neutral",						Nuke = "friend", 						EMP = "friend"},
+        weapon_available = 	{Homing = random(1,10)<=(8-difficulty),	HVLI = random(1,10)<=(9-difficulty),	Mine = random(1,10)<=(7-difficulty),	Nuke = random(1,10)<=(5-difficulty),	EMP = random(1,10)<=(6-difficulty)},
+        service_cost = 		{supplydrop = math.random(80,120), reinforcements = math.random(125,175)},
+        reputation_cost_multipliers = {friend = 1.0, neutral = 3.0},
+        max_weapon_refill_amount = {friend = 1.0, neutral = 0.5 },
+        goods = {	warp =	{quantity = 5,	cost = 36} },
+        trade = {	food = false, medicine = false, luxury = random(1,100) < 62 },
+		buy =	{	[randomMineral()] = math.random(40,200)	},
+        public_relations = true,
+        general_information = "We provide warp drive engines and components",
+    	history = "This station is named after Chris Van Den Broeck who did some initial research into the possibility of warp drive in the late 20th century on Earth"
+	}
 	if stationFaction == "Human Navy" then
+		stationBroeck.comms_data.goods.food = {quantity = math.random(5,10), cost = 1}
 		if random(1,5) <= 1 then
-			goods[stationBroeck] = {{"food",math.random(5,10),1},{"medicine",5,5},{"warp",5,130}}
-			if random(1,100) < 62 then tradeLuxury[stationBroeck] = true end
+			stationBroeck.comms_data.goods.medicine = {quantity = 5, cost = 5}
 		else
-			goods[stationBroeck] = {{"food",math.random(5,10),1},{"warp",5,130}}		
-			if random(1,100) < 53 then tradeMedicine[stationBroeck] = true end
-			if random(1,100) < 62 then tradeLuxury[stationBroeck] = true end
+			stationBroeck.comms_data.trade.medicine = random(1,100) < 53
 		end
 	else
-		goods[stationBroeck] = {{"warp",5,130}}
-		if random(1,100) < 53 then tradeMedicine[stationBroeck] = true end
-		if random(1,100) < 14 then tradeFood[stationBroeck] = true end
-		if random(1,100) < 62 then tradeLuxury[stationBroeck] = true end
+		stationBroeck.comms_data.trade.medicine = random(1,100) < 53
+		stationBroeck.comms_data.trade.food = random(1,100) < 14
 	end
-	stationBroeck.publicRelations = true
-	stationBroeck.generalInformation = "We provide warp drive engines and components"
-	stationBroeck.stationHistory = "This station is named after Chris Van Den Broeck who did some initial research into the possibility of warp drive in the late 20th century on Earth"
 	return stationBroeck
 end
 function placeCalifornia()
 	--California
 	stationCalifornia = SpaceStation():setTemplate(szt()):setFaction(stationFaction):setCommsScript(""):setCommsFunction(commsStation)
 	stationCalifornia:setPosition(psx,psy):setCallSign("California"):setDescription("Mining station")
+    stationCalifornia.comms_data = {
+    	friendlyness = random(0,100),
+        weapons = 			{Homing = "neutral",					HVLI = "neutral", 						Mine = "neutral",						Nuke = "friend", 						EMP = "friend"},
+        weapon_available = 	{Homing = random(1,10)<=(8-difficulty),	HVLI = random(1,10)<=(9-difficulty),	Mine = random(1,10)<=(7-difficulty),	Nuke = random(1,10)<=(5-difficulty),	EMP = random(1,10)<=(6-difficulty)},
+        service_cost = 		{supplydrop = math.random(80,120), reinforcements = math.random(125,175)},
+        reputation_cost_multipliers = {friend = 1.0, neutral = 3.0},
+        max_weapon_refill_amount = {friend = 1.0, neutral = 0.5 },
+        goods = {	gold =		{quantity = 5,	cost = 90},
+        			dilithium =	{quantity = 2,	cost = 25} },
+        trade = {	food = false, medicine = false, luxury = false },
+		buy =	{	[randomComponent()] = math.random(40,200)	}
+	}
 	if stationFaction == "Human Navy" then
+		stationCalifornia.comms_data.goods.food = {quantity = math.random(5,10), cost = 1}
 		if random(1,5) <= 1 then
-			goods[stationCalifornia] = {{"food",math.random(5,10),1},{"medicine",5,5},{"gold",5,25},{"dilithium",2,25}}
-		else
-			goods[stationCalifornia] = {{"food",math.random(5,10),1},{"gold",5,25},{"dilithium",2,25}}		
+			stationCalifornia.comms_data.goods.medicine = {quantity = 5, cost = 5}
 		end
-	else
-		goods[stationCalifornia] = {{"gold",5,25},{"dilithium",2,25}}
 	end
 	return stationCalifornia
 end
@@ -1724,220 +2077,304 @@ function placeCalvin()
 	--Calvin 
 	stationCalvin = SpaceStation():setTemplate(szt()):setFaction(stationFaction):setCommsScript(""):setCommsFunction(commsStation)
 	stationCalvin:setPosition(psx,psy):setCallSign("Calvin"):setDescription("Robotic research")
+    stationCalvin.comms_data = {
+    	friendlyness = random(0,100),
+        weapons = 			{Homing = "neutral",					HVLI = "neutral", 						Mine = "neutral",						Nuke = "friend", 						EMP = "friend"},
+        weapon_available = 	{Homing = random(1,10)<=(8-difficulty),	HVLI = random(1,10)<=(9-difficulty),	Mine = random(1,10)<=(7-difficulty),	Nuke = random(1,10)<=(5-difficulty),	EMP = random(1,10)<=(6-difficulty)},
+        service_cost = 		{supplydrop = math.random(80,120), reinforcements = math.random(125,175)},
+        reputation_cost_multipliers = {friend = 1.0, neutral = 3.0},
+        max_weapon_refill_amount = {friend = 1.0, neutral = 0.5 },
+        goods = {	robotic =	{quantity = 5,	cost = 90} },
+        trade = {	food = false, medicine = false, luxury = true },
+		buy =	{	[randomComponent("robotic")] = math.random(40,200)	},
+        public_relations = true,
+        general_information = "We research and provide robotic systems and components",
+    	history = "This station is named after Dr. Susan Calvin who pioneered robotic behavioral research and programming"
+	}
 	if stationFaction == "Human Navy" then
+		stationCalvin.comms_data.goods.food = {quantity = math.random(5,10), cost = 1}
 		if random(1,5) <= 1 then
-			goods[stationCalvin] = {{"food",math.random(5,10),1},{"medicine",5,5},{"robotic",5,87}}
-		else
-			goods[stationCalvin] = {{"food",math.random(5,10),1},{"robotic",5,87}}		
+			stationCalvin.comms_data.goods.medicine = {quantity = 5, cost = 5}
 		end
 	else
-		goods[stationCalvin] = {{"robotic",5,87}}
-		if random(1,100) < 8 then tradeFood[stationCalvin] = true end
+		stationCalvin.comms_data.trade.food = random(1,100) < 8
 	end
-	tradeLuxury[stationCalvin] = true
-	stationCalvin.publicRelations = true
-	stationCalvin.generalInformation = "We research and provide robotic systems and components"
-	stationCalvin.stationHistory = "This station is named after Dr. Susan Calvin who pioneered robotic behavioral research and programming"
 	return stationCalvin
 end
 function placeCavor()
 	--Cavor 
 	stationCavor = SpaceStation():setTemplate(szt()):setFaction(stationFaction):setCommsScript(""):setCommsFunction(commsStation)
 	stationCavor:setPosition(psx,psy):setCallSign("Cavor"):setDescription("Advanced Material components")
+    stationCavor.comms_data = {
+    	friendlyness = random(0,100),
+        weapons = 			{Homing = "neutral",					HVLI = "neutral", 						Mine = "neutral",						Nuke = "friend", 						EMP = "friend"},
+        weapon_available = 	{Homing = random(1,10)<=(8-difficulty),	HVLI = random(1,10)<=(9-difficulty),	Mine = random(1,10)<=(7-difficulty),	Nuke = random(1,10)<=(5-difficulty),	EMP = random(1,10)<=(6-difficulty)},
+        service_cost = 		{supplydrop = math.random(80,120), reinforcements = math.random(125,175)},
+        reputation_cost_multipliers = {friend = 1.0, neutral = 3.0},
+        max_weapon_refill_amount = {friend = 1.0, neutral = 0.5 },
+        goods = {	filament =	{quantity = 5,	cost = 42} },
+        trade = {	food = false, medicine = false, luxury = false },
+        public_relations = true,
+        general_information = "We fabricate several different kinds of materials critical to various space industries like ship building, station construction and mineral extraction",
+    	history = "We named our station after Dr. Cavor, the physicist that invented a barrier material for gravity waves - Cavorite"
+	}
 	if stationFaction == "Human Navy" then
+		stationCavor.comms_data.goods.food = {quantity = math.random(5,10), cost = 1}
 		if random(1,5) <= 1 then
-			goods[stationCavor] = {{"food",math.random(5,10),1},{"medicine",5,5},{"filament",5,42}}
-			if random(1,100) < 33 then tradeLuxury[stationCavor] = true end
+			stationCavor.comms_data.goods.medicine = {quantity = 5, cost = 5}
+			stationCavor.comms_data.trade.luxury = random(1,100) < 33
 		else
-			goods[stationCavor] = {{"food",math.random(5,10),1},{"filament",5,42}}	
 			if random(1,100) < 50 then
-				tradeMedicine[stationCavor] = true
+				stationCavor.comms_data.trade.medicine = true
 			else
-				tradeLuxury[stationCavor] = true
+				stationCavor.comms_data.trade.luxury = true
 			end
 		end
 	else
-		goods[stationCavor] = {{"filament",5,42}}
-		whatTrade = random(1,100)
+		local whatTrade = random(1,100)
 		if whatTrade < 33 then
-			tradeMedicine[stationCavor] = true
+			stationCavor.comms_data.trade.medicine = true
 		elseif whatTrade > 66 then
-			tradeFood[stationCavor] = true
+			stationCavor.comms_data.trade.food = true
 		else
-			tradeLuxury[stationCavor] = true
+			stationCavor.comms_data.trade.luxury = true
 		end
 	end
-	stationCavor.publicRelations = true
-	stationCavor.generalInformation = "We fabricate several different kinds of materials critical to various space industries like ship building, station construction and mineral extraction"
-	stationCavor.stationHistory = "We named our station after Dr. Cavor, the physicist that invented a barrier material for gravity waves - Cavorite"
 	return stationCavor
 end
 function placeChatuchak()
 	--Chatuchak
 	stationChatuchak = SpaceStation():setTemplate(szt()):setFaction(stationFaction):setCommsScript(""):setCommsFunction(commsStation)
 	stationChatuchak:setPosition(psx,psy):setCallSign("Chatuchak"):setDescription("Trading station")
+    stationChatuchak.comms_data = {
+    	friendlyness = random(0,100),
+        weapons = 			{Homing = "neutral",					HVLI = "neutral", 						Mine = "neutral",						Nuke = "friend", 						EMP = "friend"},
+        weapon_available = 	{Homing = random(1,10)<=(8-difficulty),	HVLI = random(1,10)<=(9-difficulty),	Mine = random(1,10)<=(7-difficulty),	Nuke = random(1,10)<=(5-difficulty),	EMP = random(1,10)<=(6-difficulty)},
+        service_cost = 		{supplydrop = math.random(80,120), reinforcements = math.random(125,175)},
+        reputation_cost_multipliers = {friend = 1.0, neutral = 3.0},
+        max_weapon_refill_amount = {friend = 1.0, neutral = 0.5 },
+        goods = {	luxury =	{quantity = 5,	cost = 60} },
+        trade = {	food = false, medicine = false, luxury = false },
+        public_relations = true,
+        general_information = "Only the largest market and trading location in twenty sectors. You can find your heart's desire here",
+    	history = "Modeled after the early 21st century bazaar on Earth in Bangkok, Thailand. Designed and built with trade and commerce in mind"
+	}
 	if stationFaction == "Human Navy" then
+		stationChatuchak.comms_data.goods.food = {quantity = math.random(5,10), cost = 1}
 		if random(1,5) <= 1 then
-			goods[stationChatuchak] = {{"food",math.random(5,10),1},{"medicine",5,5},{"luxury",5,60}}
-		else
-			goods[stationChatuchak] = {{"food",math.random(5,10),1},{"luxury",5,60}}		
+			stationChatuchak.comms_data.goods.medicine = {quantity = 5, cost = 5}
 		end
-	else
-		goods[stationChatuchak] = {{"luxury",5,60}}		
 	end
-	stationChatuchak.publicRelations = true
-	stationChatuchak.generalInformation = "Only the largest market and trading location in twenty sectors. You can find your heart's desire here"
-	stationChatuchak.stationHistory = "Modeled after the early 21st century bazaar on Earth in Bangkok, Thailand. Designed and built with trade and commerce in mind"
 	return stationChatuchak
 end
 function placeCoulomb()
 	--Coulomb
 	stationCoulomb = SpaceStation():setTemplate(szt()):setFaction(stationFaction):setCommsScript(""):setCommsFunction(commsStation)
 	stationCoulomb:setPosition(psx,psy):setCallSign("Coulomb"):setDescription("Shielded circuitry fabrication")
+    stationCoulomb.comms_data = {
+    	friendlyness = random(0,100),
+        weapons = 			{Homing = "neutral",					HVLI = "neutral", 						Mine = "neutral",						Nuke = "friend", 						EMP = "friend"},
+        weapon_available = 	{Homing = random(1,10)<=(8-difficulty),	HVLI = random(1,10)<=(9-difficulty),	Mine = random(1,10)<=(7-difficulty),	Nuke = random(1,10)<=(5-difficulty),	EMP = random(1,10)<=(6-difficulty)},
+        service_cost = 		{supplydrop = math.random(80,120), reinforcements = math.random(125,175)},
+        reputation_cost_multipliers = {friend = 1.0, neutral = 3.0},
+        max_weapon_refill_amount = {friend = 1.0, neutral = 0.5 },
+        goods = {	circuit =	{quantity = 5,	cost = 50} },
+        trade = {	food = false, medicine = false, luxury = random(1,100) < 82 },
+		buy =	{	[randomMineral()] = math.random(40,200)	},
+        public_relations = true,
+        general_information = "We make a large variety of circuits for numerous ship systems shielded from sensor detection and external control interference",
+    	history = "Our station is named after the law which quantifies the amount of force with which stationary electrically charged particals repel or attact each other - a fundamental principle in the design of our circuits"
+	}
 	if stationFaction == "Human Navy" then
+		stationCoulomb.comms_data.goods.food = {quantity = math.random(5,10), cost = 1}
 		if random(1,5) <= 1 then
-			goods[stationCoulomb] = {{"food",math.random(5,10),1},{"medicine",5,5},{"circuit",5,50}}
+			stationCoulomb.comms_data.goods.medicine = {quantity = 5, cost = 5}
 		else
-			goods[stationCoulomb] = {{"food",math.random(5,10),1},{"circuit",5,50}}		
-			if random(1,100) < 27 then tradeMedicine[stationCoulomb] = true end
+			stationCoulomb.comms_data.trade.medicine = random(1,100) < 27
 		end
 	else
-		goods[stationCoulomb] = {{"circuit",5,50}}		
-		if random(1,100) < 27 then tradeMedicine[stationCoulomb] = true end
-		if random(1,100) < 16 then tradeFood[stationCoulomb] = true end
+		stationCoulomb.comms_data.trade.medicine = random(1,100) < 27
+		stationCoulomb.comms_data.trade.food = random(1,100) < 16
 	end
-	if random(1,100) < 82 then tradeLuxury[stationCoulomb] = true end
-	stationCoulomb.publicRelations = true
-	stationCoulomb.generalInformation = "We make a large variety of circuits for numerous ship systems shielded from sensor detection and external control interference"
-	stationCoulomb.stationHistory = "Our station is named after the law which quantifies the amount of force with which stationary electrically charged particals repel or attact each other - a fundamental principle in the design of our circuits"
 	return stationCoulomb
 end
 function placeCyrus()
 	--Cyrus
 	stationCyrus = SpaceStation():setTemplate(szt()):setFaction(stationFaction):setCommsScript(""):setCommsFunction(commsStation)
 	stationCyrus:setPosition(psx,psy):setCallSign("Cyrus"):setDescription("Impulse engine components")
+    stationCyrus.comms_data = {
+    	friendlyness = random(0,100),
+        weapons = 			{Homing = "neutral",					HVLI = "neutral", 						Mine = "neutral",						Nuke = "friend", 						EMP = "friend"},
+        weapon_available = 	{Homing = random(1,10)<=(8-difficulty),	HVLI = random(1,10)<=(9-difficulty),	Mine = random(1,10)<=(7-difficulty),	Nuke = random(1,10)<=(5-difficulty),	EMP = random(1,10)<=(6-difficulty)},
+        service_cost = 		{supplydrop = math.random(80,120), reinforcements = math.random(125,175)},
+        reputation_cost_multipliers = {friend = 1.0, neutral = 3.0},
+        max_weapon_refill_amount = {friend = 1.0, neutral = 0.5 },
+        goods = {	impulse =	{quantity = 5,	cost = 124} },
+        trade = {	food = false, medicine = false, luxury = random(1,100) < 78 },
+        public_relations = true,
+        general_information = "We supply high quality impulse engines and parts for use aboard ships",
+    	history = "This station was named after the fictional engineer, Cyrus Smith created by 19th century author Jules Verne"
+	}
 	if stationFaction == "Human Navy" then
+		stationCyrus.comms_data.goods.food = {quantity = math.random(5,10), cost = 1}
 		if random(1,5) <= 1 then
-			goods[stationCyrus] = {{"food",math.random(5,10),1},{"medicine",5,5},{"impulse",5,124}}
+			stationCyrus.comms_data.goods.medicine = {quantity = 5, cost = 5}
 		else
-			goods[stationCyrus] = {{"food",math.random(5,10),1},{"impulse",5,124}}		
-			if random(1,100) < 34 then tradeMedicine[stationCyrus] = true end
+			stationCyrus.comms_data.trade.medicine = random(1,100) < 34
 		end
 	else
-		goods[stationCyrus] = {{"impulse",5,124}}		
-		if random(1,100) < 34 then tradeMedicine[stationCyrus] = true end
-		if random(1,100) < 13 then tradeFood[stationCyrus] = true end
+		stationCyrus.comms_data.trade.medicine = random(1,100) < 34
+		stationCyrus.comms_data.trade.food = random(1,100) < 13
 	end
-	if random(1,100) < 78 then tradeLuxury[stationCyrus] = true end
-	stationCyrus.publicRelations = true
-	stationCyrus.generalInformation = "We supply high quality impulse engines and parts for use aboard ships"
-	stationCyrus.stationHistory = "This station was named after the fictional engineer, Cyrus Smith created by 19th century author Jules Verne"
 	return stationCyrus
 end
 function placeDeckard()
 	--Deckard
 	stationDeckard = SpaceStation():setTemplate(szt()):setFaction(stationFaction):setCommsScript(""):setCommsFunction(commsStation)
 	stationDeckard:setPosition(psx,psy):setCallSign("Deckard"):setDescription("Android components")
+    stationDeckard.comms_data = {
+    	friendlyness = random(0,100),
+        weapons = 			{Homing = "neutral",					HVLI = "neutral", 						Mine = "neutral",						Nuke = "friend", 						EMP = "friend"},
+        weapon_available = 	{Homing = random(1,10)<=(8-difficulty),	HVLI = random(1,10)<=(9-difficulty),	Mine = random(1,10)<=(7-difficulty),	Nuke = random(1,10)<=(5-difficulty),	EMP = random(1,10)<=(6-difficulty)},
+        service_cost = 		{supplydrop = math.random(80,120), reinforcements = math.random(125,175)},
+        reputation_cost_multipliers = {friend = 1.0, neutral = 3.0},
+        max_weapon_refill_amount = {friend = 1.0, neutral = 0.5 },
+        goods = {	android =	{quantity = 5,	cost = 73} },
+        trade = {	food = false, medicine = false, luxury = true },
+        public_relations = true,
+        general_information = "Supplier of android components, programming and service",
+    	history = "Named for Richard Deckard who inspired many of the sophisticated safety security algorithms now required for all androids"
+	}
 	if stationFaction == "Human Navy" then
+		stationDeckard.comms_data.goods.food = {quantity = math.random(5,10), cost = 1}
 		if random(1,5) <= 1 then
-			goods[stationDeckard] = {{"food",math.random(5,10),1},{"medicine",5,5},{"android",5,73}}
-		else
-			goods[stationDeckard] = {{"food",math.random(5,10),1},{"android",5,73}}		
+			stationDeckard.comms_data.goods.medicine = {quantity = 5, cost = 5}
+			stationDeckard.comms_data.goods.medicine.cost = 5
 		end
 	else
-		goods[stationDeckard] = {{"android",5,73}}		
-		tradeFood[stationDeckard] = true
+		stationDeckard.comms_data.trade.food = true
 	end
-	tradeLuxury[stationDeckard] = true
-	stationDeckard.publicRelations = true
-	stationDeckard.generalInformation = "Supplier of android components, programming and service"
-	stationDeckard.stationHistory = "Named for Richard Deckard who inspired many of the sophisticated safety security algorithms now required for all androids"
 	return stationDeckard
 end
 function placeDeer()
 	--Deer
 	stationDeer = SpaceStation():setTemplate(szt()):setFaction(stationFaction):setCommsScript(""):setCommsFunction(commsStation)
 	stationDeer:setPosition(psx,psy):setCallSign("Deer"):setDescription("Repulsor and Tractor Beam Components")
+    stationDeer.comms_data = {
+    	friendlyness = random(0,100),
+        weapons = 			{Homing = "neutral",					HVLI = "neutral", 						Mine = "neutral",						Nuke = "friend", 						EMP = "friend"},
+        weapon_available = 	{Homing = random(1,10)<=(8-difficulty),	HVLI = random(1,10)<=(9-difficulty),	Mine = random(1,10)<=(7-difficulty),	Nuke = random(1,10)<=(5-difficulty),	EMP = random(1,10)<=(6-difficulty)},
+        service_cost = 		{supplydrop = math.random(80,120), reinforcements = math.random(125,175)},
+        reputation_cost_multipliers = {friend = 1.0, neutral = 3.0},
+        max_weapon_refill_amount = {friend = 1.0, neutral = 0.5 },
+        goods = {	tractor =	{quantity = 5,	cost = 90},
+        			repulsor =	{quantity = 5,	cost = 95} },
+        trade = {	food = false, medicine = false, luxury = true },
+		buy =	{	[randomMineral()] = math.random(40,200)	},
+        public_relations = true,
+        general_information = "We can meet all your pushing and pulling needs with specialized equipment custom made",
+    	history = "The station name comes from a short story by the 20th century author Clifford D. Simak as well as from the 19th century developer John Deere who inspired a company that makes the Earth bound equivalents of our products"
+	}
 	if stationFaction == "Human Navy" then
+		stationDeer.comms_data.goods.food = {quantity = math.random(5,10), cost = 1}
+		stationDeer.comms_data.goods.food.cost = 1
 		if random(1,5) <= 1 then
-			goods[stationDeer] = {{"food",math.random(5,10),1},{"medicine",5,5},{"tractor",5,90},{"repulsor",5,95}}
+			stationDeer.comms_data.goods.medicine = {quantity = 5, cost = 5}
 		else
-			goods[stationDeer] = {{"food",math.random(5,10),1},{"tractor",5,90},{"repulsor",5,95}}		
-			tradeMedicine[stationDeer] = true
+			stationDeer.comms_data.trade.medicine = true
 		end
 	else
-		goods[stationDeer] = {{"tractor",5,90},{"repulsor",5,95}}		
-		tradeFood[stationDeer] = true
-		tradeMedicine[stationDeer] = true
+		stationDeer.comms_data.trade.medicine = true
+		stationDeer.comms_data.trade.food = true
 	end
-	tradeLuxury[stationDeer] = true
-	stationDeer.publicRelations = true
-	stationDeer.generalInformation = "We can meet all your pushing and pulling needs with specialized equipment custom made"
-	stationDeer.stationHistory = "The station name comes from a short story by the 20th century author Clifford D. Simak as well as from the 19th century developer John Deere who inspired a company that makes the Earth bound equivalents of our products"
 	return stationDeer
 end
 function placeErickson()
 	--Erickson
 	stationErickson = SpaceStation():setTemplate(szt()):setFaction(stationFaction):setCommsScript(""):setCommsFunction(commsStation)
 	stationErickson:setPosition(psx,psy):setCallSign("Erickson"):setDescription("Transporter components")
+    stationErickson.comms_data = {
+    	friendlyness = random(0,100),
+        weapons = 			{Homing = "neutral",					HVLI = "neutral", 						Mine = "neutral",						Nuke = "friend", 						EMP = "friend"},
+        weapon_available = 	{Homing = random(1,10)<=(8-difficulty),	HVLI = random(1,10)<=(9-difficulty),	Mine = random(1,10)<=(7-difficulty),	Nuke = random(1,10)<=(5-difficulty),	EMP = random(1,10)<=(6-difficulty)},
+        service_cost = 		{supplydrop = math.random(80,120), reinforcements = math.random(125,175)},
+        reputation_cost_multipliers = {friend = 1.0, neutral = 3.0},
+        max_weapon_refill_amount = {friend = 1.0, neutral = 0.5 },
+        goods = {	transporter =	{quantity = 5,	cost = 90} },
+        trade = {	food = false, medicine = false, luxury = true },
+        public_relations = true,
+        general_information = "We provide transporters used aboard ships as well as the components for repair and maintenance",
+    	history = "The station is named after the early 22nd century inventor of the transporter, Dr. Emory Erickson. This station is proud to have received the endorsement of Admiral Leonard McCoy"
+	}
 	if stationFaction == "Human Navy" then
+		stationErickson.comms_data.goods.food = {quantity = math.random(5,10), cost = 1}
 		if random(1,5) <= 1 then
-			goods[stationErickson] = {{"food",math.random(5,10),1},{"medicine",5,5},{"transporter",5,63}}
+			stationErickson.comms_data.goods.medicine = {quantity = 5, cost = 5}
 		else
-			goods[stationErickson] = {{"food",math.random(5,10),1},{"transporter",5,63}}		
-			tradeMedicine[stationErickson] = true 
+			stationErickson.comms_data.trade.medicine = true
 		end
 	else
-		goods[stationErickson] = {{"transporter",5,63}}		
-		tradeFood[stationErickson] = true
-		tradeMedicine[stationErickson] = true 
+		stationErickson.comms_data.trade.medicine = true
+		stationErickson.comms_data.trade.food = true
 	end
-	tradeLuxury[stationErickson] = true 
-	stationErickson.publicRelations = true
-	stationErickson.generalInformation = "We provide transporters used aboard ships as well as the components for repair and maintenance"
-	stationErickson.stationHistory = "The station is named after the early 22nd century inventor of the transporter, Dr. Emory Erickson. This station is proud to have received the endorsement of Admiral Leonard McCoy"
 	return stationErickson
 end
 function placeEvondos()
 	--Evondos
 	stationEvondos = SpaceStation():setTemplate(szt()):setFaction(stationFaction):setCommsScript(""):setCommsFunction(commsStation)
 	stationEvondos:setPosition(psx,psy):setCallSign("Evondos"):setDescription("Autodoc components")
+    stationEvondos.comms_data = {
+    	friendlyness = random(0,100),
+        weapons = 			{Homing = "neutral",					HVLI = "neutral", 						Mine = "neutral",						Nuke = "friend", 						EMP = "friend"},
+        weapon_available = 	{Homing = random(1,10)<=(8-difficulty),	HVLI = random(1,10)<=(9-difficulty),	Mine = random(1,10)<=(7-difficulty),	Nuke = random(1,10)<=(5-difficulty),	EMP = random(1,10)<=(6-difficulty)},
+        service_cost = 		{supplydrop = math.random(80,120), reinforcements = math.random(125,175)},
+        reputation_cost_multipliers = {friend = 1.0, neutral = 3.0},
+        max_weapon_refill_amount = {friend = 1.0, neutral = 0.5 },
+        goods = {	autodoc =	{quantity = 5,	cost = 56} },
+        trade = {	food = false, medicine = false, luxury = random(1,100) < 41 },
+        public_relations = true,
+        general_information = "We provide components for automated medical machinery",
+    	history = "The station is the evolution of the company that started automated pharmaceutical dispensing in the early 21st century on Earth in Finland"
+	}
 	if stationFaction == "Human Navy" then
+		stationEvondos.comms_data.goods.food = {quantity = math.random(5,10), cost = 1}
 		if random(1,5) <= 1 then
-			goods[stationEvondos] = {{"food",math.random(5,10),1},{"medicine",5,5},{"autodoc",5,56}}
+			stationEvondos.comms_data.goods.medicine = {quantity = 5, cost = 5}
 		else
-			goods[stationEvondos] = {{"food",math.random(5,10),1},{"autodoc",5,56}}		
-			tradeMedicine[stationEvondos] = true 
+			stationEvondos.comms_data.trade.medicine = true
 		end
 	else
-		goods[stationEvondos] = {{"autodoc",5,56}}		
-		tradeMedicine[stationEvondos] = true 
+		stationEvondos.comms_data.trade.medicine = true
 	end
-	if random(1,100) < 41 then tradeLuxury[stationEvondos] = true end
-	stationEvondos.publicRelations = true
-	stationEvondos.generalInformation = "We provide components for automated medical machinery"
-	stationEvondos.stationHistory = "The station is the evolution of the company that started automated pharmaceutical dispensing in the early 21st century on Earth in Finland"
 	return stationEvondos
 end
 function placeFeynman()
 	--Feynman 
 	stationFeynman = SpaceStation():setTemplate(szt()):setFaction(stationFaction):setCommsScript(""):setCommsFunction(commsStation)
 	stationFeynman:setPosition(psx,psy):setCallSign("Feynman"):setDescription("Nanotechnology research")
+    stationFeynman.comms_data = {
+    	friendlyness = random(0,100),
+        weapons = 			{Homing = "neutral",					HVLI = "neutral", 						Mine = "neutral",						Nuke = "friend", 						EMP = "friend"},
+        weapon_available = 	{Homing = random(1,10)<=(8-difficulty),	HVLI = random(1,10)<=(9-difficulty),	Mine = random(1,10)<=(7-difficulty),	Nuke = random(1,10)<=(5-difficulty),	EMP = random(1,10)<=(6-difficulty)},
+        service_cost = 		{supplydrop = math.random(80,120), reinforcements = math.random(125,175)},
+        reputation_cost_multipliers = {friend = 1.0, neutral = 3.0},
+        max_weapon_refill_amount = {friend = 1.0, neutral = 0.5 },
+        goods = {	software =	{quantity = 5,	cost = 115},
+        			nanites =	{quantity = 5,	cost = 79} },
+        trade = {	food = false, medicine = false, luxury = true },
+        public_relations = true,
+        general_information = "We provide nanites and software for a variety of ship-board systems",
+    	history = "This station's name recognizes one of the first scientific researchers into nanotechnology, physicist Richard Feynman"
+	}
 	if stationFaction == "Human Navy" then
+		stationFeynman.comms_data.goods.food = {quantity = math.random(5,10), cost = 1}
 		if random(1,5) <= 1 then
-			goods[stationFeynman] = {{"food",math.random(5,10),1},{"medicine",5,5},{"nanites",5,79},{"software",5,115}}
-		else
-			goods[stationFeynman] = {{"food",math.random(5,10),1},{"nanites",5,79},{"software",5,115}}		
+			stationFeynman.comms_data.goods.medicine = {quantity = 5, cost = 5}
 		end
 	else
-		goods[stationFeynman] = {{"nanites",5,79},{"software",5,115}}		
-		tradeFood[stationFeynman] = true
-		if random(1,100) < 26 then tradeFood[stationFeynman] = true end
+		stationFeynman.comms_data.trade.medicine = true
+		stationFeynman.comms_data.trade.food = random(1,100) < 26
 	end
-	tradeLuxury[stationFeynman] = true
-	stationFeynman.publicRelations = true
-	stationFeynman.generalInformation = "We provide nanites and software for a variety of ship-board systems"
-	stationFeynman.stationHistory = "This station's name recognizes one of the first scientific researchers into nanotechnology, physicist Richard Feynman"
 	return stationFeynman
 end
 function placeGrasberg()
@@ -1945,43 +2382,38 @@ function placeGrasberg()
 	placeRandomAroundPoint(Asteroid,15,1,15000,psx,psy)
 	stationGrasberg = SpaceStation():setTemplate(szt()):setFaction(stationFaction):setCommsScript(""):setCommsFunction(commsStation)
 	stationGrasberg:setPosition(psx,psy):setCallSign("Grasberg"):setDescription("Mining")
-	stationGrasberg.publicRelations = true
-	stationGrasberg.generalInformation = "We mine nearby asteroids for precious minerals and process them for sale"
-	stationGrasberg.stationHistory = "This station's name is inspired by a large gold mine on Earth in Indonesia. The station builders hoped to have a similar amount of minerals found amongst these asteroids"
-	grasbergGoods = random(1,100)
+    stationGrasberg.comms_data = {
+    	friendlyness = random(0,100),
+        weapons = 			{Homing = "neutral",					HVLI = "neutral", 						Mine = "neutral",						Nuke = "friend", 						EMP = "friend"},
+        weapon_available = 	{Homing = random(1,10)<=(8-difficulty),	HVLI = random(1,10)<=(9-difficulty),	Mine = random(1,10)<=(7-difficulty),	Nuke = random(1,10)<=(5-difficulty),	EMP = random(1,10)<=(6-difficulty)},
+        service_cost = 		{supplydrop = math.random(80,120), reinforcements = math.random(125,175)},
+        reputation_cost_multipliers = {friend = 1.0, neutral = 3.0},
+        max_weapon_refill_amount = {friend = 1.0, neutral = 0.5 },
+        goods = {	luxury =	{quantity = 5,	cost = 70} },
+        trade = {	food = false, medicine = false, luxury = false },
+		buy =	{	[randomComponent()] = math.random(40,200)	},
+        public_relations = true,
+        general_information = "We mine nearby asteroids for precious minerals and process them for sale",
+    	history = "This station's name is inspired by a large gold mine on Earth in Indonesia. The station builders hoped to have a similar amount of minerals found amongst these asteroids"
+	}
 	if stationFaction == "Human Navy" then
+		stationGrasberg.comms_data.goods.food = {quantity = math.random(5,10), cost = 1}
 		if random(1,5) <= 1 then
-			if grasbergGoods < 20 then
-				goods[stationGrasberg] = {{"luxury",5,70},{"gold",5,25},{"cobalt",4,50},{"food",math.random(5,10),1},{"medicine",5,5}}
-			elseif grasbergGoods < 40 then
-				goods[stationGrasberg] = {{"luxury",5,70},{"gold",5,25},{"food",math.random(5,10),1},{"medicine",5,5}}
-			elseif grasbergGoods < 60 then
-				goods[stationGrasberg] = {{"luxury",5,70},{"cobalt",4,50},{"food",math.random(5,10),1},{"medicine",5,5}}
-			else
-				goods[stationGrasberg] = {{"luxury",5,70},{"food",math.random(5,10),1},{"medicine",5,5}}
-			end
-		else
-			if grasbergGoods < 20 then
-				goods[stationGrasberg] = {{"luxury",5,70},{"gold",5,25},{"cobalt",4,50},{"food",math.random(5,10),1}}
-			elseif grasbergGoods < 40 then
-				goods[stationGrasberg] = {{"luxury",5,70},{"gold",5,25},{"food",math.random(5,10),1}}
-			elseif grasbergGoods < 60 then
-				goods[stationGrasberg] = {{"luxury",5,70},{"cobalt",4,50},{"food",math.random(5,10),1}}
-			else
-				goods[stationGrasberg] = {{"luxury",5,70},{"food",math.random(5,10),1}}
-			end
+			stationGrasberg.comms_data.goods.medicine = {quantity = 5, cost = 5}
 		end
 	else
-		if grasbergGoods < 20 then
-			goods[stationGrasberg] = {{"luxury",5,70},{"gold",5,25},{"cobalt",4,50}}
-		elseif grasbergGoods < 40 then
-			goods[stationGrasberg] = {{"luxury",5,70},{"gold",5,25}}
-		elseif grasbergGoods < 60 then
-			goods[stationGrasberg] = {{"luxury",5,70},{"cobalt",4,50}}
-		else
-			goods[stationGrasberg] = {{"luxury",5,70}}
-		end
-		tradeFood[stationGrasberg] = true
+		stationGrasberg.comms_data.trade.food = true
+	end
+	local grasbergGoods = random(1,100)
+	if grasbergGoods < 20 then
+		stationGrasberg.comms_data.goods.gold = {quantity = 5, cost = 25}
+		stationGrasberg.comms_data.goods.cobalt = {quantity = 4, cost = 50}
+	elseif grasbergGoods < 40 then
+		stationGrasberg.comms_data.goods.gold = {quantity = 5, cost = 25}
+	elseif grasbergGoods < 60 then
+		stationGrasberg.comms_data.goods.cobalt = {quantity = 4, cost = 50}
+	else
+		stationGrasberg.comms_data.goods.nickel = {quantity = 5, cost = 47}
 	end
 	return stationGrasberg
 end
@@ -1989,58 +2421,81 @@ function placeHayden()
 	--Hayden
 	stationHayden = SpaceStation():setTemplate(szt()):setFaction(stationFaction):setCommsScript(""):setCommsFunction(commsStation)
 	stationHayden:setPosition(psx,psy):setCallSign("Hayden"):setDescription("Observatory and stellar mapping")
+    stationHayden.comms_data = {
+    	friendlyness = random(0,100),
+        weapons = 			{Homing = "neutral",					HVLI = "neutral", 						Mine = "neutral",						Nuke = "friend", 						EMP = "friend"},
+        weapon_available = 	{Homing = random(1,10)<=(8-difficulty),	HVLI = random(1,10)<=(9-difficulty),	Mine = random(1,10)<=(7-difficulty),	Nuke = random(1,10)<=(5-difficulty),	EMP = random(1,10)<=(6-difficulty)},
+        service_cost = 		{supplydrop = math.random(80,120), reinforcements = math.random(125,175)},
+        reputation_cost_multipliers = {friend = 1.0, neutral = 3.0},
+        max_weapon_refill_amount = {friend = 1.0, neutral = 0.5 },
+        goods = {	nanites =	{quantity = 5,	cost = 65} },
+        trade = {	food = false, medicine = false, luxury = false },
+        public_relations = true,
+        general_information = "We study the cosmos and map stellar phenomena. We also track moving asteroids. Look out! Just kidding",
+    	history = "Statin named in honor of Charles Hayden whose philanthropy continued astrophysical research and education on Earth in the early 20th century"
+	}
 	if stationFaction == "Human Navy" then
+		stationHayden.comms_data.goods.food = {quantity = math.random(5,10), cost = 1}
 		if random(1,5) <= 1 then
-			goods[stationHayden] = {{"food",math.random(5,10),1},{"medicine",5,5},{"nanites",5,65}}
-		else
-			goods[stationHayden] = {{"food",math.random(5,10),1},{"nanites",5,65}}		
+			stationHayden.comms_data.goods.medicine = {quantity = 5, cost = 5}
 		end
-	else
-		goods[stationHayden] = {{"nanites",5,65}}		
 	end
-	stationHayden.publicRelations = true
-	stationHayden.generalInformation = "We study the cosmos and map stellar phenomena. We also track moving asteroids. Look out! Just kidding"
 	return stationHayden
 end
 function placeHeyes()
 	--Heyes
 	stationHeyes = SpaceStation():setTemplate(szt()):setFaction(stationFaction):setCommsScript(""):setCommsFunction(commsStation)
 	stationHeyes:setPosition(psx,psy):setCallSign("Heyes"):setDescription("Sensor components")
+    stationHeyes.comms_data = {
+    	friendlyness = random(0,100),
+        weapons = 			{Homing = "neutral",					HVLI = "neutral", 						Mine = "neutral",						Nuke = "friend", 						EMP = "friend"},
+        weapon_available = 	{Homing = random(1,10)<=(8-difficulty),	HVLI = random(1,10)<=(9-difficulty),	Mine = random(1,10)<=(7-difficulty),	Nuke = random(1,10)<=(5-difficulty),	EMP = random(1,10)<=(6-difficulty)},
+        service_cost = 		{supplydrop = math.random(80,120), reinforcements = math.random(125,175)},
+        reputation_cost_multipliers = {friend = 1.0, neutral = 3.0},
+        max_weapon_refill_amount = {friend = 1.0, neutral = 0.5 },
+        goods = {	sensor =	{quantity = 5,	cost = 72} },
+        trade = {	food = false, medicine = false, luxury = true },
+		buy =	{	[randomMineral()] = math.random(40,200)	},
+        public_relations = true,
+        general_information = "We research and manufacture sensor components and systems",
+    	history = "The station is named after Tony Heyes the inventor of some of the earliest electromagnetic sensors in the mid 20th century on Earth in the United Kingdom to assist blind human mobility"
+	}
 	if stationFaction == "Human Navy" then
+		stationHeyes.comms_data.goods.food = {quantity = math.random(5,10), cost = 1}
 		if random(1,5) <= 1 then
-			goods[stationHeyes] = {{"food",math.random(5,10),1},{"medicine",5,5},{"sensor",5,72}}
-		else
-			goods[stationHeyes] = {{"food",math.random(5,10),1},{"sensor",5,72}}		
+			stationHeyes.comms_data.goods.medicine = {quantity = 5, cost = 5}
 		end
-	else
-		goods[stationHeyes] = {{"sensor",5,72}}		
 	end
-	tradeLuxury[stationHeyes] = true 
-	stationHeyes.publicRelations = true
-	stationHeyes.generalInformation = "We research and manufacture sensor components and systems"
-	stationHeyes.stationHistory = "The station is named after Tony Heyes the inventor of some of the earliest electromagnetic sensors in the mid 20th century on Earth in the United Kingdom to assist blind human mobility"
 	return stationHeyes
 end
 function placeHossam()
 	--Hossam
 	stationHossam = SpaceStation():setTemplate(szt()):setFaction(stationFaction):setCommsScript(""):setCommsFunction(commsStation)
 	stationHossam:setPosition(psx,psy):setCallSign("Hossam"):setDescription("Nanite supplier")
+    stationHossam.comms_data = {
+    	friendlyness = random(0,100),
+        weapons = 			{Homing = "neutral",					HVLI = "neutral", 						Mine = "neutral",						Nuke = "friend", 						EMP = "friend"},
+        weapon_available = 	{Homing = random(1,10)<=(8-difficulty),	HVLI = random(1,10)<=(9-difficulty),	Mine = random(1,10)<=(7-difficulty),	Nuke = random(1,10)<=(5-difficulty),	EMP = random(1,10)<=(6-difficulty)},
+        service_cost = 		{supplydrop = math.random(80,120), reinforcements = math.random(125,175)},
+        reputation_cost_multipliers = {friend = 1.0, neutral = 3.0},
+        max_weapon_refill_amount = {friend = 1.0, neutral = 0.5 },
+        goods = {	nanites =	{quantity = 5,	cost = 90} },
+        trade = {	food = false, medicine = false, luxury = random(1,100) < 63 },
+        public_relations = true,
+        general_information = "We provide nanites for various organic and non-organic systems",
+    	history = "This station is named after the nanotechnologist Hossam Haick from the early 21st century on Earth in Israel"
+	}
 	if stationFaction == "Human Navy" then
+		stationHossam.comms_data.goods.food = {quantity = math.random(5,10), cost = 1}
 		if random(1,5) <= 1 then
-			goods[stationHossam] = {{"food",math.random(5,10),1},{"medicine",5,5},{"nanites",5,48}}
+			stationHossam.comms_data.goods.medicine = {quantity = 5, cost = 5}
 		else
-			goods[stationHossam] = {{"food",math.random(5,10),1},{"nanites",5,48}}		
-			if random(1,100) < 44 then tradeMedicine[stationHossam] = true end
+			stationHossam.comms_data.trade.medicine = random(1,100) < 44
 		end
 	else
-		goods[stationHossam] = {{"nanites",5,48}}		
-		if random(1,100) < 44 then tradeMedicine[stationHossam] = true end
-		if random(1,100) < 24 then tradeFood[stationHossam] = true end
+		stationHossam.comms_data.trade.medicine = random(1,100) < 44
+		stationHossam.comms_data.trade.food = random(1,100) < 24
 	end
-	if random(1,100) < 63 then tradeLuxury[stationHossam] = true end
-	stationHossam.publicRelations = true
-	stationHossam.generalInformation = "We provide nanites for various organic and non-organic systems"
-	stationHossam.stationHistory = "This station is named after the nanotechnologist Hossam Haick from the early 21st century on Earth in Israel"
 	return stationHossam
 end
 function placeImpala()
@@ -2048,44 +2503,39 @@ function placeImpala()
 	placeRandomAroundPoint(Asteroid,15,1,15000,psx,psy)
 	stationImpala = SpaceStation():setTemplate(szt()):setFaction(stationFaction):setCommsScript(""):setCommsFunction(commsStation)
 	stationImpala:setPosition(psx,psy):setCallSign("Impala"):setDescription("Mining")
-	tradeFood[stationImpala] = true
-	tradeLuxury[stationImpala] = true
-	stationImpala.publicRelations = true
-	stationImpala.generalInformation = "We mine nearby asteroids for precious minerals"
-	impalaGoods = random(1,100)
+    stationImpala.comms_data = {
+    	friendlyness = random(0,100),
+        weapons = 			{Homing = "neutral",					HVLI = "neutral", 						Mine = "neutral",						Nuke = "friend", 						EMP = "friend"},
+        weapon_available = 	{Homing = random(1,10)<=(8-difficulty),	HVLI = random(1,10)<=(9-difficulty),	Mine = random(1,10)<=(7-difficulty),	Nuke = random(1,10)<=(5-difficulty),	EMP = random(1,10)<=(6-difficulty)},
+        service_cost = 		{supplydrop = math.random(80,120), reinforcements = math.random(125,175)},
+        reputation_cost_multipliers = {friend = 1.0, neutral = 3.0},
+        max_weapon_refill_amount = {friend = 1.0, neutral = 0.5 },
+        goods = {	luxury =	{quantity = 5,	cost = 70} },
+        trade = {	food = false, medicine = false, luxury = true },
+		buy =	{	[randomComponent()] = math.random(40,200)	},
+        public_relations = true,
+        general_information = "We mine nearby asteroids for precious minerals"
+	}
+	local impalaGoods = random(1,100)
+	if impalaGoods < 20 then
+		stationImpala.comms_data.goods.gold = {quantity = 5, cost = 25}
+		stationImpala.comms_data.goods.cobalt = {quantity = 4, cost = 50}
+	elseif impalaGoods < 40 then
+		stationImpala.comms_data.goods.gold = {quantity = 5, cost = 25}
+	elseif impalaGoods < 60 then
+		stationImpala.comms_data.goods.cobalt = {quantity = 4, cost = 50}
+	else
+		stationImpala.comms_data.goods.tritanium = {quantity = 5, cost = 42}
+	end
 	if stationFaction == "Human Navy" then
+		stationImpala.comms_data.goods.food = {quantity = math.random(5,10), cost = 1}
 		if random(1,5) <= 1 then
-			if impalaGoods < 20 then
-				goods[stationImpala] = {{"luxury",5,70},{"gold",5,25},{"cobalt",4,50},{"food",math.random(5,10),1},{"medicine",5,5}}
-			elseif impalaGoods < 40 then
-				goods[stationImpala] = {{"luxury",5,70},{"gold",5,25},{"food",math.random(5,10),1},{"medicine",5,5}}
-			elseif impalaGoods < 60 then
-				goods[stationImpala] = {{"luxury",5,70},{"cobalt",4,50},{"food",math.random(5,10),1},{"medicine",5,5}}
-			else
-				goods[stationImpala] = {{"luxury",5,70},{"food",math.random(5,10),1},{"medicine",5,5}}
-			end
+			stationImpala.comms_data.goods.medicine = {quantity = 5, cost = 5}
 		else
-			if impalaGoods < 20 then
-				goods[stationImpala] = {{"luxury",5,70},{"gold",5,25},{"cobalt",4,50},{"food",math.random(5,10),1}}
-			elseif impalaGoods < 40 then
-				goods[stationImpala] = {{"luxury",5,70},{"gold",5,25},{"food",math.random(5,10),1}}
-			elseif impalaGoods < 60 then
-				goods[stationImpala] = {{"luxury",5,70},{"cobalt",4,50},{"food",math.random(5,10),1}}
-			else
-				goods[stationImpala] = {{"luxury",5,70},{"food",math.random(5,10),1}}
-			end
+			stationImpala.comms_data.trade.medicine = random(1,100) < 28
 		end
 	else
-		if impalaGoods < 20 then
-			goods[stationImpala] = {{"luxury",5,70},{"gold",5,25},{"cobalt",4,50}}
-		elseif impalaGoods < 40 then
-			goods[stationImpala] = {{"luxury",5,70},{"gold",5,25}}
-		elseif impalaGoods < 60 then
-			goods[stationImpala] = {{"luxury",5,70},{"cobalt",4,50}}
-		else
-			goods[stationImpala] = {{"luxury",5,70}}
-		end
-		tradeFood[stationImpala] = true
+		stationImpala.comms_data.trade.food = true
 	end
 	return stationImpala
 end
@@ -2093,344 +2543,478 @@ function placeKomov()
 	--Komov
 	stationKomov = SpaceStation():setTemplate(szt()):setFaction(stationFaction):setCommsScript(""):setCommsFunction(commsStation)
 	stationKomov:setPosition(psx,psy):setCallSign("Komov"):setDescription("Xenopsychology training")
+    stationKomov.comms_data = {
+    	friendlyness = random(0,100),
+        weapons = 			{Homing = "neutral",					HVLI = "neutral", 						Mine = "neutral",						Nuke = "friend", 						EMP = "friend"},
+        weapon_available = 	{Homing = random(1,10)<=(8-difficulty),	HVLI = random(1,10)<=(9-difficulty),	Mine = random(1,10)<=(7-difficulty),	Nuke = random(1,10)<=(5-difficulty),	EMP = random(1,10)<=(6-difficulty)},
+        service_cost = 		{supplydrop = math.random(80,120), reinforcements = math.random(125,175)},
+        reputation_cost_multipliers = {friend = 1.0, neutral = 3.0},
+        max_weapon_refill_amount = {friend = 1.0, neutral = 0.5 },
+        goods = {	filament =	{quantity = 5,	cost = 46} },
+        trade = {	food = false, medicine = false, luxury = false },
+        public_relations = true,
+        general_information = "We provide classes and simulation to help train diverse species in how to relate to each other",
+    	history = "A continuation of the research initially conducted by Dr. Gennady Komov in the early 22nd century on Venus, supported by the application of these principles"
+	}
 	if stationFaction == "Human Navy" then
+		stationKomov.comms_data.goods.food = {quantity = math.random(5,10), cost = 1}
 		if random(1,5) <= 1 then
-			goods[stationKomov] = {{"food",math.random(5,10),1},{"medicine",5,5},{"filament",5,46}}
+			stationKomov.comms_data.goods.medicine = {quantity = 5, cost = 5}
 		else
-			goods[stationKomov] = {{"food",math.random(5,10),1},{"filament",5,46}}
-			if random(1,100) < 44 then tradeMedicine[stationKomov] = true end
+			stationKomov.comms_data.trade.medicine = random(1,100) < 44
 		end
 	else
-		goods[stationKomov] = {{"filament",5,46}}		
-		if random(1,100) < 44 then tradeMedicine[stationKomov] = true end
-		if random(1,100) < 24 then tradeFood[stationKomov] = true end
+		stationKomov.comms_data.trade.medicine = random(1,100) < 44
+		stationKomov.comms_data.trade.food = random(1,100) < 24
 	end
-	stationKomov.publicRelations = true
-	stationKomov.generalInformation = "We provide classes and simulation to help train diverse species in how to relate to each other"
-	stationKomov.stationHistory = "A continuation of the research initially conducted by Dr. Gennady Komov in the early 22nd century on Venus, supported by the application of these principles"
 	return stationKomov
 end
 function placeKrak()
 	--Krak
 	stationKrak = SpaceStation():setTemplate(szt()):setFaction(stationFaction):setCommsScript(""):setCommsFunction(commsStation)
 	stationKrak:setPosition(psx,psy):setCallSign("Krak"):setDescription("Mining station")
-	posAxisKrak = random(0,360)
-	posKrak = random(10000,60000)
-	negKrak = random(10000,60000)
-	spreadKrak = random(4000,7000)
-	negAxisKrak = posAxisKrak + 180
-	xPosAngleKrak, yPosAngleKrak = vectorFromAngle(posAxisKrak, posKrak)
-	posKrakEnd = random(30,70)
+    stationKrak.comms_data = {
+    	friendlyness = random(0,100),
+        weapons = 			{Homing = "neutral",					HVLI = "neutral", 						Mine = "neutral",						Nuke = "friend", 						EMP = "friend"},
+        weapon_available = 	{Homing = random(1,10)<=(8-difficulty),	HVLI = random(1,10)<=(9-difficulty),	Mine = random(1,10)<=(7-difficulty),	Nuke = random(1,10)<=(5-difficulty),	EMP = random(1,10)<=(6-difficulty)},
+        service_cost = 		{supplydrop = math.random(80,120), reinforcements = math.random(125,175)},
+        reputation_cost_multipliers = {friend = 1.0, neutral = 3.0},
+        max_weapon_refill_amount = {friend = 1.0, neutral = 0.5 },
+        goods = {	nickel =	{quantity = 5,	cost = 20} },
+        trade = {	food = random(1,100) < 50, medicine = true, luxury = random(1,100) < 50 },
+		buy =	{	[randomComponent()] = math.random(40,200)	}
+	}
+	local posAxisKrak = random(0,360)
+	local posKrak = random(10000,60000)
+	local negKrak = random(10000,60000)
+	local spreadKrak = random(4000,7000)
+	local negAxisKrak = posAxisKrak + 180
+	local xPosAngleKrak, yPosAngleKrak = vectorFromAngle(posAxisKrak, posKrak)
+	local posKrakEnd = random(30,70)
 	createRandomAlongArc(Asteroid, 30+posKrakEnd, psx+xPosAngleKrak, psy+yPosAngleKrak, posKrak, negAxisKrak, negAxisKrak+posKrakEnd, spreadKrak)
-	xNegAngleKrak, yNegAngleKrak = vectorFromAngle(negAxisKrak, negKrak)
-	negKrakEnd = random(40,80)
+	local xNegAngleKrak, yNegAngleKrak = vectorFromAngle(negAxisKrak, negKrak)
+	local negKrakEnd = random(40,80)
 	createRandomAlongArc(Asteroid, 30+negKrakEnd, psx+xNegAngleKrak, psy+yNegAngleKrak, negKrak, posAxisKrak, posAxisKrak+negKrakEnd, spreadKrak)
-	if random(1,100) < 50 then tradeFood[stationKrak] = true end
-	if random(1,100) < 50 then tradeLuxury[stationKrak] = true end
-	krakGoods = random(1,100)
+	local krakGoods = random(1,100)
 	if krakGoods < 10 then
-		goods[stationKrak] = {{"nickel",5,20},{"platinum",5,70},{"tritanium",5,50},{"dilithium",5,50}}
+		stationKrak.comms_data.goods.platinum = {quantity = 5, cost = 70}
+		stationKrak.comms_data.goods.tritanium = {quantity = 5, cost = 50}
+		stationKrak.comms_data.goods.dilithium = {quantity = 5, cost = 52}
 	elseif krakGoods < 20 then
-		goods[stationKrak] = {{"nickel",5,20},{"platinum",5,70},{"tritanium",5,50}}
+		stationKrak.comms_data.goods.platinum = {quantity = 5, cost = 70}
+		stationKrak.comms_data.goods.tritanium = {quantity = 5, cost = 50}
 	elseif krakGoods < 30 then
-		goods[stationKrak] = {{"nickel",5,20},{"platinum",5,70},{"dilithium",5,50}}
+		stationKrak.comms_data.goods.platinum = {quantity = 5, cost = 70}
+		stationKrak.comms_data.goods.dilithium = {quantity = 5, cost = 52}
 	elseif krakGoods < 40 then
-		goods[stationKrak] = {{"nickel",5,20},{"tritanium",5,50},{"dilithium",5,50}}
+		stationKrak.comms_data.goods.tritanium = {quantity = 5, cost = 50}
+		stationKrak.comms_data.goods.dilithium = {quantity = 5, cost = 52}
 	elseif krakGoods < 50 then
-		goods[stationKrak] = {{"nickel",5,20},{"dilithium",5,50}}
+		stationKrak.comms_data.goods.dilithium = {quantity = 5, cost = 52}
 	elseif krakGoods < 60 then
-		goods[stationKrak] = {{"nickel",5,20},{"platinum",5,70}}
+		stationKrak.comms_data.goods.platinum = {quantity = 5, cost = 70}
 	elseif krakGoods < 70 then
-		goods[stationKrak] = {{"nickel",5,20},{"tritanium",5,50}}
+		stationKrak.comms_data.goods.tritanium = {quantity = 5, cost = 50}
 	elseif krakGoods < 80 then
-		goods[stationKrak] = {{"platinum",5,70},{"tritanium",5,50},{"dilithium",5,50}}
+		stationKrak.comms_data.goods.gold = {quantity = 5, cost = 50}
+		stationKrak.comms_data.goods.tritanium = {quantity = 5, cost = 50}
+	elseif krakGoods < 90 then
+		stationKrak.comms_data.goods.gold = {quantity = 5, cost = 50}
+		stationKrak.comms_data.goods.dilithium = {quantity = 5, cost = 52}
 	else
-		goods[stationKrak] = {{"nickel",5,20}}
+		stationKrak.comms_data.goods.gold = {quantity = 5, cost = 50}
 	end
-	tradeMedicine[stationKrak] = true
 	return stationKrak
 end
 function placeKruk()
 	--Kruk
 	stationKruk = SpaceStation():setTemplate(szt()):setFaction(stationFaction):setCommsScript(""):setCommsFunction(commsStation)
 	stationKruk:setPosition(psx,psy):setCallSign("Kruk"):setDescription("Mining station")
-	posAxisKruk = random(0,360)
-	posKruk = random(10000,60000)
-	negKruk = random(10000,60000)
-	spreadKruk = random(4000,7000)
-	negAxisKruk = posAxisKruk + 180
-	xPosAngleKruk, yPosAngleKruk = vectorFromAngle(posAxisKruk, posKruk)
-	posKrukEnd = random(30,70)
+    stationKruk.comms_data = {
+    	friendlyness = random(0,100),
+        weapons = 			{Homing = "neutral",					HVLI = "neutral", 						Mine = "neutral",						Nuke = "friend", 						EMP = "friend"},
+        weapon_available = 	{Homing = random(1,10)<=(8-difficulty),	HVLI = random(1,10)<=(9-difficulty),	Mine = random(1,10)<=(7-difficulty),	Nuke = random(1,10)<=(5-difficulty),	EMP = random(1,10)<=(6-difficulty)},
+        service_cost = 		{supplydrop = math.random(80,120), reinforcements = math.random(125,175)},
+        reputation_cost_multipliers = {friend = 1.0, neutral = 3.0},
+        max_weapon_refill_amount = {friend = 1.0, neutral = 0.5 },
+        goods = {	nickel =	{quantity = 5,	cost = math.random(25,35)} },
+        trade = {	food = random(1,100) < 50, medicine = random(1,100) < 50, luxury = true },
+		buy =	{	[randomComponent()] = math.random(40,200)	}
+	}
+	local posAxisKruk = random(0,360)
+	local posKruk = random(10000,60000)
+	local negKruk = random(10000,60000)
+	local spreadKruk = random(4000,7000)
+	local negAxisKruk = posAxisKruk + 180
+	local xPosAngleKruk, yPosAngleKruk = vectorFromAngle(posAxisKruk, posKruk)
+	local posKrukEnd = random(30,70)
 	createRandomAlongArc(Asteroid, 30+posKrukEnd, psx+xPosAngleKruk, psy+yPosAngleKruk, posKruk, negAxisKruk, negAxisKruk+posKrukEnd, spreadKruk)
-	xNegAngleKruk, yNegAngleKruk = vectorFromAngle(negAxisKruk, negKruk)
-	negKrukEnd = random(40,80)
+	local xNegAngleKruk, yNegAngleKruk = vectorFromAngle(negAxisKruk, negKruk)
+	local negKrukEnd = random(40,80)
 	createRandomAlongArc(Asteroid, 30+negKrukEnd, psx+xNegAngleKruk, psy+yNegAngleKruk, negKruk, posAxisKruk, posAxisKruk+negKrukEnd, spreadKruk)
-	krukGoods = random(1,100)
+	local krukGoods = random(1,100)
 	if krukGoods < 10 then
-		goods[stationKruk] = {{"nickel",5,20},{"platinum",5,70},{"tritanium",5,50},{"dilithium",5,50}}
+		stationKruk.comms_data.goods.platinum = {quantity = 5, cost = math.random(65,75)}
+		stationKruk.comms_data.goods.tritanium = {quantity = 5, cost = math.random(45,55)}
+		stationKruk.comms_data.goods.dilithium = {quantity = 5, cost = math.random(45,55)}
 	elseif krukGoods < 20 then
-		goods[stationKruk] = {{"nickel",5,20},{"platinum",5,70},{"tritanium",5,50}}
+		stationKruk.comms_data.goods.platinum = {quantity = 5, cost = math.random(65,75)}
+		stationKruk.comms_data.goods.tritanium = {quantity = 5, cost = math.random(45,55)}
 	elseif krukGoods < 30 then
-		goods[stationKruk] = {{"nickel",5,20},{"platinum",5,70},{"dilithium",5,50}}
+		stationKruk.comms_data.goods.platinum = {quantity = 5, cost = math.random(65,75)}
+		stationKruk.comms_data.goods.dilithium = {quantity = 5, cost = math.random(45,55)}
 	elseif krukGoods < 40 then
-		goods[stationKruk] = {{"nickel",5,20},{"tritanium",5,50},{"dilithium",5,50}}
+		stationKruk.comms_data.goods.tritanium = {quantity = 5, cost = math.random(45,55)}
+		stationKruk.comms_data.goods.dilithium = {quantity = 5, cost = math.random(45,55)}
 	elseif krukGoods < 50 then
-		goods[stationKruk] = {{"nickel",5,20},{"dilithium",5,50}}
+		stationKruk.comms_data.goods.dilithium = {quantity = 5, cost = math.random(45,55)}
 	elseif krukGoods < 60 then
-		goods[stationKruk] = {{"nickel",5,20},{"platinum",5,70}}
+		stationKruk.comms_data.goods.platinum = {quantity = 5, cost = math.random(65,75)}
 	elseif krukGoods < 70 then
-		goods[stationKruk] = {{"nickel",5,20},{"tritanium",5,50}}
+		stationKruk.comms_data.goods.tritanium = {quantity = 5, cost = math.random(45,55)}
 	elseif krukGoods < 80 then
-		goods[stationKruk] = {{"platinum",5,70},{"tritanium",5,50},{"dilithium",5,50}}
+		stationKruk.comms_data.goods.gold = {quantity = 5, cost = math.random(45,55)}
+		stationKruk.comms_data.goods.tritanium = {quantity = 5, cost = math.random(45,55)}
+	elseif krukGoods < 90 then
+		stationKruk.comms_data.goods.gold = {quantity = 5, cost = math.random(45,55)}
+		stationKruk.comms_data.goods.dilithium = {quantity = 5, cost = math.random(45,55)}
 	else
-		goods[stationKruk] = {{"nickel",5,20}}
+		stationKruk.comms_data.goods.gold = {quantity = 5, cost = math.random(45,55)}
 	end
-	tradeLuxury[stationKruk] = true
-	if random(1,100) < 50 then tradeFood[stationKruk] = true end
-	if random(1,100) < 50 then tradeMedicine[stationKruk] = true end
 	return stationKruk
 end
 function placeLipkin()
 	--Lipkin
 	stationLipkin = SpaceStation():setTemplate(szt()):setFaction(stationFaction):setCommsScript(""):setCommsFunction(commsStation)
 	stationLipkin:setPosition(psx,psy):setCallSign("Lipkin"):setDescription("Autodoc components")
+    stationLipkin.comms_data = {
+    	friendlyness = random(0,100),
+        weapons = 			{Homing = "neutral",					HVLI = "neutral", 						Mine = "neutral",						Nuke = "friend", 						EMP = "friend"},
+        weapon_available = 	{Homing = random(1,10)<=(8-difficulty),	HVLI = random(1,10)<=(9-difficulty),	Mine = random(1,10)<=(7-difficulty),	Nuke = random(1,10)<=(5-difficulty),	EMP = random(1,10)<=(6-difficulty)},
+        service_cost = 		{supplydrop = math.random(80,120), reinforcements = math.random(125,175)},
+        reputation_cost_multipliers = {friend = 1.0, neutral = 3.0},
+        max_weapon_refill_amount = {friend = 1.0, neutral = 0.5 },
+        goods = {	autodoc =	{quantity = 5,	cost = 76} },
+        trade = {	food = false, medicine = false, luxury = true },
+        public_relations = true,
+        general_information = "We build and repair and provide components and upgrades for automated facilities designed for ships where a doctor cannot be a crew member (commonly called autodocs)",
+    	history = "The station is named after Dr. Lipkin who pioneered some of the research and application around robot assisted surgery in the area of partial nephrectomy for renal tumors in the early 21st century on Earth"
+	}
 	if stationFaction == "Human Navy" then
+		stationLipkin.comms_data.goods.food = {quantity = math.random(5,10), cost = 1}
 		if random(1,5) <= 1 then
-			goods[stationLipkin] = {{"food",math.random(5,10),1},{"medicine",5,5},{"autodoc",5,76}}
-		else
-			goods[stationLipkin] = {{"food",math.random(5,10),1},{"autodoc",5,76}}		
+			stationLipkin.comms_data.goods.medicine = {quantity = 5, cost = 5}
 		end
 	else
-		goods[stationLipkin] = {{"autodoc",5,76}}		
-		tradeFood[stationLipkin] = true 
+		stationLipkin.comms_data.trade.food = true
 	end
-	tradeLuxury[stationLipkin] = true 
-	stationLipkin.publicRelations = true
-	stationLipkin.generalInformation = "We build and repair and provide components and upgrades for automated facilities designed for ships where a doctor cannot be a crew member (commonly called autodocs)"
-	stationLipkin.stationHistory = "The station is named after Dr. Lipkin who pioneered some of the research and application around robot assisted surgery in the area of partial nephrectomy for renal tumors in the early 21st century on Earth"
 	return stationLipkin
 end
 function placeMadison()
 	--Madison
 	stationMadison = SpaceStation():setTemplate(szt()):setFaction(stationFaction):setCommsScript(""):setCommsFunction(commsStation)
 	stationMadison:setPosition(psx,psy):setCallSign("Madison"):setDescription("Zero gravity sports and entertainment")
+    stationMadison.comms_data = {
+    	friendlyness = random(0,100),
+        weapons = 			{Homing = "neutral",					HVLI = "neutral", 						Mine = "neutral",						Nuke = "friend", 						EMP = "friend"},
+        weapon_available = 	{Homing = random(1,10)<=(8-difficulty),	HVLI = random(1,10)<=(9-difficulty),	Mine = random(1,10)<=(7-difficulty),	Nuke = random(1,10)<=(5-difficulty),	EMP = random(1,10)<=(6-difficulty)},
+        service_cost = 		{supplydrop = math.random(80,120), reinforcements = math.random(125,175)},
+        reputation_cost_multipliers = {friend = 1.0, neutral = 3.0},
+        max_weapon_refill_amount = {friend = 1.0, neutral = 0.5 },
+        goods = {	luxury =	{quantity = 5,	cost = 70} },
+        trade = {	food = false, medicine = false, luxury = false },
+        public_relations = true,
+        general_information = "Come take in a game or two or perhaps see a show",
+    	history = "Named after Madison Square Gardens from 21st century Earth, this station was designed to serve similar purposes in space - a venue for sports and entertainment"
+	}
 	if stationFaction == "Human Navy" then
+		stationMadison.comms_data.goods.food = {quantity = math.random(5,10), cost = 1}
 		if random(1,5) <= 1 then
-			goods[stationMadison] = {{"food",math.random(5,10),1},{"medicine",5,5},{"luxury",5,70}}
+			stationMadison.comms_data.goods.medicine = {quantity = 5, cost = 5}
 		else
-			goods[stationMadison] = {{"food",math.random(5,10),1},{"luxury",5,70}}		
-			tradeMedicine[stationMadison] = true 
+			stationMadison.comms_data.trade.medicine = true
 		end
 	else
-		goods[stationMadison] = {{"luxury",5,70}}		
-		tradeMedicine[stationMadison] = true 
+		stationMadison.comms_data.trade.medicine = true
 	end
-	stationMadison.publicRelations = true
-	stationMadison.generalInformation = "Come take in a game or two or perhaps see a show"
-	stationMadison.stationHistory = "Named after Madison Square Gardens from 21st century Earth, this station was designed to serve similar purposes in space - a venue for sports and entertainment"
 	return stationMadison
 end
 function placeMaiman()
 	--Maiman
 	stationMaiman = SpaceStation():setTemplate(szt()):setFaction(stationFaction):setCommsScript(""):setCommsFunction(commsStation)
 	stationMaiman:setPosition(psx,psy):setCallSign("Maiman"):setDescription("Energy beam components")
+    stationMaiman.comms_data = {
+    	friendlyness = random(0,100),
+        weapons = 			{Homing = "neutral",					HVLI = "neutral", 						Mine = "neutral",						Nuke = "friend", 						EMP = "friend"},
+        weapon_available = 	{Homing = random(1,10)<=(8-difficulty),	HVLI = random(1,10)<=(9-difficulty),	Mine = random(1,10)<=(7-difficulty),	Nuke = random(1,10)<=(5-difficulty),	EMP = random(1,10)<=(6-difficulty)},
+        service_cost = 		{supplydrop = math.random(80,120), reinforcements = math.random(125,175)},
+        reputation_cost_multipliers = {friend = 1.0, neutral = 3.0},
+        max_weapon_refill_amount = {friend = 1.0, neutral = 0.5 },
+        goods = {	beam =	{quantity = 5,	cost = 70} },
+        trade = {	food = false, medicine = false, luxury = false },
+		buy =	{	[randomMineral()] = math.random(40,200)	},
+        public_relations = true,
+        general_information = "We research and manufacture energy beam components and systems",
+    	history = "The station is named after Theodore Maiman who researched and built the first laser in the mid 20th centuryon Earth"
+	}
 	if stationFaction == "Human Navy" then
+		stationMaiman.comms_data.goods.food = {quantity = math.random(5,10), cost = 1}
 		if random(1,5) <= 1 then
-			goods[stationMaiman] = {{"food",math.random(5,10),1},{"medicine",5,5},{"beam",5,70}}
+			stationMaiman.comms_data.goods.medicine = {quantity = 5, cost = 5}
 		else
-			goods[stationMaiman] = {{"food",math.random(5,10),1},{"beam",5,70}}		
-			tradeMedicine[stationMaiman] = true 
+			stationMaiman.comms_data.trade.medicine = true
 		end
 	else
-		goods[stationMaiman] = {{"beam",5,70}}		
-		tradeMedicine[stationMaiman] = true 
+		stationMaiman.comms_data.trade.medicine = true
 	end
-	stationMaiman.publicRelations = true
-	stationMaiman.generalInformation = "We research and manufacture energy beam components and systems"
-	stationMaiman.stationHistory = "The station is named after Theodore Maiman who researched and built the first laser in the mid 20th centuryon Earth"
 	return stationMaiman
 end
 function placeMarconi()
 	--Marconi 
 	stationMarconi = SpaceStation():setTemplate(szt()):setFaction(stationFaction):setCommsScript(""):setCommsFunction(commsStation)
 	stationMarconi:setPosition(psx,psy):setCallSign("Marconi"):setDescription("Energy Beam Components")
+    stationMarconi.comms_data = {
+    	friendlyness = random(0,100),
+        weapons = 			{Homing = "neutral",					HVLI = "neutral", 						Mine = "neutral",						Nuke = "friend", 						EMP = "friend"},
+        weapon_available = 	{Homing = random(1,10)<=(8-difficulty),	HVLI = random(1,10)<=(9-difficulty),	Mine = random(1,10)<=(7-difficulty),	Nuke = random(1,10)<=(5-difficulty),	EMP = random(1,10)<=(6-difficulty)},
+        service_cost = 		{supplydrop = math.random(80,120), reinforcements = math.random(125,175)},
+        reputation_cost_multipliers = {friend = 1.0, neutral = 3.0},
+        max_weapon_refill_amount = {friend = 1.0, neutral = 0.5 },
+        goods = {	beam =	{quantity = 5,	cost = 80} },
+        trade = {	food = false, medicine = false, luxury = true },
+        public_relations = true,
+        general_information = "We manufacture energy beam components",
+    	history = "Station named after Guglielmo Marconi an Italian inventor from early 20th century Earth who, along with Nicolo Tesla, claimed to have invented a death ray or particle beam weapon"
+	}
 	if stationFaction == "Human Navy" then
+		stationMarconi.comms_data.goods.food = {quantity = math.random(5,10), cost = 1}
 		if random(1,5) <= 1 then
-			goods[stationMarconi] = {{"food",math.random(5,10),1},{"medicine",5,5},{"beam",5,80}}
+			stationMarconi.comms_data.goods.medicine = {quantity = 5, cost = 5}
 		else
-			goods[stationMarconi] = {{"food",math.random(5,10),1},{"beam",5,80}}		
-			tradeMedicine[stationMarconi] = true 
+			stationMarconi.comms_data.trade.medicine = true
 		end
 	else
-		goods[stationMarconi] = {{"beam",5,80}}		
-		tradeMedicine[stationMarconi] = true 
-		tradeFood[stationMarconi] = true
+		stationMarconi.comms_data.trade.medicine = true
+		stationMarconi.comms_data.trade.food = true
 	end
-	tradeLuxury[stationMarconi] = true
-	stationMarconi.publicRelations = true
-	stationMarconi.generalInformation = "We manufacture energy beam components"
-	stationMarconi.stationHistory = "Station named after Guglielmo Marconi an Italian inventor from early 20th century Earth who, along with Nicolo Tesla, claimed to have invented a death ray or particle beam weapon"
 	return stationMarconi
 end
 function placeMayo()
 	--Mayo
 	stationMayo = SpaceStation():setTemplate(szt()):setFaction(stationFaction):setCommsScript(""):setCommsFunction(commsStation)
 	stationMayo:setPosition(psx,psy):setCallSign("Mayo"):setDescription("Medical Research")
-	goods[stationMayo] = {{"food",5,1},{"medicine",5,5},{"autodoc",5,128}}
-	stationMayo.publicRelations = true
-	stationMayo.generalInformation = "We research exotic diseases and other human medical conditions"
-	stationMayo.stationHistory = "We continue the medical work started by William Worrall Mayo in the late 19th century on Earth"
+    stationMayo.comms_data = {
+    	friendlyness = random(0,100),
+        weapons = 			{Homing = "neutral",					HVLI = "neutral", 						Mine = "neutral",						Nuke = "friend", 						EMP = "friend"},
+        weapon_available = 	{Homing = random(1,10)<=(8-difficulty),	HVLI = random(1,10)<=(9-difficulty),	Mine = random(1,10)<=(7-difficulty),	Nuke = random(1,10)<=(5-difficulty),	EMP = random(1,10)<=(6-difficulty)},
+        service_cost = 		{supplydrop = math.random(80,120), reinforcements = math.random(125,175)},
+        reputation_cost_multipliers = {friend = 1.0, neutral = 3.0},
+        max_weapon_refill_amount = {friend = 1.0, neutral = 0.5 },
+        goods = {	autodoc =	{quantity = 5,	cost = 128},
+        			food =		{quantity = 5,	cost = 1},
+        			medicine = 	{quantity = 5,	cost = 5} },
+        trade = {	food = false, medicine = false, luxury = false },
+        public_relations = true,
+        general_information = "We research exotic diseases and other human medical conditions",
+    	history = "We continue the medical work started by William Worrall Mayo in the late 19th century on Earth"
+	}
 	return stationMayo
 end
 function placeMiller()
 	--Miller
 	stationMiller = SpaceStation():setTemplate(szt()):setFaction(stationFaction):setCommsScript(""):setCommsFunction(commsStation)
 	stationMiller:setPosition(psx,psy):setCallSign("Miller"):setDescription("Exobiology research")
+    stationMiller.comms_data = {
+    	friendlyness = random(0,100),
+        weapons = 			{Homing = "neutral",					HVLI = "neutral", 						Mine = "neutral",						Nuke = "friend", 						EMP = "friend"},
+        weapon_available = 	{Homing = random(1,10)<=(8-difficulty),	HVLI = random(1,10)<=(9-difficulty),	Mine = random(1,10)<=(7-difficulty),	Nuke = random(1,10)<=(5-difficulty),	EMP = random(1,10)<=(6-difficulty)},
+        service_cost = 		{supplydrop = math.random(80,120), reinforcements = math.random(125,175)},
+        reputation_cost_multipliers = {friend = 1.0, neutral = 3.0},
+        max_weapon_refill_amount = {friend = 1.0, neutral = 0.5 },
+        goods = {	optic =	{quantity = 5,	cost = 60} },
+        trade = {	food = false, medicine = false, luxury = false },
+        public_relations = true,
+        general_information = "We study recently discovered life forms not native to Earth",
+    	history = "This station was named after one of the early exobiologists from mid 20th century Earth, Dr. Stanley Miller"
+	}
 	if stationFaction == "Human Navy" then
+		stationMiller.comms_data.goods.food = {quantity = math.random(5,10), cost = 1}
 		if random(1,5) <= 1 then
-			goods[stationMiller] = {{"food",math.random(5,10),1},{"medicine",5,5},{"optic",10,60}}
-		else
-			goods[stationMiller] = {{"food",math.random(5,10),1},{"optic",10,60}}		
+			stationMiller.comms_data.goods.medicine = {quantity = 5, cost = 5}
 		end
-	else
-		goods[stationMiller] = {{"optic",10,60}}		
 	end
-	stationMiller.publicRelations = true
-	stationMiller.generalInformation = "We study recently discovered life forms not native to Earth"
-	stationMiller.stationHistory = "This station was named after one the early exobiologists from mid 20th century Earth, Dr. Stanley Miller"
 	return stationMiller
 end
 function placeMuddville()
 	--Muddville 
 	stationMudd = SpaceStation():setTemplate(szt()):setFaction(stationFaction):setCommsScript(""):setCommsFunction(commsStation)
 	stationMudd:setPosition(psx,psy):setCallSign("Muddville"):setDescription("Trading station")
+    stationMudd.comms_data = {
+    	friendlyness = random(0,100),
+        weapons = 			{Homing = "neutral",					HVLI = "neutral", 						Mine = "neutral",						Nuke = "friend", 						EMP = "friend"},
+        weapon_available = 	{Homing = random(1,10)<=(8-difficulty),	HVLI = random(1,10)<=(9-difficulty),	Mine = random(1,10)<=(7-difficulty),	Nuke = random(1,10)<=(5-difficulty),	EMP = random(1,10)<=(6-difficulty)},
+        service_cost = 		{supplydrop = math.random(80,120), reinforcements = math.random(125,175)},
+        reputation_cost_multipliers = {friend = 1.0, neutral = 3.0},
+        max_weapon_refill_amount = {friend = 1.0, neutral = 0.5 },
+        goods = {	luxury =	{quantity = 5,	cost = 60} },
+        trade = {	food = false, medicine = false, luxury = false },
+        public_relations = true,
+        general_information = "Come to Muddvile for all your trade and commerce needs and desires",
+    	history = "Upon retirement, Harry Mudd started this commercial venture using his leftover inventory and extensive connections obtained while he traveled the stars as a salesman"
+	}
 	if stationFaction == "Human Navy" then
+		stationMudd.comms_data.goods.food = {quantity = math.random(5,10), cost = 1}
 		if random(1,5) <= 1 then
-			goods[stationMudd] = {{"food",math.random(5,10),1},{"medicine",5,5},{"luxury",10,60}}
-		else
-			goods[stationMudd] = {{"food",math.random(5,10),1},{"luxury",10,60}}		
+			stationMudd.comms_data.goods.medicine = {quantity = 5, cost = 5}
 		end
-	else
-		goods[stationMudd] = {{"luxury",10,60}}		
 	end
-	stationMudd.publicRelations = true
-	stationMudd.generalInformation = "Come to Muddvile for all your trade and commerce needs and desires"
-	stationMudd.stationHistory = "Upon retirement, Harry Mudd started this commercial venture using his leftover inventory and extensive connections obtained while he traveled the stars as a salesman"
 	return stationMudd
 end
 function placeNexus6()
 	--Nexus-6
 	stationNexus6 = SpaceStation():setTemplate(szt()):setFaction(stationFaction):setCommsScript(""):setCommsFunction(commsStation)
 	stationNexus6:setPosition(psx,psy):setCallSign("Nexus-6"):setDescription("Android components")
+    stationNexus6.comms_data = {
+    	friendlyness = random(0,100),
+        weapons = 			{Homing = "neutral",					HVLI = "neutral", 						Mine = "neutral",						Nuke = "friend", 						EMP = "friend"},
+        weapon_available = 	{Homing = random(1,10)<=(8-difficulty),	HVLI = random(1,10)<=(9-difficulty),	Mine = random(1,10)<=(7-difficulty),	Nuke = random(1,10)<=(5-difficulty),	EMP = random(1,10)<=(6-difficulty)},
+        service_cost = 		{supplydrop = math.random(80,120), reinforcements = math.random(125,175)},
+        reputation_cost_multipliers = {friend = 1.0, neutral = 3.0},
+        max_weapon_refill_amount = {friend = 1.0, neutral = 0.5 },
+        goods = {	android =	{quantity = 5,	cost = 93} },
+        trade = {	food = false, medicine = false, luxury = false },
+		buy =	{	[randomMineral()] = math.random(40,200),
+					[randomComponent("android")] = math.random(40,200)	},
+        public_relations = true,
+        general_information = "We research and manufacture android components and systems. Our design our androids to maximize their likeness to humans",
+    	history = "We named the station after the ground breaking android model produced by the Tyrell corporation"
+	}
 	if stationFaction == "Human Navy" then
+		stationNexus6.comms_data.goods.food = {quantity = math.random(5,10), cost = 1}
 		if random(1,5) <= 1 then
-			goods[stationNexus6] = {{"food",math.random(5,10),1},{"medicine",5,5},{"android",5,93}}
+			stationNexus6.comms_data.goods.medicine = {quantity = 5, cost = 5}
 		else
-			goods[stationNexus6] = {{"food",math.random(5,10),1},{"android",5,93}}		
-			tradeMedicine[stationNexus6] = true 
+			stationNexus6.comms_data.trade.medicine = true
 		end
 	else
-		goods[stationNexus6] = {{"android",5,93}}		
-		tradeMedicine[stationNexus6] = true 
+		stationNexus6.comms_data.trade.medicine = true
 	end
-	stationNexus6.publicRelations = true
-	stationNexus6.generalInformation = "We research and manufacture android components and systems. Our design our androids to maximize their likeness to humans"
-	stationNexus6.stationHistory = "The station is named after the ground breaking model of android produced by the Tyrell corporation"
 	return stationNexus6
 end
 function placeOBrien()
 	--O'Brien
 	stationOBrien = SpaceStation():setTemplate(szt()):setFaction(stationFaction):setCommsScript(""):setCommsFunction(commsStation)
 	stationOBrien:setPosition(psx,psy):setCallSign("O'Brien"):setDescription("Transporter components")
+    stationOBrien.comms_data = {
+    	friendlyness = random(0,100),
+        weapons = 			{Homing = "neutral",					HVLI = "neutral", 						Mine = "neutral",						Nuke = "friend", 						EMP = "friend"},
+        weapon_available = 	{Homing = random(1,10)<=(8-difficulty),	HVLI = random(1,10)<=(9-difficulty),	Mine = random(1,10)<=(7-difficulty),	Nuke = random(1,10)<=(5-difficulty),	EMP = random(1,10)<=(6-difficulty)},
+        service_cost = 		{supplydrop = math.random(80,120), reinforcements = math.random(125,175)},
+        reputation_cost_multipliers = {friend = 1.0, neutral = 3.0},
+        max_weapon_refill_amount = {friend = 1.0, neutral = 0.5 },
+        goods = {	transporter =	{quantity = 5,	cost = 76} },
+        trade = {	food = false, medicine = false, luxury = false },
+        public_relations = true,
+        general_information = "We research and fabricate high quality transporters and transporter components for use aboard ships",
+    	history = "Miles O'Brien started this business after his experience as a transporter chief"
+	}
 	if stationFaction == "Human Navy" then
+		stationOBrien.comms_data.goods.food = {quantity = math.random(5,10), cost = 1}
 		if random(1,5) <= 1 then
-			goods[stationOBrien] = {{"food",math.random(5,10),1},{"medicine",5,5},{"transporter",5,76}}
+			stationOBrien.comms_data.goods.medicine = {quantity = 5, cost = 5}
 		else
-			goods[stationOBrien] = {{"food",math.random(5,10),1},{"transporter",5,76}}		
-			if random(1,100) < 34 then tradeMedicine[stationOBrien] = true end
+			stationOBrien.comms_data.trade.medicine = random(1,100) < 34
 		end
 	else
-		goods[stationOBrien] = {{"transporter",5,76}}		
-		tradeMedicine[stationOBrien] = true 
-		if random(1,100) < 13 then tradeFood[stationOBrien] = true end
-		if random(1,100) < 34 then tradeMedicine[stationOBrien] = true end
+		stationOBrien.comms_data.trade.medicine = true
+		stationOBrien.comms_data.trade.food = random(1,100) < 13
 	end
-	if random(1,100) < 43 then tradeLuxury[stationOBrien] = true end
-	stationOBrien.publicRelations = true
-	stationOBrien.generalInformation = "We research and fabricate high quality transporters and transporter components for use aboard ships"
-	stationOBrien.stationHistory = "Miles O'Brien started this business after his experience as a transporter chief"
+	stationOBrien.comms_data.trade.luxury = random(1,100) < 43
 	return stationOBrien
 end
 function placeOlympus()
 	--Olympus
 	stationOlympus = SpaceStation():setTemplate(szt()):setFaction(stationFaction):setCommsScript(""):setCommsFunction(commsStation)
 	stationOlympus:setPosition(psx,psy):setCallSign("Olympus"):setDescription("Optical components")
+    stationOlympus.comms_data = {
+    	friendlyness = random(0,100),
+        weapons = 			{Homing = "neutral",					HVLI = "neutral", 						Mine = "neutral",						Nuke = "friend", 						EMP = "friend"},
+        weapon_available = 	{Homing = random(1,10)<=(8-difficulty),	HVLI = random(1,10)<=(9-difficulty),	Mine = random(1,10)<=(7-difficulty),	Nuke = random(1,10)<=(5-difficulty),	EMP = random(1,10)<=(6-difficulty)},
+        service_cost = 		{supplydrop = math.random(80,120), reinforcements = math.random(125,175)},
+        reputation_cost_multipliers = {friend = 1.0, neutral = 3.0},
+        max_weapon_refill_amount = {friend = 1.0, neutral = 0.5 },
+        goods = {	optic =	{quantity = 5,	cost = 66} },
+        trade = {	food = false, medicine = false, luxury = false },
+        public_relations = true,
+        general_information = "We fabricate optical lenses and related equipment as well as fiber optic cabling and components",
+    	history = "This station grew out of the Olympus company based on earth in the early 21st century. It merged with Infinera, then bought several software comapnies before branching out into space based industry"
+	}
 	if stationFaction == "Human Navy" then
+		stationOlympus.comms_data.goods.food = {quantity = math.random(5,10), cost = 1}
 		if random(1,5) <= 1 then
-			goods[stationOlympus] = {{"food",math.random(5,10),1},{"medicine",5,5},{"optic",5,66}}
+			stationOlympus.comms_data.goods.medicine = {quantity = 5, cost = 5}
 		else
-			goods[stationOlympus] = {{"food",math.random(5,10),1},{"optic",5,66}}		
-			tradeMedicine[stationOlympus] = true
+			stationOlympus.comms_data.trade.medicine = true
 		end
 	else
-		goods[stationOlympus] = {{"optic",5,66}}		
-		tradeFood[stationOlympus] = true
-		tradeMedicine[stationOlympus] = true
+		stationOlympus.comms_data.trade.medicine = true
+		stationOlympus.comms_data.trade.food = true
 	end
-	stationOlympus.publicRelations = true
-	stationOlympus.generalInformation = "We fabricate optical lenses and related equipment as well as fiber optic cabling and components"
-	stationOlympus.stationHistory = "This station grew out of the Olympus company based on earth in the early 21st century. It merged with Infinera, then bought several software comapnies before branching out into space based industry"
 	return stationOlympus
 end
 function placeOrgana()
 	--Organa
 	stationOrgana = SpaceStation():setTemplate(szt()):setFaction(stationFaction):setCommsScript(""):setCommsFunction(commsStation)
 	stationOrgana:setPosition(psx,psy):setCallSign("Organa"):setDescription("Diplomatic training")
-	goods[stationOrgana] = {{"luxury",5,96}}		
-	stationOrgana.publicRelations = true
-	stationOrgana.generalInformation = "The premeire academy for leadership and diplomacy training in the region"
-	stationOrgana.stationHistory = "Established by the royal family so critical during the political upheaval era"
+    stationOrgana.comms_data = {
+    	friendlyness = random(0,100),
+        weapons = 			{Homing = "neutral",					HVLI = "neutral", 						Mine = "neutral",						Nuke = "friend", 						EMP = "friend"},
+        weapon_available = 	{Homing = random(1,10)<=(8-difficulty),	HVLI = random(1,10)<=(9-difficulty),	Mine = random(1,10)<=(7-difficulty),	Nuke = random(1,10)<=(5-difficulty),	EMP = random(1,10)<=(6-difficulty)},
+        service_cost = 		{supplydrop = math.random(80,120), reinforcements = math.random(125,175)},
+        reputation_cost_multipliers = {friend = 1.0, neutral = 3.0},
+        max_weapon_refill_amount = {friend = 1.0, neutral = 0.5 },
+        goods = {	luxury =	{quantity = 5,	cost = 96} },
+        trade = {	food = false, medicine = false, luxury = false },
+        public_relations = true,
+        general_information = "The premeire academy for leadership and diplomacy training in the region",
+    	history = "Established by the royal family so critical during the political upheaval era"
+	}
 	return stationOrgana
 end
 function placeOutpost15()
 	--Outpost 15
 	stationOutpost15 = SpaceStation():setTemplate(szt()):setFaction(stationFaction):setCommsScript(""):setCommsFunction(commsStation)
 	stationOutpost15:setPosition(psx,psy):setCallSign("Outpost-15"):setDescription("Mining and trade")
-	tradeFood[stationOutpost15] = true
-	outpost15Goods = random(1,100)
+    stationOutpost15.comms_data = {
+    	friendlyness = random(0,100),
+        weapons = 			{Homing = "neutral",					HVLI = "neutral", 						Mine = "neutral",						Nuke = "friend", 						EMP = "friend"},
+        weapon_available = 	{Homing = random(1,10)<=(8-difficulty),	HVLI = random(1,10)<=(9-difficulty),	Mine = random(1,10)<=(7-difficulty),	Nuke = random(1,10)<=(5-difficulty),	EMP = random(1,10)<=(6-difficulty)},
+        service_cost = 		{supplydrop = math.random(80,120), reinforcements = math.random(125,175)},
+        reputation_cost_multipliers = {friend = 1.0, neutral = 3.0},
+        max_weapon_refill_amount = {friend = 1.0, neutral = 0.5 },
+        goods = {	luxury =	{quantity = 5,	cost = 70} },
+        trade = {	food = true, medicine = false, luxury = false }
+	}
+	local outpost15Goods = random(1,100)
+	if outpost15Goods < 20 then
+		stationOutpost15.comms_data.goods.gold = {quantity = 5, cost = math.random(22,30)}
+		stationOutpost15.comms_data.goods.cobalt = {quantity = 4, cost = math.random(45,55)}
+	elseif outpost15Goods < 40 then
+		stationOutpost15.comms_data.goods.gold = {quantity = 5, cost = math.random(22,30)}
+	elseif outpost15Goods < 60 then
+		stationOutpost15.comms_data.goods.cobalt = {quantity = 4, cost = math.random(45,55)}
+	else
+		stationOutpost15.comms_data.goods.platinum = {quantity = 4, cost = math.random(55,65)}
+	end
 	if stationFaction == "Human Navy" then
+		stationOutpost15.comms_data.goods.food = {quantity = math.random(5,10), cost = 1}
 		if random(1,5) <= 1 then
-			if outpost15Goods < 20 then
-				goods[stationOutpost15] = {{"luxury",5,70},{"gold",5,25},{"cobalt",4,50},{"food",math.random(5,10),1},{"medicine",5,5}}
-			elseif outpost15Goods < 40 then
-				goods[stationOutpost15] = {{"luxury",5,70},{"gold",5,25},{"food",math.random(5,10),1},{"medicine",5,5}}
-			elseif outpost15Goods < 60 then
-				goods[stationOutpost15] = {{"luxury",5,70},{"cobalt",4,50},{"food",math.random(5,10),1},{"medicine",5,5}}
-			else
-				goods[stationOutpost15] = {{"luxury",5,70},{"food",math.random(5,10),1},{"medicine",5,5}}
-			end
+			stationOutpost15.comms_data.goods.medicine = {quantity = 5, cost = 5}
 		else
-			if outpost15Goods < 20 then
-				goods[stationOutpost15] = {{"luxury",5,70},{"gold",5,25},{"cobalt",4,50},{"food",math.random(5,10),1}}
-			elseif outpost15Goods < 40 then
-				goods[stationOutpost15] = {{"luxury",5,70},{"gold",5,25},{"food",math.random(5,10),1}}
-			elseif outpost15Goods < 60 then
-				goods[stationOutpost15] = {{"luxury",5,70},{"cobalt",4,50},{"food",math.random(5,10),1}}
-			else
-				goods[stationOutpost15] = {{"luxury",5,70},{"food",math.random(5,10),1}}
-			end
+			stationOutpost15.comms_data.trade.medicine = true		
 		end
 	else
-		if outpost15Goods < 20 then
-			goods[stationOutpost15] = {{"luxury",5,70},{"gold",5,25},{"cobalt",4,50}}
-		elseif outpost15Goods < 40 then
-			goods[stationOutpost15] = {{"luxury",5,70},{"gold",5,25}}
-		elseif outpost15Goods < 60 then
-			goods[stationOutpost15] = {{"luxury",5,70},{"cobalt",4,50}}
-		else
-			goods[stationOutpost15] = {{"luxury",5,70}}
-		end
-		tradeFood[stationOutpost15] = true
+		stationOutpost15.comms_data.trade.food = true
 	end
 	placeRandomAroundPoint(Asteroid,15,1,15000,psx,psy)
 	return stationOutpost15
@@ -2439,342 +3023,457 @@ function placeOutpost21()
 	--Outpost 21
 	stationOutpost21 = SpaceStation():setTemplate(szt()):setFaction(stationFaction):setCommsScript(""):setCommsFunction(commsStation)
 	stationOutpost21:setPosition(psx,psy):setCallSign("Outpost-21"):setDescription("Mining and gambling")
+    stationOutpost21.comms_data = {
+    	friendlyness = random(0,100),
+        weapons = 			{Homing = "neutral",					HVLI = "neutral", 						Mine = "neutral",						Nuke = "friend", 						EMP = "friend"},
+        weapon_available = 	{Homing = random(1,10)<=(8-difficulty),	HVLI = random(1,10)<=(9-difficulty),	Mine = random(1,10)<=(7-difficulty),	Nuke = random(1,10)<=(5-difficulty),	EMP = random(1,10)<=(6-difficulty)},
+        service_cost = 		{supplydrop = math.random(80,120), reinforcements = math.random(125,175)},
+        reputation_cost_multipliers = {friend = 1.0, neutral = 3.0},
+        max_weapon_refill_amount = {friend = 1.0, neutral = 0.5 },
+        goods = {	luxury =	{quantity = 5,	cost = 70} },
+        trade = {	food = false, medicine = false, luxury = true }
+	}
 	placeRandomAroundPoint(Asteroid,15,1,15000,psx,psy)
-	outpost21Goods = random(1,100)
+	local outpost21Goods = random(1,100)
+	if outpost21Goods < 20 then
+		stationOutpost21.comms_data.goods.gold = {quantity = 5, cost = math.random(22,30)}
+		stationOutpost21.comms_data.goods.cobalt = {quantity = 4, cost = math.random(45,55)}
+	elseif outpost21Goods < 40 then
+		stationOutpost21.comms_data.goods.gold = {quantity = 5, cost = math.random(22,30)}
+	elseif outpost21Goods < 60 then
+		stationOutpost21.comms_data.goods.cobalt = {quantity = 4, cost = math.random(45,55)}
+	else
+		stationOutpost21.comms_data.goods.dilithium = {quantity = 4, cost = math.random(45,55)}
+	end
 	if stationFaction == "Human Navy" then
+		stationOutpost21.comms_data.goods.food = {quantity = math.random(5,10), cost = 1}
 		if random(1,5) <= 1 then
-			if outpost21Goods < 20 then
-				goods[stationOutpost21] = {{"luxury",5,70},{"gold",5,25},{"cobalt",4,50},{"food",math.random(5,10),1},{"medicine",5,5}}
-			elseif outpost21Goods < 40 then
-				goods[stationOutpost21] = {{"luxury",5,70},{"gold",5,25},{"food",math.random(5,10),1},{"medicine",5,5}}
-			elseif outpost21Goods < 60 then
-				goods[stationOutpost21] = {{"luxury",5,70},{"cobalt",4,50},{"food",math.random(5,10),1},{"medicine",5,5}}
-			else
-				goods[stationOutpost21] = {{"luxury",5,70},{"food",math.random(5,10),1},{"medicine",5,5}}
-			end
+			stationOutpost21.comms_data.goods.medicine = {quantity = 5, cost = 5}
 		else
-			if outpost21Goods < 20 then
-				goods[stationOutpost21] = {{"luxury",5,70},{"gold",5,25},{"cobalt",4,50},{"food",math.random(5,10),1}}
-			elseif outpost21Goods < 40 then
-				goods[stationOutpost21] = {{"luxury",5,70},{"gold",5,25},{"food",math.random(5,10),1}}
-			elseif outpost21Goods < 60 then
-				goods[stationOutpost21] = {{"luxury",5,70},{"cobalt",4,50},{"food",math.random(5,10),1}}
-			else
-				goods[stationOutpost21] = {{"luxury",5,70},{"food",math.random(5,10),1}}
-			end
-			if random(1,100) < 50 then tradeMedicine[stationOutpost21] = true end
+			stationOutpost21.comms_data.trade.medicine = random(1,100) < 50
 		end
 	else
-		if outpost21Goods < 20 then
-			goods[stationOutpost21] = {{"luxury",5,70},{"gold",5,25},{"cobalt",4,50}}
-		elseif outpost21Goods < 40 then
-			goods[stationOutpost21] = {{"luxury",5,70},{"gold",5,25}}
-		elseif outpost21Goods < 60 then
-			goods[stationOutpost21] = {{"luxury",5,70},{"cobalt",4,50}}
-		else
-			goods[stationOutpost21] = {{"luxury",5,70}}
-		end
-		tradeFood[stationOutpost21] = true
-		if random(1,100) < 50 then tradeMedicine[stationOutpost21] = true end
+		stationOutpost21.comms_data.trade.food = true
+		stationOutpost21.comms_data.trade.medicine = random(1,100) < 50
 	end
-	tradeLuxury[stationOutpost21] = true
 	return stationOutpost21
 end
 function placeOwen()
 	--Owen
 	stationOwen = SpaceStation():setTemplate(szt()):setFaction(stationFaction):setCommsScript(""):setCommsFunction(commsStation)
 	stationOwen:setPosition(psx,psy):setCallSign("Owen"):setDescription("Load lifters and components")
+    stationOwen.comms_data = {
+    	friendlyness = random(0,100),
+        weapons = 			{Homing = "neutral",					HVLI = "neutral", 						Mine = "neutral",						Nuke = "friend", 						EMP = "friend"},
+        weapon_available = 	{Homing = random(1,10)<=(8-difficulty),	HVLI = random(1,10)<=(9-difficulty),	Mine = random(1,10)<=(7-difficulty),	Nuke = random(1,10)<=(5-difficulty),	EMP = random(1,10)<=(6-difficulty)},
+        service_cost = 		{supplydrop = math.random(80,120), reinforcements = math.random(125,175)},
+        reputation_cost_multipliers = {friend = 1.0, neutral = 3.0},
+        max_weapon_refill_amount = {friend = 1.0, neutral = 0.5 },
+        goods = {	lifter =	{quantity = 5,	cost = 61} },
+        trade = {	food = false, medicine = false, luxury = true },
+        public_relations = true,
+        general_information = "We provide load lifters and components for various ship systems",
+    	history = "The station is named after Lars Owen. After his extensive eperience with tempermental machinery on Tatooine, he used his subject matter expertise to expand into building and manufacturing the equipment adding innovations based on his years of experience using load lifters and their relative cousins, moisture vaporators"
+	}
 	if stationFaction == "Human Navy" then
+		stationOwen.comms_data.goods.food = {quantity = math.random(5,10), cost = 1}
 		if random(1,5) <= 1 then
-			goods[stationOwen] = {{"food",math.random(5,10),1},{"medicine",5,5},{"lifter",5,61}}
-		else
-			goods[stationOwen] = {{"food",math.random(5,10),1},{"lifter",5,61}}		
+			stationOwen.comms_data.goods.medicine = {quantity = 5, cost = 5}
 		end
 	else
-		goods[stationOwen] = {{"lifter",5,61}}		
-		tradeFood[stationOwen] = true 
+		stationOwen.comms_data.trade.food = true
 	end
-	tradeLuxury[stationOwen] = true 
-	stationOwen.publicRelations = true
-	stationOwen.generalInformation = "We provide load lifters and components for various ship systems"
-	stationOwen.stationHistory = "The station is named after Lars Owen. After his extensive eperience with tempermental machinery on Tatooine, he used his subject matter expertise to expand into building and manufacturing the equipment adding innovations based on his years of experience using load lifters and their relative cousins, moisture vaporators"
 	return stationOwen
 end
 function placePanduit()
 	--Panduit
 	stationPanduit = SpaceStation():setTemplate(szt()):setFaction(stationFaction):setCommsScript(""):setCommsFunction(commsStation)
 	stationPanduit:setPosition(psx,psy):setCallSign("Panduit"):setDescription("Optic components")
+    stationPanduit.comms_data = {
+    	friendlyness = random(0,100),
+        weapons = 			{Homing = "neutral",					HVLI = "neutral", 						Mine = "neutral",						Nuke = "friend", 						EMP = "friend"},
+        weapon_available = 	{Homing = random(1,10)<=(8-difficulty),	HVLI = random(1,10)<=(9-difficulty),	Mine = random(1,10)<=(7-difficulty),	Nuke = random(1,10)<=(5-difficulty),	EMP = random(1,10)<=(6-difficulty)},
+        service_cost = 		{supplydrop = math.random(80,120), reinforcements = math.random(125,175)},
+        reputation_cost_multipliers = {friend = 1.0, neutral = 3.0},
+        max_weapon_refill_amount = {friend = 1.0, neutral = 0.5 },
+        goods = {	optic =	{quantity = 5,	cost = 79} },
+        trade = {	food = false, medicine = false, luxury = true },
+        public_relations = true,
+        general_information = "We provide optic components for various ship systems",
+    	history = "This station is an outgrowth of the Panduit corporation started in the mid 20th century on Earth in the United States"
+	}
 	if stationFaction == "Human Navy" then
+		stationPanduit.comms_data.goods.food = {quantity = math.random(5,10), cost = 1}
 		if random(1,5) <= 1 then
-			goods[stationPanduit] = {{"food",math.random(5,10),1},{"medicine",5,5},{"optic",5,79}}
+			stationPanduit.comms_data.goods.medicine = {quantity = 5, cost = 5}
 		else
-			goods[stationPanduit] = {{"food",math.random(5,10),1},{"optic",5,79}}		
-			if random(1,100) < 33 then tradeMedicine[stationPanduit] = true end
+			stationPanduit.comms_data.trade.medicine = random(1,100) < 33
 		end
 	else
-		goods[stationPanduit] = {{"optic",5,79}}		
-		if random(1,100) < 33 then tradeMedicine[stationPanduit] = true end
-		if random(1,100) < 27 then tradeFood[stationPanduit] = true end
+		stationPanduit.comms_data.trade.medicine = random(1,100) < 33
+		stationPanduit.comms_data.trade.food = random(1,100) < 27
 	end
-	tradeLuxury[stationPanduit] = true
-	stationPanduit.publicRelations = true
-	stationPanduit.generalInformation = "We provide optic components for various ship systems"
-	stationPanduit.stationHistory = "This station is an outgrowth of the Panduit corporation started in the mid 20th century on Earth in the United States"
 	return stationPanduit
 end
 function placeRipley()
 	--Ripley
 	stationRipley = SpaceStation():setTemplate(szt()):setFaction(stationFaction):setCommsScript(""):setCommsFunction(commsStation)
 	stationRipley:setPosition(psx,psy):setCallSign("Ripley"):setDescription("Load lifters and components")
+    stationRipley.comms_data = {
+    	friendlyness = random(0,100),
+        weapons = 			{Homing = "neutral",					HVLI = "neutral", 						Mine = "neutral",						Nuke = "friend", 						EMP = "friend"},
+        weapon_available = 	{Homing = random(1,10)<=(8-difficulty),	HVLI = random(1,10)<=(9-difficulty),	Mine = random(1,10)<=(7-difficulty),	Nuke = random(1,10)<=(5-difficulty),	EMP = random(1,10)<=(6-difficulty)},
+        service_cost = 		{supplydrop = math.random(80,120), reinforcements = math.random(125,175)},
+        reputation_cost_multipliers = {friend = 1.0, neutral = 3.0},
+        max_weapon_refill_amount = {friend = 1.0, neutral = 0.5 },
+        goods = {	lifter =	{quantity = 5,	cost = 82} },
+        trade = {	food = false, medicine = false, luxury = random(1,100) < 47 },
+        public_relations = true,
+        general_information = "We provide load lifters and components",
+    	history = "The station is named after Ellen Ripley who made creative and effective use of one of our load lifters when defending her ship"
+	}
 	if stationFaction == "Human Navy" then
+		stationRipley.comms_data.goods.food = {quantity = math.random(5,10), cost = 1}
 		if random(1,5) <= 1 then
-			goods[stationRipley] = {{"food",math.random(5,10),1},{"medicine",5,5},{"lifter",5,82}}
+			stationRipley.comms_data.goods.medicine = {quantity = 5, cost = 5}
 		else
-			goods[stationRipley] = {{"food",math.random(5,10),1},{"lifter",5,82}}		
-			tradeMedicine[stationRipley] = true 
+			stationRipley.comms_data.trade.medicine = true
 		end
 	else
-		goods[stationRipley] = {{"lifter",5,82}}		
-		if random(1,100) < 17 then tradeFood[stationRipley] = true end
-		tradeMedicine[stationRipley] = true 
+		stationRipley.comms_data.trade.food = random(1,100) < 17
+		stationRipley.comms_data.trade.medicine = true
 	end
-	if random(1,100) < 47 then tradeLuxury[stationRipley] = true end
-	stationRipley.publicRelations = true
-	stationRipley.generalInformation = "We provide load lifters and components"
-	stationRipley.stationHistory = "The station is named after Ellen Ripley who made creative and effective use of one of our load lifters when defending her ship"
 	return stationRipley
 end
 function placeRutherford()
 	--Rutherford
 	stationRutherford = SpaceStation():setTemplate(szt()):setFaction(stationFaction):setCommsScript(""):setCommsFunction(commsStation)
 	stationRutherford:setPosition(psx,psy):setCallSign("Rutherford"):setDescription("Shield components and research")
+    stationRutherford.comms_data = {
+    	friendlyness = random(0,100),
+        weapons = 			{Homing = "neutral",					HVLI = "neutral", 						Mine = "neutral",						Nuke = "friend", 						EMP = "friend"},
+        weapon_available = 	{Homing = random(1,10)<=(8-difficulty),	HVLI = random(1,10)<=(9-difficulty),	Mine = random(1,10)<=(7-difficulty),	Nuke = random(1,10)<=(5-difficulty),	EMP = random(1,10)<=(6-difficulty)},
+        service_cost = 		{supplydrop = math.random(80,120), reinforcements = math.random(125,175)},
+        reputation_cost_multipliers = {friend = 1.0, neutral = 3.0},
+        max_weapon_refill_amount = {friend = 1.0, neutral = 0.5 },
+        goods = {	shield =	{quantity = 5,	cost = 90} },
+        trade = {	food = false, medicine = false, luxury = random(1,100) < 43 },
+        public_relations = true,
+        general_information = "We research and fabricate components for ship shield systems",
+    	history = "This station was named after the national research institution Rutherford Appleton Laboratory in the United Kingdom which conducted some preliminary research into the feasability of generating an energy shield in the late 20th century"
+	}
 	if stationFaction == "Human Navy" then
+		stationRutherford.comms_data.goods.food = {quantity = math.random(5,10), cost = 1}
 		if random(1,5) <= 1 then
-			goods[stationRutherford] = {{"food",math.random(5,10),1},{"medicine",5,5},{"shield",5,90}}
+			stationRutherford.comms_data.goods.medicine = {quantity = 5, cost = 5}
 		else
-			goods[stationRutherford] = {{"food",math.random(5,10),1},{"shield",5,90}}		
-			tradeMedicine[stationRutherford] = true 
+			stationRutherford.comms_data.trade.medicine = true
 		end
 	else
-		goods[stationRutherford] = {{"shield",5,90}}		
-		tradeMedicine[stationRutherford] = true 
+		stationRutherford.comms_data.trade.food = true
+		stationRutherford.comms_data.trade.medicine = true
 	end
-	tradeMedicine[stationRutherford] = true
-	if random(1,100) < 43 then tradeLuxury[stationRutherford] = true end
-	stationRutherford.publicRelations = true
-	stationRutherford.generalInformation = "We research and fabricate components for ship shield systems"
-	stationRutherford.stationHistory = "This station was named after the national research institution Rutherford Appleton Laboratory in the United Kingdom which conducted some preliminary research into the feasability of generating an energy shield in the late 20th century"
 	return stationRutherford
 end
 function placeScience7()
 	--Science 7
 	stationScience7 = SpaceStation():setTemplate(szt()):setFaction(stationFaction):setCommsScript(""):setCommsFunction(commsStation)
 	stationScience7:setPosition(psx,psy):setCallSign("Science-7"):setDescription("Observatory")
-	goods[stationScience7] = {{"food",2,1}}
+    stationScience7.comms_data = {
+    	friendlyness = random(0,100),
+        weapons = 			{Homing = "neutral",					HVLI = "neutral", 						Mine = "neutral",						Nuke = "friend", 						EMP = "friend"},
+        weapon_available = 	{Homing = random(1,10)<=(8-difficulty),	HVLI = random(1,10)<=(9-difficulty),	Mine = random(1,10)<=(7-difficulty),	Nuke = random(1,10)<=(5-difficulty),	EMP = random(1,10)<=(6-difficulty)},
+        service_cost = 		{supplydrop = math.random(80,120), reinforcements = math.random(125,175)},
+        reputation_cost_multipliers = {friend = 1.0, neutral = 3.0},
+        max_weapon_refill_amount = {friend = 1.0, neutral = 0.5 },
+        goods = {	food =	{quantity = 2,	cost = 1} },
+        trade = {	food = false, medicine = false, luxury = false }
+	}
 	return stationScience7
 end
 function placeShawyer()
 	--Shawyer
 	stationShawyer = SpaceStation():setTemplate(szt()):setFaction(stationFaction):setCommsScript(""):setCommsFunction(commsStation)
 	stationShawyer:setPosition(psx,psy):setCallSign("Shawyer"):setDescription("Impulse engine components")
+    stationShawyer.comms_data = {
+    	friendlyness = random(0,100),
+        weapons = 			{Homing = "neutral",					HVLI = "neutral", 						Mine = "neutral",						Nuke = "friend", 						EMP = "friend"},
+        weapon_available = 	{Homing = random(1,10)<=(8-difficulty),	HVLI = random(1,10)<=(9-difficulty),	Mine = random(1,10)<=(7-difficulty),	Nuke = random(1,10)<=(5-difficulty),	EMP = random(1,10)<=(6-difficulty)},
+        service_cost = 		{supplydrop = math.random(80,120), reinforcements = math.random(125,175)},
+        reputation_cost_multipliers = {friend = 1.0, neutral = 3.0},
+        max_weapon_refill_amount = {friend = 1.0, neutral = 0.5 },
+        goods = {	impulse =	{quantity = 5,	cost = 100} },
+        trade = {	food = false, medicine = false, luxury = true },
+        public_relations = true,
+        general_information = "We research and manufacture impulse engine components and systems",
+    	history = "The station is named after Roger Shawyer who built the first prototype impulse engine in the early 21st century"
+	}
 	if stationFaction == "Human Navy" then
+		stationShawyer.comms_data.goods.food = {quantity = math.random(5,10), cost = 1}
 		if random(1,5) <= 1 then
-			goods[stationShawyer] = {{"food",math.random(5,10),1},{"medicine",5,5},{"impulse",5,100}}
+			stationShawyer.comms_data.goods.medicine = {quantity = 5, cost = 5}
 		else
-			goods[stationShawyer] = {{"food",math.random(5,10),1},{"impulse",5,100}}		
-			tradeMedicine[stationShawyer] = true 
+			stationShawyer.comms_data.trade.medicine = true
 		end
 	else
-		goods[stationShawyer] = {{"impulse",5,100}}		
-		tradeMedicine[stationShawyer] = true 
+		stationShawyer.comms_data.trade.medicine = true
 	end
-	tradeLuxury[stationShawyer] = true 
-	stationShawyer.publicRelations = true
-	stationShawyer.generalInformation = "We research and manufacture impulse engine components and systems"
-	stationShawyer.stationHistory = "The station is named after Roger Shawyer who built the first prototype impulse engine in the early 21st century"
 	return stationShawyer
 end
 function placeShree()
 	--Shree
 	stationShree = SpaceStation():setTemplate(szt()):setFaction(stationFaction):setCommsScript(""):setCommsFunction(commsStation)
 	stationShree:setPosition(psx,psy):setCallSign("Shree"):setDescription("Repulsor and tractor beam components")
+    stationShree.comms_data = {
+    	friendlyness = random(0,100),
+        weapons = 			{Homing = "neutral",					HVLI = "neutral", 						Mine = "neutral",						Nuke = "friend", 						EMP = "friend"},
+        weapon_available = 	{Homing = random(1,10)<=(8-difficulty),	HVLI = random(1,10)<=(9-difficulty),	Mine = random(1,10)<=(7-difficulty),	Nuke = random(1,10)<=(5-difficulty),	EMP = random(1,10)<=(6-difficulty)},
+        service_cost = 		{supplydrop = math.random(80,120), reinforcements = math.random(125,175)},
+        reputation_cost_multipliers = {friend = 1.0, neutral = 3.0},
+        max_weapon_refill_amount = {friend = 1.0, neutral = 0.5 },
+        goods = {	tractor =	{quantity = 5,	cost = 90},
+        			repulsor =	{quantity = 5,	cost = math.random(85,95)} },
+        trade = {	food = false, medicine = false, luxury = true },
+        public_relations = true,
+        general_information = "We make ship systems designed to push or pull other objects around in space",
+    	history = "Our station is named Shree after one of many tugboat manufacturers in the early 21st century on Earth in India. Tugboats serve a similar purpose for ocean-going vessels on earth as tractor and repulsor beams serve for space-going vessels today"
+	}
 	if stationFaction == "Human Navy" then
+		stationShree.comms_data.goods.food = {quantity = math.random(5,10), cost = 1}
 		if random(1,5) <= 1 then
-			goods[stationShree] = {{"food",math.random(5,10),1},{"medicine",5,5},{"tractor",5,90},{"repulsor",5,95}}
+			stationShree.comms_data.goods.medicine = {quantity = 5, cost = 5}
 		else
-			goods[stationShree] = {{"food",math.random(5,10),1},{"tractor",5,90},{"repulsor",5,95}}		
-			tradeMedicine[stationShree] = true 
+			stationShree.comms_data.trade.medicine = true
 		end
 	else
-		goods[stationShree] = {{"tractor",5,90},{"repulsor",5,95}}		
-		tradeMedicine[stationShree] = true 
-		tradeFood[stationShree] = true 
+		stationShree.comms_data.trade.medicine = true
+		stationShree.comms_data.trade.food = true
 	end
-	tradeLuxury[stationShree] = true 
-	stationShree.publicRelations = true
-	stationShree.generalInformation = "We make ship systems designed to push or pull other objects around in space"
-	stationShree.stationHistory = "Our station is named Shree after one of many tugboat manufacturers in the early 21st century on Earth in India. Tugboats serve a similar purpose for ocean-going vessels on earth as tractor and repulsor beams serve for space-going vessels today"
 	return stationShree
 end
 function placeSoong()
 	--Soong 
 	stationSoong = SpaceStation():setTemplate(szt()):setFaction(stationFaction):setCommsScript(""):setCommsFunction(commsStation)
 	stationSoong:setPosition(psx,psy):setCallSign("Soong"):setDescription("Android components")
+    stationSoong.comms_data = {
+    	friendlyness = random(0,100),
+        weapons = 			{Homing = "neutral",					HVLI = "neutral", 						Mine = "neutral",						Nuke = "friend", 						EMP = "friend"},
+        weapon_available = 	{Homing = random(1,10)<=(8-difficulty),	HVLI = random(1,10)<=(9-difficulty),	Mine = random(1,10)<=(7-difficulty),	Nuke = random(1,10)<=(5-difficulty),	EMP = random(1,10)<=(6-difficulty)},
+        service_cost = 		{supplydrop = math.random(80,120), reinforcements = math.random(125,175)},
+        reputation_cost_multipliers = {friend = 1.0, neutral = 3.0},
+        max_weapon_refill_amount = {friend = 1.0, neutral = 0.5 },
+        goods = {	android =	{quantity = 5,	cost = 73} },
+        trade = {	food = false, medicine = false, luxury = true },
+        public_relations = true,
+        general_information = "We create androids and android components",
+    	history = "The station is named after Dr. Noonian Soong, the famous android researcher and builder"
+	}
 	if stationFaction == "Human Navy" then
+		stationSoong.comms_data.goods.food = {quantity = math.random(5,10), cost = 1}
 		if random(1,5) <= 1 then
-			goods[stationSoong] = {{"food",math.random(5,10),1},{"medicine",5,5},{"android",5,73}}
-		else
-			goods[stationSoong] = {{"food",math.random(5,10),1},{"android",5,73}}		
+			stationSoong.comms_data.goods.medicine = {quantity = 5, cost = 5}
 		end
 	else
-		goods[stationSoong] = {{"android",5,73}}		
-		tradeFood[stationSoong] = true 
+		stationSoong.comms_data.trade.food = true
 	end
-	tradeLuxury[stationSoong] = true 
-	stationSoong.publicRelations = true
-	stationSoong.generalInformation = "We create androids and android components"
-	stationSoong.stationHistory = "The station is named after Dr. Noonian Soong, the famous android researcher and builder"
 	return stationSoong
 end
 function placeTiberius()
 	--Tiberius
 	stationTiberius = SpaceStation():setTemplate(szt()):setFaction(stationFaction):setCommsScript(""):setCommsFunction(commsStation)
 	stationTiberius:setPosition(psx,psy):setCallSign("Tiberius"):setDescription("Logistics coordination")
-	goods[stationTiberius] = {{"food",5,1}}
-	stationTiberius.publicRelations = true
-	stationTiberius.generalInformation = "We support the stations and ships in the area with planning and communication services"
-	stationTiberius.stationHistory = "We recognize the influence of Starfleet Captain James Tiberius Kirk in the 23rd century in our station name"
+    stationTiberius.comms_data = {
+    	friendlyness = random(0,100),
+        weapons = 			{Homing = "neutral",					HVLI = "neutral", 						Mine = "neutral",						Nuke = "friend", 						EMP = "friend"},
+        weapon_available = 	{Homing = random(1,10)<=(8-difficulty),	HVLI = random(1,10)<=(9-difficulty),	Mine = random(1,10)<=(7-difficulty),	Nuke = random(1,10)<=(5-difficulty),	EMP = random(1,10)<=(6-difficulty)},
+        service_cost = 		{supplydrop = math.random(80,120), reinforcements = math.random(125,175)},
+        reputation_cost_multipliers = {friend = 1.0, neutral = 3.0},
+        max_weapon_refill_amount = {friend = 1.0, neutral = 0.5 },
+        goods = {	food =	{quantity = 5,	cost = 1} },
+        trade = {	food = false, medicine = false, luxury = false },
+        public_relations = true,
+        general_information = "We support the stations and ships in the area with planning and communication services",
+    	history = "We recognize the influence of Starfleet Captain James Tiberius Kirk in the 23rd century in our station name"
+	}
 	return stationTiberius
 end
 function placeTokra()
 	--Tokra
 	stationTokra = SpaceStation():setTemplate(szt()):setFaction(stationFaction):setCommsScript(""):setCommsFunction(commsStation)
 	stationTokra:setPosition(psx,psy):setCallSign("Tokra"):setDescription("Advanced material components")
-	whatTrade = random(1,100)
+    stationTokra.comms_data = {
+    	friendlyness = random(0,100),
+        weapons = 			{Homing = "neutral",					HVLI = "neutral", 						Mine = "neutral",						Nuke = "friend", 						EMP = "friend"},
+        weapon_available = 	{Homing = random(1,10)<=(8-difficulty),	HVLI = random(1,10)<=(9-difficulty),	Mine = random(1,10)<=(7-difficulty),	Nuke = random(1,10)<=(5-difficulty),	EMP = random(1,10)<=(6-difficulty)},
+        service_cost = 		{supplydrop = math.random(80,120), reinforcements = math.random(125,175)},
+        reputation_cost_multipliers = {friend = 1.0, neutral = 3.0},
+        max_weapon_refill_amount = {friend = 1.0, neutral = 0.5 },
+        goods = {	filament =	{quantity = 5,	cost = 42} },
+        trade = {	food = false, medicine = false, luxury = false },
+        public_relations = true,
+        general_information = "We create multiple types of advanced material components. Our most popular products are our filaments",
+    	history = "We learned several of our critical industrial processes from the Tokra race, so we honor our fortune by naming the station after them"
+	}
+	local whatTrade = random(1,100)
 	if stationFaction == "Human Navy" then
+		stationTokra.comms_data.goods.food = {quantity = math.random(5,10), cost = 1}
 		if random(1,5) <= 1 then
-			goods[stationTokra] = {{"food",math.random(5,10),1},{"medicine",5,5},{"filament",5,42}}
-			tradeLuxury[stationTokra] = true
+			stationTokra.comms_data.goods.medicine = {quantity = 5, cost = 5}
+			stationTokra.comms_data.trade.luxury = true
 		else
-			goods[stationTokra] = {{"food",math.random(5,10),1},{"filament",5,42}}	
 			if whatTrade < 50 then
-				tradeMedicine[stationTokra] = true
+				stationTokra.comms_data.trade.medicine = true
 			else
-				tradeLuxury[stationTokra] = true
+				stationTokra.comms_data.trade.luxury = true
 			end
 		end
 	else
-		goods[stationTokra] = {{"filament",5,42}}		
 		if whatTrade < 33 then
-			tradeFood[stationTokra] = true
+			stationTokra.comms_data.trade.food = true
 		elseif whatTrade > 66 then
-			tradeMedicine[stationTokra] = true
+			stationTokra.comms_data.trade.medicine = true
 		else
-			tradeLuxury[stationTokra] = true
+			stationTokra.comms_data.trade.luxury = true
 		end
 	end
-	stationTokra.publicRelations = true
-	stationTokra.generalInformation = "We create multiple types of advanced material components. Our most popular products are our filaments"
-	stationTokra.stationHistory = "We learned several of our critical industrial processes from the Tokra race, so we honor our fortune by naming the station after them"
 	return stationTokra
 end
 function placeToohie()
 	--Toohie
 	stationToohie = SpaceStation():setTemplate(szt()):setFaction(stationFaction):setCommsScript(""):setCommsFunction(commsStation)
 	stationToohie:setPosition(psx,psy):setCallSign("Toohie"):setDescription("Shield and armor components and research")
+    stationToohie.comms_data = {
+    	friendlyness = random(0,100),
+        weapons = 			{Homing = "neutral",					HVLI = "neutral", 						Mine = "neutral",						Nuke = "friend", 						EMP = "friend"},
+        weapon_available = 	{Homing = random(1,10)<=(8-difficulty),	HVLI = random(1,10)<=(9-difficulty),	Mine = random(1,10)<=(7-difficulty),	Nuke = random(1,10)<=(5-difficulty),	EMP = random(1,10)<=(6-difficulty)},
+        service_cost = 		{supplydrop = math.random(80,120), reinforcements = math.random(125,175)},
+        reputation_cost_multipliers = {friend = 1.0, neutral = 3.0},
+        max_weapon_refill_amount = {friend = 1.0, neutral = 0.5 },
+        goods = {	shield =	{quantity = 5,	cost = 90} },
+        trade = {	food = false, medicine = false, luxury = true },
+        public_relations = true,
+        general_information = "We research and make general and specialized components for ship shield and ship armor systems",
+    	history = "This station was named after one of the earliest researchers in shield technology, Alexander Toohie back when it was considered impractical to construct shields due to the physics involved."
+	}
 	if stationFaction == "Human Navy" then
+		stationToohie.comms_data.goods.food = {quantity = math.random(5,10), cost = 1}
 		if random(1,5) <= 1 then
-			goods[stationToohie] = {{"food",math.random(5,10),1},{"medicine",5,5},{"shield",5,90}}
+			stationToohie.comms_data.goods.medicine = {quantity = 5, cost = 5}
 		else
-			goods[stationToohie] = {{"food",math.random(5,10),1},{"shield",5,90}}		
-			if random(1,100) < 25 then tradeMedicine[stationToohie] = true end
+			stationToohie.comms_data.trade.medicine = random(1,100) < 25
 		end
 	else
-		goods[stationToohie] = {{"shield",5,90}}		
-		if random(1,100) < 25 then tradeMedicine[stationToohie] = true end
+		stationToohie.comms_data.trade.medicine = random(1,100) < 25
 	end
-	tradeLuxury[stationToohie] = true
-	stationToohie.publicRelations = true
-	stationToohie.generalInformation = "We research and make general and specialized components for ship shield and ship armor systems"
-	stationToohie.stationHistory = "This station was named after one of the earliest researchers in shield technology, Alexander Toohie back when it was considered impractical to construct shields due to the physics involved."
 	return stationToohie
 end
 function placeUtopiaPlanitia()
 	--Utopia Planitia
 	stationUtopiaPlanitia = SpaceStation():setTemplate(szt()):setFaction(stationFaction):setCommsScript(""):setCommsFunction(commsStation)
 	stationUtopiaPlanitia:setPosition(psx,psy):setCallSign("Utopia Planitia"):setDescription("Ship building and maintenance facility")
+    stationUtopiaPlanitia.comms_data = {
+    	friendlyness = random(0,100),
+        weapons = 			{Homing = "neutral",					HVLI = "neutral", 						Mine = "neutral",						Nuke = "friend", 						EMP = "friend"},
+        weapon_available = 	{Homing = random(1,10)<=(8-difficulty),	HVLI = random(1,10)<=(9-difficulty),	Mine = random(1,10)<=(7-difficulty),	Nuke = random(1,10)<=(5-difficulty),	EMP = random(1,10)<=(6-difficulty)},
+        service_cost = 		{supplydrop = math.random(80,120), reinforcements = math.random(125,175)},
+        reputation_cost_multipliers = {friend = 1.0, neutral = 3.0},
+        max_weapon_refill_amount = {friend = 1.0, neutral = 0.5 },
+        goods = {	warp =	{quantity = 5,	cost = 167} },
+        trade = {	food = false, medicine = false, luxury = false },
+        public_relations = true,
+        general_information = "We work on all aspects of naval ship building and maintenance. Many of the naval models are researched, designed and built right here on this station. Our design goals seek to make the space faring experience as simple as possible given the tremendous capabilities of the modern naval vessel"
+	}
 	if stationFaction == "Human Navy" then
+		stationUtopiaPlanitia.comms_data.goods.food = {quantity = math.random(5,10), cost = 1}
 		if random(1,5) <= 1 then
-			goods[stationUtopiaPlanitia] = {{"food",math.random(5,10),1},{"medicine",5,5},{"warp",5,167}}
-		else
-			goods[stationUtopiaPlanitia] = {{"food",math.random(5,10),1},{"warp",5,167}}
+			stationUtopiaPlanitia.comms_data.goods.medicine = {quantity = 5, cost = 5}
 		end
-	else
-		goods[stationUtopiaPlanitia] = {{"warp",5,167}}
 	end
-	stationUtopiaPlanitia.publicRelations = true
-	stationUtopiaPlanitia.generalInformation = "We work on all aspects of naval ship building and maintenance. Many of the naval models are researched, designed and built right here on this station. Our design goals seek to make the space faring experience as simple as possible given the tremendous capabilities of the modern naval vessel"
 	return stationUtopiaPlanitia
 end
 function placeVactel()
 	--Vactel
 	stationVactel = SpaceStation():setTemplate(szt()):setFaction(stationFaction):setCommsScript(""):setCommsFunction(commsStation)
 	stationVactel:setPosition(psx,psy):setCallSign("Vactel"):setDescription("Shielded Circuitry Fabrication")
+    stationVactel.comms_data = {
+    	friendlyness = random(0,100),
+        weapons = 			{Homing = "neutral",					HVLI = "neutral", 						Mine = "neutral",						Nuke = "friend", 						EMP = "friend"},
+        weapon_available = 	{Homing = random(1,10)<=(8-difficulty),	HVLI = random(1,10)<=(9-difficulty),	Mine = random(1,10)<=(7-difficulty),	Nuke = random(1,10)<=(5-difficulty),	EMP = random(1,10)<=(6-difficulty)},
+        service_cost = 		{supplydrop = math.random(80,120), reinforcements = math.random(125,175)},
+        reputation_cost_multipliers = {friend = 1.0, neutral = 3.0},
+        max_weapon_refill_amount = {friend = 1.0, neutral = 0.5 },
+        goods = {	circuit =	{quantity = 5,	cost = 50} },
+        trade = {	food = false, medicine = false, luxury = false },
+        public_relations = true,
+        general_information = "We specialize in circuitry shielded from external hacking suitable for ship systems",
+    	history = "We started as an expansion from the lunar based chip manufacturer of Earth legacy Intel electronic chips"
+	}
 	if stationFaction == "Human Navy" then
+		stationVactel.comms_data.goods.food = {quantity = math.random(5,10), cost = 1}
 		if random(1,5) <= 1 then
-			goods[stationVactel] = {{"food",math.random(5,10),1},{"medicine",5,5},{"circuit",5,50}}
-		else
-			goods[stationVactel] = {{"food",math.random(5,10),1},{"circuit",5,50}}		
+			stationVactel.comms_data.goods.medicine = {quantity = 5, cost = 5}
 		end
-	else
-		goods[stationVactel] = {{"circuit",5,50}}		
 	end
-	stationVactel.publicRelations = true
-	stationVactel.generalInformation = "We specialize in circuitry shielded from external hacking suitable for ship systems"
-	stationVactel.stationHistory = "We started as an expansion from the lunar based chip manufacturer of Earth legacy Intel electronic chips"
 	return stationVactel
 end
 function placeVeloquan()
 	--Veloquan
 	stationVeloquan = SpaceStation():setTemplate(szt()):setFaction(stationFaction):setCommsScript(""):setCommsFunction(commsStation)
 	stationVeloquan:setPosition(psx,psy):setCallSign("Veloquan"):setDescription("Sensor components")
+    stationVeloquan.comms_data = {
+    	friendlyness = random(0,100),
+        weapons = 			{Homing = "neutral",					HVLI = "neutral", 						Mine = "neutral",						Nuke = "friend", 						EMP = "friend"},
+        weapon_available = 	{Homing = random(1,10)<=(8-difficulty),	HVLI = random(1,10)<=(9-difficulty),	Mine = random(1,10)<=(7-difficulty),	Nuke = random(1,10)<=(5-difficulty),	EMP = random(1,10)<=(6-difficulty)},
+        service_cost = 		{supplydrop = math.random(80,120), reinforcements = math.random(125,175)},
+        reputation_cost_multipliers = {friend = 1.0, neutral = 3.0},
+        max_weapon_refill_amount = {friend = 1.0, neutral = 0.5 },
+        goods = {	sensor =	{quantity = 5,	cost = 68} },
+        trade = {	food = false, medicine = false, luxury = false },
+        public_relations = true,
+        general_information = "We research and construct components for the most powerful and accurate sensors used aboard ships along with the software to make them easy to use",
+    	history = "The Veloquan company has its roots in the manufacturing of LIDAR sensors in the early 21st century on Earth in the United States for autonomous ground-based vehicles. They expanded research and manufacturing operations to include various sensors for space vehicles. Veloquan was the result of numerous mergers and acquisitions of several companies including Velodyne and Quanergy"
+	}
 	if stationFaction == "Human Navy" then
+		stationVeloquan.comms_data.goods.food = {quantity = math.random(5,10), cost = 1}
 		if random(1,5) <= 1 then
-			goods[stationVeloquan] = {{"food",math.random(5,10),1},{"medicine",5,5},{"sensor",5,68}}
+			stationVeloquan.comms_data.goods.medicine = {quantity = 5, cost = 5}
 		else
-			goods[stationVeloquan] = {{"food",math.random(5,10),1},{"sensor",5,68}}		
-			tradeMedicine[stationVeloquan] = true 
+			stationVeloquan.comms_data.trade.medicine = true
 		end
 	else
-		goods[stationVeloquan] = {{"sensor",5,68}}		
-		tradeMedicine[stationVeloquan] = true 
-		tradeFood[stationVeloquan] = true 
+		stationVeloquan.comms_data.trade.medicine = true
+		stationVeloquan.comms_data.trade.food = true
 	end
-	stationVeloquan.publicRelations = true
-	stationVeloquan.generalInformation = "We research and construct components for the most powerful and accurate sensors used aboard ships along with the software to make them easy to use"
-	stationVeloquan.stationHistory = "The Veloquan company has its roots in the manufacturing of LIDAR sensors in the early 21st century on Earth in the United States for autonomous ground-based vehicles. They expanded research and manufacturing operations to include various sensors for space vehicles. Veloquan was the result of numerous mergers and acquisitions of several companies including Velodyne and Quanergy"
 	return stationVeloquan
 end
 function placeZefram()
 	--Zefram
 	stationZefram = SpaceStation():setTemplate(szt()):setFaction(stationFaction):setCommsScript(""):setCommsFunction(commsStation)
 	stationZefram:setPosition(psx,psy):setCallSign("Zefram"):setDescription("Warp engine components")
+    stationZefram.comms_data = {
+    	friendlyness = random(0,100),
+        weapons = 			{Homing = "neutral",					HVLI = "neutral", 						Mine = "neutral",						Nuke = "friend", 						EMP = "friend"},
+        weapon_available = 	{Homing = random(1,10)<=(8-difficulty),	HVLI = random(1,10)<=(9-difficulty),	Mine = random(1,10)<=(7-difficulty),	Nuke = random(1,10)<=(5-difficulty),	EMP = random(1,10)<=(6-difficulty)},
+        service_cost = 		{supplydrop = math.random(80,120), reinforcements = math.random(125,175)},
+        reputation_cost_multipliers = {friend = 1.0, neutral = 3.0},
+        max_weapon_refill_amount = {friend = 1.0, neutral = 0.5 },
+        goods = {	warp =	{quantity = 5,	cost = 140} },
+        trade = {	food = false, medicine = false, luxury = true },
+        public_relations = true,
+        general_information = "We specialize in the esoteric components necessary to make warp drives function properly",
+    	history = "Zefram Cochrane constructed the first warp drive in human history. We named our station after him because of the specialized warp systems work we do"
+	}
 	if stationFaction == "Human Navy" then
+		stationZefram.comms_data.goods.food = {quantity = math.random(5,10), cost = 1}
 		if random(1,5) <= 1 then
-			goods[stationZefram] = {{"food",math.random(5,10),1},{"medicine",5,5},{"warp",5,140}}
+			stationZefram.comms_data.goods.medicine = {quantity = 5, cost = 5}
 		else
-			goods[stationZefram] = {{"food",math.random(5,10),1},{"warp",5,140}}		
-			if random(1,100) < 27 then tradeMedicine[stationZefram] = true end
+			stationZefram.comms_data.trade.medicine = random(1,100) < 27
 		end
 	else
-		goods[stationZefram] = {{"warp",5,140}}		
-		if random(1,100) < 27 then tradeMedicine[stationZefram] = true end
-		if random(1,100) < 16 then tradeFood[stationZefram] = true end
+		stationZefram.comms_data.trade.medicine = random(1,100) < 27
+		stationZefram.comms_data.trade.food = random(1,100) < 16
 	end
-	tradeLuxury[stationZefram] = true
-	stationZefram.publicRelations = true
-	stationZefram.generalInformation = "We specialize in the esoteric components necessary to make warp drives function properly"
-	stationZefram.stationHistory = "Zefram Cochrane constructed the first warp drive in human history. We named our station after him because of the specialized warp systems work we do"
 	return stationZefram
 end
 --[[-------------------------------------------------------------------
@@ -2784,55 +3483,81 @@ function placeJabba()
 	--Jabba
 	stationJabba = SpaceStation():setTemplate(szt()):setFaction(stationFaction):setCommsScript(""):setCommsFunction(commsStation)
 	stationJabba:setPosition(psx,psy):setCallSign("Jabba"):setDescription("Commerce and gambling")
-	stationGoodChoice = math.random(1,3)
+    stationJabba.comms_data = {
+    	friendlyness = random(0,100),
+        weapons = 			{Homing = "neutral",					HVLI = "neutral", 						Mine = "neutral",						Nuke = "friend", 						EMP = "friend"},
+        weapon_available = 	{Homing = random(1,10)<=(8-difficulty),	HVLI = random(1,10)<=(9-difficulty),	Mine = random(1,10)<=(7-difficulty),	Nuke = random(1,10)<=(5-difficulty),	EMP = random(1,10)<=(6-difficulty)},
+        service_cost = 		{supplydrop = math.random(80,120), reinforcements = math.random(125,175)},
+        reputation_cost_multipliers = {friend = 1.0, neutral = 3.0},
+        max_weapon_refill_amount = {friend = 1.0, neutral = 0.5 },
+        goods = {},
+        trade = {	food = false, medicine = false, luxury = false },
+        public_relations = true,
+        general_information = "Come play some games and shop. House take does not exceed 4 percent"
+	}
+	local stationGoodChoice = math.random(1,3)
 	if stationGoodChoice == 1 then
-		goods[stationJabba] = {{"luxury",5,math.random(68,81)}}
+		stationJabba.comms_data.goods.luxury = {quantity = 5, cost = math.random(68,81)}
 	elseif stationGoodChoice == 2 then
-		goods[stationJabba] = {{"gold",5,math.random(61,77)}}
+		stationJabba.comms_data.goods.gold = {quantity = 5, cost = math.random(61,77)}
 	else
-		goods[stationJabba] = {{"platinum",5,math.random(65,79)}}
+		stationJabba.comms_data.goods.platinum = {quantity = 5, cost = math.random(65,79)}
 	end
-	stationJabba.publicRelations = true
-	stationJabba.generalInformation = "Come play some games and shop. House take does not exceed 4 percent"
 	return stationJabba
 end
 function placeKrik()
 	--Krik
 	stationKrik = SpaceStation():setTemplate(szt()):setFaction(stationFaction):setCommsScript(""):setCommsFunction(commsStation)
 	stationKrik:setPosition(psx,psy):setCallSign("Krik"):setDescription("Mining station")
-	posAxisKrik = random(0,360)
-	posKrik = random(30000,80000)
-	negKrik = random(20000,60000)
-	spreadKrik = random(5000,8000)
-	negAxisKrik = posAxisKrik + 180
-	xPosAngleKrik, yPosAngleKrik = vectorFromAngle(posAxisKrik, posKrik)
-	posKrikEnd = random(40,90)
+    stationKrik.comms_data = {
+    	friendlyness = random(0,100),
+        weapons = 			{Homing = "neutral",					HVLI = "neutral", 						Mine = "neutral",						Nuke = "friend", 						EMP = "friend"},
+        weapon_available = 	{Homing = random(1,10)<=(8-difficulty),	HVLI = random(1,10)<=(9-difficulty),	Mine = random(1,10)<=(7-difficulty),	Nuke = random(1,10)<=(5-difficulty),	EMP = random(1,10)<=(6-difficulty)},
+        service_cost = 		{supplydrop = math.random(80,120), reinforcements = math.random(125,175)},
+        reputation_cost_multipliers = {friend = 1.0, neutral = 3.0},
+        max_weapon_refill_amount = {friend = 1.0, neutral = 0.5 },
+        goods = {	nickel =	{quantity = 5,	cost = 20} },
+        trade = {	food = true, medicine = true, luxury = random(1,100) < 50 },
+        public_relations = true,
+        general_information = "The finest shield and armor manufacturer in the quadrant",
+    	history = "We named this station for the pioneering spirit of the 22nd century Starfleet explorer, Captain Jonathan Archer"
+	}
+	local posAxisKrik = random(0,360)
+	local posKrik = random(30000,80000)
+	local negKrik = random(20000,60000)
+	local spreadKrik = random(5000,8000)
+	local negAxisKrik = posAxisKrik + 180
+	local xPosAngleKrik, yPosAngleKrik = vectorFromAngle(posAxisKrik, posKrik)
+	local posKrikEnd = random(40,90)
 	createRandomAlongArc(Asteroid, 30+posKrikEnd, psx+xPosAngleKrik, psy+yPosAngleKrik, posKrik, negAxisKrik, negAxisKrik+posKrikEnd, spreadKrik)
-	xNegAngleKrik, yNegAngleKrik = vectorFromAngle(negAxisKrik, negKrik)
-	negKrikEnd = random(30,60)
+	local xNegAngleKrik, yNegAngleKrik = vectorFromAngle(negAxisKrik, negKrik)
+	local negKrikEnd = random(30,60)
 	createRandomAlongArc(Asteroid, 30+negKrikEnd, psx+xNegAngleKrik, psy+yNegAngleKrik, negKrik, posAxisKrik, posAxisKrik+negKrikEnd, spreadKrik)
-	tradeFood[stationKrik] = true
-	if random(1,100) < 50 then tradeLuxury[stationKrik] = true end
-	tradeMedicine[stationKrik] = true
-	krikGoods = random(1,100)
+	local krikGoods = random(1,100)
 	if krikGoods < 10 then
-		goods[stationKrik] = {{"nickel",5,20},{"platinum",5,70},{"tritanium",5,50},{"dilithium",5,50}}
+		stationKrik.comms_data.goods.platinum = {quantity = 5, cost = math.random(65,75)}
+		stationKrik.comms_data.goods.tritanium = {quantity = 5, cost = math.random(45,55)}
+		stationKrik.comms_data.goods.dilithium = {quantity = 5, cost = math.random(45,55)}
 	elseif krikGoods < 20 then
-		goods[stationKrik] = {{"nickel",5,20},{"platinum",5,70},{"tritanium",5,50}}
+		stationKrik.comms_data.goods.platinum = {quantity = 5, cost = math.random(65,75)}
+		stationKrik.comms_data.goods.tritanium = {quantity = 5, cost = math.random(45,55)}
 	elseif krikGoods < 30 then
-		goods[stationKrik] = {{"nickel",5,20},{"platinum",5,70},{"dilithium",5,50}}
+		stationKrik.comms_data.goods.platinum = {quantity = 5, cost = math.random(65,75)}
+		stationKrik.comms_data.goods.dilithium = {quantity = 5, cost = math.random(45,55)}
 	elseif krikGoods < 40 then
-		goods[stationKrik] = {{"nickel",5,20},{"tritanium",5,50},{"dilithium",5,50}}
+		stationKrik.comms_data.goods.tritanium = {quantity = 5, cost = math.random(45,55)}
+		stationKrik.comms_data.goods.dilithium = {quantity = 5, cost = math.random(45,55)}
 	elseif krikGoods < 50 then
-		goods[stationKrik] = {{"nickel",5,20},{"dilithium",5,50}}
+		stationKrik.comms_data.goods.dilithium = {quantity = 5, cost = math.random(45,55)}
 	elseif krikGoods < 60 then
-		goods[stationKrik] = {{"nickel",5,20},{"platinum",5,70}}
+		stationKrik.comms_data.goods.platinum = {quantity = 5, cost = math.random(65,75)}
 	elseif krikGoods < 70 then
-		goods[stationKrik] = {{"nickel",5,20},{"tritanium",5,50}}
+		stationKrik.comms_data.goods.tritanium = {quantity = 5, cost = math.random(45,55)}
 	elseif krikGoods < 80 then
-		goods[stationKrik] = {{"platinum",5,70},{"tritanium",5,50},{"dilithium",5,50}}
+		stationKrik.comms_data.goods.cobalt = {quantity = 5, cost = math.random(55,65)}
 	else
-		goods[stationKrik] = {{"nickel",5,20}}
+		stationKrik.comms_data.goods.cobalt = {quantity = 5, cost = math.random(55,65)}
+		stationKrik.comms_data.goods.dilithium = {quantity = 5, cost = math.random(45,55)}
 	end
 	return stationKrik
 end
@@ -2840,13 +3565,23 @@ function placeLando()
 	--Lando
 	stationLando = SpaceStation():setTemplate(szt()):setFaction(stationFaction):setCommsScript(""):setCommsFunction(commsStation)
 	stationLando:setPosition(psx,psy):setCallSign("Lando"):setDescription("Casino and Gambling")
-	stationGoodChoice = math.random(1,3)
+    stationLando.comms_data = {
+    	friendlyness = random(0,100),
+        weapons = 			{Homing = "neutral",					HVLI = "neutral", 						Mine = "neutral",						Nuke = "friend", 						EMP = "friend"},
+        weapon_available = 	{Homing = random(1,10)<=(8-difficulty),	HVLI = random(1,10)<=(9-difficulty),	Mine = random(1,10)<=(7-difficulty),	Nuke = random(1,10)<=(5-difficulty),	EMP = random(1,10)<=(6-difficulty)},
+        service_cost = 		{supplydrop = math.random(80,120), reinforcements = math.random(125,175)},
+        reputation_cost_multipliers = {friend = 1.0, neutral = 3.0},
+        max_weapon_refill_amount = {friend = 1.0, neutral = 0.5 },
+        goods = {	shield =	{quantity = 5,	cost = 90} },
+        trade = {	food = false, medicine = false, luxury = false }
+	}
+	local stationGoodChoice = math.random(1,3)
 	if stationGoodChoice == 1 then
-		goods[stationLando] = {{"luxury",5,math.random(68,81)}}
+		stationLando.comms_data.goods.luxury = {quantity = 5, cost = math.random(68,81)}
 	elseif stationGoodChoice == 2 then
-		goods[stationLando] = {{"gold",5,math.random(61,77)}}
+		stationLando.comms_data.goods.gold = {quantity = 5, cost = math.random(61,77)}
 	else
-		goods[stationLando] = {{"platinum",5,math.random(65,79)}}
+		stationLando.comms_data.goods.platinum = {quantity = 5, cost = math.random(65,79)}
 	end
 	return stationLando
 end
@@ -2854,36 +3589,66 @@ function placeMaverick()
 	--Maverick
 	stationMaverick = SpaceStation():setTemplate(szt()):setFaction(stationFaction):setCommsScript(""):setCommsFunction(commsStation)
 	stationMaverick:setPosition(psx,psy):setCallSign("Maverick"):setDescription("Gambling and resupply")
-	stationGoodChoice = math.random(1,3)
+    stationMaverick.comms_data = {
+    	friendlyness = random(0,100),
+        weapons = 			{Homing = "neutral",					HVLI = "neutral", 						Mine = "neutral",						Nuke = "friend", 						EMP = "friend"},
+        weapon_available = 	{Homing = random(1,10)<=(8-difficulty),	HVLI = random(1,10)<=(9-difficulty),	Mine = random(1,10)<=(7-difficulty),	Nuke = random(1,10)<=(5-difficulty),	EMP = random(1,10)<=(6-difficulty)},
+        service_cost = 		{supplydrop = math.random(80,120), reinforcements = math.random(125,175)},
+        reputation_cost_multipliers = {friend = 1.0, neutral = 3.0},
+        max_weapon_refill_amount = {friend = 1.0, neutral = 0.5 },
+        goods = {},
+        trade = {	food = false, medicine = false, luxury = false },
+        public_relations = true,
+        general_information = "Relax and meet some interesting players"
+	}
+	local stationGoodChoice = math.random(1,3)
 	if stationGoodChoice == 1 then
-		goods[stationMaverick] = {{"luxury",5,math.random(68,81)}}
+		stationMaverick.comms_data.goods.luxury = {quantity = 5, cost = math.random(68,81)}
 	elseif stationGoodChoice == 2 then
-		goods[stationMaverick] = {{"gold",5,math.random(61,77)}}
+		stationMaverick.comms_data.goods.gold = {quantity = 5, cost = math.random(61,77)}
 	else
-		goods[stationMaverick] = {{"tritanium",5,math.random(65,79)}}
+		stationMaverick.comms_data.goods.platinum = {quantity = 5, cost = math.random(65,79)}
 	end
-	stationMaverick.publicRelations = true
-	stationMaverick.generalInformation = "Relax and meet some interesting players"
 	return stationMaverick
 end
 function placeNefatha()
 	--Nefatha
 	stationNefatha = SpaceStation():setTemplate(szt()):setFaction(stationFaction):setCommsScript(""):setCommsFunction(commsStation)
 	stationNefatha:setPosition(psx,psy):setCallSign("Nefatha"):setDescription("Commerce and recreation")
-	goods[stationNefatha] = {{"luxury",5,70}}
+    stationNefatha.comms_data = {
+    	friendlyness = random(0,100),
+        weapons = 			{Homing = "neutral",					HVLI = "neutral", 						Mine = "neutral",						Nuke = "friend", 						EMP = "friend"},
+        weapon_available = 	{Homing = random(1,10)<=(8-difficulty),	HVLI = random(1,10)<=(9-difficulty),	Mine = random(1,10)<=(7-difficulty),	Nuke = random(1,10)<=(5-difficulty),	EMP = random(1,10)<=(6-difficulty)},
+        service_cost = 		{supplydrop = math.random(80,120), reinforcements = math.random(125,175)},
+        reputation_cost_multipliers = {friend = 1.0, neutral = 3.0},
+        max_weapon_refill_amount = {friend = 1.0, neutral = 0.5 },
+        goods = {	luxury =	{quantity = 5,	cost = 70} },
+        trade = {	food = false, medicine = false, luxury = false }
+	}
 	return stationNefatha
 end
 function placeOkun()
 	--Okun
 	stationOkun = SpaceStation():setTemplate(szt()):setFaction(stationFaction):setCommsScript(""):setCommsFunction(commsStation)
 	stationOkun:setPosition(psx,psy):setCallSign("Okun"):setDescription("Xenopsychology research")
-	stationGoodChoice = math.random(1,3)
+    stationOkun.comms_data = {
+    	friendlyness = random(0,100),
+        weapons = 			{Homing = "neutral",					HVLI = "neutral", 						Mine = "neutral",						Nuke = "friend", 						EMP = "friend"},
+        weapon_available = 	{Homing = random(1,10)<=(8-difficulty),	HVLI = random(1,10)<=(9-difficulty),	Mine = random(1,10)<=(7-difficulty),	Nuke = random(1,10)<=(5-difficulty),	EMP = random(1,10)<=(6-difficulty)},
+        service_cost = 		{supplydrop = math.random(80,120), reinforcements = math.random(125,175)},
+        reputation_cost_multipliers = {friend = 1.0, neutral = 3.0},
+        max_weapon_refill_amount = {friend = 1.0, neutral = 0.5 },
+        goods = {},
+        trade = {	food = false, medicine = false, luxury = false },
+        public_relations = false
+	}
+	local stationGoodChoice = math.random(1,3)
 	if stationGoodChoice == 1 then
-		goods[stationOkun] = {{"optic",5,math.random(52,65)}}
+		stationOkun.comms_data.goods.optic = {quantity = 5, cost = math.random(52,65)}
 	elseif stationGoodChoice == 2 then
-		goods[stationOkun] = {{"filament",5,math.random(55,67)}}
+		stationOkun.comms_data.goods.filament = {quantity = 5, cost = math.random(55,67)}
 	else
-		goods[stationOkun] = {{"lifter",5,math.random(48,69)}}
+		stationOkun.comms_data.goods.lifter = {quantity = 5, cost = math.random(48,69)}
 	end
 	return stationOkun
 end
@@ -2891,20 +3656,39 @@ function placeOutpost7()
 	--Outpost 7
 	stationOutpost7 = SpaceStation():setTemplate(szt()):setFaction(stationFaction):setCommsScript(""):setCommsFunction(commsStation)
 	stationOutpost7:setPosition(psx,psy):setCallSign("Outpost-7"):setDescription("Resupply")
-	goods[stationOutpost7] = {{"luxury",5,80}}
+    stationOutpost7.comms_data = {
+    	friendlyness = random(0,100),
+        weapons = 			{Homing = "neutral",					HVLI = "neutral", 						Mine = "neutral",						Nuke = "friend", 						EMP = "friend"},
+        weapon_available = 	{Homing = random(1,10)<=(8-difficulty),	HVLI = random(1,10)<=(9-difficulty),	Mine = random(1,10)<=(7-difficulty),	Nuke = random(1,10)<=(5-difficulty),	EMP = random(1,10)<=(6-difficulty)},
+        service_cost = 		{supplydrop = math.random(80,120), reinforcements = math.random(125,175)},
+        reputation_cost_multipliers = {friend = 1.0, neutral = 3.0},
+        max_weapon_refill_amount = {friend = 1.0, neutral = 0.5 },
+        goods = {	luxury =	{quantity = 5,	cost = 80} },
+        trade = {	food = false, medicine = false, luxury = false }
+	}
 	return stationOutpost7
 end
 function placeOutpost8()
 	--Outpost 8
 	stationOutpost8 = SpaceStation():setTemplate(szt()):setFaction(stationFaction):setCommsScript(""):setCommsFunction(commsStation)
 	stationOutpost8:setPosition(psx,psy):setCallSign("Outpost-8")
-	stationGoodChoice = math.random(1,3)
+    stationOutpost8.comms_data = {
+    	friendlyness = random(0,100),
+        weapons = 			{Homing = "neutral",					HVLI = "neutral", 						Mine = "neutral",						Nuke = "friend", 						EMP = "friend"},
+        weapon_available = 	{Homing = random(1,10)<=(8-difficulty),	HVLI = random(1,10)<=(9-difficulty),	Mine = random(1,10)<=(7-difficulty),	Nuke = random(1,10)<=(5-difficulty),	EMP = random(1,10)<=(6-difficulty)},
+        service_cost = 		{supplydrop = math.random(80,120), reinforcements = math.random(125,175)},
+        reputation_cost_multipliers = {friend = 1.0, neutral = 3.0},
+        max_weapon_refill_amount = {friend = 1.0, neutral = 0.5 },
+        goods = {},
+        trade = {	food = false, medicine = false, luxury = false }
+	}
+	local stationGoodChoice = math.random(1,3)
 	if stationGoodChoice == 1 then
-		goods[stationOutpost8] = {{"impulse",5,math.random(69,75)}}
+		stationOutpost8.comms_data.goods.impulse = {quantity = 5, cost = math.random(69,75)}
 	elseif stationGoodChoice == 2 then
-		goods[stationOutpost8] = {{"tractor",5,math.random(55,67)}}
+		stationOutpost8.comms_data.goods.tractor = {quantity = 5, cost = math.random(55,67)}
 	else
-		goods[stationOutpost8] = {{"beam",5,math.random(61,69)}}
+		stationOutpost8.comms_data.goods.beam = {quantity = 5, cost = math.random(61,69)}
 	end
 	return stationOutpost8
 end
@@ -2912,20 +3696,39 @@ function placeOutpost33()
 	--Outpost 33
 	stationOutpost33 = SpaceStation():setTemplate(szt()):setFaction(stationFaction):setCommsScript(""):setCommsFunction(commsStation)
 	stationOutpost33:setPosition(psx,psy):setCallSign("Outpost-33"):setDescription("Resupply")
-	goods[stationOutpost33] = {{"luxury",5,75}}
+    stationOutpost33.comms_data = {
+    	friendlyness = random(0,100),
+        weapons = 			{Homing = "neutral",					HVLI = "neutral", 						Mine = "neutral",						Nuke = "friend", 						EMP = "friend"},
+        weapon_available = 	{Homing = random(1,10)<=(8-difficulty),	HVLI = random(1,10)<=(9-difficulty),	Mine = random(1,10)<=(7-difficulty),	Nuke = random(1,10)<=(5-difficulty),	EMP = random(1,10)<=(6-difficulty)},
+        service_cost = 		{supplydrop = math.random(80,120), reinforcements = math.random(125,175)},
+        reputation_cost_multipliers = {friend = 1.0, neutral = 3.0},
+        max_weapon_refill_amount = {friend = 1.0, neutral = 0.5 },
+        goods = {	luxury =	{quantity = 5,	cost = 75} },
+        trade = {	food = false, medicine = false, luxury = false }
+	}
 	return stationOutpost33
 end
 function placePrada()
 	--Prada
 	stationPrada = SpaceStation():setTemplate(szt()):setFaction(stationFaction):setCommsScript(""):setCommsFunction(commsStation)
 	stationPrada:setPosition(psx,psy):setCallSign("Prada"):setDescription("Textiles and fashion")
-	stationGoodChoice = math.random(1,3)
+    stationPrada.comms_data = {
+    	friendlyness = random(0,100),
+        weapons = 			{Homing = "neutral",					HVLI = "neutral", 						Mine = "neutral",						Nuke = "friend", 						EMP = "friend"},
+        weapon_available = 	{Homing = random(1,10)<=(8-difficulty),	HVLI = random(1,10)<=(9-difficulty),	Mine = random(1,10)<=(7-difficulty),	Nuke = random(1,10)<=(5-difficulty),	EMP = random(1,10)<=(6-difficulty)},
+        service_cost = 		{supplydrop = math.random(80,120), reinforcements = math.random(125,175)},
+        reputation_cost_multipliers = {friend = 1.0, neutral = 3.0},
+        max_weapon_refill_amount = {friend = 1.0, neutral = 0.5 },
+        goods = {},
+        trade = {	food = false, medicine = false, luxury = false }
+	}
+	local stationGoodChoice = math.random(1,3)
 	if stationGoodChoice == 1 then
-		goods[stationPrada] = {{"luxury",5,math.random(69,75)}}
+		stationPrada.comms_data.goods.luxury = {quantity = 5, cost = math.random(69,75)}
 	elseif stationGoodChoice == 2 then
-		goods[stationPrada] = {{"cobalt",5,math.random(55,67)}}
+		stationPrada.comms_data.goods.cobalt = {quantity = 5, cost = math.random(55,67)}
 	else
-		goods[stationPrada] = {{"dilithium",5,math.random(61,69)}}
+		stationPrada.comms_data.goods.dilithium = {quantity = 5, cost = math.random(61,69)}
 	end
 	return stationPrada
 end
@@ -2933,13 +3736,23 @@ function placeResearch11()
 	--Research-11
 	stationResearch11 = SpaceStation():setTemplate(szt()):setFaction(stationFaction):setCommsScript(""):setCommsFunction(commsStation)
 	stationResearch11:setPosition(psx,psy):setCallSign("Research-11"):setDescription("Stress Psychology Research")
-	stationGoodChoice = math.random(1,3)
+    stationResearch11.comms_data = {
+    	friendlyness = random(0,100),
+        weapons = 			{Homing = "neutral",					HVLI = "neutral", 						Mine = "neutral",						Nuke = "friend", 						EMP = "friend"},
+        weapon_available = 	{Homing = random(1,10)<=(8-difficulty),	HVLI = random(1,10)<=(9-difficulty),	Mine = random(1,10)<=(7-difficulty),	Nuke = random(1,10)<=(5-difficulty),	EMP = random(1,10)<=(6-difficulty)},
+        service_cost = 		{supplydrop = math.random(80,120), reinforcements = math.random(125,175)},
+        reputation_cost_multipliers = {friend = 1.0, neutral = 3.0},
+        max_weapon_refill_amount = {friend = 1.0, neutral = 0.5 },
+        goods = {},
+        trade = {	food = false, medicine = false, luxury = false }
+	}
+	local stationGoodChoice = math.random(1,3)
 	if stationGoodChoice == 1 then
-		goods[stationResearch11] = {{"warp",5,math.random(85,120)}}
+		stationResearch11.comms_data.goods.warp = {quantity = 5, cost = math.random(85,120)}
 	elseif stationGoodChoice == 2 then
-		goods[stationResearch11] = {{"repulsor",5,math.random(62,75)}}
+		stationResearch11.comms_data.goods.repulsor = {quantity = 5, cost = math.random(62,75)}
 	else
-		goods[stationResearch11] = {{"robotic",5,math.random(75,89)}}
+		stationResearch11.comms_data.goods.robotic = {quantity = 5, cost = math.random(75,89)}
 	end
 	return stationResearch11
 end
@@ -2947,13 +3760,23 @@ function placeResearch19()
 	--Research-19
 	stationResearch19 = SpaceStation():setTemplate(szt()):setFaction(stationFaction):setCommsScript(""):setCommsFunction(commsStation)
 	stationResearch19:setPosition(psx,psy):setCallSign("Research-19"):setDescription("Low gravity research")
-	stationGoodChoice = math.random(1,3)
+    stationResearch19.comms_data = {
+    	friendlyness = random(0,100),
+        weapons = 			{Homing = "neutral",					HVLI = "neutral", 						Mine = "neutral",						Nuke = "friend", 						EMP = "friend"},
+        weapon_available = 	{Homing = random(1,10)<=(8-difficulty),	HVLI = random(1,10)<=(9-difficulty),	Mine = random(1,10)<=(7-difficulty),	Nuke = random(1,10)<=(5-difficulty),	EMP = random(1,10)<=(6-difficulty)},
+        service_cost = 		{supplydrop = math.random(80,120), reinforcements = math.random(125,175)},
+        reputation_cost_multipliers = {friend = 1.0, neutral = 3.0},
+        max_weapon_refill_amount = {friend = 1.0, neutral = 0.5 },
+        goods = {},
+        trade = {	food = false, medicine = false, luxury = false }
+	}
+	local stationGoodChoice = math.random(1,3)
 	if stationGoodChoice == 1 then
-		goods[stationResearch19] = {{"transporter",5,math.random(85,94)}}
+		stationResearch19.comms_data.goods.transporter = {quantity = 5, cost = math.random(85,94)}
 	elseif stationGoodChoice == 2 then
-		goods[stationResearch19] = {{"sensor",5,math.random(62,75)}}
+		stationResearch19.comms_data.goods.sensor = {quantity = 5, cost = math.random(62,75)}
 	else
-		goods[stationResearch19] = {{"communication",5,math.random(55,89)}}
+		stationResearch19.comms_data.goods.communication = {quantity = 5, cost = math.random(55,89)}
 	end
 	return stationResearch19
 end
@@ -2961,22 +3784,41 @@ function placeRubis()
 	--Rubis
 	stationRubis = SpaceStation():setTemplate(szt()):setFaction(stationFaction):setCommsScript(""):setCommsFunction(commsStation)
 	stationRubis:setPosition(psx,psy):setCallSign("Rubis"):setDescription("Resupply")
-	goods[stationRubis] = {{"luxury",5,76}}
-	stationRubis.publicRelations = true
-	stationRubis.generalInformation = "Get your energy here! Grab a drink before you go!"
+    stationRubis.comms_data = {
+    	friendlyness = random(0,100),
+        weapons = 			{Homing = "neutral",					HVLI = "neutral", 						Mine = "neutral",						Nuke = "friend", 						EMP = "friend"},
+        weapon_available = 	{Homing = random(1,10)<=(8-difficulty),	HVLI = random(1,10)<=(9-difficulty),	Mine = random(1,10)<=(7-difficulty),	Nuke = random(1,10)<=(5-difficulty),	EMP = random(1,10)<=(6-difficulty)},
+        service_cost = 		{supplydrop = math.random(80,120), reinforcements = math.random(125,175)},
+        reputation_cost_multipliers = {friend = 1.0, neutral = 3.0},
+        max_weapon_refill_amount = {friend = 1.0, neutral = 0.5 },
+        goods = {	luxury =	{quantity = 5,	cost = 76} },
+        trade = {	food = false, medicine = false, luxury = false },
+        public_relations = true,
+        general_information = "Get your energy here! Grab a drink before you go!"
+	}
 	return stationRubis
 end
 function placeScience2()
 	--Science 2
 	stationScience2 = SpaceStation():setTemplate(szt()):setFaction(stationFaction):setCommsScript(""):setCommsFunction(commsStation)
 	stationScience2:setPosition(psx,psy):setCallSign("Science-2"):setDescription("Research Lab and Observatory")
-	stationGoodChoice = math.random(1,3)
+    stationScience2.comms_data = {
+    	friendlyness = random(0,100),
+        weapons = 			{Homing = "neutral",					HVLI = "neutral", 						Mine = "neutral",						Nuke = "friend", 						EMP = "friend"},
+        weapon_available = 	{Homing = random(1,10)<=(8-difficulty),	HVLI = random(1,10)<=(9-difficulty),	Mine = random(1,10)<=(7-difficulty),	Nuke = random(1,10)<=(5-difficulty),	EMP = random(1,10)<=(6-difficulty)},
+        service_cost = 		{supplydrop = math.random(80,120), reinforcements = math.random(125,175)},
+        reputation_cost_multipliers = {friend = 1.0, neutral = 3.0},
+        max_weapon_refill_amount = {friend = 1.0, neutral = 0.5 },
+        goods = {},
+        trade = {	food = false, medicine = false, luxury = false }
+	}
+	local stationGoodChoice = math.random(1,3)
 	if stationGoodChoice == 1 then
-		goods[stationScience2] = {{"autodoc",5,math.random(85,94)}}
+		stationScience2.comms_data.goods.autodoc = {quantity = 5, cost = math.random(85,94)}
 	elseif stationGoodChoice == 2 then
-		goods[stationScience2] = {{"android",5,math.random(62,75)}}
+		stationScience2.comms_data.goods.android = {quantity = 5, cost = math.random(62,75)}
 	else
-		goods[stationScience2] = {{"nanites",5,math.random(55,89)}}
+		stationScience2.comms_data.goods.nanites = {quantity = 5, cost = math.random(55,89)}
 	end
 	return stationScience2
 end
@@ -2984,13 +3826,26 @@ function placeScience4()
 	--Science 4
 	stationScience4 = SpaceStation():setTemplate(szt()):setFaction(stationFaction):setCommsScript(""):setCommsFunction(commsStation)
 	stationScience4:setPosition(psx,psy):setCallSign("Science-4"):setDescription("Biotech research")
-	stationGoodChoice = math.random(1,3)
+    stationScience4.comms_data = {
+    	friendlyness = random(0,100),
+        weapons = 			{Homing = "neutral",					HVLI = "neutral", 						Mine = "neutral",						Nuke = "friend", 						EMP = "friend"},
+        weapon_available = 	{Homing = random(1,10)<=(8-difficulty),	HVLI = random(1,10)<=(9-difficulty),	Mine = random(1,10)<=(7-difficulty),	Nuke = random(1,10)<=(5-difficulty),	EMP = random(1,10)<=(6-difficulty)},
+        service_cost = 		{supplydrop = math.random(80,120), reinforcements = math.random(125,175)},
+        reputation_cost_multipliers = {friend = 1.0, neutral = 3.0},
+        max_weapon_refill_amount = {friend = 1.0, neutral = 0.5 },
+        goods = {},
+        trade = {	food = false, medicine = false, luxury = false },
+        public_relations = true,
+        general_information = "The finest shield and armor manufacturer in the quadrant",
+    	history = "We named this station for the pioneering spirit of the 22nd century Starfleet explorer, Captain Jonathan Archer"
+	}
+	local stationGoodChoice = math.random(1,3)
 	if stationGoodChoice == 1 then
-		goods[stationScience4] = {{"software",5,math.random(85,94)}}
+		stationScience4.comms_data.goods.software = {quantity = 5, cost = math.random(85,94)}
 	elseif stationGoodChoice == 2 then
-		goods[stationScience4] = {{"circuit",5,math.random(62,75)}}
+		stationScience4.comms_data.goods.circuit = {quantity = 5, cost = math.random(62,75)}
 	else
-		goods[stationScience4] = {{"battery",5,math.random(55,89)}}
+		stationScience4.comms_data.goods.battery = {quantity = 5, cost = math.random(55,89)}
 	end
 	return stationScience4
 end
@@ -2998,23 +3853,42 @@ function placeSkandar()
 	--Skandar
 	stationSkandar = SpaceStation():setTemplate(szt()):setFaction(stationFaction):setCommsScript(""):setCommsFunction(commsStation)
 	stationSkandar:setPosition(psx,psy):setCallSign("Skandar"):setDescription("Routine maintenance and entertainment")
-	goods[stationSkandar] = {{"luxury",5,87}}
-	stationSkandar.publicRelations = true
-	stationSkandar.generalInformation = "Stop by for repairs. Take in one of our juggling shows featuring the four-armed Skandars"
-	stationSkandar.stationHistory = "The nomadic Skandars have set up at this station to practice their entertainment and maintenance skills as well as build a community where Skandars can relax"
+    stationSkandar.comms_data = {
+    	friendlyness = random(0,100),
+        weapons = 			{Homing = "neutral",					HVLI = "neutral", 						Mine = "neutral",						Nuke = "friend", 						EMP = "friend"},
+        weapon_available = 	{Homing = random(1,10)<=(8-difficulty),	HVLI = random(1,10)<=(9-difficulty),	Mine = random(1,10)<=(7-difficulty),	Nuke = random(1,10)<=(5-difficulty),	EMP = random(1,10)<=(6-difficulty)},
+        service_cost = 		{supplydrop = math.random(80,120), reinforcements = math.random(125,175)},
+        reputation_cost_multipliers = {friend = 1.0, neutral = 3.0},
+        max_weapon_refill_amount = {friend = 1.0, neutral = 0.5 },
+        goods = {	luxury =	{quantity = 5,	cost = 87} },
+        trade = {	food = false, medicine = false, luxury = false },
+        public_relations = true,
+        general_information = "Stop by for repairs. Take in one of our juggling shows featuring the four-armed Skandars",
+    	history = "The nomadic Skandars have set up at this station to practice their entertainment and maintenance skills as well as build a community where Skandars can relax"
+	}
 	return stationSkandar
 end
 function placeSpot()
 	--Spot
 	stationSpot = SpaceStation():setTemplate(szt()):setFaction(stationFaction):setCommsScript(""):setCommsFunction(commsStation)
 	stationSpot:setPosition(psx,psy):setCallSign("Spot"):setDescription("Observatory")
-	stationGoodChoice = math.random(1,3)
+    stationSpot.comms_data = {
+    	friendlyness = random(0,100),
+        weapons = 			{Homing = "neutral",					HVLI = "neutral", 						Mine = "neutral",						Nuke = "friend", 						EMP = "friend"},
+        weapon_available = 	{Homing = random(1,10)<=(8-difficulty),	HVLI = random(1,10)<=(9-difficulty),	Mine = random(1,10)<=(7-difficulty),	Nuke = random(1,10)<=(5-difficulty),	EMP = random(1,10)<=(6-difficulty)},
+        service_cost = 		{supplydrop = math.random(80,120), reinforcements = math.random(125,175)},
+        reputation_cost_multipliers = {friend = 1.0, neutral = 3.0},
+        max_weapon_refill_amount = {friend = 1.0, neutral = 0.5 },
+        goods = {},
+        trade = {	food = false, medicine = false, luxury = false }
+	}
+	local stationGoodChoice = math.random(1,3)
 	if stationGoodChoice == 1 then
-		goods[stationSpot] = {{"optic",5,math.random(85,94)}}
+		stationSpot.comms_data.goods.optic = {quantity = 5, cost = math.random(85,94)}
 	elseif stationGoodChoice == 2 then
-		goods[stationSpot] = {{"software",5,math.random(62,75)}}
+		stationSpot.comms_data.goods.software = {quantity = 5, cost = math.random(62,75)}
 	else
-		goods[stationSpot] = {{"sensor",5,math.random(55,89)}}
+		stationSpot.comms_data.goods.sensor = {quantity = 5, cost = math.random(55,89)}
 	end
 	return stationSpot
 end
@@ -3022,29 +3896,52 @@ function placeStarnet()
 	--Starnet 
 	stationStarnet = SpaceStation():setTemplate(szt()):setFaction(stationFaction):setCommsScript(""):setCommsFunction(commsStation)
 	stationStarnet:setPosition(psx,psy):setCallSign("Starnet"):setDescription("Automated weapons systems")
-	stationGoodChoice = math.random(1,3)
+    stationStarnet.comms_data = {
+    	friendlyness = random(0,100),
+        weapons = 			{Homing = "neutral",					HVLI = "neutral", 						Mine = "neutral",						Nuke = "friend", 						EMP = "friend"},
+        weapon_available = 	{Homing = random(1,10)<=(8-difficulty),	HVLI = random(1,10)<=(9-difficulty),	Mine = random(1,10)<=(7-difficulty),	Nuke = random(1,10)<=(5-difficulty),	EMP = random(1,10)<=(6-difficulty)},
+        service_cost = 		{supplydrop = math.random(80,120), reinforcements = math.random(125,175)},
+        reputation_cost_multipliers = {friend = 1.0, neutral = 3.0},
+        max_weapon_refill_amount = {friend = 1.0, neutral = 0.5 },
+        goods = {},
+        trade = {	food = false, medicine = false, luxury = false },
+        public_relations = true,
+        general_information = "We research and create automated weapons systems to improve ship combat capability"
+	}
+	local stationGoodChoice = math.random(1,3)
 	if stationGoodChoice == 1 then
-		goods[stationStarnet] = {{"shield",5,math.random(85,94)}}
+		stationStarnet.comms_data.goods.shield = {quantity = 5, cost = math.random(85,94)}
 	elseif stationGoodChoice == 2 then
-		goods[stationStarnet] = {{"beam",5,math.random(62,75)}}
+		stationStarnet.comms_data.goods.beam = {quantity = 5, cost = math.random(62,75)}
 	else
-		goods[stationStarnet] = {{"lifter",5,math.random(55,89)}}
+		stationStarnet.comms_data.goods.lifter = {quantity = 5, cost = math.random(55,89)}
 	end
-	stationStarnet.publicRelations = true
-	stationStarnet.generalInformation = "We research and create automated weapons systems to improve ship combat capability"
 	return stationStarnet
 end
 function placeTandon()
 	--Tandon
 	stationTandon = SpaceStation():setTemplate(szt()):setFaction(stationFaction):setCommsScript(""):setCommsFunction(commsStation)
 	stationTandon:setPosition(psx,psy):setCallSign("Tandon"):setDescription("Biotechnology research")
-	stationGoodChoice = math.random(1,3)
+    stationTandon.comms_data = {
+    	friendlyness = random(0,100),
+        weapons = 			{Homing = "neutral",					HVLI = "neutral", 						Mine = "neutral",						Nuke = "friend", 						EMP = "friend"},
+        weapon_available = 	{Homing = random(1,10)<=(8-difficulty),	HVLI = random(1,10)<=(9-difficulty),	Mine = random(1,10)<=(7-difficulty),	Nuke = random(1,10)<=(5-difficulty),	EMP = random(1,10)<=(6-difficulty)},
+        service_cost = 		{supplydrop = math.random(80,120), reinforcements = math.random(125,175)},
+        reputation_cost_multipliers = {friend = 1.0, neutral = 3.0},
+        max_weapon_refill_amount = {friend = 1.0, neutral = 0.5 },
+        goods = {},
+        trade = {	food = false, medicine = false, luxury = false },
+        public_relations = true,
+        general_information = "The finest shield and armor manufacturer in the quadrant",
+    	history = "We named this station for the pioneering spirit of the 22nd century Starfleet explorer, Captain Jonathan Archer"
+	}
+	local stationGoodChoice = math.random(1,3)
 	if stationGoodChoice == 1 then
-		goods[stationTandon] = {{"autodoc",5,math.random(85,94)}}
+		stationTandon.comms_data.goods.autodoc = {quantity = 5, cost = math.random(85,94)}
 	elseif stationGoodChoice == 2 then
-		goods[stationTandon] = {{"robotic",5,math.random(62,75)}}
+		stationTandon.comms_data.goods.robotic = {quantity = 5, cost = math.random(62,75)}
 	else
-		goods[stationTandon] = {{"android",5,math.random(55,89)}}
+		stationTandon.comms_data.goods.android = {quantity = 5, cost = math.random(55,89)}
 	end
 	return stationTandon
 end
@@ -3052,14 +3949,33 @@ function placeVaiken()
 	--Vaiken
 	stationVaiken = SpaceStation():setTemplate(szt()):setFaction(stationFaction):setCommsScript(""):setCommsFunction(commsStation)
 	stationVaiken:setPosition(psx,psy):setCallSign("Vaiken"):setDescription("Ship building and maintenance facility")
-	goods[stationVaiken] = {{"food",10,1},{"medicine",5,5}}
+    stationVaiken.comms_data = {
+    	friendlyness = random(0,100),
+        weapons = 			{Homing = "neutral",					HVLI = "neutral", 						Mine = "neutral",						Nuke = "friend", 						EMP = "friend"},
+        weapon_available = 	{Homing = random(1,10)<=(8-difficulty),	HVLI = random(1,10)<=(9-difficulty),	Mine = random(1,10)<=(7-difficulty),	Nuke = random(1,10)<=(5-difficulty),	EMP = random(1,10)<=(6-difficulty)},
+        service_cost = 		{supplydrop = math.random(80,120), reinforcements = math.random(125,175)},
+        reputation_cost_multipliers = {friend = 1.0, neutral = 3.0},
+        max_weapon_refill_amount = {friend = 1.0, neutral = 0.5 },
+        goods = {	food =		{quantity = 10,	cost = 1},
+        			medicine =	{quantity = 5,	cost = 5} },
+        trade = {	food = false, medicine = false, luxury = false }
+	}
 	return stationVaiken
 end
 function placeValero()
 	--Valero
 	stationValero = SpaceStation():setTemplate(szt()):setFaction(stationFaction):setCommsScript(""):setCommsFunction(commsStation)
 	stationValero:setPosition(psx,psy):setCallSign("Valero"):setDescription("Resupply")
-	goods[stationValero] = {{"luxury",5,77}}
+    stationValero.comms_data = {
+    	friendlyness = random(0,100),
+        weapons = 			{Homing = "neutral",					HVLI = "neutral", 						Mine = "neutral",						Nuke = "friend", 						EMP = "friend"},
+        weapon_available = 	{Homing = random(1,10)<=(8-difficulty),	HVLI = random(1,10)<=(9-difficulty),	Mine = random(1,10)<=(7-difficulty),	Nuke = random(1,10)<=(5-difficulty),	EMP = random(1,10)<=(6-difficulty)},
+        service_cost = 		{supplydrop = math.random(80,120), reinforcements = math.random(125,175)},
+        reputation_cost_multipliers = {friend = 1.0, neutral = 3.0},
+        max_weapon_refill_amount = {friend = 1.0, neutral = 0.5 },
+        goods = {	luxury =	{quantity = 5,	cost = 90} },
+        trade = {	food = false, medicine = false, luxury = false }
+	}
 	return stationValero
 end
 --[[-------------------------------------------------------------------
@@ -3134,17 +4050,19 @@ end
 -----------------------------------------------------------------]]--
 function setFleets()
 	--enemy defensive fleets
-	enemyResource = 300 + difficulty*200
+	local enemyResource = 300 + difficulty*200
 	enemyFleetList = {}
 	enemyDefensiveFleetList = {}
 	enemyFleet1base = kraylorStationList[math.random(1,#kraylorStationList)]
-	f1bx, f1by = enemyFleet1base:getPosition()
-	enemyFleet1, enemyFleet1Power = spawnEnemyFleet(f1bx, f1by, random(90,130))
+	local f1bx, f1by = enemyFleet1base:getPosition()
+	local enemyFleet1, enemyFleet1Power = spawnEnemyFleet(f1bx, f1by, random(90,130))
 	for _, enemy in ipairs(enemyFleet1) do
 		enemy:orderDefendTarget(enemyFleet1base)
 	end
 	table.insert(enemyFleetList,enemyFleet1)
 	table.insert(enemyDefensiveFleetList,enemyFleet1)
+	intelGatherArtifacts[1]:setDescriptions("Scan to gather intelligence",string.format("Enemy fleet detected in sector %s",enemyFleet1base:getSectorName()))
+	intelGatherArtifacts[1].startSector = enemyFleet1base:getSectorName()
 	enemyResource = enemyResource - enemyFleet1Power
 	if enemyResource > 120 then
 		enemyFleet2Power = random(80,120)
@@ -3157,13 +4075,15 @@ function setFleets()
 			enemyFleet2base = candidate
 		end
 	until(enemyFleet2base ~= nil)
-	f2bx, f2by = enemyFleet2base:getPosition()
+	local f2bx, f2by = enemyFleet2base:getPosition()
 	enemyFleet2, enemyFleet2Power = spawnEnemyFleet(f2bx, f2by, enemyFleet2Power)
 	for _, enemy in ipairs(enemyFleet2) do
 		enemy:orderDefendTarget(enemyFleet2base)
 	end
 	table.insert(enemyFleetList,enemyFleet2)
 	table.insert(enemyDefensiveFleetList,enemyFleet2)
+	intelGatherArtifacts[2]:setDescriptions("Scan to gather intelligence",string.format("Enemy fleet detected in sector %s",enemyFleet2base:getSectorName()))
+	intelGatherArtifacts[2].startSector = enemyFleet2base:getSectorName()
 	enemyResource = enemyResource - enemyFleet2Power
 	if enemyResource > 120 then
 		enemyFleet3Power = random(80,120)
@@ -3176,13 +4096,15 @@ function setFleets()
 			enemyFleet3base = candidate
 		end
 	until(enemyFleet3base ~= nil)
-	f3bx, f3by = enemyFleet3base:getPosition()
+	local f3bx, f3by = enemyFleet3base:getPosition()
 	enemyFleet3, enemyFleet3Power = spawnEnemyFleet(f3bx, f3by, enemyFleet3Power)
 	for _, enemy in ipairs(enemyFleet3) do
 		enemy:orderDefendTarget(enemyFleet3base)
 	end
 	table.insert(enemyFleetList,enemyFleet3)
 	table.insert(enemyDefensiveFleetList,enemyFleet3)
+	intelGatherArtifacts[3]:setDescriptions("Scan to gather intelligence",string.format("Enemy fleet detected in sector %s",enemyFleet3base:getSectorName()))
+	intelGatherArtifacts[3].startSector = enemyFleet3base:getSectorName()
 	enemyResource = enemyResource - enemyFleet3Power
 	repeat
 		candidate = kraylorStationList[math.random(1,#kraylorStationList)]
@@ -3190,13 +4112,15 @@ function setFleets()
 			enemyFleet4base = candidate
 		end
 	until(enemyFleet4base ~= nil)
-	f4bx, f4by = enemyFleet4base:getPosition()
+	local f4bx, f4by = enemyFleet4base:getPosition()
 	enemyFleet4, enemyFleet4Power = spawnEnemyFleet(f4bx, f4by, enemyResource/2)
 	for _, enemy in ipairs(enemyFleet4) do
 		enemy:orderDefendTarget(enemyFleet4base)
 	end
 	table.insert(enemyFleetList,enemyFleet4)
 	table.insert(enemyDefensiveFleetList,enemyFleet4)
+	intelGatherArtifacts[4]:setDescriptions("Scan to gather intelligence",string.format("Enemy fleet detected in sector %s",enemyFleet4base:getSectorName()))
+	intelGatherArtifacts[4].startSector = enemyFleet4base:getSectorName()
 	enemyResource = enemyResource - enemyFleet4Power
 	repeat
 		candidate = kraylorStationList[math.random(1,#kraylorStationList)]
@@ -3204,27 +4128,32 @@ function setFleets()
 			enemyFleet5base = candidate
 		end
 	until(enemyFleet5base ~= nil)
-	f5bx, f5by = enemyFleet5base:getPosition()
+	local f5bx, f5by = enemyFleet5base:getPosition()
 	enemyFleet5, enemyFleet5Power = spawnEnemyFleet(f5bx, f5by, enemyResource)
 	for _, enemy in ipairs(enemyFleet5) do
 		enemy:orderDefendTarget(enemyFleet5base)
 	end
 	table.insert(enemyFleetList,enemyFleet5)
 	table.insert(enemyDefensiveFleetList,enemyFleet5)
+	intelGatherArtifacts[5]:setDescriptions("Scan to gather intelligence",string.format("Enemy fleet detected in sector %s",enemyFleet5base:getSectorName()))
+	intelGatherArtifacts[5].startSector = enemyFleet5base:getSectorName()
 	
 	--friendly defensive fleets
 	
-	friendlyResource = 500
+	local friendlyResource = 500
 	friendlyFleetList = {}
 	friendlyHelperFleet = {}
+	friendlyDefensiveFleetList = {}
 	table.insert(friendlyFleetList,friendlyHelperFleet)
 	friendlyFleet1base = humanStationList[math.random(1,#humanStationList)]
 	f1bx, f1by = friendlyFleet1base:getPosition()
-	friendlyFleet1, friendlyFleet1Power = spawnEnemyFleet(f1bx, f1by, random(90,130), 1, "Human Navy")
+	local fleetName = friendlyFleet1base:getCallSign() .. " defensive fleet"
+	local friendlyFleet1, friendlyFleet1Power = spawnEnemyFleet(f1bx, f1by, random(90,130), 1, "Human Navy", fleetName)
 	for _, enemy in ipairs(friendlyFleet1) do
 		enemy:orderDefendTarget(friendlyFleet1base):setScanned(true)
 	end
 	table.insert(friendlyFleetList,friendlyFleet1)
+	friendlyDefensiveFleetList[fleetName] = friendlyFleet1
 	friendlyResource = friendlyResource - friendlyFleet1Power
 	if friendlyResource > 120 then
 		friendlyFleet2Power = random(80,120)
@@ -3238,11 +4167,13 @@ function setFleets()
 		end
 	until(friendlyFleet2base ~= nil)
 	f2bx, f2by = friendlyFleet2base:getPosition()
-	friendlyFleet2, friendlyFleet2Power = spawnEnemyFleet(f2bx, f2by, friendlyFleet2Power, 1, "Human Navy")
+	fleetName = friendlyFleet2base:getCallSign() .. " defensive fleet"
+	friendlyFleet2, friendlyFleet2Power = spawnEnemyFleet(f2bx, f2by, friendlyFleet2Power, 1, "Human Navy", fleetName)
 	for _, enemy in ipairs(friendlyFleet2) do
 		enemy:orderDefendTarget(friendlyFleet2base):setScanned(true)
 	end
 	table.insert(friendlyFleetList,friendlyFleet2)
+	friendlyDefensiveFleetList[fleetName] = friendlyFleet2
 	friendlyResource = friendlyResource - friendlyFleet2Power
 	if friendlyResource > 120 then
 		friendlyFleet3Power = random(80,120)
@@ -3256,11 +4187,13 @@ function setFleets()
 		end
 	until(friendlyFleet3base ~= nil)
 	f3bx, f3by = friendlyFleet3base:getPosition()
-	friendlyFleet3, friendlyFleet3Power = spawnEnemyFleet(f3bx, f3by, friendlyFleet3Power, 1, "Human Navy")
+	fleetName = friendlyFleet3base:getCallSign() .. " defensive fleet"
+	friendlyFleet3, friendlyFleet3Power = spawnEnemyFleet(f3bx, f3by, friendlyFleet3Power, 1, "Human Navy", fleetName)
 	for _, enemy in ipairs(friendlyFleet3) do
 		enemy:orderDefendTarget(friendlyFleet3base):setScanned(true)
 	end
 	table.insert(friendlyFleetList,friendlyFleet3)
+	friendlyDefensiveFleetList[fleetName] = friendlyFleet3
 	friendlyResource = friendlyResource - friendlyFleet3Power
 	repeat
 		candidate = humanStationList[math.random(1,#humanStationList)]
@@ -3269,45 +4202,50 @@ function setFleets()
 		end
 	until(friendlyFleet4base ~= nil)
 	f4bx, f4by = friendlyFleet4base:getPosition()
-	friendlyFleet4, friendlyFleet4Power = spawnEnemyFleet(f4bx, f4by, friendlyResource/2, 1, "Human Navy")
+	fleetName = friendlyFleet4base:getCallSign() .. " defensive fleet"
+	friendlyFleet4, friendlyFleet4Power = spawnEnemyFleet(f4bx, f4by, friendlyResource/2, 1, "Human Navy", fleetName)
 	for _, enemy in ipairs(friendlyFleet4) do
 		enemy:orderDefendTarget(friendlyFleet4base):setScanned(true)
 	end
 	table.insert(friendlyFleetList,friendlyFleet4)
+	friendlyDefensiveFleetList[fleetName] = friendlyFleet4
 	friendlyResource = friendlyResource - friendlyFleet4Power
 	repeat
 		candidate = humanStationList[math.random(1,#humanStationList)]
-		if candidate ~= enemyFleet1base and candidate ~= friendlyFleet2base and candidate ~= friendlyFleet3base and candidate ~= friendlyFleet4base then
+		if candidate ~= friendlyFleet1base and candidate ~= friendlyFleet2base and candidate ~= friendlyFleet3base and candidate ~= friendlyFleet4base then
 			friendlyFleet5base = candidate
 		end
 	until(friendlyFleet5base ~= nil)
 	f5bx, f5by = friendlyFleet5base:getPosition()
-	friendlyFleet5, enemyFleet5Power = spawnEnemyFleet(f5bx, f5by, friendlyResource, 1, "Human Navy")
+	fleetName = friendlyFleet5base:getCallSign() .. " defensive fleet"
+	friendlyFleet5, friendlyFleet5Power = spawnEnemyFleet(f5bx, f5by, friendlyResource, 1, "Human Navy", fleetName)
 	for _, enemy in ipairs(friendlyFleet5) do
 		enemy:orderDefendTarget(friendlyFleet5base):setScanned(true)
 	end
 	table.insert(friendlyFleetList,friendlyFleet5)
+	friendlyDefensiveFleetList[fleetName] = friendlyFleet5
 end
-function spawnEnemyFleet(xOrigin, yOrigin, power, danger, enemyFaction)
+function spawnEnemyFleet(xOrigin, yOrigin, power, danger, enemyFaction, fleetName)
 	if enemyFaction == nil then
 		enemyFaction = "Kraylor"
 	end
 	if danger == nil then 
 		danger = 1
 	end
-	enemyStrength = math.max(power * danger * difficulty, 5)
-	enemyPosition = 0
-	sp = irandom(400,900)			--random spacing of spawned group
-	deployConfig = random(1,100)	--randomly choose between squarish formation and hexagonish formation
-	enemyList = {}
-	fleetPower = 0
+	local enemyStrength = math.max(power * danger * difficulty, 5)
+	local enemyPosition = 0
+	local sp = irandom(400,900)			--random spacing of spawned group
+	local deployConfig = random(1,100)	--randomly choose between squarish formation and hexagonish formation
+	local enemyList = {}
+	local fleetPower = 0
+	local prefix = generateCallSignPrefix(1)
 	while enemyStrength > 0 do
-		shipTemplateType = irandom(1,#stsl)
+		local shipTemplateType = irandom(1,#stsl)
 		while stsl[shipTemplateType] > enemyStrength * 1.1 + 5 do
 			shipTemplateType = irandom(1,#stsl)
 		end
 		fleetPower = fleetPower + stsl[shipTemplateType]
-		ship = CpuShip():setFaction(enemyFaction):setTemplate(stnl[shipTemplateType]):orderRoaming()
+		local ship = CpuShip():setFaction(enemyFaction):setTemplate(stnl[shipTemplateType]):orderRoaming()
 		if enemyFaction == "Kraylor" then
 			rawKraylorShipStrength = rawKraylorShipStrength + stsl[shipTemplateType]
 			ship:onDestruction(enemyVesselDestroyed)
@@ -3322,7 +4260,11 @@ function spawnEnemyFleet(xOrigin, yOrigin, power, danger, enemyFaction)
 			ship:setPosition(xOrigin+fleetPosDelta2x[enemyPosition]*sp,yOrigin+fleetPosDelta2y[enemyPosition]*sp)
 		end
 		ship:setCommsScript(""):setCommsFunction(commsShip)
+		if fleetName ~= nil then
+			ship.fleet = fleetName
+		end
 		table.insert(enemyList, ship)
+		ship:setCallSign(generateCallSign(prefix))
 		enemyStrength = enemyStrength - stsl[shipTemplateType]
 	end
 	fleetPower = math.max(fleetPower/danger/difficulty, 5)
@@ -3331,69 +4273,131 @@ end
 --[[-----------------------------------------------------------------
     Optional mission initialization and routines
 -----------------------------------------------------------------]]--
-function setOptionalMissions()
-	--	faster beams
-	missionAttemptCount = 0
+function chooseUpgradeBase()
+	local upgradeBase = nil
+	local candidate = humanStationList[math.random(1,#humanStationList)]
+	local ctd = candidate.comms_data
+	local goodCount = 0
+	local missionAttemptCount = 0
 	repeat
 		candidate = humanStationList[math.random(1,#humanStationList)]
-		if candidate ~= nil and candidate:isValid() then
-			if #goods[candidate] > 0 then
-				gi = 1
-				repeat
-					if goods[candidate][gi][1] ~= "food" and goods[candidate][gi][1] ~= "medicine" then
-						beamTimeBase = candidate
+		ctd = candidate.comms_data
+		if candidate ~= nil and candidate:isValid() and not inUpgradeList(candidate) then
+			for good, goodData in pairs(ctd.goods) do
+				goodCount = goodCount + 1
+			end
+			if goodCount > 0 then
+				for good, goodData in pairs(ctd.goods) do
+					if good ~= "food" and good ~= "medicine" then
+						upgradeBase = candidate
 					end
-					gi = gi + 1
-				until(gi > #goods[candidate])
+				end
 			end
 		end
 		missionAttemptCount = missionAttemptCount + 1
-	until(beamTimeBase ~= nil or missionAttemptCount > repeatExitBoundary)	
-	if beamTimeBase ~= nil then
-		missionAttemptCount = 0
-		matchAway = nil
-		repeat
-			candidate = humanStationList[math.random(1,#humanStationList)]
-			if candidate ~= nil and candidate:isValid() and candidate ~= beamTimeBase then
-				if #goods[candidate] > 0 then
-					beamTimeGoodBase = candidate
-					gi = 1
-					repeat
-						beamTimeGood = goods[beamTimeGoodBase][gi][1]
-						matchAway = false
-						gj = 1
-						repeat
-							if beamTimeGood == "food" or beamTimeGood == "medicine" or beamTimeGood == goods[beamTimeBase][gj][1] then
+	until(upgradeBase ~= nil or missionAttemptCount > repeatExitBoundary)
+	if upgradeBase ~= nil then
+		table.insert(upgradeBaseList,upgradeBase)
+	end
+	return upgradeBase
+end
+function inUpgradeList(station)
+	if #upgradeBaseList < 1 then
+		return false
+	else
+		for i=1,#upgradeBaseList do
+			if station == upgradeBaseList[i] then
+				return true
+			end
+		end
+		return false
+	end
+end
+function chooseUpgradeGoodBase(upgradeBase)
+	if optionalMissionDiagnostic then print("in upgrade good base") end
+	if optionalMissionDiagnostic then print("upgrade base: " .. upgradeBase:getCallSign()) end
+	local upgradeGoodBase = nil
+	local upgradeGood = nil
+	local matchAway = nil
+	local candidate = humanStationList[math.random(1,#humanStationList)]
+	local ctd = candidate.comms_data
+	local goodCount = 0
+	local missionAttemptCount = 0
+	repeat
+		candidate = humanStationList[math.random(1,#humanStationList)]
+		if optionalMissionDiagnostic then print("candidate: " .. candidate:getCallSign()) end
+		ctd = candidate.comms_data
+		if candidate ~= nil and candidate:isValid() and candidate ~= upgradeBase then
+			if optionalMissionDiagnostic then print("valid candidate") end
+			goodCount = 0
+			for good, goodData in pairs(ctd.goods) do
+				goodCount = goodCount + 1
+			end
+			if goodCount > 0 then
+				if optionalMissionDiagnostic then print("candidate has goods") end
+				upgradeGoodBase = candidate
+				for good, goodData in pairs(ctd.goods) do
+					upgradeGood = good
+					matchAway = false
+					if good == "food" or good == "medicine" then
+						if optionalMissionDiagnostic then print("skip food or medicine") end
+						matchAway = true
+					else
+						for upgradeBaseGood, upgradeBaseGoodData in pairs(upgradeBase.comms_data.goods) do
+							print(string.format("upgrade base good: %s",upgradeBaseGood))
+							if good == upgradeBaseGood then
+								if optionalMissionDiagnostic then print("matched upgrade base good, exit loop") end
 								matchAway = true
 								break
 							end
-							gj = gj + 1
-						until(gj > #goods[beamTimeBase])
-						if not matchAway then break end
-						gi = gi + 1
-					until(gi > #goods[beamTimeGoodBase])
+						end
+					end
+					if not matchAway then 
+						if optionalMissionDiagnostic then print("base and good qualifies: is not food or medicine and does not match upgrade base") end
+						break 
+					end
 				end
 			end
-			missionAttemptCount = missionAttemptCount + 1
-		until(not matchAway or missionAttemptCount > repeatExitBoundary)
-		beamTimeBase.character = "Horace Grayson"
-		beamTimeBase.characterDescription = "He dabbles in ship system innovations. He's been working on improving beam weapons by reducing the amount of time between firing. I hear he's already installed some improvements on ships that have docked here previously"
-		beamTimeBase.characterFunction = "shrinkBeamCycle"
-		if matchAway then
-			beamTimeBase.characterGood = "gold pressed latinum"			
+		end
+		missionAttemptCount = missionAttemptCount + 1
+	until(not matchAway or missionAttemptCount > repeatExitBoundary)
+	if matchAway then
+		if optionalMissionDiagnostic then print("did not find qualifying good and base") end
+		return nil
+	else
+		if optionalMissionDiagnostic then print("found qualifying good and base") end
+		return upgradeGood, upgradeGoodBase
+	end
+end
+function setOptionalMissions()
+	--	faster beams
+	local missionAttemptCount = 0
+	local goodCount = 0
+	local matchAway = false
+	local candidate = humanStationList[math.random(1,#humanStationList)]
+	local ctd = candidate.comms_data
+	upgradeBaseList = {}
+	beamTimeBase = chooseUpgradeBase()
+	if beamTimeBase ~= nil then
+		beamTimeGood, beamTimeGoodBase = chooseUpgradeGoodBase(beamTimeBase)
+		beamTimeBase.comms_data.character = "Horace Grayson"
+		beamTimeBase.comms_data.characterDescription = "He dabbles in ship system innovations. He's been working on improving beam weapons by reducing the amount of time between firing. I hear he's already installed some improvements on ships that have docked here previously"
+		beamTimeBase.comms_data.characterFunction = "shrinkBeamCycle"
+		if beamTimeGood == nil then
+			beamTimeBase.comms_data.characterGood = "gold pressed latinum"			
 		else
-			beamTimeBase.characterGood = beamTimeGood
+			beamTimeBase.comms_data.characterGood = beamTimeGood
 			clueStation = nil
 			missionAttemptCount = 0
 			repeat
 				candidate = humanStationList[math.random(1,#humanStationList)]
-				if candidate ~= nil and candidate:isValid() and candidate ~= beamTimeBase and candidate.gossip == nil then
+				if candidate ~= nil and candidate:isValid() and candidate ~= beamTimeBase and candidate.comms_data.gossip == nil then
 					clueStation = candidate
 				end
 				missionAttemptCount = missionAttemptCount + 1
 			until(clueStation ~= nil or missionAttemptCount > repeatExitBoundary)
 			if clueStation ~= nil then
-				clueStation.gossip = string.format("I heard there's a guy named %s that can fix ship beam systems up so that they shoot faster. He lives out on %s in %s. He won't charge you much, but it won't be free.",beamTimeBase.character,beamTimeBase:getCallSign(),beamTimeBase:getSectorName())
+				clueStation.comms_data.gossip = string.format("I heard there's a guy named %s that can fix ship beam systems up so that they shoot faster. He lives out on %s in %s. He won't charge you much, but it won't be free.",beamTimeBase.comms_data.character,beamTimeBase:getCallSign(),beamTimeBase:getSectorName())
 			end
 		end
 	end
@@ -3415,67 +4419,27 @@ function setOptionalMissions()
 		end
 	end
 	--	spin faster
-	missionAttemptCount = 0
-	repeat
-		candidate = humanStationList[math.random(1,#humanStationList)]
-		if candidate ~= nil and candidate:isValid() and candidate ~= beamTimeBase then
-			if #goods[candidate] > 0 then
-				gi = 1
-				repeat
-					if goods[candidate][gi][1] ~= "food" and goods[candidate][gi][1] ~= "medicine" then
-						spinBase = candidate
-					end
-					gi = gi + 1
-				until(gi > #goods[candidate])
-			end
-		end
-		missionAttemptCount = missionAttemptCount + 1
-	until(spinBase ~= nil or missionAttemptCount > repeatExitBoundary)	
+	spinBase = chooseUpgradeBase()
 	if spinBase ~= nil then
-		missionAttemptCount = 0
-		matchAway = nil
-		repeat
-			candidate = humanStationList[math.random(1,#humanStationList)]
-			if candidate ~= nil and candidate:isValid() and candidate ~= spinBase then
-				if #goods[candidate] > 0 then
-					spinGoodBase = candidate
-					gi = 1
-					repeat
-						spinGood = goods[spinGoodBase][gi][1]
-						matchAway = false
-						gj = 1
-						repeat
-							if spinGood == "food" or spinGood == "medicine" or spinGood == goods[spinBase][gj][1] then
-								matchAway = true
-								break
-							end
-							gj = gj + 1
-						until(gj > #goods[spinBase])
-						if not matchAway then break end
-						gi = gi + 1
-					until(gi > #goods[spinGoodBase])
-				end
-			end
-			missionAttemptCount = missionAttemptCount + 1
-		until(not matchAway or missionAttemptCount > repeatExitBoundary)
-		spinBase.character = "Emily Patel"
-		spinBase.characterDescription = "She tinkers with ship systems like engines and thrusters. She's consulted with the military on tuning spin time by increasing thruster power. She's got prototypes that are awaiting formal military approval before installation"
-		spinBase.characterFunction = "increaseSpin"
-		if matchAway then
-			beamTimeBase.characterGood = "gold pressed latinum"			
+		spinGood, spinGoodBase = chooseUpgradeGoodBase(spinBase)
+		spinBase.comms_data.character = "Emily Patel"
+		spinBase.comms_data.characterDescription = "She tinkers with ship systems like engines and thrusters. She's consulted with the military on tuning spin time by increasing thruster power. She's got prototypes that are awaiting formal military approval before installation"
+		spinBase.comms_data.characterFunction = "increaseSpin"
+		if spinGood == nil then
+			spinBase.comms_data.characterGood = "gold pressed latinum"			
 		else
-			spinBase.characterGood = spinGood
+			spinBase.comms_data.characterGood = spinGood
 			clueStation = nil
 			missionAttemptCount = 0
 			repeat
 				candidate = humanStationList[math.random(1,#humanStationList)]
-				if candidate ~= nil and candidate:isValid() and candidate ~= spinBase and candidate.gossip == nil then
+				if candidate ~= nil and candidate:isValid() and candidate ~= spinBase and candidate.comms_data.gossip == nil then
 					clueStation = candidate
 				end
 				missionAttemptCount = missionAttemptCount + 1
 			until(clueStation ~= nil or missionAttemptCount > repeatExitBoundary)
 			if clueStation ~= nil then
-				clueStation.gossip = string.format("My friend, %s recently quit her job as a ship maintenance technician to set up this side gig. She's been improving ship systems and she's pretty good at it. She set up shop on %s in %s. I hear she's even lining up a contract with the navy for her improvements.",spinBase.character,spinBase:getCallSign(),spinBase:getSectorName())
+				clueStation.comms_data.gossip = string.format("My friend, %s recently quit her job as a ship maintenance technician to set up this side gig. She's been improving ship systems and she's pretty good at it. She set up shop on %s in %s. I hear she's even lining up a contract with the navy for her improvements.",spinBase.comms_data.character,spinBase:getCallSign(),spinBase:getSectorName())
 			end
 		end
 	end
@@ -3497,67 +4461,27 @@ function setOptionalMissions()
 		end
 	end
 	--	extra missile tube
-	missionAttemptCount = 0
-	repeat
-		candidate = humanStationList[math.random(1,#humanStationList)]
-		if candidate ~= nil and candidate:isValid() and candidate ~= beamTimeBase and candidate ~= spinBase then
-			if #goods[candidate] > 0 then
-				gi = 1
-				repeat
-					if goods[candidate][gi][1] ~= "food" and goods[candidate][gi][1] ~= "medicine" then
-						auxTubeBase = candidate
-					end
-					gi = gi + 1
-				until(gi > #goods[candidate])
-			end
-		end
-		missionAttemptCount = missionAttemptCount + 1
-	until(auxTubeBase ~= nil or missionAttemptCount > repeatExitBoundary)	
+	auxTubeBase = chooseUpgradeBase()
 	if auxTubeBase ~= nil then
-		missionAttemptCount = 0
-		matchAway = nil
-		repeat
-			candidate = humanStationList[math.random(1,#humanStationList)]
-			if candidate ~= nil and candidate:isValid() and candidate ~= auxTubeBase then
-				if #goods[candidate] > 0 then
-					auxTubeGoodBase = candidate
-					gi = 1
-					repeat
-						auxTubeGood = goods[auxTubeGoodBase][gi][1]
-						matchAway = false
-						gj = 1
-						repeat
-							if auxTubeGood == "food" or auxTubeGood == "medicine" or auxTubeGood == goods[auxTubeBase][gj][1] then
-								matchAway = true
-								break
-							end
-							gj = gj + 1
-						until(gj > #goods[auxTubeBase])
-						if not matchAway then break end
-						gi = gi + 1
-					until(gi > #goods[auxTubeGoodBase])
-				end
-			end
-			missionAttemptCount = missionAttemptCount + 1
-		until(not matchAway or missionAttemptCount > repeatExitBoundary)
-		auxTubeBase.character = "Fred McLassiter"
-		auxTubeBase.characterDescription = "He specializes in miniaturization of weapons systems. He's come up with a way to add a missile tube and some missiles to any ship regardless of size or configuration"
-		auxTubeBase.characterFunction = "addAuxTube"
-		if matchAway then
-			beamTimeBase.characterGood = "gold pressed latinum"			
+		auxTubeGood, auxTubeGoodBase = chooseUpgradeGoodBase(auxTubeBase)
+		auxTubeBase.comms_data.character = "Fred McLassiter"
+		auxTubeBase.comms_data.characterDescription = "He specializes in miniaturization of weapons systems. He's come up with a way to add a missile tube and some missiles to any ship regardless of size or configuration"
+		auxTubeBase.comms_data.characterFunction = "addAuxTube"
+		if auxTubeGood == nil then
+			auxTubeBase.comms_data.characterGood = "gold pressed latinum"			
 		else
-			auxTubeBase.characterGood = auxTubeGood
+			auxTubeBase.comms_data.characterGood = auxTubeGood
 			clueStation = nil
 			missionAttemptCount = 0
 			repeat
 				candidate = humanStationList[math.random(1,#humanStationList)]
-				if candidate ~= nil and candidate:isValid() and candidate ~= auxTubeBase and candidate.gossip == nil then
+				if candidate ~= nil and candidate:isValid() and candidate ~= auxTubeBase and candidate.comms_data.gossip == nil then
 					clueStation = candidate
 				end
 				missionAttemptCount = missionAttemptCount + 1
 			until(clueStation ~= nil or missionAttemptCount > repeatExitBoundary)
 			if clueStation ~= nil then
-				clueStation.gossip = string.format("There's this guy, %s out on %s in %s that can add a missile tube to your ship. He even added one to my cousin's souped up freighter. You should see the new paint job: amusingly phallic",auxTubeBase.character,auxTubeBase:getCallSign(),auxTubeBase:getSectorName())
+				clueStation.comms_data.gossip = string.format("There's this guy, %s out on %s in %s that can add a missile tube to your ship. He even added one to my cousin's souped up freighter. You should see the new paint job: amusingly phallic",auxTubeBase.comms_data.character,auxTubeBase:getCallSign(),auxTubeBase:getSectorName())
 			end
 		end
 	end
@@ -3579,67 +4503,27 @@ function setOptionalMissions()
 		end
 	end
 	--	cooler beam weapon firing
-	missionAttemptCount = 0
-	repeat
-		candidate = humanStationList[math.random(1,#humanStationList)]
-		if candidate ~= nil and candidate:isValid() and candidate ~= beamTimeBase and candidate ~= spinBase and candidate ~= auxTubeBase then
-			if #goods[candidate] > 0 then
-				gi = 1
-				repeat
-					if goods[candidate][gi][1] ~= "food" and goods[candidate][gi][1] ~= "medicine" then
-						coolBeamBase = candidate
-					end
-					gi = gi + 1
-				until(gi > #goods[candidate])
-			end
-		end
-		missionAttemptCount = missionAttemptCount + 1
-	until(coolBeamBase ~= nil or missionAttemptCount > repeatExitBoundary)	
+	coolBeamBase = chooseUpgradeBase()
 	if coolBeamBase ~= nil then
-		missionAttemptCount = 0
-		matchAway = nil
-		repeat
-			candidate = humanStationList[math.random(1,#humanStationList)]
-			if candidate ~= nil and candidate:isValid() and candidate ~= coolBeamBase then
-				if #goods[candidate] > 0 then
-					coolBeamGoodBase = candidate
-					gi = 1
-					repeat
-						coolBeamGood = goods[coolBeamGoodBase][gi][1]
-						matchAway = false
-						gj = 1
-						repeat
-							if coolBeamGood == "food" or coolBeamGood == "medicine" or coolBeamGood == goods[coolBeamBase][gj][1] then
-								matchAway = true
-								break
-							end
-							gj = gj + 1
-						until(gj > #goods[coolBeamBase])
-						if not matchAway then break end
-						gi = gi + 1
-					until(gi > #goods[coolBeamGoodBase])
-				end
-			end
-			missionAttemptCount = missionAttemptCount + 1
-		until(not matchAway or missionAttemptCount > repeatExitBoundary)
-		coolBeamBase.character = "Dorothy Ly"
-		coolBeamBase.characterDescription = "She developed this technique for cooling beam systems so that they can be fired more often without burning out"
-		coolBeamBase.characterFunction = "coolBeam"
-		if matchAway then
-			beamTimeBase.characterGood = "gold pressed latinum"			
+		coolBeamGood, coolBeamGoodBase = chooseUpgradeGoodBase(coolBeamBase)
+		coolBeamBase.comms_data.character = "Dorothy Ly"
+		coolBeamBase.comms_data.characterDescription = "She developed this technique for cooling beam systems so that they can be fired more often without burning out"
+		coolBeamBase.comms_data.characterFunction = "coolBeam"
+		if coolBeamGood == nil then
+			coolBeamBase.comms_data.characterGood = "gold pressed latinum"			
 		else
-			coolBeamBase.characterGood = coolBeamGood
+			coolBeamBase.comms_data.characterGood = coolBeamGood
 			clueStation = nil
 			missionAttemptCount = 0
 			repeat
 				candidate = humanStationList[math.random(1,#humanStationList)]
-				if candidate ~= nil and candidate:isValid() and candidate ~= coolBeamBase and candidate.gossip == nil then
+				if candidate ~= nil and candidate:isValid() and candidate ~= coolBeamBase and candidate.comms_data.gossip == nil then
 					clueStation = candidate
 				end
 				missionAttemptCount = missionAttemptCount + 1
 			until(clueStation ~= nil or missionAttemptCount > repeatExitBoundary)
 			if clueStation ~= nil then
-				clueStation.gossip = string.format("There's this girl on %s in %s. She is hot. Her name is %s. When I say she is hot, I mean she has a way of keeping your beam weapons from excessive heat.",coolBeamBase:getCallSign(),coolBeamBase:getSectorName(),coolBeamBase.character)
+				clueStation.comms_data.gossip = string.format("There's this girl on %s in %s. She is hot. Her name is %s. When I say she is hot, I mean she has a way of keeping your beam weapons from excessive heat.",coolBeamBase:getCallSign(),coolBeamBase:getSectorName(),coolBeamBase.comms_data.character)
 			end
 		end
 	end
@@ -3661,67 +4545,27 @@ function setOptionalMissions()
 		end
 	end
 	--	longer beam range
-	missionAttemptCount = 0
-	repeat
-		candidate = humanStationList[math.random(1,#humanStationList)]
-		if candidate ~= nil and candidate:isValid() and candidate ~= beamTimeBase and candidate ~= spinBase and candidate ~= auxTubeBase and candidate ~= coolBeamBase then
-			if #goods[candidate] > 0 then
-				gi = 1
-				repeat
-					if goods[candidate][gi][1] ~= "food" and goods[candidate][gi][1] ~= "medicine" then
-						longerBeamBase = candidate
-					end
-					gi = gi + 1
-				until(gi > #goods[candidate])
-			end
-		end
-		missionAttemptCount = missionAttemptCount + 1
-	until(longerBeamBase ~= nil or missionAttemptCount > repeatExitBoundary)	
+	longerBeamBase = chooseUpgradeBase()
 	if longerBeamBase ~= nil then
-		missionAttemptCount = 0
-		matchAway = nil
-		repeat
-			candidate = humanStationList[math.random(1,#humanStationList)]
-			if candidate ~= nil and candidate:isValid() and candidate ~= longerBeamBase then
-				if #goods[candidate] > 0 then
-					longerBeamGoodBase = candidate
-					gi = 1
-					repeat
-						longerBeamGood = goods[longerBeamGoodBase][gi][1]
-						matchAway = false
-						gj = 1
-						repeat
-							if longerBeamGood == "food" or longerBeamGood == "medicine" or longerBeamGood == goods[longerBeamBase][gj][1] then
-								matchAway = true
-								break
-							end
-							gj = gj + 1
-						until(gj > #goods[longerBeamBase])
-						if not matchAway then break end
-						gi = gi + 1
-					until(gi > #goods[longerBeamGoodBase])
-				end
-			end
-			missionAttemptCount = missionAttemptCount + 1
-		until(not matchAway or missionAttemptCount > repeatExitBoundary)
-		longerBeamBase.character = "Gerald Cook"
-		longerBeamBase.characterDescription = "He knows how to modify beam systems to extend their range"
-		longerBeamBase.characterFunction = "longerBeam"
-		if matchAway then
-			beamTimeBase.characterGood = "gold pressed latinum"			
+		longerBeamGood, longerBeamGoodBase = chooseUpgradeGoodBase(longerBeamBase)
+		longerBeamBase.comms_data.character = "Gerald Cook"
+		longerBeamBase.comms_data.characterDescription = "He knows how to modify beam systems to extend their range"
+		longerBeamBase.comms_data.characterFunction = "longerBeam"
+		if longerBeamGood == nil then
+			longerBeamBase.comms_data.characterGood = "gold pressed latinum"			
 		else
-			longerBeamBase.characterGood = longerBeamGood
+			longerBeamBase.comms_data.characterGood = longerBeamGood
 			clueStation = nil
 			missionAttemptCount = 0
 			repeat
 				candidate = humanStationList[math.random(1,#humanStationList)]
-				if candidate ~= nil and candidate:isValid() and candidate ~= longerBeamBase and candidate.gossip == nil then
+				if candidate ~= nil and candidate:isValid() and candidate ~= longerBeamBase and candidate.comms_data.gossip == nil then
 					clueStation = candidate
 				end
 				missionAttemptCount = missionAttemptCount + 1
 			until(clueStation ~= nil or missionAttemptCount > repeatExitBoundary)
 			if clueStation ~= nil then
-				clueStation.gossip = string.format("Do you know about %s? He can extend the range of your beam weapons. He's on %s in %s",longerBeamBase.character,longerBeamBase:getCallSign(),longerBeamBase:getSectorName())
+				clueStation.comms_data.gossip = string.format("Do you know about %s? He can extend the range of your beam weapons. He's on %s in %s",longerBeamBase.comms_data.character,longerBeamBase:getCallSign(),longerBeamBase:getSectorName())
 			end
 		end
 	end
@@ -3743,67 +4587,27 @@ function setOptionalMissions()
 		end
 	end
 	--	increased beam damage
-	missionAttemptCount = 0
-	repeat
-		candidate = humanStationList[math.random(1,#humanStationList)]
-		if candidate ~= nil and candidate:isValid() and candidate ~= beamTimeBase and candidate ~= spinBase and candidate ~= auxTubeBase and candidate ~= coolBeamBase and candidate ~= longerBeamBase then
-			if #goods[candidate] > 0 then
-				gi = 1
-				repeat
-					if goods[candidate][gi][1] ~= "food" and goods[candidate][gi][1] ~= "medicine" then
-						damageBeamBase = candidate
-					end
-					gi = gi + 1
-				until(gi > #goods[candidate])
-			end
-		end
-		missionAttemptCount = missionAttemptCount + 1
-	until(damageBeamBase ~= nil or missionAttemptCount > repeatExitBoundary)	
+	damageBeamBase = chooseUpgradeBase()
 	if damageBeamBase ~= nil then
-		missionAttemptCount = 0
-		matchAway = nil
-		repeat
-			candidate = humanStationList[math.random(1,#humanStationList)]
-			if candidate ~= nil and candidate:isValid() and candidate ~= damageBeamBase then
-				if #goods[candidate] > 0 then
-					damageBeamGoodBase = candidate
-					gi = 1
-					repeat
-						damageBeamGood = goods[damageBeamGoodBase][gi][1]
-						matchAway = false
-						gj = 1
-						repeat
-							if damageBeamGood == "food" or damageBeamGood == "medicine" or damageBeamGood == goods[damageBeamBase][gj][1] then
-								matchAway = true
-								break
-							end
-							gj = gj + 1
-						until(gj > #goods[damageBeamBase])
-						if not matchAway then break end
-						gi = gi + 1
-					until(gi > #goods[damageBeamGoodBase])
-				end
-			end
-			missionAttemptCount = missionAttemptCount + 1
-		until(not matchAway or missionAttemptCount > repeatExitBoundary)
-		damageBeamBase.character = "Sally Jenkins"
-		damageBeamBase.characterDescription = "She can make your beams hit harder"
-		damageBeamBase.characterFunction = "damageBeam"
-		if matchAway then
-			beamTimeBase.characterGood = "gold pressed latinum"			
+		damageBeamGood, damageBeamGoodBase = chooseUpgradeGoodBase(damageBeamBase)
+		damageBeamBase.comms_data.character = "Sally Jenkins"
+		damageBeamBase.comms_data.characterDescription = "She can make your beams hit harder"
+		damageBeamBase.comms_data.characterFunction = "damageBeam"
+		if damageBeamGood == nil then
+			damageBeamBase.comms_data.characterGood = "gold pressed latinum"			
 		else
-			damageBeamBase.characterGood = damageBeamGood
+			damageBeamBase.comms_data.characterGood = damageBeamGood
 			clueStation = nil
 			missionAttemptCount = 0
 			repeat
 				candidate = humanStationList[math.random(1,#humanStationList)]
-				if candidate ~= nil and candidate:isValid() and candidate ~= damageBeamBase and candidate.gossip == nil then
+				if candidate ~= nil and candidate:isValid() and candidate ~= damageBeamBase and candidate.comms_data.gossip == nil then
 					clueStation = candidate
 				end
 				missionAttemptCount = missionAttemptCount + 1
 			until(clueStation ~= nil or missionAttemptCount > repeatExitBoundary)
 			if clueStation ~= nil then
-				clueStation.gossip = string.format("You should visit %s in %s. There's a specialist in beam technology that can increase the damage done by your beams. Her name is %s",damageBeamBase:getCallSign(),damageBeamBase:getSectorName(),damageBeamBase.character)
+				clueStation.comms_data.gossip = string.format("You should visit %s in %s. There's a specialist in beam technology that can increase the damage done by your beams. Her name is %s",damageBeamBase:getCallSign(),damageBeamBase:getSectorName(),damageBeamBase.comms_data.character)
 			end
 		end
 	end
@@ -3825,67 +4629,27 @@ function setOptionalMissions()
 		end
 	end
 	--	increased maximum missile storage capacity
-	missionAttemptCount = 0
-	repeat
-		candidate = humanStationList[math.random(1,#humanStationList)]
-		if candidate ~= nil and candidate:isValid() and candidate ~= beamTimeBase and candidate ~= spinBase and candidate ~= auxTubeBase and candidate ~= coolBeamBase and candidate ~= longerBeamBase and candidate ~= damageBeamBase then
-			if #goods[candidate] > 0 then
-				gi = 1
-				repeat
-					if goods[candidate][gi][1] ~= "food" and goods[candidate][gi][1] ~= "medicine" then
-						moreMissilesBase = candidate
-					end
-					gi = gi + 1
-				until(gi > #goods[candidate])
-			end
-		end
-		missionAttemptCount = missionAttemptCount + 1
-	until(moreMissilesBase ~= nil or missionAttemptCount > repeatExitBoundary)	
+	moreMissilesBase = chooseUpgradeBase()
 	if moreMissilesBase ~= nil then
-		missionAttemptCount = 0
-		matchAway = nil
-		repeat
-			candidate = humanStationList[math.random(1,#humanStationList)]
-			if candidate ~= nil and candidate:isValid() and candidate ~= moreMissilesBase then
-				if #goods[candidate] > 0 then
-					moreMissilesGoodBase = candidate
-					gi = 1
-					repeat
-						moreMissilesGood = goods[moreMissilesGoodBase][gi][1]
-						matchAway = false
-						gj = 1
-						repeat
-							if moreMissilesGood == "food" or moreMissilesGood == "medicine" or moreMissilesGood == goods[moreMissilesBase][gj][1] then
-								matchAway = true
-								break
-							end
-							gj = gj + 1
-						until(gj > #goods[moreMissilesBase])
-						if not matchAway then break end
-						gi = gi + 1
-					until(gi > #goods[moreMissilesGoodBase])
-				end
-			end
-			missionAttemptCount = missionAttemptCount + 1
-		until(not matchAway or missionAttemptCount > repeatExitBoundary)
-		moreMissilesBase.character = "Anh Dung Ly"
-		moreMissilesBase.characterDescription = "He can fit more missiles aboard your ship"
-		moreMissilesBase.characterFunction = "moreMissiles"
-		if matchAway then
-			beamTimeBase.characterGood = "gold pressed latinum"			
+		moreMissilesGood, moreMissilesGoodBase = chooseUpgradeGoodBase(moreMissilesBase)
+		moreMissilesBase.comms_data.character = "Anh Dung Ly"
+		moreMissilesBase.comms_data.characterDescription = "He can fit more missiles aboard your ship"
+		moreMissilesBase.comms_data.characterFunction = "moreMissiles"
+		if moreMissilesGood == nil then
+			moreMissilesBase.comms_data.characterGood = "gold pressed latinum"			
 		else
-			moreMissilesBase.characterGood = moreMissilesGood
+			moreMissilesBase.comms_data.characterGood = moreMissilesGood
 			clueStation = nil
 			missionAttemptCount = 0
 			repeat
 				candidate = humanStationList[math.random(1,#humanStationList)]
-				if candidate ~= nil and candidate:isValid() and candidate ~= moreMissilesBase and candidate.gossip == nil then
+				if candidate ~= nil and candidate:isValid() and candidate ~= moreMissilesBase and candidate.comms_data.gossip == nil then
 					clueStation = candidate
 				end
 				missionAttemptCount = missionAttemptCount + 1
 			until(clueStation ~= nil or missionAttemptCount > repeatExitBoundary)
 			if clueStation ~= nil then
-				clueStation.gossip = string.format("Want to store more missiles on your ship? Talk to %s on station %s in %s. He can retrain your missile loaders and missile storage automation such that you will be able to store more missiles",moreMissilesBase.character,moreMissilesBase:getCallSign(),moreMissilesBase:getSectorName())
+				clueStation.comms_data.gossip = string.format("Want to store more missiles on your ship? Talk to %s on station %s in %s. He can retrain your missile loaders and missile storage automation such that you will be able to store more missiles",moreMissilesBase.comms_data.character,moreMissilesBase:getCallSign(),moreMissilesBase:getSectorName())
 			end
 		end
 	end
@@ -3907,67 +4671,27 @@ function setOptionalMissions()
 		end
 	end
 	--	faster impulse
-	missionAttemptCount = 0
-	repeat
-		candidate = humanStationList[math.random(1,#humanStationList)]
-		if candidate ~= nil and candidate:isValid() and candidate ~= beamTimeBase and candidate ~= spinBase and candidate ~= auxTubeBase and candidate ~= coolBeamBase and candidate ~= longerBeamBase and candidate ~= damageBeamBase and candidate ~= moreMissilesBase then
-			if #goods[candidate] > 0 then
-				gi = 1
-				repeat
-					if goods[candidate][gi][1] ~= "food" and goods[candidate][gi][1] ~= "medicine" then
-						fasterImpulseBase = candidate
-					end
-					gi = gi + 1
-				until(gi > #goods[candidate])
-			end
-		end
-		missionAttemptCount = missionAttemptCount + 1
-	until(fasterImpulseBase ~= nil or missionAttemptCount > repeatExitBoundary)	
+	fasterImpulseBase = chooseUpgradeBase()
 	if fasterImpulseBase ~= nil then
-		missionAttemptCount = 0
-		matchAway = nil
-		repeat
-			candidate = humanStationList[math.random(1,#humanStationList)]
-			if candidate ~= nil and candidate:isValid() and candidate ~= fasterImpulseBase then
-				if #goods[candidate] > 0 then
-					fasterImpulseGoodBase = candidate
-					gi = 1
-					repeat
-						fasterImpulseGood = goods[fasterImpulseGoodBase][gi][1]
-						matchAway = false
-						gj = 1
-						repeat
-							if fasterImpulseGood == "food" or fasterImpulseGood == "medicine" or fasterImpulseGood == goods[fasterImpulseBase][gj][1] then
-								matchAway = true
-								break
-							end
-							gj = gj + 1
-						until(gj > #goods[fasterImpulseBase])
-						if not matchAway then break end
-						gi = gi + 1
-					until(gi > #goods[fasterImpulseGoodBase])
-				end
-			end
-			missionAttemptCount = missionAttemptCount + 1
-		until(not matchAway or missionAttemptCount > repeatExitBoundary)
-		fasterImpulseBase.character = "Doralla Ognats"
-		fasterImpulseBase.characterDescription = "She can soup up your impulse engines"
-		fasterImpulseBase.characterFunction = "fasterImpulse"
-		if matchAway then
-			beamTimeBase.characterGood = "gold pressed latinum"			
+		fasterImpulseGood, fasterImpulseGoodBase = chooseUpgradeGoodBase(fasterImpulseBase)
+		fasterImpulseBase.comms_data.character = "Doralla Ognats"
+		fasterImpulseBase.comms_data.characterDescription = "She can soup up your impulse engines"
+		fasterImpulseBase.comms_data.characterFunction = "fasterImpulse"
+		if fasterImpulseGood == nil then
+			fasterImpulseBase.comms_data.characterGood = "gold pressed latinum"			
 		else
-			fasterImpulseBase.characterGood = fasterImpulseGood
+			fasterImpulseBase.comms_data.characterGood = fasterImpulseGood
 			clueStation = nil
 			missionAttemptCount = 0
 			repeat
 				candidate = humanStationList[math.random(1,#humanStationList)]
-				if candidate ~= nil and candidate:isValid() and candidate ~= fasterImpulseBase and candidate.gossip == nil then
+				if candidate ~= nil and candidate:isValid() and candidate ~= fasterImpulseBase and candidate.comms_data.gossip == nil then
 					clueStation = candidate
 				end
 				missionAttemptCount = missionAttemptCount + 1
 			until(clueStation ~= nil or missionAttemptCount > repeatExitBoundary)
 			if clueStation ~= nil then
-				clueStation.gossip = string.format("%s, an engineer/mechanic who knows propulsion systems backwards and forwards has a bay at the shipyard on %s in %s. She can give your impulse engines a significant boost to their top speed",fasterImpulseBase.character,fasterImpulseBase:getCallSign(),fasterImpulseBase:getSectorName())
+				clueStation.comms_data.gossip = string.format("%s, an engineer/mechanic who knows propulsion systems backwards and forwards has a bay at the shipyard on %s in %s. She can give your impulse engines a significant boost to their top speed",fasterImpulseBase.comms_data.character,fasterImpulseBase:getCallSign(),fasterImpulseBase:getSectorName())
 			end
 		end
 	end
@@ -3989,67 +4713,27 @@ function setOptionalMissions()
 		end
 	end
 	--	stronger hull
-	missionAttemptCount = 0
-	repeat
-		candidate = humanStationList[math.random(1,#humanStationList)]
-		if candidate ~= nil and candidate:isValid() and candidate ~= beamTimeBase and candidate ~= spinBase and candidate ~= auxTubeBase and candidate ~= coolBeamBase and candidate ~= longerBeamBase and candidate ~= damageBeamBase and candidate ~= moreMissilesBase and candidate ~= fasterImpulseBase then
-			if #goods[candidate] > 0 then
-				gi = 1
-				repeat
-					if goods[candidate][gi][1] ~= "food" and goods[candidate][gi][1] ~= "medicine" then
-						strongerHullBase = candidate
-					end
-					gi = gi + 1
-				until(gi > #goods[candidate])
-			end
-		end
-		missionAttemptCount = missionAttemptCount + 1
-	until(strongerHullBase ~= nil or missionAttemptCount > repeatExitBoundary)	
+	strongerHullBase = chooseUpgradeBase()
 	if strongerHullBase ~= nil then
-		missionAttemptCount = 0
-		matchAway = nil
-		repeat
-			candidate = humanStationList[math.random(1,#humanStationList)]
-			if candidate ~= nil and candidate:isValid() and candidate ~= strongerHullBase then
-				if #goods[candidate] > 0 then
-					strongerHullGoodBase = candidate
-					gi = 1
-					repeat
-						strongerHullGood = goods[strongerHullGoodBase][gi][1]
-						matchAway = false
-						gj = 1
-						repeat
-							if strongerHullGood == "food" or strongerHullGood == "medicine" or strongerHullGood == goods[strongerHullBase][gj][1] then
-								matchAway = true
-								break
-							end
-							gj = gj + 1
-						until(gj > #goods[strongerHullBase])
-						if not matchAway then break end
-						gi = gi + 1
-					until(gi > #goods[strongerHullGoodBase])
-				end
-			end
-			missionAttemptCount = missionAttemptCount + 1
-		until(not matchAway or missionAttemptCount > repeatExitBoundary)
-		strongerHullBase.character = "Maduka Lawal"
-		strongerHullBase.characterDescription = "He can strengthen your hull"
-		strongerHullBase.characterFunction = "strongerHull"
-		if matchAway then
-			beamTimeBase.characterGood = "gold pressed latinum"			
+		strongerHullGood, strongerHullGoodBase = chooseUpgradeGoodBase(strongerHullBase)
+		strongerHullBase.comms_data.character = "Maduka Lawal"
+		strongerHullBase.comms_data.characterDescription = "He can strengthen your hull"
+		strongerHullBase.comms_data.characterFunction = "strongerHull"
+		if strongerHullGood ~= nil then
+			strongerHullBase.comms_data.characterGood = "gold pressed latinum"			
 		else
-			strongerHullBase.characterGood = strongerHullGood
+			strongerHullBase.comms_data.characterGood = strongerHullGood
 			clueStation = nil
 			missionAttemptCount = 0
 			repeat
 				candidate = humanStationList[math.random(1,#humanStationList)]
-				if candidate ~= nil and candidate:isValid() and candidate ~= strongerHullBase and candidate.gossip == nil then
+				if candidate ~= nil and candidate:isValid() and candidate ~= strongerHullBase and candidate.comms_data.gossip == nil then
 					clueStation = candidate
 				end
 				missionAttemptCount = missionAttemptCount + 1
 			until(clueStation ~= nil or missionAttemptCount > repeatExitBoundary)
 			if clueStation ~= nil then
-				clueStation.gossip = string.format("I know of a materials specialist on %s in %s named %s. He can strengthen the hull on your ship",strongerHullBase:getCallSign(),strongerHullBase:getSectorName(),strongerHullBase.character)
+				clueStation.comms_data.gossip = string.format("I know of a materials specialist on %s in %s named %s. He can strengthen the hull on your ship",strongerHullBase:getCallSign(),strongerHullBase:getSectorName(),strongerHullBase.comms_data.character)
 			end
 		end
 	end
@@ -4071,67 +4755,27 @@ function setOptionalMissions()
 		end
 	end
 	--	efficient batteries
-	missionAttemptCount = 0
-	repeat
-		candidate = humanStationList[math.random(1,#humanStationList)]
-		if candidate ~= nil and candidate:isValid() and candidate ~= beamTimeBase and candidate ~= spinBase and candidate ~= auxTubeBase and candidate ~= coolBeamBase and candidate ~= longerBeamBase and candidate ~= damageBeamBase and candidate ~= moreMissilesBase and candidate ~= fasterImpulseBase and candidate ~= strongerHullBase then
-			if #goods[candidate] > 0 then
-				gi = 1
-				repeat
-					if goods[candidate][gi][1] ~= "food" and goods[candidate][gi][1] ~= "medicine" then
-						efficientBatteriesBase = candidate
-					end
-					gi = gi + 1
-				until(gi > #goods[candidate])
-			end
-		end
-		missionAttemptCount = missionAttemptCount + 1
-	until(efficientBatteriesBase ~= nil or missionAttemptCount > repeatExitBoundary)	
+	efficientBatteriesBase = chooseUpgradeBase()
 	if efficientBatteriesBase ~= nil then
-		missionAttemptCount = 0
-		matchAway = nil
-		repeat
-			candidate = humanStationList[math.random(1,#humanStationList)]
-			if candidate ~= nil and candidate:isValid() and candidate ~= efficientBatteriesBase then
-				if #goods[candidate] > 0 then
-					efficientBatteriesGoodBase = candidate
-					gi = 1
-					repeat
-						efficientBatteriesGood = goods[efficientBatteriesGoodBase][gi][1]
-						matchAway = false
-						gj = 1
-						repeat
-							if efficientBatteriesGood == "food" or efficientBatteriesGood == "medicine" or efficientBatteriesGood == goods[efficientBatteriesBase][gj][1] then
-								matchAway = true
-								break
-							end
-							gj = gj + 1
-						until(gj > #goods[efficientBatteriesBase])
-						if not matchAway then break end
-						gi = gi + 1
-					until(gi > #goods[efficientBatteriesGoodBase])
-				end
-			end
-			missionAttemptCount = missionAttemptCount + 1
-		until(not matchAway or missionAttemptCount > repeatExitBoundary)
-		efficientBatteriesBase.character = "Susil Tarigan"
-		efficientBatteriesBase.characterDescription = "She knows how to increase your maximum energy capacity by improving battery efficiency"
-		efficientBatteriesBase.characterFunction = "efficientBatteries"
-		if matchAway then
-			beamTimeBase.characterGood = "gold pressed latinum"			
+		efficientBatteriesGood, efficientBatteriesGoodBase = chooseUpgradeGoodBase(efficientBatteriesBase)
+		efficientBatteriesBase.comms_data.character = "Susil Tarigan"
+		efficientBatteriesBase.comms_data.characterDescription = "She knows how to increase your maximum energy capacity by improving battery efficiency"
+		efficientBatteriesBase.comms_data.characterFunction = "efficientBatteries"
+		if efficientBatteriesGood == nil then
+			efficientBatteriesBase.comms_data.characterGood = "gold pressed latinum"			
 		else
-			efficientBatteriesBase.characterGood = efficientBatteriesGood
+			efficientBatteriesBase.comms_data.characterGood = efficientBatteriesGood
 			clueStation = nil
 			missionAttemptCount = 0
 			repeat
 				candidate = humanStationList[math.random(1,#humanStationList)]
-				if candidate ~= nil and candidate:isValid() and candidate ~= efficientBatteriesBase and candidate.gossip == nil then
+				if candidate ~= nil and candidate:isValid() and candidate ~= efficientBatteriesBase and candidate.comms_data.gossip == nil then
 					clueStation = candidate
 				end
 				missionAttemptCount = missionAttemptCount + 1
 			until(clueStation ~= nil or missionAttemptCount > repeatExitBoundary)
 			if clueStation ~= nil then
-				clueStation.gossip = string.format("Have you heard about %s? She's on %s in %s and she can give your ship greater energy capacity by improving your battery efficiency",efficientBatteriesBase.character,efficientBatteriesBase:getCallSign(),efficientBatteriesBase:getSectorName())
+				clueStation.comms_data.gossip = string.format("Have you heard about %s? She's on %s in %s and she can give your ship greater energy capacity by improving your battery efficiency",efficientBatteriesBase.comms_data.character,efficientBatteriesBase:getCallSign(),efficientBatteriesBase:getSectorName())
 			end
 		end
 	end
@@ -4153,67 +4797,27 @@ function setOptionalMissions()
 		end
 	end
 	--	stronger shields
-	missionAttemptCount = 0
-	repeat
-		candidate = humanStationList[math.random(1,#humanStationList)]
-		if candidate ~= nil and candidate:isValid() and candidate ~= beamTimeBase and candidate ~= spinBase and candidate ~= auxTubeBase and candidate ~= coolBeamBase and candidate ~= longerBeamBase and candidate ~= damageBeamBase and candidate ~= moreMissilesBase and candidate ~= fasterImpulseBase and candidate ~= strongerHullBase and candidate ~= efficientBatteriesBase then
-			if #goods[candidate] > 0 then
-				gi = 1
-				repeat
-					if goods[candidate][gi][1] ~= "food" and goods[candidate][gi][1] ~= "medicine" then
-						strongerShieldsBase = candidate
-					end
-					gi = gi + 1
-				until(gi > #goods[candidate])
-			end
-		end
-		missionAttemptCount = missionAttemptCount + 1
-	until(strongerShieldsBase ~= nil or missionAttemptCount > repeatExitBoundary)	
+	strongerShieldsBase = chooseUpgradeBase()
 	if strongerShieldsBase ~= nil then
-		missionAttemptCount = 0
-		matchAway = nil
-		repeat
-			candidate = humanStationList[math.random(1,#humanStationList)]
-			if candidate ~= nil and candidate:isValid() and candidate ~= strongerShieldsBase then
-				if #goods[candidate] > 0 then
-					strongerShieldsGoodBase = candidate
-					gi = 1
-					repeat
-						strongerShieldsGood = goods[strongerShieldsGoodBase][gi][1]
-						matchAway = false
-						gj = 1
-						repeat
-							if strongerShieldsGood == "food" or strongerShieldsGood == "medicine" or strongerShieldsGood == goods[strongerShieldsBase][gj][1] then
-								matchAway = true
-								break
-							end
-							gj = gj + 1
-						until(gj > #goods[strongerShieldsBase])
-						if not matchAway then break end
-						gi = gi + 1
-					until(gi > #goods[strongerShieldsGoodBase])
-				end
-			end
-			missionAttemptCount = missionAttemptCount + 1
-		until(not matchAway or missionAttemptCount > repeatExitBoundary)
-		strongerShieldsBase.character = "Paulo Silva"
-		strongerShieldsBase.characterDescription = "He can strengthen your shields"
-		strongerShieldsBase.characterFunction = "strongerShields"
-		if matchAway then
-			beamTimeBase.characterGood = "gold pressed latinum"			
+		strongerShieldsGood, strongerShieldsGoodBase = chooseUpgradeGoodBase(strongerShieldsBase)
+		strongerShieldsBase.comms_data.character = "Paulo Silva"
+		strongerShieldsBase.comms_data.characterDescription = "He can strengthen your shields"
+		strongerShieldsBase.comms_data.characterFunction = "strongerShields"
+		if strongerShieldsGood == nil then
+			strongerShieldsBase.comms_data.characterGood = "gold pressed latinum"			
 		else
-			strongerShieldsBase.characterGood = strongerShieldsGood
+			strongerShieldsBase.comms_data.characterGood = strongerShieldsGood
 			clueStation = nil
 			missionAttemptCount = 0
 			repeat
 				candidate = humanStationList[math.random(1,#humanStationList)]
-				if candidate ~= nil and candidate:isValid() and candidate ~= strongerShieldsBase and candidate.gossip == nil then
+				if candidate ~= nil and candidate:isValid() and candidate ~= strongerShieldsBase and candidate.comms_data.gossip == nil then
 					clueStation = candidate
 				end
 				missionAttemptCount = missionAttemptCount + 1
 			until(clueStation ~= nil or missionAttemptCount > repeatExitBoundary)
 			if clueStation ~= nil then
-				clueStation.gossip = string.format("If you stop at %s in %s, you should talk to %s. He can strengthen your shields. Trust me, it's always good to have stronger shields",strongerShieldsBase:getCallSign(),strongerShieldsBase:getSectorName(),strongerShieldsBase.character)
+				clueStation.comms_data.gossip = string.format("If you stop at %s in %s, you should talk to %s. He can strengthen your shields. Trust me, it's always good to have stronger shields",strongerShieldsBase:getCallSign(),strongerShieldsBase:getSectorName(),strongerShieldsBase.comms_data.character)
 			end
 		end
 	end
@@ -4235,50 +4839,57 @@ function setOptionalMissions()
 		end
 	end
 end
+function payForUpgrade()
+	if	(difficulty == 1 and treaty) or 
+		(difficulty < 1 and treaty and treatyTimer > 0) or
+		(difficulty > 1 and treaty) or
+		(difficulty > 1 and not treaty and not targetKraylorStations) then
+		return true
+	else
+		return false
+	end
+end
 function shrinkBeamCycle()
-	if player.shrinkBeamCycleUpgrade == nil then
+	if comms_source.shrinkBeamCycleUpgrade == nil then
 		addCommsReply("Reduce beam cycle time", function()
-			if player:getBeamWeaponRange(0) > 0 then
-				if treaty then
-					local gi = 1
+			local ctd = comms_target.comms_data
+			if comms_source:getBeamWeaponRange(0) > 0 then
+				if	payForUpgrade() then
 					local partQuantity = 0
-					repeat
-						if goods[player][gi][1] == comms_target.characterGood then
-							partQuantity = goods[player][gi][2]
-						end
-						gi = gi + 1
-					until(gi > #goods[player])
+					if comms_source.goods ~= nil and comms_source.goods[ctd.characterGood] ~= nil and comms_source.goods[ctd.characterGood] > 0 then
+						partQuantity = comms_source.goods[ctd.characterGood]
+					end
 					if partQuantity > 0 then
-						player.shrinkBeamCycleUpgrade = "done"
-						decrementPlayerGoods(comms_target.characterGood)
-						player.cargo = player.cargo + 1
+						comms_source.shrinkBeamCycleUpgrade = "done"
+						comms_source.goods[ctd.characterGood] = comms_source.goods[ctd.characterGood] - 1
+						comms_source.cargo = comms_source.cargo + 1
 						local bi = 0
 						repeat
-							local tempArc = player:getBeamWeaponArc(bi)
-							local tempDir = player:getBeamWeaponDirection(bi)
-							local tempRng = player:getBeamWeaponRange(bi)
-							local tempCyc = player:getBeamWeaponCycleTime(bi)
-							local tempDmg = player:getBeamWeaponDamage(bi)
-							player:setBeamWeapon(bi,tempArc,tempDir,tempRng,tempCyc * .75,tempDmg)
+							local tempArc = comms_source:getBeamWeaponArc(bi)
+							local tempDir = comms_source:getBeamWeaponDirection(bi)
+							local tempRng = comms_source:getBeamWeaponRange(bi)
+							local tempCyc = comms_source:getBeamWeaponCycleTime(bi)
+							local tempDmg = comms_source:getBeamWeaponDamage(bi)
+							comms_source:setBeamWeapon(bi,tempArc,tempDir,tempRng,tempCyc * .75,tempDmg)
 							bi = bi + 1
-						until(player:getBeamWeaponRange(bi) < 1)
-						setCommsMessage("After accepting your gift, he reduced your Beam cycle time by 25%")
+						until(comms_source:getBeamWeaponRange(bi) < 1)
+						setCommsMessage("After accepting your gift, he reduced your Beam cycle time by 25%%")
 					else
-						setCommsMessage(string.format("%s requires %s for the upgrade",comms_target.character,comms_target.characterGood))
+						setCommsMessage(string.format("%s requires %s for the upgrade",ctd.character,ctd.characterGood))
 					end
 				else
-					player.shrinkBeamCycleUpgrade = "done"
+					comms_source.shrinkBeamCycleUpgrade = "done"
 					bi = 0
 					repeat
-						tempArc = player:getBeamWeaponArc(bi)
-						tempDir = player:getBeamWeaponDirection(bi)
-						tempRng = player:getBeamWeaponRange(bi)
-						tempCyc = player:getBeamWeaponCycleTime(bi)
-						tempDmg = player:getBeamWeaponDamage(bi)
-						player:setBeamWeapon(bi,tempArc,tempDir,tempRng,tempCyc * .75,tempDmg)
+						tempArc = comms_source:getBeamWeaponArc(bi)
+						tempDir = comms_source:getBeamWeaponDirection(bi)
+						tempRng = comms_source:getBeamWeaponRange(bi)
+						tempCyc = comms_source:getBeamWeaponCycleTime(bi)
+						tempDmg = comms_source:getBeamWeaponDamage(bi)
+						comms_source:setBeamWeapon(bi,tempArc,tempDir,tempRng,tempCyc * .75,tempDmg)
 						bi = bi + 1
-					until(player:getBeamWeaponRange(bi) < 1)
-					setCommsMessage(string.format("%s reduced your Beam cycle time by 25%% at no cost in trade with the message, 'Go get those Kraylors.'",comms_target.character))
+					until(comms_source:getBeamWeaponRange(bi) < 1)
+					setCommsMessage(string.format("%s reduced your Beam cycle time by 25%% at no cost in trade with the message, 'Go get those Kraylors.'",ctd.character))
 				end
 			else
 				setCommsMessage("Your ship type does not support a beam weapon upgrade.")				
@@ -4287,112 +4898,103 @@ function shrinkBeamCycle()
 	end
 end
 function increaseSpin()
-	if player.increaseSpinUpgrade == nil then
+	if comms_source.increaseSpinUpgrade == nil then
 		addCommsReply("Increase spin speed", function()
-			if treaty then
-				local gi = 1
+			local ctd = comms_target.comms_data
+			if payForUpgrade() then
 				local partQuantity = 0
-				repeat
-					if goods[player][gi][1] == comms_target.characterGood then
-						partQuantity = goods[player][gi][2]
-					end
-					gi = gi + 1
-				until(gi > #goods[player])
+				if comms_source.goods ~= nil and comms_source.goods[ctd.characterGood] ~= nil and comms_source.goods[ctd.characterGood] > 0 then
+					partQuantity = comms_source.goods[ctd.characterGood]
+				end
 				if partQuantity > 0 then
-					player.increaseSpinUpgrade = "done"
-					decrementPlayerGoods(comms_target.characterGood)
-					player.cargo = player.cargo + 1
-					player:setRotationMaxSpeed(player:getRotationMaxSpeed()*1.5)
-					setCommsMessage(string.format("Ship spin speed increased by 50% after you gave %s to %s",comms_target.characterGood,comms_target.character))
+					comms_source.increaseSpinUpgrade = "done"
+					comms_source.goods[ctd.characterGood] = comms_source.goods[ctd.characterGood] - 1
+					comms_source.cargo = comms_source.cargo + 1
+					comms_source:setRotationMaxSpeed(comms_source:getRotationMaxSpeed()*1.5)
+					setCommsMessage(string.format("Ship spin speed increased by 50%% after you gave %s to %s",ctd.characterGood,ctd.character))
 				else
-					setCommsMessage(string.format("%s requires %s for the spin upgrade",comms_target.character,comms_target.characterGood))
+					setCommsMessage(string.format("%s requires %s for the spin upgrade",ctd.character,ctd.characterGood))
 				end
 			else
-				player.increaseSpinUpgrade = "done"
-				player:setRotationMaxSpeed(player:getRotationMaxSpeed()*1.5)
-				setCommsMessage(string.format("%s: I increased the speed your ship spins by 50%%. Normally, I'd require %s, but seeing as you're going out to take on the Kraylors, we worked it out",comms_target.character,comms_target.characterGood))
+				comms_source.increaseSpinUpgrade = "done"
+				comms_source:setRotationMaxSpeed(player:getRotationMaxSpeed()*1.5)
+				setCommsMessage(string.format("%s: I increased the speed your ship spins by 50%%. Normally, I'd require %s, but seeing as you're going out to take on the Kraylors, we worked it out",ctd.character,ctd.characterGood))
 			end
 		end)
 	end
 end
 function addAuxTube()
-	if player.auxTubeUpgrade == nil then
+	if comms_source.auxTubeUpgrade == nil then
 		addCommsReply("Add missle tube", function()
-			if treaty then
-				local gi = 1
-				local partQuantity = 0
+			local ctd = comms_target.comms_data
+			if payForUpgrade() then
 				local luxQuantity = 0
-				repeat
-					if goods[player][gi][1] == comms_target.characterGood then
-						partQuantity = goods[player][gi][2]
-					end
-					if goods[player][gi][1] == "luxury" then
-						luxQuantity = goods[player][gi][2]
-					end
-					gi = gi + 1
-				until(gi > #goods[player])
+				local partQuantity = 0
+				if comms_source.goods ~= nil and comms_source.goods ~= nil and comms_source.goods[ctd.characterGood] ~= nil and comms_source.goods[ctd.characterGood] > 0 then
+					partQuantity = comms_source.goods[ctd.characterGood]
+				end
+				if comms_source.goods ~= nil and comms_source.goods["luxury"] ~= nil and comms_source.goods["luxury"] > 0 then
+					luxQuantity = comms_source.goods[ctd.characterGood]
+				end
 				if partQuantity > 0 and luxQuantity > 0 then
-					player.auxTubeUpgrade = "done"
-					decrementPlayerGoods(comms_target.characterGood)
-					decrementPlayerGoods("luxury")
-					player.cargo = player.cargo + 2
-					local originalTubes = player:getWeaponTubeCount()
+					comms_source.auxTubeUpgrade = "done"
+					comms_source.goods[ctd.characterGood] = comms_source.goods[ctd.characterGood] - 1
+					comms_source.goods["luxury"] = comms_source.goods["luxury"] - 1
+					comms_source.cargo = comms_source.cargo + 2
+					local originalTubes = comms_source:getWeaponTubeCount()
 					local newTubes = originalTubes + 1
-					player:setWeaponTubeCount(newTubes)
-					player:setWeaponTubeExclusiveFor(originalTubes, "Homing")
-					player:setWeaponStorageMax("Homing", player:getWeaponStorageMax("Homing") + 2)
-					player:setWeaponStorage("Homing", player:getWeaponStorage("Homing") + 2)
-					setCommsMessage(string.format("%s thanks you for the %s and the luxury and installs a homing missile tube for you",comms_target.character,comms_target.characterGood))
+					comms_source:setWeaponTubeCount(newTubes)
+					comms_source:setWeaponTubeExclusiveFor(originalTubes, "Homing")
+					comms_source:setWeaponStorageMax("Homing", comms_source:getWeaponStorageMax("Homing") + 2)
+					comms_source:setWeaponStorage("Homing", comms_source:getWeaponStorage("Homing") + 2)
+					setCommsMessage(string.format("%s thanks you for the %s and the luxury and installs a homing missile tube for you",ctd.character,ctd.characterGood))
 				else
-					setCommsMessage(string.format("%s requires %s and luxury for the missile tube",comms_target.character,comms_target.characterGood))
+					setCommsMessage(string.format("%s requires %s and luxury for the missile tube",ctd.character,ctd.characterGood))
 				end
 			else
-				player.auxTubeUpgrade = "done"
-				originalTubes = player:getWeaponTubeCount()
+				comms_source.auxTubeUpgrade = "done"
+				originalTubes = comms_source:getWeaponTubeCount()
 				newTubes = originalTubes + 1
-				player:setWeaponTubeCount(newTubes)
-				player:setWeaponTubeExclusiveFor(originalTubes, "Homing")
-				player:setWeaponStorageMax("Homing", player:getWeaponStorageMax("Homing") + 2)
-				player:setWeaponStorage("Homing", player:getWeaponStorage("Homing") + 2)
-				setCommsMessage(string.format("%s installs a homing missile tube for you. The %s required was requisitioned from wartime contingency supplies",comms_target.character,comms_target.characterGood))
+				comms_source:setWeaponTubeCount(newTubes)
+				comms_source:setWeaponTubeExclusiveFor(originalTubes, "Homing")
+				comms_source:setWeaponStorageMax("Homing", comms_source:getWeaponStorageMax("Homing") + 2)
+				comms_source:setWeaponStorage("Homing", comms_source:getWeaponStorage("Homing") + 2)
+				setCommsMessage(string.format("%s installs a homing missile tube for you. The %s required was requisitioned from wartime contingency supplies",ctd.character,ctd.characterGood))
 			end
 		end)
 	end
 end
 function coolBeam()
-	if player.coolBeamUpgrade == nil then
+	if comms_source.coolBeamUpgrade == nil then
 		addCommsReply("Reduce beam heat", function()
-			if player:getBeamWeaponRange(0) > 0 then
-				if treaty then
-					local gi = 1
+			local ctd = comms_target.comms_data
+			if comms_source:getBeamWeaponRange(0) > 0 then
+				if payForUpgrade() then
 					local partQuantity = 0
-					repeat
-						if goods[player][gi][1] == comms_target.characterGood then
-							partQuantity = goods[player][gi][2]
-						end
-						gi = gi + 1
-					until(gi > #goods[player])
+					if comms_source.goods ~= nil and comms_source.goods[ctd.characterGood] ~= nil and comms_source.goods[ctd.characterGood] > 0 then
+						partQuantity = comms_source.goods[ctd.characterGood]
+					end
 					if partQuantity > 0 then
-						player.coolBeamUpgrade = "done"
-						decrementPlayerGoods(comms_target.characterGood)
-						player.cargo = player.cargo + 1
+						comms_source.coolBeamUpgrade = "done"
+						comms_source.goods[ctd.characterGood] = comms_source.goods[ctd.characterGood] - 1
+						comms_source.cargo = comms_source.cargo + 1
 						local bi = 0
 						repeat
-							player:setBeamWeaponHeatPerFire(bi,player:getBeamWeaponHeatPerFire(bi) * 0.5)
+							comms_source:setBeamWeaponHeatPerFire(bi,comms_source:getBeamWeaponHeatPerFire(bi) * 0.5)
 							bi = bi + 1
-						until(player:getBeamWeaponRange(bi) < 1)
-						setCommsMessage("Beam heat generation reduced by 50 percent")
+						until(comms_source:getBeamWeaponRange(bi) < 1)
+						setCommsMessage("Beam heat generation reduced by 50%%")
 					else
-						setCommsMessage(string.format("%s says she needs %s before she can cool your beams",comms_target.character,comms_target.characterGood))
+						setCommsMessage(string.format("%s says she needs %s before she can cool your beams",ctd.character,ctd.characterGood))
 					end
 				else
-					player.coolBeamUpgrade = "done"
+					comms_source.coolBeamUpgrade = "done"
 					bi = 0
 					repeat
-						player:setBeamWeaponHeatPerFire(bi,player:getBeamWeaponHeatPerFire(bi) * 0.5)
+						comms_source:setBeamWeaponHeatPerFire(bi,comms_source:getBeamWeaponHeatPerFire(bi) * 0.5)
 						bi = bi + 1
-					until(player:getBeamWeaponRange(bi) < 1)
-					setCommsMessage(string.format("%s: Beam heat generation reduced by 50 percent, no %s necessary. Go shoot some Kraylors for me",comms_target.character,comms_target.characterGood))
+					until(comms_source:getBeamWeaponRange(bi) < 1)
+					setCommsMessage(string.format("%s: Beam heat generation reduced by 50%%, no %s necessary. Go shoot some Kraylors for me",ctd.character,ctd.characterGood))
 				end
 			else
 				setCommsMessage("Your ship type does not support a beam weapon upgrade.")				
@@ -4401,49 +5003,57 @@ function coolBeam()
 	end
 end
 function longerBeam()
-	if player.longerBeamUpgrade == nil then
+	if comms_source.longerBeamUpgrade == nil then
 		addCommsReply("Extend beam range", function()
-			if player:getBeamWeaponRange(0) > 0 then
-				if treaty then
-					local gi = 1
+			if optionalMissionDiagnostic then print("extending beam range") end
+			local ctd = comms_target.comms_data
+			if comms_source:getBeamWeaponRange(0) > 0 then
+				if optionalMissionDiagnostic then print("ship qualifies") end
+				if payForUpgrade() then
+					if optionalMissionDiagnostic then print("treaty still in force") end
 					local partQuantity = 0
-					repeat
-						if goods[player][gi][1] == comms_target.characterGood then
-							partQuantity = goods[player][gi][2]
+					if comms_source.goods ~= nil then
+						if comms_source.goods[ctd.characterGood] ~= nil then
+							if comms_source.goods[ctd.characterGood] > 0 then
+								partQuantity = comms_source.goods[ctd.characterGood]
+							end
 						end
-						gi = gi + 1
-					until(gi > #goods[player])
+					end
 					if partQuantity > 0 then
-						player.longerBeamUpgrade = "done"
-						decrementPlayerGoods(comms_target.characterGood)
-						player.cargo = player.cargo + 1
+						if optionalMissionDiagnostic then print("player has enough of the right goods") end
+						comms_source.longerBeamUpgrade = "done"
+						comms_source.goods[ctd.characterGood] = comms_source.goods[ctd.characterGood] - 1
+						comms_source.cargo = comms_source.cargo + 1
 						local bi = 0
 						repeat
-							local tempArc = player:getBeamWeaponArc(bi)
-							local tempDir = player:getBeamWeaponDirection(bi)
-							local tempRng = player:getBeamWeaponRange(bi)
-							local tempCyc = player:getBeamWeaponCycleTime(bi)
-							local tempDmg = player:getBeamWeaponDamage(bi)
-							player:setBeamWeapon(bi,tempArc,tempDir,tempRng * 1.25,tempCyc,tempDmg)
+							local tempArc = comms_source:getBeamWeaponArc(bi)
+							local tempDir = comms_source:getBeamWeaponDirection(bi)
+							local tempRng = comms_source:getBeamWeaponRange(bi)
+							local tempCyc = comms_source:getBeamWeaponCycleTime(bi)
+							local tempDmg = comms_source:getBeamWeaponDamage(bi)
+							comms_source:setBeamWeapon(bi,tempArc,tempDir,tempRng * 1.25,tempCyc,tempDmg)
 							bi = bi + 1
-						until(player:getBeamWeaponRange(bi) < 1)
-						setCommsMessage(string.format("%s extended your beam range by 25%% and says thanks for the %s",comms_target.character,comms_target.characterGood))
+						until(comms_source:getBeamWeaponRange(bi) < 1)
+						if optionalMissionDiagnostic then print("beam range extended") end
+						setCommsMessage(string.format("%s extended your beam range by 25%% and says thanks for the %s",ctd.character,ctd.characterGood))
 					else
-						setCommsMessage(string.format("%s requires %s for the upgrade",comms_target.character,comms_target.characterGood))
+						setCommsMessage(string.format("%s requires %s for the upgrade",ctd.character,ctd.characterGood))
 					end
 				else
-					player.longerBeamUpgrade = "done"
+					if optionalMissionDiagnostic then print("war declared") end
+					comms_source.longerBeamUpgrade = "done"
 					bi = 0
 					repeat
-						tempArc = player:getBeamWeaponArc(bi)
-						tempDir = player:getBeamWeaponDirection(bi)
-						tempRng = player:getBeamWeaponRange(bi)
-						tempCyc = player:getBeamWeaponCycleTime(bi)
-						tempDmg = player:getBeamWeaponDamage(bi)
-						player:setBeamWeapon(bi,tempArc,tempDir,tempRng * 1.25,tempCyc,tempDmg)
+						tempArc = comms_source:getBeamWeaponArc(bi)
+						tempDir = comms_source:getBeamWeaponDirection(bi)
+						tempRng = comms_source:getBeamWeaponRange(bi)
+						tempCyc = comms_source:getBeamWeaponCycleTime(bi)
+						tempDmg = comms_source:getBeamWeaponDamage(bi)
+						comms_source:setBeamWeapon(bi,tempArc,tempDir,tempRng * 1.25,tempCyc,tempDmg)
 						bi = bi + 1
-					until(player:getBeamWeaponRange(bi) < 1)
-					setCommsMessage(string.format("%s increased your beam range by 25%% without the usual %s from your ship",comms_target.character,comms_target.characterGood))
+					until(comms_source:getBeamWeaponRange(bi) < 1)
+					if optionalMissionDiagnostic then print("beam range extended for free") end
+					setCommsMessage(string.format("%s increased your beam range by 25%% without the usual %s from your ship",ctd.character,ctd.characterGood))
 				end
 			else
 				setCommsMessage("Your ship type does not support a beam weapon upgrade.")				
@@ -4452,49 +5062,46 @@ function longerBeam()
 	end
 end
 function damageBeam()
-	if player.damageBeamUpgrade == nil then
+	if comms_source.damageBeamUpgrade == nil then
 		addCommsReply("Increase beam damage", function()
-			if player:getBeamWeaponRange(0) > 0 then
-				if treaty then
-					local gi = 1
+			local ctd = comms_target.comms_data
+			if comms_source:getBeamWeaponRange(0) > 0 then
+				if payForUpgrade() then
 					local partQuantity = 0
-					repeat
-						if goods[player][gi][1] == comms_target.characterGood then
-							partQuantity = goods[player][gi][2]
-						end
-						gi = gi + 1
-					until(gi > #goods[player])
+					if comms_source.goods ~= nil and comms_source.goods[ctd.characterGood] ~= nil and comms_source.goods[ctd.characterGood] > 0 then
+						partQuantity = comms_source.goods[ctd.characterGood]
+					end
 					if partQuantity > 0 then
-						player.damageBeamUpgrade = "done"
-						decrementPlayerGoods(comms_target.characterGood)
-						player.cargo = player.cargo + 1
+						comms_source.damageBeamUpgrade = "done"
+						comms_source.goods[ctd.characterGood] = comms_source.goods[ctd.characterGood] - 1
+						comms_source.cargo = comms_source.cargo + 1
 						local bi = 0
 						repeat
-							local tempArc = player:getBeamWeaponArc(bi)
-							local tempDir = player:getBeamWeaponDirection(bi)
-							local tempRng = player:getBeamWeaponRange(bi)
-							local tempCyc = player:getBeamWeaponCycleTime(bi)
-							local tempDmg = player:getBeamWeaponDamage(bi)
-							player:setBeamWeapon(bi,tempArc,tempDir,tempRng,tempCyc,tempDmg*1.2)
+							local tempArc = comms_source:getBeamWeaponArc(bi)
+							local tempDir = comms_source:getBeamWeaponDirection(bi)
+							local tempRng = comms_source:getBeamWeaponRange(bi)
+							local tempCyc = comms_source:getBeamWeaponCycleTime(bi)
+							local tempDmg = comms_source:getBeamWeaponDamage(bi)
+							comms_source:setBeamWeapon(bi,tempArc,tempDir,tempRng,tempCyc,tempDmg*1.2)
 							bi = bi + 1
-						until(player:getBeamWeaponRange(bi) < 1)
-						setCommsMessage(string.format("%s increased your beam damage by 20%% and stores away the %s",comms_target.character,comms_target.characterGood))
+						until(comms_source:getBeamWeaponRange(bi) < 1)
+						setCommsMessage(string.format("%s increased your beam damage by 20%% and stores away the %s",ctd.character,ctd.characterGood))
 					else
-						setCommsMessage(string.format("%s requires %s for the upgrade",comms_target.character,comms_target.characterGood))
+						setCommsMessage(string.format("%s requires %s for the upgrade",ctd.character,ctd.characterGood))
 					end
 				else
-					player.damageBeamUpgrade = "done"
+					comms_source.damageBeamUpgrade = "done"
 					bi = 0
 					repeat
-						tempArc = player:getBeamWeaponArc(bi)
-						tempDir = player:getBeamWeaponDirection(bi)
-						tempRng = player:getBeamWeaponRange(bi)
-						tempCyc = player:getBeamWeaponCycleTime(bi)
-						tempDmg = player:getBeamWeaponDamage(bi)
-						player:setBeamWeapon(bi,tempArc,tempDir,tempRng,tempCyc,tempDmg*1.2)
+						tempArc = comms_source:getBeamWeaponArc(bi)
+						tempDir = comms_source:getBeamWeaponDirection(bi)
+						tempRng = comms_source:getBeamWeaponRange(bi)
+						tempCyc = comms_source:getBeamWeaponCycleTime(bi)
+						tempDmg = comms_source:getBeamWeaponDamage(bi)
+						comms_source:setBeamWeapon(bi,tempArc,tempDir,tempRng,tempCyc,tempDmg*1.2)
 						bi = bi + 1
-					until(player:getBeamWeaponRange(bi) < 1)
-					setCommsMessage(string.format("%s increased your beam damage by 20%%, waiving the usual %s requirement",comms_target.character,comms_target.characterGood))
+					until(comms_source:getBeamWeaponRange(bi) < 1)
+					setCommsMessage(string.format("%s increased your beam damage by 20%%, waiving the usual %s requirement",ctd.character,ctd.characterGood))
 				end
 			else
 				setCommsMessage("Your ship type does not support a beam weapon upgrade.")				
@@ -4503,37 +5110,34 @@ function damageBeam()
 	end
 end
 function moreMissiles()
-	if player.moreMissilesUpgrade == nil then
+	if comms_source.moreMissilesUpgrade == nil then
 		addCommsReply("Increase missile storage capacity", function()
-			if player:getWeaponTubeCount() > 0 then
-				if treaty then
-					local gi = 1
+			local ctd = comms_target.comms_data
+			if comms_source:getWeaponTubeCount() > 0 then
+				if payForUpgrade() then
 					local partQuantity = 0
-					repeat
-						if goods[player][gi][1] == comms_target.characterGood then
-							partQuantity = goods[player][gi][2]
-						end
-						gi = gi + 1
-					until(gi > #goods[player])
+					if comms_source.goods ~= nil and comms_source.goods[ctd.characterGood] ~= nil and comms_source.goods[ctd.characterGood] > 0 then
+						partQuantity = comms_source.goods[ctd.characterGood]
+					end
 					if partQuantity > 0 then
-						player.moreMissilesUpgrade = "done"
-						decrementPlayerGoods(comms_target.characterGood)
-						player.cargo = player.cargo + 1
+						comms_source.moreMissilesUpgrade = "done"
+						comms_source.goods[ctd.characterGood] = comms_source.goods[ctd.characterGood] - 1
+						comms_source.cargo = comms_source.cargo + 1
 						local missile_types = {'Homing', 'Nuke', 'Mine', 'EMP', 'HVLI'}
 						for _, missile_type in ipairs(missile_types) do
-							player:setWeaponStorageMax(missile_type, math.ceil(player:getWeaponStorageMax(missile_type)*1.25))
+							comms_source:setWeaponStorageMax(missile_type, math.ceil(comms_source:getWeaponStorageMax(missile_type)*1.25))
 						end
-						setCommsMessage(string.format("%s: You can now store at least 25%% more missiles. I appreciate the %s",comms_target.character,comms_target.characterGood))
+						setCommsMessage(string.format("%s: You can now store at least 25%% more missiles. I appreciate the %s",ctd.character,ctd.characterGood))
 					else
-						setCommsMessage(string.format("%s needs %s for the upgrade",comms_target.character,comms_target.characterGood))
+						setCommsMessage(string.format("%s needs %s for the upgrade",ctd.character,ctd.characterGood))
 					end
 				else
-					player.moreMissilesUpgrade = "done"
+					comms_source.moreMissilesUpgrade = "done"
 					missile_types = {'Homing', 'Nuke', 'Mine', 'EMP', 'HVLI'}
 					for _, missile_type in ipairs(missile_types) do
-						player:setWeaponStorageMax(missile_type, math.ceil(player:getWeaponStorageMax(missile_type)*1.25))
+						comms_source:setWeaponStorageMax(missile_type, math.ceil(comms_source:getWeaponStorageMax(missile_type)*1.25))
 					end
-					setCommsMessage(string.format("%s: You can now store at least 25%% more missiles. I found some spare %s on the station. Go launch those missiles at those perfidious treaty-breaking Kraylors",comms_target.character,comms_target.characterGood))
+					setCommsMessage(string.format("%s: You can now store at least 25%% more missiles. I found some spare %s on the station. Go launch those missiles at those perfidious treaty-breaking Kraylors",ctd.character,ctd.characterGood))
 				end
 			else
 				setCommsMessage("Your ship type does not support a missile storage capacity upgrade.")				
@@ -4542,121 +5146,117 @@ function moreMissiles()
 	end
 end
 function fasterImpulse()
-	if player.fasterImpulseUpgrade == nil then
+	if comms_source.fasterImpulseUpgrade == nil then
 		addCommsReply("Speed up impulse engines", function()
-			if treaty then
-				local gi = 1
+			local ctd = comms_target.comms_data
+			if payForUpgrade() then
 				local partQuantity = 0
-				repeat
-					if goods[player][gi][1] == comms_target.characterGood then
-						partQuantity = goods[player][gi][2]
-					end
-					gi = gi + 1
-				until(gi > #goods[player])
+				if comms_source.goods ~= nil and comms_source.goods[ctd.characterGood] ~= nil and comms_source.goods[ctd.characterGood] > 0 then
+					partQuantity = comms_source.goods[ctd.characterGood]
+				end
 				if partQuantity > 0 then
-					player.fasterImpulseUpgrade = "done"
-					decrementPlayerGoods(comms_target.characterGood)
-					player.cargo = player.cargo + 1
-					player:setImpulseMaxSpeed(player:getImpulseMaxSpeed()*1.25)
-					setCommsMessage(string.format("%s: Your impulse engines now push you up to 25%% faster. Thanks for the %s",comms_target.character,comms_target.characterGood))
+					comms_source.fasterImpulseUpgrade = "done"
+					comms_source.goods[ctd.characterGood] = comms_source.goods[ctd.characterGood] - 1
+					comms_source.cargo = comms_source.cargo + 1
+					comms_source:setImpulseMaxSpeed(comms_source:getImpulseMaxSpeed()*1.25)
+					setCommsMessage(string.format("%s: Your impulse engines now push you up to 25%% faster. Thanks for the %s",ctd.character,ctd.characterGood))
 				else
-					setCommsMessage(string.format("You need to bring %s to %s for the upgrade",comms_target.characterGood,comms_target.character))
+					setCommsMessage(string.format("You need to bring %s to %s for the upgrade",ctd.characterGood,ctd.character))
 				end
 			else
-				player.fasterImpulseUpgrade = "done"
-				player:setImpulseMaxSpeed(player:getImpulseMaxSpeed()*1.25)
-				setCommsMessage(string.format("%s: Your impulse engines now push you up to 25%% faster. I didn't need %s after all. Go run circles around those blinking Kraylors",comms_target.character,comms_target.characterGood))
+				comms_source.fasterImpulseUpgrade = "done"
+				comms_source:setImpulseMaxSpeed(comms_source:getImpulseMaxSpeed()*1.25)
+				setCommsMessage(string.format("%s: Your impulse engines now push you up to 25%% faster. I didn't need %s after all. Go run circles around those blinking Kraylors",ctd.character,ctd.characterGood))
 			end
 		end)
 	end
 end
 function strongerHull()
-	if player.strongerHullUpgrade == nil then
+	if comms_source.strongerHullUpgrade == nil then
 		addCommsReply("Strengthen hull", function()
-			if treaty then
-				local gi = 1
+			local ctd = comms_target.comms_data
+			if payForUpgrade() then
 				local partQuantity = 0
-				repeat
-					if goods[player][gi][1] == comms_target.characterGood then
-						partQuantity = goods[player][gi][2]
-					end
-					gi = gi + 1
-				until(gi > #goods[player])
+				if comms_source.goods ~= nil and comms_source.goods[ctd.characterGood] ~= nil and comms_source.goods[ctd.characterGood] > 0 then
+					partQuantity = comms_source.goods[ctd.characterGood]
+				end
 				if partQuantity > 0 then
-					player.strongerHullUpgrade = "done"
-					decrementPlayerGoods(comms_target.characterGood)
-					player.cargo = player.cargo + 1
-					player:setHullMax(player:getHullMax()*1.5)
-					player:setHull(player:getHullMax())
-					setCommsMessage(string.format("%s: Thank you for the %s. Your hull is 50%% stronger",comms_target.character,comms_target.characterGood))
+					comms_source.strongerHullUpgrade = "done"
+					comms_source.goods[ctd.characterGood] = comms_source.goods[ctd.characterGood] - 1
+					comms_source.cargo = comms_source.cargo + 1
+					comms_source:setHullMax(comms_source:getHullMax()*1.5)
+					comms_source:setHull(comms_source:getHullMax())
+					setCommsMessage(string.format("%s: Thank you for the %s. Your hull is 50%% stronger",ctd.character,ctd.characterGood))
 				else
-					setCommsMessage(string.format("%s: I need %s before I can increase your hull strength",comms_target.character,comms_target.characterGood))
+					setCommsMessage(string.format("%s: I need %s before I can increase your hull strength",ctd.character,ctd.characterGood))
 				end
 			else
-				player.strongerHullUpgrade = "done"
-				player:setHullMax(player:getHullMax()*1.5)
-				player:setHull(player:getHullMax())
-				setCommsMessage(string.format("%s: I made your hull 50%% stronger. I scrounged some %s from around here since you are on the Kraylor offense team",comms_target.character,comms_target.characterGood))
+				comms_source.strongerHullUpgrade = "done"
+				comms_source:setHullMax(comms_source:getHullMax()*1.5)
+				comms_source:setHull(comms_source:getHullMax())
+				setCommsMessage(string.format("%s: I made your hull 50%% stronger. I scrounged some %s from around here since you are on the Kraylor offense team",ctd.character,ctd.characterGood))
 			end
 		end)
 	end
 end
 function efficientBatteries()
-	if player.efficientBatteriesUpgrade == nil then
+	if comms_source.efficientBatteriesUpgrade == nil then
 		addCommsReply("Increase battery efficiency", function()
-			if treaty then
-				local gi = 1
+			local ctd = comms_target.comms_data
+			if payForUpgrade() then
 				local partQuantity = 0
-				repeat
-					if goods[player][gi][1] == comms_target.characterGood then
-						partQuantity = goods[player][gi][2]
-					end
-					gi = gi + 1
-				until(gi > #goods[player])
+				if comms_source.goods ~= nil and comms_source.goods[ctd.characterGood] ~= nil and comms_source.goods[ctd.characterGood] > 0 then
+					partQuantity = comms_source.goods[ctd.characterGood]
+				end
 				if partQuantity > 0 then
-					player.efficientBatteriesUpgrade = "done"
-					decrementPlayerGoods(comms_target.characterGood)
-					player.cargo = player.cargo + 1
-					player:setMaxEnergy(player:getMaxEnergy()*1.25)
-					player:setEnergy(player:getMaxEnergy())
-					setCommsMessage(string.format("%s: I appreciate the %s. You have a 25%% greater energy capacity due to increased battery efficiency",comms_target.character,comms_target.characterGood))
+					comms_source.efficientBatteriesUpgrade = "done"
+					comms_source.goods[ctd.characterGood] = comms_source.goods[ctd.characterGood] - 1
+					comms_source.cargo = comms_source.cargo + 1
+					comms_source:setMaxEnergy(comms_source:getMaxEnergy()*1.25)
+					comms_source:setEnergy(comms_source:getMaxEnergy())
+					setCommsMessage(string.format("%s: I appreciate the %s. You have a 25%% greater energy capacity due to increased battery efficiency",ctd.character,ctd.characterGood))
 				else
-					setCommsMessage(string.format("%s: You need to bring me some %s before I can increase your battery efficiency",comms_target.character,comms_target.characterGood))
+					setCommsMessage(string.format("%s: You need to bring me some %s before I can increase your battery efficiency",ctd.character,ctd.characterGood))
 				end
 			else
-				player.efficientBatteriesUpgrade = "done"
-				player:setMaxEnergy(player:getMaxEnergy()*1.25)
-				player:setEnergy(player:getMaxEnergy())
-				setCommsMessage(string.format("%s increased your battery efficiency by 25%% without the need for %s due to the pressing military demands on your ship",comms_target.character,comms_target.characterGood))
+				comms_source.efficientBatteriesUpgrade = "done"
+				comms_source:setMaxEnergy(comms_source:getMaxEnergy()*1.25)
+				comms_source:setEnergy(comms_source:getMaxEnergy())
+				setCommsMessage(string.format("%s increased your battery efficiency by 25%% without the need for %s due to the pressing military demands on your ship",ctd.character,ctd.characterGood))
 			end
 		end)
 	end
 end
 function strongerShields()
-	if player.strongerShieldsUpgrade == nil then
+	if comms_source.strongerShieldsUpgrade == nil then
 		addCommsReply("Strengthen shields", function()
-			if treaty then
-				local gi = 1
+			local ctd = comms_target.comms_data
+			if payForUpgrade() then
 				local partQuantity = 0
-				repeat
-					if goods[player][gi][1] == comms_target.characterGood then
-						partQuantity = goods[player][gi][2]
-					end
-					gi = gi + 1
-				until(gi > #goods[player])
+				if comms_source.goods ~= nil and comms_source.goods[ctd.characterGood] ~= nil and comms_source.goods[ctd.characterGood] > 0 then
+					partQuantity = comms_source.goods[ctd.characterGood]
+				end
 				if partQuantity > 0 then
-					player.strongerShieldsUpgrade = "done"
-					decrementPlayerGoods(comms_target.characterGood)
-					player.cargo = player.cargo + 1
-					player:setShieldsMax(player:getShieldMax(0)*1.2)
-					setCommsMessage(string.format("%s: I've raised your shield maximum by 20%%, %s. Thanks for bringing the %s",comms_target.character,player:getCallSign(),comms_target.characterGood))
+					comms_source.strongerShieldsUpgrade = "done"
+					comms_source.goods[ctd.characterGood] = comms_source.goods[ctd.characterGood] - 1
+					comms_source.cargo = comms_source.cargo + 1
+					if comms_source:getShieldCount() == 1 then
+						comms_source:setShieldsMax(comms_source:getShieldMax(0)*1.2)
+					else
+						comms_source:setShieldsMax(comms_source:getShieldMax(0)*1.2,comms_source:getShieldMax(1)*1.2)
+					end
+					setCommsMessage(string.format("%s: I've raised your shield maximum by 20%%, %s. Thanks for bringing the %s",ctd.character,comms_source:getCallSign(),ctd.characterGood))
 				else
-					setCommsMessage(string.format("%s: You need to provide %s before I can raise your shield strength",comms_target.character,comms_target.characterGood))
+					setCommsMessage(string.format("%s: You need to provide %s before I can raise your shield strength",ctd.character,ctd.characterGood))
 				end
 			else
-				player.strongerShieldsUpgrade = "done"
-				player:setShieldsMax(player:getShieldMax(0)*1.2)
-				setCommsMessage(string.format("%s: Congratulations, %s, your shields are 20%% stronger. Don't worry about the %s. Go kick those Kraylors outta here",comms_target.character,player:getCallSign(),comms_target.characterGood))
+				comms_source.strongerShieldsUpgrade = "done"
+				if comms_source:getShieldCount() == 1 then
+					comms_source:setShieldsMax(comms_source:getShieldMax(0)*1.2)
+				else
+					comms_source:setShieldsMax(comms_source:getShieldMax(0)*1.2,comms_source:getShieldMax(1)*1.2)
+				end
+				setCommsMessage(string.format("%s: Congratulations, %s, your shields are 20%% stronger. Don't worry about the %s. Go kick those Kraylors outta here",ctd.character,comms_source:getCallSign(),ctd.characterGood))
 			end
 		end)
 	end
@@ -4703,89 +5303,71 @@ function commsStation()
     })
     comms_data = comms_target.comms_data
 	setPlayers()
-	for p4idx=1,8 do
-		local p4obj = getPlayerShip(p4idx)
-		if p4obj ~= nil and p4obj:isValid() then
-			if p4obj:isCommsOpening() then
-				player = p4obj
-			end
-		end
-	end	
-    if player:isEnemy(comms_target) then
+    if comms_source:isEnemy(comms_target) then
         return false
     end
     if comms_target:areEnemiesInRange(5000) then
         setCommsMessage("We are under attack! No time for chatting!");
         return true
     end
-    if not player:isDocked(comms_target) then
+    if not comms_source:isDocked(comms_target) then
         handleUndockedState()
     else
         handleDockedState()
     end
     return true
 end
-
 function handleDockedState()
-    if player:isFriendly(comms_target) then
-		oMsg = "Good day, officer!\nWhat can we do for you today?\n"
+	local ctd = comms_target.comms_data
+    if comms_source:isFriendly(comms_target) then
+    	if ctd.friendlyness > 66 then
+    		oMsg = string.format("Greetings %s!\nHow may we help you today?",comms_source:getCallSign())
+    	elseif ctd.friendlyness > 33 then
+			oMsg = "Good day, officer!\nWhat can we do for you today?"
+		else
+			oMsg = "Hello, may I help you?"
+		end
     else
-		oMsg = "Welcome to our lovely station.\n"
+		oMsg = "Welcome to our lovely station."
     end
     if comms_target:areEnemiesInRange(20000) then
-		oMsg = oMsg .. "Forgive us if we seem a little distracted. We are carefully monitoring the enemies nearby."
+		oMsg = oMsg .. "\nForgive us if we seem a little distracted. We are carefully monitoring the enemies nearby."
 	end
 	setCommsMessage(oMsg)
 	local missilePresence = 0
 	local missile_types = {'Homing', 'Nuke', 'Mine', 'EMP', 'HVLI'}
 	for _, missile_type in ipairs(missile_types) do
-		missilePresence = missilePresence + player:getWeaponStorageMax(missile_type)
+		missilePresence = missilePresence + comms_source:getWeaponStorageMax(missile_type)
 	end
 	if missilePresence > 0 then
-		if comms_target.nukeAvail == nil then
-			if math.random(1,10) <= (4 - difficulty) then
-				comms_target.nukeAvail = true
-			else
-				comms_target.nukeAvail = false
-			end
-			if math.random(1,10) <= (5 - difficulty) then
-				comms_target.empAvail = true
-			else
-				comms_target.empAvail = false
-			end
-			if math.random(1,10) <= (6 - difficulty) then
-				comms_target.homeAvail = true
-			else
-				comms_target.homeAvail = false
-			end
-			if math.random(1,10) <= (7 - difficulty) then
-				comms_target.mineAvail = true
-			else
-				comms_target.mineAvail = false
-			end
-			if math.random(1,10) <= (9 - difficulty) then
-				comms_target.hvliAvail = true
-			else
-				comms_target.hvliAvail = false
-			end
-		end	--end set up secondary ordnance availability for station if branch
-		if comms_target.nukeAvail or comms_target.empAvail or comms_target.homeAvail or comms_target.mineAvail or comms_target.hvliAvail then
+		if 	(ctd.weapon_available.Nuke   and comms_source:getWeaponStorageMax("Nuke") > 0)   or 
+			(ctd.weapon_available.EMP    and comms_source:getWeaponStorageMax("EMP") > 0)    or 
+			(ctd.weapon_available.Homing and comms_source:getWeaponStorageMax("Homing") > 0) or 
+			(ctd.weapon_available.Mine   and comms_source:getWeaponStorageMax("Mine") > 0)   or 
+			(ctd.weapon_available.HVLI   and comms_source:getWeaponStorageMax("HVLI") > 0)   then
 			addCommsReply("I need ordnance restocked", function()
+				local ctd = comms_target.comms_data
+				if stationCommsDiagnostic then print("in restock function") end
 				setCommsMessage("What type of ordnance?")
-				if player:getWeaponStorageMax("Nuke") > 0 then
-					if comms_target.nukeAvail then
+				if stationCommsDiagnostic then print(string.format("player nuke weapon storage max: %.1f",comms_source:getWeaponStorageMax("Nuke"))) end
+				if comms_source:getWeaponStorageMax("Nuke") > 0 then
+					if stationCommsDiagnostic then print("player can fire nukes") end
+					if ctd.weapon_available.Nuke then
+						if stationCommsDiagnostic then print("station has nukes available") end
 						if math.random(1,10) <= 5 then
 							nukePrompt = "Can you supply us with some nukes? ("
 						else
 							nukePrompt = "We really need some nukes ("
 						end
+						if stationCommsDiagnostic then print("nuke prompt: " .. nukePrompt) end
 						addCommsReply(nukePrompt .. getWeaponCost("Nuke") .. " rep each)", function()
+							if stationCommsDiagnostic then print("going to handle weapon restock function") end
 							handleWeaponRestock("Nuke")
 						end)
 					end	--end station has nuke available if branch
 				end	--end player can accept nuke if branch
-				if player:getWeaponStorageMax("EMP") > 0 then
-					if comms_target.empAvail then
+				if comms_source:getWeaponStorageMax("EMP") > 0 then
+					if ctd.weapon_available.EMP then
 						if math.random(1,10) <= 5 then
 							empPrompt = "Please re-stock our EMP missiles. ("
 						else
@@ -4796,8 +5378,8 @@ function handleDockedState()
 						end)
 					end	--end station has EMP available if branch
 				end	--end player can accept EMP if branch
-				if player:getWeaponStorageMax("Homing") > 0 then
-					if comms_target.homeAvail then
+				if comms_source:getWeaponStorageMax("Homing") > 0 then
+					if ctd.weapon_available.Homing then
 						if math.random(1,10) <= 5 then
 							homePrompt = "Do you have spare homing missiles for us? ("
 						else
@@ -4808,8 +5390,8 @@ function handleDockedState()
 						end)
 					end	--end station has homing for player if branch
 				end	--end player can accept homing if branch
-				if player:getWeaponStorageMax("Mine") > 0 then
-					if comms_target.mineAvail then
+				if comms_source:getWeaponStorageMax("Mine") > 0 then
+					if ctd.weapon_available.Mine then
 						if math.random(1,10) <= 5 then
 							minePrompt = "We could use some mines. ("
 						else
@@ -4820,8 +5402,8 @@ function handleDockedState()
 						end)
 					end	--end station has mine for player if branch
 				end	--end player can accept mine if branch
-				if player:getWeaponStorageMax("HVLI") > 0 then
-					if comms_target.hvliAvail then
+				if comms_source:getWeaponStorageMax("HVLI") > 0 then
+					if ctd.weapon_available.HVLI then
 						if math.random(1,10) <= 5 then
 							hvliPrompt = "What about HVLI? ("
 						else
@@ -4835,24 +5417,24 @@ function handleDockedState()
 			end)	--end player requests secondary ordnance comms reply branch
 		end	--end secondary ordnance available from station if branch
 	end	--end missles used on player ship if branch
-	if comms_target.publicRelations then
+	if ctd.public_relations then
 		addCommsReply("Tell me more about your station", function()
 			setCommsMessage("What would you like to know?")
 			addCommsReply("General information", function()
-				setCommsMessage(comms_target.generalInformation)
+				setCommsMessage(ctd.general_information)
 				addCommsReply("Back", commsStation)
 			end)
-			if comms_target.stationHistory ~= nil then
+			if ctd.history ~= nil then
 				addCommsReply("Station history", function()
-					setCommsMessage(comms_target.stationHistory)
+					setCommsMessage(ctd.history)
 					addCommsReply("Back", commsStation)
 				end)
 			end
-			if player:isFriendly(comms_target) then
-				if comms_target.gossip ~= nil then
-					if random(1,100) < 70 then
+			if comms_source:isFriendly(comms_target) then
+				if ctd.gossip ~= nil then
+					if random(1,100) < (100 - (30 * (difficulty - .5))) then
 						addCommsReply("Gossip", function()
-							setCommsMessage(comms_target.gossip)
+							setCommsMessage(ctd.gossip)
 							addCommsReply("Back", commsStation)
 						end)
 					end
@@ -4865,64 +5447,64 @@ function handleDockedState()
 			setCommsMessage("Each neutral border zone is equipped with sensors and an auto-transmitter. If the sensors detect enemy forces in the zone, the auto-transmitter sends encoded zone identifying details through subspace. Human navy ships are equipped to recognize this data and color code the appropriate zone on the science and relay consoles.")
 		end)
 	end
-	if comms_target.character ~= nil then
-		addCommsReply(string.format("Tell me about %s",comms_target.character), function()
-			if comms_target.characterDescription ~= nil then
-				setCommsMessage(comms_target.characterDescription)
+	if ctd.character ~= nil then
+		addCommsReply(string.format("Tell me about %s",ctd.character), function()
+			if ctd.characterDescription ~= nil then
+				setCommsMessage(ctd.characterDescription)
 			else
-				if comms_target.characterDeadEnd == nil then
+				if ctd.characterDeadEnd == nil then
 					local deadEndChoice = math.random(1,5)
 					if deadEndChoice == 1 then
-						comms_target.characterDeadEnd = "Never heard of " .. comms_target.character
+						ctd.characterDeadEnd = "Never heard of " .. ctd.character
 					elseif deadEndChoice == 2 then
-						comms_target.characterDeadEnd = comms_target.character .. " died last week. The funeral was yesterday"
+						ctd.characterDeadEnd = ctd.character .. " died last week. The funeral was yesterday"
 					elseif deadEndChoice == 3 then
-						comms_target.characterDeadEnd = string.format("%s? Who's %s? There's nobody here named %s",comms_target.character,comms_target.character,comms_target.character)
+						ctd.characterDeadEnd = string.format("%s? Who's %s? There's nobody here named %s",ctd.character,ctd.character,ctd.character)
 					elseif deadEndChoice == 4 then
-						comms_target.characterDeadEnd = string.format("We don't talk about %s. They are gone and good riddance",comms_target.character)
+						ctd.characterDeadEnd = string.format("We don't talk about %s. They are gone and good riddance",ctd.character)
 					else
-						comms_target.characterDeadEnd = string.format("I think %s moved away",comms_target.character)
+						ctd.characterDeadEnd = string.format("I think %s moved away",ctd.character)
 					end
 				end
-				setCommsMessage(comms_target.characterDeadEnd)
+				setCommsMessage(ctd.characterDeadEnd)
 			end
-			if comms_target.characterFunction == "shrinkBeamCycle" then
+			if ctd.characterFunction == "shrinkBeamCycle" then
 				shrinkBeamCycle()
 			end
-			if comms_target.characterFunction == "increaseSpin" then
+			if ctd.characterFunction == "increaseSpin" then
 				increaseSpin()
 			end
-			if comms_target.characterFunction == "addAuxTube" then
+			if ctd.characterFunction == "addAuxTube" then
 				addAuxTube()
 			end
-			if comms_target.characterFunction == "coolBeam" then
+			if ctd.characterFunction == "coolBeam" then
 				coolBeam()
 			end
-			if comms_target.characterFunction == "longerBeam" then
+			if ctd.characterFunction == "longerBeam" then
 				longerBeam()
 			end
-			if comms_target.characterFunction == "damageBeam" then
+			if ctd.characterFunction == "damageBeam" then
 				damageBeam()
 			end
-			if comms_target.characterFunction == "moreMissiles" then
+			if ctd.characterFunction == "moreMissiles" then
 				moreMissiles()
 			end
-			if comms_target.characterFunction == "fasterImpulse" then
+			if ctd.characterFunction == "fasterImpulse" then
 				fasterImpulse()
 			end
-			if comms_target.characterFunction == "strongerHull" then
+			if ctd.characterFunction == "strongerHull" then
 				strongerHull()
 			end
-			if comms_target.characterFunction == "efficientBatteries" then
+			if ctd.characterFunction == "efficientBatteries" then
 				efficientBatteries()
 			end
-			if comms_target.characterFunction == "strongerShields" then
+			if ctd.characterFunction == "strongerShields" then
 				strongerShields()
 			end
 			addCommsReply("Back", commsStation)
 		end)
 	end
-	if player:isFriendly(comms_target) then
+	if comms_source:isFriendly(comms_target) then
 		addCommsReply("What are my current orders?", function()
 			setOptionalOrders()
 			setSecondaryOrders()
@@ -4934,240 +5516,237 @@ function handleDockedState()
 			addCommsReply("Back", commsStation)
 		end)
 		if math.random(1,5) <= (3 - difficulty) then
-			if player:getRepairCrewCount() < player.maxRepairCrew then
+			local hireCost = math.random(45,90)
+			if comms_source:getRepairCrewCount() < comms_source.maxRepairCrew then
 				hireCost = math.random(30,60)
-			else
-				hireCost = math.random(45,90)
 			end
 			addCommsReply(string.format("Recruit repair crew member for %i reputation",hireCost), function()
-				if not player:takeReputationPoints(hireCost) then
+				if not comms_source:takeReputationPoints(hireCost) then
 					setCommsMessage("Insufficient reputation")
 				else
-					player:setRepairCrewCount(player:getRepairCrewCount() + 1)
+					comms_source:setRepairCrewCount(comms_source:getRepairCrewCount() + 1)
 					setCommsMessage("Repair crew member hired")
 				end
+				addCommsReply("Back", commsStation)
 			end)
+		end
+		if comms_source.initialCoolant ~= nil then
+			if math.random(1,5) <= (3 - difficulty) then
+				local coolantCost = math.random(45,90)
+				if comms_source:getMaxCoolant() < comms_source.initialCoolant then
+					coolantCost = math.random(30,60)
+				end
+				addCommsReply(string.format("Purchase coolant for %i reputation",coolantCost), function()
+					if not comms_source:takeReputationPoints(coolantCost) then
+						setCommsMessage("Insufficient reputation")
+					else
+						comms_source:setMaxCoolant(comms_source:getMaxCoolant() + 2)
+						setCommsMessage("Additional coolant purchased")
+					end
+					addCommsReply("Back", commsStation)
+				end)
+			end
 		end
 	else
 		if math.random(1,5) <= (3 - difficulty) then
-			if player:getRepairCrewCount() < player.maxRepairCrew then
+			local hireCost = math.random(60,120)
+			if comms_source:getRepairCrewCount() < comms_source.maxRepairCrew then
 				hireCost = math.random(45,90)
-			else
-				hireCost = math.random(60,120)
 			end
 			addCommsReply(string.format("Recruit repair crew member for %i reputation",hireCost), function()
-				if not player:takeReputationPoints(hireCost) then
+				if not comms_source:takeReputationPoints(hireCost) then
 					setCommsMessage("Insufficient reputation")
 				else
-					player:setRepairCrewCount(player:getRepairCrewCount() + 1)
+					comms_source:setRepairCrewCount(comms_source:getRepairCrewCount() + 1)
 					setCommsMessage("Repair crew member hired")
 				end
+				addCommsReply("Back", commsStation)
 			end)
 		end
-	end
-	if goods[comms_target] ~= nil then
-		addCommsReply("Buy, sell, trade", function()
-			oMsg = string.format("Station %s:\nGoods or components available: quantity, cost in reputation\n",comms_target:getCallSign())
-			local gi = 1		-- initialize goods index
-			repeat
-				local goodsType = goods[comms_target][gi][1]
-				local goodsQuantity = goods[comms_target][gi][2]
-				local goodsRep = goods[comms_target][gi][3]
-				oMsg = oMsg .. string.format("     %s: %i, %i\n",goodsType,goodsQuantity,goodsRep)
-				gi = gi + 1
-			until(gi > #goods[comms_target])
-			oMsg = oMsg .. "Current Cargo:\n"
-			gi = 1
-			local cargoHoldEmpty = true
-			repeat
-				local playerGoodsType = goods[player][gi][1]
-				local playerGoodsQuantity = goods[player][gi][2]
-				if playerGoodsQuantity > 0 then
-					oMsg = oMsg .. string.format("     %s: %i\n",playerGoodsType,playerGoodsQuantity)
-					cargoHoldEmpty = false
+		if comms_source.initialCoolant ~= nil then
+			if math.random(1,5) <= (3 - difficulty) then
+				local coolantCost = math.random(60,120)
+				if comms_source:getMaxCoolant() < comms_source.initialCoolant then
+					coolantCost = math.random(45,90)
 				end
-				gi = gi + 1
-			until(gi > #goods[player])
-			if cargoHoldEmpty then
-				oMsg = oMsg .. "     Empty\n"
-			end
-			local playerRep = math.floor(player:getReputationPoints())
-			oMsg = oMsg .. string.format("Available Space: %i, Available Reputation: %i\n",player.cargo,playerRep)
-			setCommsMessage(oMsg)
-			-- Buttons for reputation purchases
-			gi = 1
-			repeat
-				local goodsType = goods[comms_target][gi][1]
-				local goodsQuantity = goods[comms_target][gi][2]
-				local goodsRep = goods[comms_target][gi][3]
-				addCommsReply(string.format("Buy one %s for %i reputation",goods[comms_target][gi][1],goods[comms_target][gi][3]), function()
-					oMsg = string.format("Type: %s, Quantity: %i, Rep: %i",goodsType,goodsQuantity,goodsRep)
-					if player.cargo < 1 then
-						oMsg = oMsg .. "\nInsufficient cargo space for purchase"
-					elseif goodsRep > playerRep then
-						oMsg = oMsg .. "\nInsufficient reputation for purchase"
-					elseif goodsQuantity < 1 then
-						oMsg = oMsg .. "\nInsufficient station inventory"
+				addCommsReply(string.format("Purchase coolant for %i reputation",coolantCost), function()
+					if not comms_source:takeReputationPoints(coolantCost) then
+						setCommsMessage("Insufficient reputation")
 					else
-						if not player:takeReputationPoints(goodsRep) then
-							oMsg = oMsg .. "\nInsufficient reputation for purchase"
+						comms_source:setMaxCoolant(comms_source:getMaxCoolant() + 2)
+						setCommsMessage("Additional coolant purchased")
+					end
+					addCommsReply("Back", commsStation)
+				end)
+			end
+		end
+	end
+	local goodCount = 0
+	for good, goodData in pairs(ctd.goods) do
+		goodCount = goodCount + 1
+	end
+	if goodCount > 0 then
+		addCommsReply("Buy, sell, trade", function()
+			local ctd = comms_target.comms_data
+			local goodsReport = string.format("Station %s:\nGoods or components available for sale: quantity, cost in reputation\n",comms_target:getCallSign())
+			for good, goodData in pairs(ctd.goods) do
+				goodsReport = goodsReport .. string.format("     %s: %i, %i\n",good,goodData["quantity"],goodData["cost"])
+			end
+			if ctd.buy ~= nil then
+				goodsReport = goodsReport .. "Goods or components station will buy: price in reputation\n"
+				for good, price in pairs(ctd.buy) do
+					goodsReport = goodsReport .. string.format("     %s: %i\n",good,price)
+				end
+			end
+			goodsReport = goodsReport .. string.format("Current cargo aboard %s:\n",comms_source:getCallSign())
+			local cargoHoldEmpty = true
+			local goodCount = 0
+			if comms_source.goods ~= nil then
+				for good, goodQuantity in pairs(comms_source.goods) do
+					goodCount = goodCount + 1
+					goodsReport = goodsReport .. string.format("     %s: %i\n",good,goodQuantity)
+				end
+			end
+			if goodCount < 1 then
+				goodsReport = goodsReport .. "     Empty\n"
+			end
+			goodsReport = goodsReport .. string.format("Available Space: %i, Available Reputation: %i\n",comms_source.cargo,math.floor(comms_source:getReputationPoints()))
+			setCommsMessage(goodsReport)
+			for good, goodData in pairs(ctd.goods) do
+				addCommsReply(string.format("Buy one %s for %i reputation",good,goodData["cost"]), function()
+					local goodTransactionMessage = string.format("Type: %s, Quantity: %i, Rep: %i",good,goodData["quantity"],goodData["cost"])
+					if comms_source.cargo < 1 then
+						goodTransactionMessage = goodTransactionMessage .. "\nInsufficient cargo space for purchase"
+					elseif goodData["cost"] > math.floor(comms_source:getReputationPoints()) then
+						goodTransactionMessage = goodTransactionMessage .. "\nInsufficient reputation for purchase"
+					elseif goodData["quantity"] < 1 then
+						goodTransactionMessage = goodTransactionMessage .. "\nInsufficient station inventory"
+					else
+						if comms_source:takeReputationPoints(goodData["cost"]) then
+							comms_source.cargo = comms_source.cargo - 1
+							goodData["quantity"] = goodData["quantity"] - 1
+							if comms_source.goods == nil then
+								comms_source.goods = {}
+							end
+							if comms_source.goods[good] == nil then
+								comms_source.goods[good] = 0
+							end
+							comms_source.goods[good] = comms_source.goods[good] + 1
+							goodTransactionMessage = goodTransactionMessage .. "\npurchased"
 						else
-							player.cargo = player.cargo - 1
-							decrementStationGoods(goodsType)
-							incrementPlayerGoods(goodsType)
-							oMsg = oMsg .. "\npurchased"
+							goodTransactionMessage = goodTransactionMessage .. "\nInsufficient reputation for purchase"
 						end
 					end
-					setCommsMessage(oMsg)
+					setCommsMessage(goodTransactionMessage)
 					addCommsReply("Back", commsStation)
-				end)	--end buy goods from station for player reputation comms reply branch
-				gi = gi + 1
-			until(gi > #goods[comms_target])
-			-- Buttons for food trades
-			if tradeFood[comms_target] ~= nil then
-				gi = 1
-				local foodQuantity = 0
-				repeat
-					if goods[player][gi][1] == "food" then
-						foodQuantity = goods[player][gi][2]
-					end
-					gi = gi + 1
-				until(gi > #goods[player])
-				if foodQuantity > 0 then
-					gi = 1
-					repeat
-						local goodsType = goods[comms_target][gi][1]
-						local goodsQuantity = goods[comms_target][gi][2]
-						addCommsReply(string.format("Trade food for %s",goods[comms_target][gi][1]), function()
-							oMsg = string.format("Type: %s,  Quantity: %i",goodsType,goodsQuantity)
-							if goodsQuantity < 1 then
-								oMsg = oMsg .. "\nInsufficient station inventory"
-							else
-								decrementStationGoods(goodsType)
-								incrementPlayerGoods(goodsType)
-								decrementPlayerGoods("food")
-								oMsg = oMsg .. "\nTraded"
-							end
-							setCommsMessage(oMsg)
-							addCommsReply("Back", commsStation)
-						end)	--end trade food on player ship for goods on station comms reply branch
-						gi = gi + 1
-					until(gi > #goods[comms_target])
-				end	--end food available on player ship if branch
-			end	--end food trade if branch
-			-- Buttons for luxury trades
-			if tradeLuxury[comms_target] ~= nil then
-				gi = 1
-				local luxuryQuantity = 0
-				repeat
-					if goods[player][gi][1] == "luxury" then
-						luxuryQuantity = goods[player][gi][2]
-					end
-					gi = gi + 1
-				until(gi > #goods[player])
-				if luxuryQuantity > 0 then
-					gi = 1
-					repeat
-						local goodsType = goods[comms_target][gi][1]
-						local goodsQuantity = goods[comms_target][gi][2]
-						addCommsReply(string.format("Trade luxury for %s",goods[comms_target][gi][1]), function()
-							oMsg = string.format("Type: %s,  Quantity: %i",goodsType,goodsQuantity)
-							if goodsQuantity < 1 then
-								oMsg = oMsg .. "\nInsufficient station inventory"
-							else
-								decrementStationGoods(goodsType)
-								incrementPlayerGoods(goodsType)
-								decrementPlayerGoods("luxury")
-								oMsg = oMsg .. "\nTraded"
-							end
-							setCommsMessage(oMsg)
-							addCommsReply("Back", commsStation)
-						end)	--end trade luxury on player ship for goods on station comms reply branch
-						gi = gi + 1
-					until(gi > #goods[comms_target])
-				end	--end luxury available on player ship if branch
-			end	--end luxury trade if branch
-			-- Buttons for medicine trades
-			if tradeMedicine[comms_target] ~= nil then
-				gi = 1
-				local medicineQuantity = 0
-				repeat
-					if goods[player][gi][1] == "medicine" then
-						medicineQuantity = goods[player][gi][2]
-					end
-					gi = gi + 1
-				until(gi > #goods[player])
-				if medicineQuantity > 0 then
-					gi = 1
-					repeat
-						local goodsType = goods[comms_target][gi][1]
-						local goodsQuantity = goods[comms_target][gi][2]
-						addCommsReply(string.format("Trade medicine for %s",goods[comms_target][gi][1]), function()
-							oMsg = string.format("Type: %s,  Quantity: %i",goodsType,goodsQuantity)
-							if goodsQuantity < 1 then
-								oMsg = oMsg .. "\nInsufficient station inventory"
-							else
-								decrementStationGoods(goodsType)
-								incrementPlayerGoods(goodsType)
-								decrementPlayerGoods("medicine")
-								oMsg = oMsg .. "\nTraded"
-							end
-							setCommsMessage(oMsg)
-							addCommsReply("Back", commsStation)
-						end)	--end trade medicine on player ship for goods on station comms reply branch
-						gi = gi + 1
-					until(gi > #goods[comms_target])
-				end	--end medicine available on player ship if branch
-			end	--end medicine trade if branch
-			addCommsReply("Back", commsStation)
-		end)	--end of buy, sell trade comms reply branch
-		gi = 1
-		cargoHoldEmpty = true
-		repeat
-			playerGoodsType = goods[player][gi][1]
-			playerGoodsQuantity = goods[player][gi][2]
-			if playerGoodsQuantity > 0 then
-				cargoHoldEmpty = false
+				end)
 			end
-			gi = gi + 1
-		until(gi > #goods[player])
-		if not cargoHoldEmpty then
-			addCommsReply("Jettison cargo", function()
-				setCommsMessage(string.format("Available space: %i\nWhat would you like to jettison?",player.cargo))
-				gi = 1
-				repeat
-					local goodsType = goods[player][gi][1]
-					local goodsQuantity = goods[player][gi][2]
-					if goodsQuantity > 0 then
-						addCommsReply(goodsType, function()
-							decrementPlayerGoods(goodsType)
-							player.cargo = player.cargo + 1
-							setCommsMessage(string.format("One %s jettisoned",goodsType))
+			if ctd.buy ~= nil then
+				for good, price in pairs(ctd.buy) do
+					if comms_source.goods[good] ~= nil and comms_source.goods[good] > 0 then
+						addCommsReply(string.format("Sell one %s for %i reputation",good,price), function()
+							local goodTransactionMessage = string.format("Type: %s,  Reputation price: %i",good,price)
+							comms_source.goods[good] = comms_source.goods[good] - 1
+							comms_source:addReputationPoints(price)
+							goodTransactionMessage = goodTransactionMessage .. "\nOne sold"
+							comms_source.cargo = comms_source.cargo + 1
+							setCommsMessage(goodTransactionMessage)
 							addCommsReply("Back", commsStation)
 						end)
 					end
-					gi = gi + 1
-				until(gi > #goods[player])
-				addCommsReply("Back", commsStation)
-			end)	--end of cargo present, allow jettison if and comms reply branch
-		end	
-	end	--end of goods present on comms target if branch
+				end
+			end
+			if ctd.trade.food and comms_source.goods ~= nil and comms_source.goods.food ~= nil and comms_source.goods.food.quantity > 0 then
+				for good, goodData in pairs(ctd.goods) do
+					addCommsReply(string.format("Trade food for %s",good), function()
+						local goodTransactionMessage = string.format("Type: %s,  Quantity: %i",good,goodData["quantity"])
+						if goodData["quantity"] < 1 then
+							goodTransactionMessage = goodTransactionMessage .. "\nInsufficient station inventory"
+						else
+							goodData["quantity"] = goodData["quantity"] - 1
+							if comms_source.goods == nil then
+								comms_source.goods = {}
+							end
+							if comms_source.goods[good] == nil then
+								comms_source.goods[good] = 0
+							end
+							comms_source.goods[good] = comms_source.goods[good] + 1
+							comms_source.goods["food"] = comms_source.goods["food"] - 1
+							goodTransactionMessage = goodTransactionMessage .. "\nTraded"
+						end
+						setCommsMessage(goodTransactionMessage)
+						addCommsReply("Back", commsStation)
+					end)
+				end
+			end
+			if ctd.trade.medicine and comms_source.goods ~= nil and comms_source.goods.medicine ~= nil and comms_source.goods.medicine.quantity > 0 then
+				for good, goodData in pairs(ctd.goods) do
+					addCommsReply(string.format("Trade medicine for %s",good), function()
+						local goodTransactionMessage = string.format("Type: %s,  Quantity: %i",good,goodData["quantity"])
+						if goodData["quantity"] < 1 then
+							goodTransactionMessage = goodTransactionMessage .. "\nInsufficient station inventory"
+						else
+							goodData["quantity"] = goodData["quantity"] - 1
+							if comms_source.goods == nil then
+								comms_source.goods = {}
+							end
+							if comms_source.goods[good] == nil then
+								comms_source.goods[good] = 0
+							end
+							comms_source.goods[good] = comms_source.goods[good] + 1
+							comms_source.goods["medicine"] = comms_source.goods["medicine"] - 1
+							goodTransactionMessage = goodTransactionMessage .. "\nTraded"
+						end
+						setCommsMessage(goodTransactionMessage)
+						addCommsReply("Back", commsStation)
+					end)
+				end
+			end
+			if ctd.trade.luxury and comms_source.goods ~= nil and comms_source.goods.luxury ~= nil and comms_source.goods.luxury.quantity > 0 then
+				for good, goodData in pairs(ctd.goods) do
+					addCommsReply(string.format("Trade luxury for %s",good), function()
+						local goodTransactionMessage = string.format("Type: %s,  Quantity: %i",good,goodData["quantity"])
+						if goodData[quantity] < 1 then
+							goodTransactionMessage = goodTransactionMessage .. "\nInsufficient station inventory"
+						else
+							goodData["quantity"] = goodData["quantity"] - 1
+							if comms_source.goods == nil then
+								comms_source.goods = {}
+							end
+							if comms_source.goods[good] == nil then
+								comms_source.goods[good] = 0
+							end
+							comms_source.goods[good] = comms_source.goods[good] + 1
+							comms_source.goods["luxury"] = comms_source.goods["luxury"] - 1
+							goodTransactionMessage = goodTransactionMessage .. "\nTraded"
+						end
+						setCommsMessage(goodTransactionMessage)
+						addCommsReply("Back", commsStation)
+					end)
+				end
+			end
+			addCommsReply("Back", commsStation)
+		end)
+		addCommsReply("No tutorial covered goods or cargo. Explain", function()
+			setCommsMessage("Different types of cargo or goods may be obtained from stations, freighters or other sources. They go by one word descriptions such as dilithium, optic, warp, etc. Certain mission goals may require a particular type or types of cargo. Each player ship differs in cargo carrying capacity. Goods may be obtained by spending reputation points or by trading other types of cargo (typically food, medicine or luxury)")
+			addCommsReply("Back", commsStation)
+		end)
+	end
 end	--end of handleDockedState function
 function setOptionalOrders()
 	optionalOrders = ""
 end
 function isAllowedTo(state)
-    if state == "friend" and player:isFriendly(comms_target) then
+    if state == "friend" and comms_source:isFriendly(comms_target) then
         return true
     end
-    if state == "neutral" and not player:isEnemy(comms_target) then
+    if state == "neutral" and not comms_source:isEnemy(comms_target) then
         return true
     end
     return false
 end
-
 function handleWeaponRestock(weapon)
-    if not player:isDocked(comms_target) then 
+    if not comms_source:isDocked(comms_target) then 
 		setCommsMessage("You need to stay docked for that action.")
 		return
 	end
@@ -5178,7 +5757,7 @@ function handleWeaponRestock(weapon)
         return
     end
     local points_per_item = getWeaponCost(weapon)
-    local item_amount = math.floor(player:getWeaponStorageMax(weapon) * comms_data.max_weapon_refill_amount[getFriendStatus()]) - player:getWeaponStorage(weapon)
+    local item_amount = math.floor(comms_source:getWeaponStorageMax(weapon) * comms_data.max_weapon_refill_amount[getFriendStatus()]) - comms_source:getWeaponStorage(weapon)
     if item_amount <= 0 then
         if weapon == "Nuke" then
             setCommsMessage("All nukes are charged and primed for destruction.");
@@ -5187,10 +5766,10 @@ function handleWeaponRestock(weapon)
         end
         addCommsReply("Back", commsStation)
     else
-		if player:getReputationPoints() > points_per_item * item_amount then
-			if player:takeReputationPoints(points_per_item * item_amount) then
-				player:setWeaponStorage(weapon, player:getWeaponStorage(weapon) + item_amount)
-				if player:getWeaponStorage(weapon) == player:getWeaponStorageMax(weapon) then
+		if comms_source:getReputationPoints() > points_per_item * item_amount then
+			if comms_source:takeReputationPoints(points_per_item * item_amount) then
+				comms_source:setWeaponStorage(weapon, comms_source:getWeaponStorage(weapon) + item_amount)
+				if comms_source:getWeaponStorage(weapon) == comms_source:getWeaponStorageMax(weapon) then
 					setCommsMessage("You are fully loaded and ready to explode things.")
 				else
 					setCommsMessage("We generously resupplied you with some weapon charges.\nPut them to good use.")
@@ -5200,12 +5779,12 @@ function handleWeaponRestock(weapon)
 				return
 			end
 		else
-			if player:getReputationPoints() > points_per_item then
+			if comms_source:getReputationPoints() > points_per_item then
 				setCommsMessage("You can't afford as much as I'd like to give you")
 				addCommsReply("Get just one", function()
-					if player:takeReputationPoints(points_per_item) then
-						player:setWeaponStorage(weapon, player:getWeaponStorage(weapon) + 1)
-						if player:getWeaponStorage(weapon) == player:getWeaponStorageMax(weapon) then
+					if comms_source:takeReputationPoints(points_per_item) then
+						comms_source:setWeaponStorage(weapon, comms_source:getWeaponStorage(weapon) + 1)
+						if comms_source:getWeaponStorage(weapon) == comms_source:getWeaponStorageMax(weapon) then
 							setCommsMessage("You are fully loaded and ready to explode things.")
 						else
 							setCommsMessage("We generously resupplied you with one weapon charge.\nPut it to good use.")
@@ -5226,43 +5805,16 @@ end
 function getWeaponCost(weapon)
     return math.ceil(comms_data.weapon_cost[weapon] * comms_data.reputation_cost_multipliers[getFriendStatus()])
 end
-
 function handleUndockedState()
     --Handle communications when we are not docked with the station.
-    if player:isFriendly(comms_target) then
+    local ctd = comms_target.comms_data
+    if comms_source:isFriendly(comms_target) then
         oMsg = "Good day, officer.\nIf you need supplies, please dock with us first."
     else
         oMsg = "Greetings.\nIf you want to do business, please dock with us first."
     end
     if comms_target:areEnemiesInRange(20000) then
 		oMsg = oMsg .. "\nBe aware that if enemies in the area get much closer, we will be too busy to conduct business with you."
-	end
-	if comms_target.nukeAvail == nil then
-		if math.random(1,10) <= (4 - difficulty) then
-			comms_target.nukeAvail = true
-		else
-			comms_target.nukeAvail = false
-		end
-		if math.random(1,10) <= (5 - difficulty) then
-			comms_target.empAvail = true
-		else
-			comms_target.empAvail = false
-		end
-		if math.random(1,10) <= (6 - difficulty) then
-			comms_target.homeAvail = true
-		else
-			comms_target.homeAvail = false
-		end
-		if math.random(1,10) <= (7 - difficulty) then
-			comms_target.mineAvail = true
-		else
-			comms_target.mineAvail = false
-		end
-		if math.random(1,10) <= (9 - difficulty) then
-			comms_target.hvliAvail = true
-		else
-			comms_target.hvliAvail = false
-		end
 	end
 	setCommsMessage(oMsg)
  	addCommsReply("I need information", function()
@@ -5278,102 +5830,130 @@ function handleUndockedState()
 			addCommsReply("Back", commsStation)
 		end)
 		addCommsReply("What ordnance do you have available for restock?", function()
+			local ctd = comms_target.comms_data
 			local missileTypeAvailableCount = 0
-			oMsg = ""
-			if comms_target.nukeAvail then
+			local ordnanceListMsg = ""
+			if ctd.weapon_available.Nuke then
 				missileTypeAvailableCount = missileTypeAvailableCount + 1
-				oMsg = oMsg .. "\n   Nuke"
+				ordnanceListMsg = ordnanceListMsg .. "\n   Nuke"
 			end
-			if comms_target.empAvail then
+			if ctd.weapon_available.EMP then
 				missileTypeAvailableCount = missileTypeAvailableCount + 1
-				oMsg = oMsg .. "\n   EMP"
+				ordnanceListMsg = ordnanceListMsg .. "\n   EMP"
 			end
-			if comms_target.homeAvail then
+			if ctd.weapon_available.Homing then
 				missileTypeAvailableCount = missileTypeAvailableCount + 1
-				oMsg = oMsg .. "\n   Homing"
+				ordnanceListMsg = ordnanceListMsg .. "\n   Homing"
 			end
-			if comms_target.mineAvail then
+			if ctd.weapon_available.Mine then
 				missileTypeAvailableCount = missileTypeAvailableCount + 1
-				oMsg = oMsg .. "\n   Mine"
+				ordnanceListMsg = ordnanceListMsg .. "\n   Mine"
 			end
-			if comms_target.hvliAvail then
+			if ctd.weapon_available.HVLI then
 				missileTypeAvailableCount = missileTypeAvailableCount + 1
-				oMsg = oMsg .. "\n   HVLI"
+				ordnanceListMsg = ordnanceListMsg .. "\n   HVLI"
 			end
 			if missileTypeAvailableCount == 0 then
-				oMsg = "We have no ordnance available for restock"
+				ordnanceListMsg = "We have no ordnance available for restock"
 			elseif missileTypeAvailableCount == 1 then
-				oMsg = "We have the following type of ordnance available for restock:" .. oMsg
+				ordnanceListMsg = "We have the following type of ordnance available for restock:" .. ordnanceListMsg
 			else
-				oMsg = "We have the following types of ordnance available for restock:" .. oMsg
+				ordnanceListMsg = "We have the following types of ordnance available for restock:" .. ordnanceListMsg
 			end
-			setCommsMessage(oMsg)
+			setCommsMessage(ordnanceListMsg)
 			addCommsReply("Back", commsStation)
 		end)
-		local goodsQuantityAvailable = 0
-		local gi = 1
-		repeat
-			if goods[comms_target][gi][2] > 0 then
-				goodsQuantityAvailable = goodsQuantityAvailable + goods[comms_target][gi][2]
+		local goodsAvailable = false
+		if ctd.goods ~= nil then
+			for good, goodData in pairs(ctd.goods) do
+				if goodData["quantity"] > 0 then
+					goodsAvailable = true
+				end
 			end
-			gi = gi + 1
-		until(gi > #goods[comms_target])
-		if goodsQuantityAvailable > 0 then
+		end
+		if goodsAvailable then
 			addCommsReply("What goods do you have available for sale or trade?", function()
-				oMsg = string.format("Station %s:\nGoods or components available: quantity, cost in reputation\n",comms_target:getCallSign())
-				gi = 1		-- initialize goods index
-				repeat
-					goodsType = goods[comms_target][gi][1]
-					goodsQuantity = goods[comms_target][gi][2]
-					goodsRep = goods[comms_target][gi][3]
-					oMsg = oMsg .. string.format("   %14s: %2i, %3i\n",goodsType,goodsQuantity,goodsRep)
-					gi = gi + 1
-				until(gi > #goods[comms_target])
-				setCommsMessage(oMsg)
+				local ctd = comms_target.comms_data
+				local goodsAvailableMsg = string.format("Station %s:\nGoods or components available: quantity, cost in reputation",comms_target:getCallSign())
+				for good, goodData in pairs(ctd.goods) do
+					goodsAvailableMsg = goodsAvailableMsg .. string.format("\n   %14s: %2i, %3i",good,goodData["quantity"],goodData["cost"])
+				end
+				setCommsMessage(goodsAvailableMsg)
 				addCommsReply("Back", commsStation)
 			end)
 		end
 		addCommsReply("Where can I find particular goods?", function()
-			gkMsg = "Friendly stations generally have food or medicine or both. Neutral stations often trade their goods for food, medicine or luxury."
-			if comms_target.goodsKnowledge == nil then
-				gkMsg = gkMsg .. " Beyond that, I have no knowledge of specific stations.\n\nCheck back later, someone else may have better knowledge"
-				setCommsMessage(gkMsg)
-				addCommsReply("Back", commsStation)
-				fillStationBrains()
-			else
-				if #comms_target.goodsKnowledge == 0 then
-					gkMsg = gkMsg .. " Beyond that, I have no knowledge of specific stations"
-				else
-					gkMsg = gkMsg .. "\n\nWhat goods are you interested in?\nI've heard about these:"
-					for gk=1,#comms_target.goodsKnowledge do
-						addCommsReply(comms_target.goodsKnowledgeType[gk],function()
-							setCommsMessage(string.format("Station %s in sector %s has %s%s",comms_target.goodsKnowledge[gk],comms_target.goodsKnowledgeSector[gk],comms_target.goodsKnowledgeType[gk],comms_target.goodsKnowledgeTrade[gk]))
-							addCommsReply("Back", commsStation)
-						end)
+			local ctd = comms_target.comms_data
+			gkMsg = "Friendly stations often have food or medicine or both. Neutral stations may trade their goods for food, medicine or luxury."
+			if ctd.goodsKnowledge == nil then
+				ctd.goodsKnowledge = {}
+				local knowledgeCount = 0
+				local knowledgeMax = 10
+				for i=1,#humanStationList do
+					local station = humanStationList[i]
+					if station ~= nil and station:isValid() then
+						local brainCheckChance = 60
+						if distance(comms_target,station) > 75000 then
+							brainCheckChance = 20
+						end
+						for good, goodData in pairs(ctd.goods) do
+							if random(1,100) <= brainCheckChance then
+								local stationCallSign = station:getCallSign()
+								local stationSector = station:getSectorName()
+								ctd.goodsKnowledge[good] =	{	station = stationCallSign,
+																sector = stationSector,
+																cost = goodData["cost"] }
+								knowledgeCount = knowledgeCount + 1
+								if knowledgeCount >= knowledgeMax then
+									break
+								end
+							end
+						end
+					end
+					if knowledgeCount >= knowledgeMax then
+						break
 					end
 				end
-				setCommsMessage(gkMsg)
-				addCommsReply("Back", commsStation)
 			end
+			local goodsKnowledgeCount = 0
+			for good, goodKnowledge in pairs(ctd.goodsKnowledge) do
+				goodsKnowledgeCount = goodsKnowledgeCount + 1
+				addCommsReply(good, function()
+					local ctd = comms_target.comms_data
+					local stationName = ctd.goodsKnowledge[good]["station"]
+					local sectorName = ctd.goodsKnowledge[good]["sector"]
+					local goodName = good
+					local goodCost = ctd.goodsKnowledge[good]["cost"]
+					setCommsMessage(string.format("Station %s in sector %s has %s for %i reputation",stationName,sectorName,goodName,goodCost))
+					addCommsReply("Back", commsStation)
+				end)
+			end
+			if goodsKnowledgeCount > 0 then
+				gkMsg = gkMsg .. "\n\nWhat goods are you interested in?\nI've heard about these:"
+			else
+				gkMsg = gkMsg .. " Beyond that, I have no knowledge of specific stations"
+			end
+			setCommsMessage(gkMsg)
+			addCommsReply("Back", commsStation)
 		end)
-		if comms_target.publicRelations then
+		if ctd.public_relations then
 			addCommsReply("Tell me more about your station", function()
 				setCommsMessage("What would you like to know?")
 				addCommsReply("General information", function()
-					setCommsMessage(comms_target.generalInformation)
+					setCommsMessage(ctd.general_information)
 					addCommsReply("Back", commsStation)
 				end)
-				if comms_target.stationHistory ~= nil then
+				if ctd.history ~= nil then
 					addCommsReply("Station history", function()
-						setCommsMessage(comms_target.stationHistory)
+						setCommsMessage(ctd.history)
 						addCommsReply("Back", commsStation)
 					end)
 				end
-				if player:isFriendly(comms_target) then
-					if comms_target.gossip ~= nil then
+				if comms_source:isFriendly(comms_target) then
+					if ctd.gossip ~= nil then
 						if random(1,100) < 50 then
 							addCommsReply("Gossip", function()
-								setCommsMessage(comms_target.gossip)
+								setCommsMessage(ctd.gossip)
 								addCommsReply("Back", commsStation)
 							end)
 						end
@@ -5381,6 +5961,31 @@ function handleUndockedState()
 				end
 			end)	--end station info comms reply branch
 		end	--end public relations if branch
+		if ctd.character ~= nil then
+			if random(1,100) < (70 - (20 * difficulty)) then
+				addCommsReply(string.format("Tell me about %s",ctd.character), function()
+					if ctd.characterDescription ~= nil then
+						setCommsMessage(ctd.characterDescription)
+					else
+						if ctd.characterDeadEnd == nil then
+							local deadEndChoice = math.random(1,5)
+							if deadEndChoice == 1 then
+								ctd.characterDeadEnd = "Never heard of " .. ctd.character
+							elseif deadEndChoice == 2 then
+								ctd.characterDeadEnd = ctd.character .. " died last week. The funeral was yesterday"
+							elseif deadEndChoice == 3 then
+								ctd.characterDeadEnd = string.format("%s? Who's %s? There's nobody here named %s",ctd.character,ctd.character,ctd.character)
+							elseif deadEndChoice == 4 then
+								ctd.characterDeadEnd = string.format("We don't talk about %s. They are gone and good riddance",ctd.character)
+							else
+								ctd.characterDeadEnd = string.format("I think %s moved away",ctd.character)
+							end
+						end
+						setCommsMessage(ctd.characterDeadEnd)
+					end
+				end)
+			end
+		end
 		if enemyEverDetected then
 			addCommsReply("Why the yellow neutral border zones?", function()
 				setCommsMessage("Each neutral border zone is equipped with sensors and an auto-transmitter. If the sensors detect enemy forces in the zone, the auto-transmitter sends encoded zone identifying details through subspace. Human navy ships are equipped to recognize this data and color code the appropriate zone on the science and relay consoles.")
@@ -5402,15 +6007,15 @@ function handleUndockedState()
 	end)
 	if isAllowedTo(comms_target.comms_data.services.supplydrop) then
         addCommsReply("Can you send a supply drop? ("..getServiceCost("supplydrop").."rep)", function()
-            if player:getWaypointCount() < 1 then
+            if comms_source:getWaypointCount() < 1 then
                 setCommsMessage("You need to set a waypoint before you can request backup.");
             else
                 setCommsMessage("To which waypoint should we deliver your supplies?");
-                for n=1,player:getWaypointCount() do
+                for n=1,comms_source:getWaypointCount() do
                     addCommsReply("WP" .. n, function()
-						if player:takeReputationPoints(getServiceCost("supplydrop")) then
+						if comms_source:takeReputationPoints(getServiceCost("supplydrop")) then
 							local position_x, position_y = comms_target:getPosition()
-							local target_x, target_y = player:getWaypoint(n)
+							local target_x, target_y = comms_source:getWaypoint(n)
 							local script = Script()
 							script:setVariable("position_x", position_x):setVariable("position_y", position_y)
 							script:setVariable("target_x", target_x):setVariable("target_y", target_y)
@@ -5428,14 +6033,14 @@ function handleUndockedState()
     end
     if isAllowedTo(comms_target.comms_data.services.reinforcements) then
         addCommsReply("Please send reinforcements! ("..getServiceCost("reinforcements").."rep)", function()
-            if player:getWaypointCount() < 1 then
+            if comms_source:getWaypointCount() < 1 then
                 setCommsMessage("You need to set a waypoint before you can request reinforcements.");
             else
                 setCommsMessage("To which waypoint should we dispatch the reinforcements?");
-                for n=1,player:getWaypointCount() do
+                for n=1,comms_source:getWaypointCount() do
                     addCommsReply("WP" .. n, function()
 						if treaty then
-							local tempAsteroid = VisualAsteroid():setPosition(player:getWaypoint(n))
+							local tempAsteroid = VisualAsteroid():setPosition(comms_source:getWaypoint(n))
 							local waypointInBorderZone = false
 							for i=1,#borderZone do
 								if borderZone[i]:isInside(tempAsteroid) then
@@ -5448,8 +6053,8 @@ function handleUndockedState()
 							elseif outerZone:isInside(tempAsteroid) then
 								setCommsMessage("We cannot break the treaty by sending reinforcements to WP" .. n .. " across the neutral border zones")							
 							else
-								if player:takeReputationPoints(getServiceCost("reinforcements")) then
-									local ship = CpuShip():setFactionId(comms_target:getFactionId()):setPosition(comms_target:getPosition()):setTemplate("Adder MK5"):setScanned(true):orderDefendLocation(player:getWaypoint(n))
+								if comms_source:takeReputationPoints(getServiceCost("reinforcements")) then
+									local ship = CpuShip():setFactionId(comms_target:getFactionId()):setPosition(comms_target:getPosition()):setTemplate("Adder MK5"):setScanned(true):orderDefendLocation(comms_source:getWaypoint(n))
 									ship:setCommsScript(""):setCommsFunction(commsShip):onDestruction(friendlyVesselDestroyed)
 									table.insert(friendlyHelperFleet,ship)
 									setCommsMessage("We have dispatched " .. ship:getCallSign() .. " to assist at WP" .. n);
@@ -5459,8 +6064,8 @@ function handleUndockedState()
 							end
 							tempAsteroid:destroy()
 						else
-							if player:takeReputationPoints(getServiceCost("reinforcements")) then
-								ship = CpuShip():setFactionId(comms_target:getFactionId()):setPosition(comms_target:getPosition()):setTemplate("Adder MK5"):setScanned(true):orderDefendLocation(player:getWaypoint(n))
+							if comms_source:takeReputationPoints(getServiceCost("reinforcements")) then
+								ship = CpuShip():setFactionId(comms_target:getFactionId()):setPosition(comms_target:getPosition()):setTemplate("Adder MK5"):setScanned(true):orderDefendLocation(comms_source:getWaypoint(n))
 								ship:setCommsScript(""):setCommsFunction(commsShip):onDestruction(friendlyVesselDestroyed)
 								table.insert(friendlyHelperFleet,ship)
 								setCommsMessage("We have dispatched " .. ship:getCallSign() .. " to assist at WP" .. n);
@@ -5476,64 +6081,13 @@ function handleUndockedState()
         end)
     end
 end
-
+function getServiceCost(service)
 -- Return the number of reputation points that a specified service costs for
 -- the current player.
-function getServiceCost(service)
     return math.ceil(comms_data.service_cost[service])
 end
-function fillStationBrains()
-	comms_target.goodsKnowledge = {}
-	comms_target.goodsKnowledgeSector = {}
-	comms_target.goodsKnowledgeType = {}
-	comms_target.goodsKnowledgeTrade = {}
-	local knowledgeCount = 0
-	local knowledgeMax = 10
-	for sti=1,#humanStationList do
-		if humanStationList[sti] ~= nil and humanStationList[sti]:isValid() then
-			if distance(comms_target,humanStationList[sti]) < 75000 then
-				brainCheck = 3
-			else
-				brainCheck = 1
-			end
-			for gi=1,#goods[humanStationList[sti]] do
-				if random(1,10) <= brainCheck then
-					table.insert(comms_target.goodsKnowledge,humanStationList[sti]:getCallSign())
-					table.insert(comms_target.goodsKnowledgeSector,humanStationList[sti]:getSectorName())
-					table.insert(comms_target.goodsKnowledgeType,goods[humanStationList[sti]][gi][1])
-					tradeString = ""
-					stationTrades = false
-					if tradeMedicine[humanStationList[sti]] ~= nil then
-						tradeString = " and will trade it for medicine"
-						stationTrades = true
-					end
-					if tradeFood[humanStationList[sti]] ~= nil then
-						if stationTrades then
-							tradeString = tradeString .. " or food"
-						else
-							tradeString = tradeString .. " and will trade it for food"
-							stationTrades = true
-						end
-					end
-					if tradeLuxury[humanStationList[sti]] ~= nil then
-						if stationTrades then
-							tradeString = tradeString .. " or luxury"
-						else
-							tradeString = tradeString .. " and will trade it for luxury"
-						end
-					end
-					table.insert(comms_target.goodsKnowledgeTrade,tradeString)
-					knowledgeCount = knowledgeCount + 1
-					if knowledgeCount >= knowledgeMax then
-						return
-					end
-				end
-			end
-		end
-	end
-end
 function getFriendStatus()
-    if player:isFriendly(comms_target) then
+    if comms_source:isFriendly(comms_target) then
         return "friend"
     else
         return "neutral"
@@ -5546,23 +6100,28 @@ function commsShip()
 	if comms_target.comms_data == nil then
 		comms_target.comms_data = {friendlyness = random(0.0, 100.0)}
 	end
-	if goods[comms_target] == nil then
-		goods[comms_target] = {goodsList[irandom(1,#goodsList)][1], 1, random(20,80)}
-	end
 	comms_data = comms_target.comms_data
-	setPlayers()
-	for p4idx=1,8 do
-		local p4obj = getPlayerShip(p4idx)
-		if p4obj ~= nil and p4obj:isValid() then
-			if p4obj:isCommsOpening() then
-				player = p4obj
+	if comms_data.goods == nil then
+		comms_data.goods = {}
+		comms_data.goods[commonGoods[math.random(1,#commonGoods)]] = {quantity = 1, cost = random(20,80)}
+		local shipType = comms_target:getTypeName()
+		if shipType:find("Freighter") ~= nil then
+			if shipType:find("Goods") ~= nil or shipType:find("Equipment") ~= nil then
+				repeat
+					comms_data.goods[commonGoods[math.random(1,#commonGoods)]] = {quantity = 1, cost = random(20,80)}
+					local goodCount = 0
+					for good, goodData in pairs(comms_data.goods) do
+						goodCount = goodCount + 1
+					end
+				until(goodCount >= 3)
 			end
 		end
-	end	
-	if player:isFriendly(comms_target) then
+	end
+	setPlayers()
+	if comms_source:isFriendly(comms_target) then
 		return friendlyComms(comms_data)
 	end
-	if player:isEnemy(comms_target) and comms_target:isFriendOrFoeIdentifiedBy(player) then
+	if comms_source:isEnemy(comms_target) and comms_target:isFriendOrFoeIdentifiedBy(comms_source) then
 		return enemyComms(comms_data)
 	end
 	return neutralComms(comms_data)
@@ -5574,15 +6133,15 @@ function friendlyComms(comms_data)
 		setCommsMessage("Sir, how can we assist?");
 	end
 	addCommsReply("Defend a waypoint", function()
-		if player:getWaypointCount() == 0 then
+		if comms_source:getWaypointCount() == 0 then
 			setCommsMessage("No waypoints set. Please set a waypoint first.");
 			addCommsReply("Back", commsShip)
 		else
 			setCommsMessage("Which waypoint should we defend?");
-			for n=1,player:getWaypointCount() do
+			for n=1,comms_source:getWaypointCount() do
 				addCommsReply("Defend WP" .. n, function()
 					if treaty then
-						local tempAsteroid = VisualAsteroid():setPosition(player:getWaypoint(n))
+						local tempAsteroid = VisualAsteroid():setPosition(comms_source:getWaypoint(n))
 						local waypointInBorderZone = false
 						for i=1,#borderZone do
 							if borderZone[i]:isInside(tempAsteroid) then
@@ -5595,12 +6154,12 @@ function friendlyComms(comms_data)
 						elseif outerZone:isInside(tempAsteroid) then
 							setCommsMessage("We cannot break the treaty by defending WP" .. n .. " across the neutral border zones")							
 						else
-							comms_target:orderDefendLocation(player:getWaypoint(n))
+							comms_target:orderDefendLocation(comms_source:getWaypoint(n))
 							setCommsMessage("We are heading to assist at WP" .. n ..".");
 						end
 						tempAsteroid:destroy()
 					else
-						comms_target:orderDefendLocation(player:getWaypoint(n))
+						comms_target:orderDefendLocation(comms_source:getWaypoint(n))
 						setCommsMessage("We are heading to assist at WP" .. n ..".");
 					end
 					addCommsReply("Back", commsShip)
@@ -5611,7 +6170,7 @@ function friendlyComms(comms_data)
 	if comms_data.friendlyness > 0.2 then
 		addCommsReply("Assist me", function()
 			setCommsMessage("Heading toward you to assist.");
-			comms_target:orderDefendTarget(player)
+			comms_target:orderDefendTarget(comms_source)
 			addCommsReply("Back", commsShip)
 		end)
 	end
@@ -5648,152 +6207,263 @@ function friendlyComms(comms_data)
 			end)
 		end
 	end
-	local shipType = comms_target:getTypeName()
-	if shipType:find("Freighter") ~= nil then
-		if comms_data.friendlyness > 66 then
-			-- Offer to trade goods if goods or equipment freighter
-			if distance(player,comms_target) < 5000 then
-				if shipType:find("Goods") ~= nil or shipType:find("Equipment") ~= nil then
-					local gi = 1
-					local luxuryQuantity = 0
-					repeat
-						if goods[player][gi][1] == "luxury" then
-							luxuryQuantity = goods[player][gi][2]
+	if comms_target.fleet ~= nil and initialAssetsEvaluated then
+		addCommsReply(string.format("Direct %s",comms_target.fleet), function()
+			setCommsMessage(string.format("What command should be given to %s?",comms_target.fleet))
+			addCommsReply("Report hull and shield status", function()
+				msg = "Fleet status:"
+				for _, fleetShip in ipairs(friendlyDefensiveFleetList[comms_target.fleet]) do
+					if fleetShip ~= nil and fleetShip:isValid() then
+						msg = msg .. "\n  " .. fleetShip:getCallSign() .. ":"
+						msg = msg .. "\n    Hull: " .. math.floor(fleetShip:getHull() / fleetShip:getHullMax() * 100) .. "%"
+						local shields = fleetShip:getShieldCount()
+						if shields == 1 then
+							msg = msg .. "\n    Shield: " .. math.floor(fleetShip:getShieldLevel(0) / fleetShip:getShieldMax(0) * 100) .. "%"
+						else
+							msg = msg .. "\n    Shields: "
+							if shields == 2 then
+								msg = msg .. "Front:" .. math.floor(fleetShip:getShieldLevel(0) / fleetShip:getShieldMax(0) * 100) .. "% Rear:" .. math.floor(fleetShip:getShieldLevel(1) / fleetShip:getShieldMax(1) * 100) .. "%"
+							else
+								for n=0,shields-1 do
+									msg = msg .. " " .. n .. ":" .. math.floor(fleetShip:getShieldLevel(n) / fleetShip:getShieldMax(n) * 100) .. "%"
+								end
+							end
 						end
-						gi = gi + 1
-					until(gi > #goods[player])
-					if luxuryQuantity > 0 then
-						gi = 1
-						repeat
-							local goodsType = goods[comms_target][gi][1]
-							local goodsQuantity = goods[comms_target][gi][2]
-							addCommsReply(string.format("Trade luxury for %s",goods[comms_target][gi][1]), function()
-								if goodsQuantity < 1 then
-									setCommsMessage("Insufficient inventory on freighter for trade")
+					end
+				end
+				setCommsMessage(msg)
+				addCommsReply("Back", commsShip)
+			end)
+			addCommsReply("Report missile status", function()
+				msg = "Fleet missile status:"
+				for _, fleetShip in ipairs(friendlyDefensiveFleetList[comms_target.fleet]) do
+					if fleetShip ~= nil and fleetShip:isValid() then
+						msg = msg .. "\n  " .. fleetShip:getCallSign() .. ":"
+						local missile_types = {'Homing', 'Nuke', 'Mine', 'EMP', 'HVLI'}
+						missileMsg = ""
+						for _, missile_type in ipairs(missile_types) do
+							if fleetShip:getWeaponStorageMax(missile_type) > 0 then
+								missileMsg = missileMsg .. "\n      " .. missile_type .. ": " .. math.floor(fleetShip:getWeaponStorage(missile_type)) .. "/" .. math.floor(fleetShip:getWeaponStorageMax(missile_type))
+							end
+						end
+						if missileMsg ~= "" then
+							msg = msg .. "\n    Missiles: " .. missileMsg
+						end
+					end
+				end
+				setCommsMessage(msg)
+				addCommsReply("Back", commsShip)
+			end)
+			addCommsReply("Assist me", function()
+				for _, fleetShip in ipairs(friendlyDefensiveFleetList[comms_target.fleet]) do
+					if fleetShip ~= nil and fleetShip:isValid() then
+						fleetShip:orderDefendTarget(comms_source)
+					end
+				end
+				setCommsMessage(string.format("%s heading toward you to assist",comms_target.fleet))
+				addCommsReply("Back", commsShip)
+			end)
+			addCommsReply("Defend a waypoint", function()
+				if comms_source:getWaypointCount() == 0 then
+					setCommsMessage("No waypoints set. Please set a waypoint first.");
+					addCommsReply("Back", commsShip)
+				else
+					setCommsMessage("Which waypoint should we defend?");
+					for n=1,comms_source:getWaypointCount() do
+						addCommsReply("Defend WP" .. n, function()
+							for _, fleetShip in ipairs(friendlyDefensiveFleetList[comms_target.fleet]) do
+								if fleetShip ~= nil and fleetShip:isValid() then
+									fleetShip:orderDefendLocation(comms_source:getWaypoint(n))
+								end
+							end
+							setCommsMessage("We are heading to assist at WP" .. n ..".");
+							addCommsReply("Back", commsShip)
+						end)
+					end
+				end
+			end)
+			if not treaty and limitedWarTimer <= 0 then
+				addCommsReply("Go offensive, attack all enemy targets", function()
+					for _, fleetShip in ipairs(friendlyDefensiveFleetList[comms_target.fleet]) do
+						if fleetShip ~= nil and fleetShip:isValid() then
+							fleetShip:orderRoaming()
+						end
+					end
+					setCommsMessage(string.format("%s is on an offensive rampage",comms_target.fleet))
+					addCommsReply("Back", commsShip)
+				end)
+			end
+		end)
+	end
+	if shipCommsDiagnostic then print("done with fleet buttons") end
+	local shipType = comms_target:getTypeName()
+	if shipCommsDiagnostic then print("got ship type") end
+	if shipType:find("Freighter") ~= nil then
+		if shipCommsDiagnostic then print("it's a freighter") end
+		if distance(comms_source, comms_target) < 5000 then
+			if shipCommsDiagnostic then print("close enough to trade or sell") end
+			if comms_data.friendlyness > 66 then
+				if shipCommsDiagnostic then print("friendliest branch") end
+				if shipType:find("Goods") ~= nil or shipType:find("Equipment") ~= nil then
+					if shipCommsDiagnostic then print("goods or equipment freighter") end
+					if comms_source.goods ~= nil and comms_source.goods.luxury ~= nil and comms_source.goods.luxury > 0 then
+						if shipCommsDiagnostic then print("player has luxury to trade") end
+						for good, goodData in pairs(comms_data.goods) do
+							if shipCommsDiagnostic then print("in freighter goods loop") end
+							if goodData.quantity > 0 and good ~= "luxury" then
+								if shipCommsDiagnostic then print("has something other than luxury") end
+								addCommsReply(string.format("Trade luxury for %s",good), function()
+									goodData.quantity = goodData.quantity - 1
+									if comms_source.goods == nil then
+										comms_source.goods = {}
+									end
+									if comms_source.goods[good] == nil then
+										comms_source.goods[good] = 0
+									end
+									comms_source.goods[good] = comms_source.goods[good] + 1
+									comms_source.goods.luxury = comms_source.goods.luxury - 1
+									setCommsMessage(string.format("Traded your luxury for %s from %s",good,comms_target:getCallSign()))
+									addCommsReply("Back", commsShip)
+								end)
+							end
+						end	--freighter goods loop
+					end	--player has luxury branch
+				end	--goods or equipment freighter
+				if comms_source.cargo > 0 then
+					if shipCommsDiagnostic then print("player has room to purchase") end
+					for good, goodData in pairs(comms_data.goods) do
+						if shipCommsDiagnostic then print("in freighter goods loop") end
+						if goodData.quantity > 0 then
+							if shipCommsDiagnostic then print("found something to sell") end
+							addCommsReply(string.format("Buy one %s for %i reputation",good,math.floor(goodData.cost)), function()
+								if comms_source:takeReputationPoints(goodData.cost) then
+									goodData.quantity = goodData.quantity - 1
+									if comms_source.goods == nil then
+										comms_source.goods = {}
+									end
+									if comms_source.goods[good] == nil then
+										comms_source.goods[good] = 0
+									end
+									comms_source.goods[good] = comms_source.goods[good] + 1
+									comms_source.cargo = comms_source.cargo - 1
+									setCommsMessage(string.format("Purchased %s from %s",good,comms_target:getCallSign()))
 								else
-									decrementShipGoods(goodsType)
-									incrementPlayerGoods(goodsType)
-									decrementPlayerGoods("luxury")
-									setCommsMessage("Traded")
+									setCommsMessage("Insufficient reputation for purchase")
 								end
 								addCommsReply("Back", commsShip)
 							end)
-							gi = gi + 1
-						until(gi > #goods[comms_target])
+						end
+					end	--freighter goods loop
+				end	--player has cargo space branch
+			elseif comms_data.friendlyness > 33 then
+				if shipCommsDiagnostic then print("average frienliness branch") end
+				if comms_source.cargo > 0 then
+					if shipCommsDiagnostic then print("player has room to purchase") end
+					if shipType:find("Goods") ~= nil or shipType:find("Equipment") ~= nil then
+						if shipCommsDiagnostic then print("goods or equipment type freighter") end
+						for good, goodData in pairs(comms_data.goods) do
+							if shipCommsDiagnostic then print("in freighter cargo loop") end
+							if goodData.quantity > 0 then
+								if shipCommsDiagnostic then print("Found something to sell") end
+								addCommsReply(string.format("Buy one %s for %i reputation",good,math.floor(goodData.cost)), function()
+									if comms_source:takeReputationPoints(goodData.cost) then
+										goodData.quantity = goodData.quantity - 1
+										if comms_source.goods == nil then
+											comms_source.goods = {}
+										end
+										if comms_source.goods[good] == nil then
+											comms_source.goods[good] = 0
+										end
+										comms_source.goods[good] = comms_source.goods[good] + 1
+										comms_source.cargo = comms_source.cargo - 1
+										setCommsMessage(string.format("Purchased %s from %s",good,comms_target:getCallSign()))
+									else
+										setCommsMessage("Insufficient reputation for purchase")
+									end
+									addCommsReply("Back", commsShip)
+								end)
+							end	--freighter has something to sell branch
+						end	--freighter goods loop
+					else	--not goods or equipment freighter
+						if shipCommsDiagnostic then print("not a goods or equipment freighter") end
+						for good, goodData in pairs(comms_data.goods) do
+							if shipCommsDiagnostic then print("in freighter cargo loop") end
+							if goodData.quantity > 0 then
+								if shipCommsDiagnostic then print("found something to sell") end
+								addCommsReply(string.format("Buy one %s for %i reputation",good,math.floor(goodData.cost*2)), function()
+									if comms_source:takeReputationPoints(goodData.cost*2) then
+										goodData.quantity = goodData.quantity - 1
+										if comms_source.goods == nil then
+											comms_source.goods = {}
+										end
+										if comms_source.goods[good] == nil then
+											comms_source.goods[good] = 0
+										end
+										comms_source.goods[good] = comms_source.goods[good] + 1
+										comms_source.cargo = comms_source.cargo - 1
+										setCommsMessage(string.format("Purchased %s from %s",good,comms_target:getCallSign()))
+									else
+										setCommsMessage("Insufficient reputation for purchase")
+									end
+									addCommsReply("Back", commsShip)
+								end)
+							end	--freighter has something to sell branch
+						end	--freighter goods loop
 					end
-				else	-- Offer to sell goods
-					gi = 1
-					repeat
-						local goodsType = goods[comms_target][gi][1]
-						local goodsQuantity = goods[comms_target][gi][2]
-						local goodsRep = goods[comms_target][gi][3]
-						addCommsReply(string.format("Buy one %s for %i reputation",goods[comms_target][gi][1],goods[comms_target][gi][3]), function()
-							if player.cargo < 1 then
-								setCommsMessage("Insufficient cargo space for purchase")
-							elseif goodsQuantity < 1 then
-								setCommsMessage("Insufficient inventory on freighter")
-							else
-								if not player:takeReputationPoints(goodsRep) then
-									setCommsMessage("Insufficient reputation for purchase")
-								else
-									player.cargo = player.cargo - 1
-									decrementShipGoods(goodsType)
-									incrementPlayerGoods(goodsType)
-									setCommsMessage("Purchased")
-								end
-							end
-							addCommsReply("Back", commsShip)
-						end)	--end sell goods comms reply branch
-						gi = gi + 1
-					until(gi > #goods[comms_target])
-				end	--end sell goods if branch
-			end	--end nearby freighter if branch
-		elseif comms_data.friendlyness > 33 then
-			-- Offer to sell goods if goods or equipment freighter
-			if distance(player,comms_target) < 5000 then
-				if shipType:find("Goods") ~= nil or shipType:find("Equipment") ~= nil then
-					gi = 1
-					repeat
-						local goodsType = goods[comms_target][gi][1]
-						local goodsQuantity = goods[comms_target][gi][2]
-						local goodsRep = goods[comms_target][gi][3]
-						addCommsReply(string.format("Buy one %s for %i reputation",goods[comms_target][gi][1],goods[comms_target][gi][3]), function()
-							if player.cargo < 1 then
-								setCommsMessage("Insufficient cargo space for purchase")
-							elseif goodsQuantity < 1 then
-								setCommsMessage("Insufficient inventory on freighter")
-							else
-								if not player:takeReputationPoints(goodsRep) then
-									setCommsMessage("Insufficient reputation for purchase")
-								else
-									player.cargo = player.cargo - 1
-									decrementShipGoods(goodsType)
-									incrementPlayerGoods(goodsType)
-									setCommsMessage("Purchased")
-								end
-							end
-							addCommsReply("Back", commsShip)
-						end)	--end buy goods from freighter comms reply branch
-						gi = gi + 1
-					until(gi > #goods[comms_target])
-				else	-- Offer to sell goods double price
-					gi = 1
-					repeat
-						local goodsType = goods[comms_target][gi][1]
-						local goodsQuantity = goods[comms_target][gi][2]
-						local goodsRep = goods[comms_target][gi][3]*2
-						addCommsReply(string.format("Buy one %s for %i reputation",goods[comms_target][gi][1],goods[comms_target][gi][3]*2), function()
-							if player.cargo < 1 then
-								setCommsMessage("Insufficient cargo space for purchase")
-							elseif goodsQuantity < 1 then
-								setCommsMessage("Insufficient inventory on freighter")
-							else
-								if not player:takeReputationPoints(goodsRep) then
-									setCommsMessage("Insufficient reputation for purchase")
-								else
-									player.cargo = player.cargo - 1
-									decrementShipGoods(goodsType)
-									incrementPlayerGoods(goodsType)
-									setCommsMessage("Purchased")
-								end
-							end
-							addCommsReply("Back", commsShip)
-						end)	--end buy goods from freighter comms reply branch
-						gi = gi + 1
-					until(gi > #goods[comms_target])
-				end	--end goods sold at double price else branch
-			end	--end nearby freighter if branch
-		else	--least friendly comms else branch
-			-- Offer to sell goods if goods or equipment freighter double price
-			if distance(player,comms_target) < 5000 then
-				if shipType:find("Goods") ~= nil or shipType:find("Equipment") ~= nil then
-					gi = 1
-					repeat
-						local goodsType = goods[comms_target][gi][1]
-						local goodsQuantity = goods[comms_target][gi][2]
-						local goodsRep = goods[comms_target][gi][3]*2
-						addCommsReply(string.format("Buy one %s for %i reputation",goods[comms_target][gi][1],goods[comms_target][gi][3]*2), function()
-							if player.cargo < 1 then
-								setCommsMessage("Insufficient cargo space for purchase")
-							elseif goodsQuantity < 1 then
-								setCommsMessage("Insufficient inventory on freighter")
-							else
-								if not player:takeReputationPoints(goodsRep) then
-									setCommsMessage("Insufficient reputation for purchase")
-								else
-									player.cargo = player.cargo - 1
-									decrementShipGoods(goodsType)
-									incrementPlayerGoods(goodsType)
-									setCommsMessage("Purchased")
-								end
-							end
-							addCommsReply("Back", commsShip)
-						end)	--end buy goods from freighter comms reply branch
-						gi = gi + 1
-					until(gi > #goods[comms_target])
-				end	--end goods or equipment freighter if branch
-			end	--end nearby freighter if branch
-		end	--end least friendly freighter comms else branch
+				end	--player has room for cargo branch
+			else	--least friendly
+				if shipCommsDiagnostic then print("least friendly branch") end
+				if comms_source.cargo > 0 then
+					if shipCommsDiagnostic then print("player has room for purchase") end
+					if shipType:find("Goods") ~= nil or shipType:find("Equipment") ~= nil then
+						if shipCommsDiagnostic then print("goods or equipment freighter") end
+						for good, goodData in pairs(comms_data.goods) do
+							if shipCommsDiagnostic then print("in freighter cargo loop") end
+							if goodData.quantity > 0 then
+								if shipCommsDiagnostic then print("found something to sell") end
+								addCommsReply(string.format("Buy one %s for %i reputation",good,math.floor(goodData.cost*2)), function()
+									if comms_source:takeReputationPoints(goodData.cost*2) then
+										goodData.quantity = goodData.quantity - 1
+										if comms_source.goods == nil then
+											comms_source.goods = {}
+										end
+										if comms_source.goods[good] == nil then
+											comms_source.goods[good] = 0
+										end
+										comms_source.goods[good] = comms_source.goods[good] + 1
+										comms_source.cargo = comms_source.cargo - 1
+										setCommsMessage(string.format("Purchased %s from %s",good,comms_target:getCallSign()))
+									else
+										setCommsMessage("Insufficient reputation for purchase")
+									end
+									addCommsReply("Back", commsShip)
+								end)
+							end	--freighter has something to sell branch
+						end	--freighter goods loop
+					end	--goods or equipment freighter
+				end	--player has room to get goods
+			end	--various friendliness choices
+		else	--not close enough to sell
+			addCommsReply("Do you have cargo you might sell?", function()
+				local goodCount = 0
+				local cargoMsg = "We've got "
+				for good, goodData in pairs(comms_data.goods) do
+					if goodData.quantity > 0 then
+						if goodCount > 0 then
+							cargoMsg = cargoMsg .. ", " .. good
+						else
+							cargoMsg = cargoMsg .. good
+						end
+					end
+					goodCount = goodCount + goodData.quantity
+				end
+				if goodCount == 0 then
+					cargoMsg = cargoMsg .. "nothing"
+				end
+				setCommsMessage(cargoMsg)
+				addCommsReply("Back", commsShip)
+			end)
+		end
 	end
 	return true
 end
@@ -5838,7 +6508,7 @@ function enemyComms(comms_data)
 		comms_data.friendlyness = comms_data.friendlyness - random(0, 10)
 		addCommsReply(taunt_option, function()
 			if random(0, 100) < 30 then
-				comms_target:orderAttack(player)
+				comms_target:orderAttack(comms_source)
 				setCommsMessage(taunt_success_reply);
 			else
 				setCommsMessage(taunt_failed_reply);
@@ -5851,172 +6521,147 @@ end
 function neutralComms(comms_data)
 	local shipType = comms_target:getTypeName()
 	if shipType:find("Freighter") ~= nil then
-		if comms_data.friendlyness > 66 then
-			setCommsMessage("Yes?")
-			-- Offer destination information
-			addCommsReply("Where are you headed?", function()
-				setCommsMessage(comms_target.target:getCallSign())
-				addCommsReply("Back", commsShip)
-			end)
-			-- Offer to trade goods if goods or equipment freighter
-			if distance(player,comms_target) < 5000 then
-				if shipType:find("Goods") ~= nil or shipType:find("Equipment") ~= nil then
-					local gi = 1
-					local luxuryQuantity = 0
-					repeat
-						if goods[player][gi][1] == "luxury" then
-							luxuryQuantity = goods[player][gi][2]
-						end
-						gi = gi + 1
-					until(gi > #goods[player])
-					if luxuryQuantity > 0 then
-						gi = 1
-						repeat
-							local goodsType = goods[comms_target][gi][1]
-							local goodsQuantity = goods[comms_target][gi][2]
-							addCommsReply(string.format("Trade luxury for %s",goods[comms_target][gi][1]), function()
-								if goodsQuantity < 1 then
-									setCommsMessage("Insufficient inventory on freighter for trade")
-								else
-									decrementShipGoods(goodsType)
-									incrementPlayerGoods(goodsType)
-									decrementPlayerGoods("luxury")
-									setCommsMessage("Traded")
-								end
-								addCommsReply("Back", commsShip)
-							end)
-							gi = gi + 1
-						until(gi > #goods[comms_target])
+		setCommsMessage("Yes?")
+		addCommsReply("Do you have cargo you might sell?", function()
+			local goodCount = 0
+			local cargoMsg = "We've got "
+			for good, goodData in pairs(comms_data.goods) do
+				if goodData.quantity > 0 then
+					if goodCount > 0 then
+						cargoMsg = cargoMsg .. ", " .. good
 					else
-						setCommsMessage("Insufficient luxury to trade")
+						cargoMsg = cargoMsg .. good
 					end
-					addCommsReply("Back", commsShip)
-				else	-- Offer to sell goods
-					gi = 1
-					repeat
-						local goodsType = goods[comms_target][gi][1]
-						local goodsQuantity = goods[comms_target][gi][2]
-						local goodsRep = goods[comms_target][gi][3]
-						addCommsReply(string.format("Buy one %s for %i reputation",goods[comms_target][gi][1],goods[comms_target][gi][3]), function()
-							if player.cargo < 1 then
-								setCommsMessage("Insufficient cargo space for purchase")
-							elseif goodsQuantity < 1 then
-								setCommsMessage("Insufficient inventory on freighter")
-							else
-								if not player:takeReputationPoints(goodsRep) then
-									setCommsMessage("Insufficient reputation for purchase")
-								else
-									player.cargo = player.cargo - 1
-									decrementShipGoods(goodsType)
-									incrementPlayerGoods(goodsType)
-									setCommsMessage("Purchased")
-								end
-							end
-							addCommsReply("Back", commsShip)
-						end)	--end sell goods comms reply branch
-						gi = gi + 1
-					until(gi > #goods[comms_target])
-				end	--end sell goods if branch
-			end	--end nearby freighter if branch
-		elseif comms_data.friendlyness > 33 then
-			setCommsMessage("What do you want?")
-			-- Offer to sell destination information
-			local destRep = random(1,5)
-			addCommsReply(string.format("Where are you headed? (cost: %f reputation)",destRep), function()
-				if not player:takeReputationPoints(destRep) then
-					setCommsMessage("Insufficient reputation")
-				else
-					setCommsMessage(comms_target.target:getCallSign())
 				end
-				addCommsReply("Back", commsShip)
-			end)
-			-- Offer to sell goods if goods or equipment freighter
-			if distance(player,comms_target) < 5000 then
-				if shipType:find("Goods") ~= nil or shipType:find("Equipment") ~= nil then
-					gi = 1
-					repeat
-						local goodsType = goods[comms_target][gi][1]
-						local goodsQuantity = goods[comms_target][gi][2]
-						local goodsRep = goods[comms_target][gi][3]
-						addCommsReply(string.format("Buy one %s for %i reputation",goods[comms_target][gi][1],goods[comms_target][gi][3]), function()
-							if player.cargo < 1 then
-								setCommsMessage("Insufficient cargo space for purchase")
-							elseif goodsQuantity < 1 then
-								setCommsMessage("Insufficient inventory on freighter")
-							else
-								if not player:takeReputationPoints(goodsRep) then
-									setCommsMessage("Insufficient reputation for purchase")
-								else
-									player.cargo = player.cargo - 1
-									decrementShipGoods(goodsType)
-									incrementPlayerGoods(goodsType)
-									setCommsMessage("Purchased")
-								end
+				goodCount = goodCount + goodData.quantity
+			end
+			if goodCount == 0 then
+				cargoMsg = cargoMsg .. "nothing"
+			end
+			setCommsMessage(cargoMsg)
+		end)
+		if distance(comms_source,comms_target) < 5000 then
+			if comms_source.cargo > 0 then
+				if comms_data.friendlyness > 66 then
+					if shipType:find("Goods") ~= nil or shipType:find("Equipment") ~= nil then
+						for good, goodData in pairs(comms_data.goods) do
+							if goodData.quantity > 0 then
+								addCommsReply(string.format("Buy one %s for %i reputation",good,math.floor(goodData.cost)), function()
+									if comms_source:takeReputationPoints(goodData.cost) then
+										goodData.quantity = goodData.quantity - 1
+										if comms_source.goods == nil then
+											comms_source.goods = {}
+										end
+										if comms_source.goods[good] == nil then
+											comms_source.goods[good] = 0
+										end
+										comms_source.goods[good] = comms_source.goods[good] + 1
+										comms_source.cargo = comms_source.cargo - 1
+										setCommsMessage(string.format("Purchased %s from %s",good,comms_target:getCallSign()))
+									else
+										setCommsMessage("Insufficient reputation for purchase")
+									end
+									addCommsReply("Back", commsShip)
+								end)
 							end
-							addCommsReply("Back", commsShip)
-						end)	--end buy goods from freighter comms reply branch
-						gi = gi + 1
-					until(gi > #goods[comms_target])
-				else	-- Offer to sell goods double price
-					gi = 1
-					repeat
-						local goodsType = goods[comms_target][gi][1]
-						local goodsQuantity = goods[comms_target][gi][2]
-						local goodsRep = goods[comms_target][gi][3]*2
-						addCommsReply(string.format("Buy one %s for %i reputation",goods[comms_target][gi][1],goods[comms_target][gi][3]*2), function()
-							if player.cargo < 1 then
-								setCommsMessage("Insufficient cargo space for purchase")
-							elseif goodsQuantity < 1 then
-								setCommsMessage("Insufficient inventory on freighter")
-							else
-								if not player:takeReputationPoints(goodsRep) then
-									setCommsMessage("Insufficient reputation for purchase")
-								else
-									player.cargo = player.cargo - 1
-									decrementShipGoods(goodsType)
-									incrementPlayerGoods(goodsType)
-									setCommsMessage("Purchased")
-								end
+						end	--freighter goods loop
+					else
+						for good, goodData in pairs(comms_data.goods) do
+							if goodData.quantity > 0 then
+								addCommsReply(string.format("Buy one %s for %i reputation",good,math.floor(goodData.cost*2)), function()
+									if comms_source:takeReputationPoints(goodData.cost*2) then
+										goodData.quantity = goodData.quantity - 1
+										if comms_source.goods == nil then
+											comms_source.goods = {}
+										end
+										if comms_source.goods[good] == nil then
+											comms_source.goods[good] = 0
+										end
+										comms_source.goods[good] = comms_source.goods[good] + 1
+										comms_source.cargo = comms_source.cargo - 1
+										setCommsMessage(string.format("Purchased %s from %s",good,comms_target:getCallSign()))
+									else
+										setCommsMessage("Insufficient reputation for purchase")
+									end
+									addCommsReply("Back", commsShip)
+								end)
 							end
-							addCommsReply("Back", commsShip)
-						end)	--end buy goods from freighter comms reply branch
-						gi = gi + 1
-					until(gi > #goods[comms_target])
-				end	--end goods sold at double price else branch
-			end	--end nearby freighter if branch
-		else	--least friendly comms else branch
-			setCommsMessage("Why are you bothering me?")
-			-- Offer to sell goods if goods or equipment freighter double price
-			if distance(player,comms_target) < 5000 then
-				if shipType:find("Goods") ~= nil or shipType:find("Equipment") ~= nil then
-					gi = 1
-					repeat
-						local goodsType = goods[comms_target][gi][1]
-						local goodsQuantity = goods[comms_target][gi][2]
-						local goodsRep = goods[comms_target][gi][3]*2
-						addCommsReply(string.format("Buy one %s for %i reputation",goods[comms_target][gi][1],goods[comms_target][gi][3]*2), function()
-							if player.cargo < 1 then
-								setCommsMessage("Insufficient cargo space for purchase")
-							elseif goodsQuantity < 1 then
-								setCommsMessage("Insufficient inventory on freighter")
-							else
-								if not player:takeReputationPoints(goodsRep) then
-									setCommsMessage("Insufficient reputation for purchase")
-								else
-									player.cargo = player.cargo - 1
-									decrementShipGoods(goodsType)
-									incrementPlayerGoods(goodsType)
-									setCommsMessage("Purchased")
-								end
+						end	--freighter goods loop
+					end
+				elseif comms_data.friendlyness > 33 then
+					if shipType:find("Goods") ~= nil or shipType:find("Equipment") ~= nil then
+						for good, goodData in pairs(comms_data.goods) do
+							if goodData.quantity > 0 then
+								addCommsReply(string.format("Buy one %s for %i reputation",good,math.floor(goodData.cost*2)), function()
+									if comms_source:takeReputationPoints(goodData.cost*2) then
+										goodData.quantity = goodData.quantity - 1
+										if comms_source.goods == nil then
+											comms_source.goods = {}
+										end
+										if comms_source.goods[good] == nil then
+											comms_source.goods[good] = 0
+										end
+										comms_source.goods[good] = comms_source.goods[good] + 1
+										comms_source.cargo = comms_source.cargo - 1
+										setCommsMessage(string.format("Purchased %s from %s",good,comms_target:getCallSign()))
+									else
+										setCommsMessage("Insufficient reputation for purchase")
+									end
+									addCommsReply("Back", commsShip)
+								end)
 							end
-							addCommsReply("Back", commsShip)
-						end)	--end buy goods from freighter comms reply branch
-						gi = gi + 1
-					until(gi > #goods[comms_target])
-				end	--end goods or equipment freighter if branch
-			end	--end nearby freighter if branch
-		end	--end least friendly freighter comms else branch
-	else
+						end	--freighter goods loop
+					else
+						for good, goodData in pairs(comms_data.goods) do
+							if goodData.quantity > 0 then
+								addCommsReply(string.format("Buy one %s for %i reputation",good,math.floor(goodData.cost*3)), function()
+									if comms_source:takeReputationPoints(goodData.cost*3) then
+										goodData.quantity = goodData.quantity - 1
+										if comms_source.goods == nil then
+											comms_source.goods = {}
+										end
+										if comms_source.goods[good] == nil then
+											comms_source.goods[good] = 0
+										end
+										comms_source.goods[good] = comms_source.goods[good] + 1
+										comms_source.cargo = comms_source.cargo - 1
+										setCommsMessage(string.format("Purchased %s from %s",good,comms_target:getCallSign()))
+									else
+										setCommsMessage("Insufficient reputation for purchase")
+									end
+									addCommsReply("Back", commsShip)
+								end)
+							end
+						end	--freighter goods loop
+					end
+				else	--least friendly
+					if shipType:find("Goods") ~= nil or shipType:find("Equipment") ~= nil then
+						for good, goodData in pairs(comms_data.goods) do
+							if goodData.quantity > 0 then
+								addCommsReply(string.format("Buy one %s for %i reputation",good,math.floor(goodData.cost*3)), function()
+									if comms_source:takeReputationPoints(goodData.cost*3) then
+										goodData.quantity = goodData.quantity - 1
+										if comms_source.goods == nil then
+											comms_source.goods = {}
+										end
+										if comms_source.goods[good] == nil then
+											comms_source.goods[good] = 0
+										end
+										comms_source.goods[good] = comms_source.goods[good] + 1
+										comms_source.cargo = comms_source.cargo - 1
+										setCommsMessage(string.format("Purchased %s from %s",good,comms_target:getCallSign()))
+									else
+										setCommsMessage("Insufficient reputation for purchase")
+									end
+									addCommsReply("Back", commsShip)
+								end)
+							end
+						end	--freighter goods loop
+					end
+				end	--end friendly branches
+			end	--player has room for cargo
+		end	--close enough to sell
+	else	--not a freighter
 		if comms_data.friendlyness > 50 then
 			setCommsMessage("Sorry, we have no time to chat with you.\nWe are on an important mission.");
 		else
@@ -6026,47 +6671,9 @@ function neutralComms(comms_data)
 	return true
 end	--end neutral communications function
 --[[-----------------------------------------------------------------
-      Cargo management 
------------------------------------------------------------------]]--
-function incrementPlayerGoods(goodsType)
-	local gi = 1
-	repeat
-		if goods[player][gi][1] == goodsType then
-			goods[player][gi][2] = goods[player][gi][2] + 1
-		end
-		gi = gi + 1
-	until(gi > #goods[player])
-end
-function decrementPlayerGoods(goodsType)
-	local gi = 1
-	repeat
-		if goods[player][gi][1] == goodsType then
-			goods[player][gi][2] = goods[player][gi][2] - 1
-		end
-		gi = gi + 1
-	until(gi > #goods[player])
-end
-function decrementStationGoods(goodsType)
-	local gi = 1
-	repeat
-		if goods[comms_target][gi][1] == goodsType then
-			goods[comms_target][gi][2] = goods[comms_target][gi][2] - 1
-		end
-		gi = gi + 1
-	until(gi > #goods[comms_target])
-end
-function decrementShipGoods(goodsType)
-	local gi = 1
-	repeat
-		if goods[comms_target][gi][1] == goodsType then
-			goods[comms_target][gi][2] = goods[comms_target][gi][2] - 1
-		end
-		gi = gi + 1
-	until(gi > #goods[comms_target])
-end
---[[-----------------------------------------------------------------
       Utility functions 
 -----------------------------------------------------------------]]--
+function createRandomAlongArc(object_type, amount, x, y, distance, startArc, endArcClockwise, randomize)
 -- Create amount of objects of type object_type along arc
 -- Center defined by x and y
 -- Radius defined by distance
@@ -6074,7 +6681,6 @@ end
 -- Use randomize to vary the distance from the center point. Omit to keep distance constant
 -- Example:
 --   createRandomAlongArc(Asteroid, 100, 500, 3000, 65, 120, 450)
-function createRandomAlongArc(object_type, amount, x, y, distance, startArc, endArcClockwise, randomize)
 	if randomize == nil then randomize = 0 end
 	if amount == nil then amount = 1 end
 	local arcLen = endArcClockwise - startArc
@@ -6101,10 +6707,23 @@ function createRandomAlongArc(object_type, amount, x, y, distance, startArc, end
 		end
 	end
 end
+function placeRandomListAroundPoint(object_type, amount, dist_min, dist_max, x0, y0)
+-- create amount of object_type, at a distance between dist_min and dist_max around the point (x0, y0) 
+-- save in a list that is returned to caller
+	local object_list = {}
+    for n=1,amount do
+        local r = random(0, 360)
+        local distance = random(dist_min, dist_max)
+        x = x0 + math.cos(r / 180 * math.pi) * distance
+        y = y0 + math.sin(r / 180 * math.pi) * distance
+        table.insert(object_list,object_type():setPosition(x, y))
+    end
+    return object_list
+end
+function closestPlayerTo(obj)
 -- Return the player ship closest to passed object parameter
 -- Return nil if no valid result
 -- Assumes a maximum of 8 player ships
-function closestPlayerTo(obj)
 	if obj ~= nil and obj:isValid() then
 		local closestDistance = 9999999
 		local closestPlayer = nil
@@ -6123,9 +6742,9 @@ function closestPlayerTo(obj)
 		return nil
 	end
 end
+function nearStations(nobj, compareStationList)
 --nobj = named object for comparison purposes (stations, players, etc)
 --compareStationList = list of stations to compare against
-function nearStations(nobj, compareStationList)
 	local remainingStations = {}
 	local closestDistance = 9999999
 	for ri, obj in ipairs(compareStationList) do
@@ -6146,18 +6765,21 @@ function nearStations(nobj, compareStationList)
 	end
 	return closestObj, remainingStations
 end
-function spawnEnemies(xOrigin, yOrigin, danger, enemyFaction)
+function spawnEnemies(xOrigin, yOrigin, danger, enemyFaction, enemyStrength)
 	if enemyFaction == nil then
 		enemyFaction = "Kraylor"
 	end
 	if danger == nil then 
 		danger = 1
 	end
-	local enemyStrength = math.max(danger * difficulty * playerPower(),5)
+	if enemyStrength == nil then
+		enemyStrength = math.max(danger * difficulty * playerPower(),5)
+	end
 	local enemyPosition = 0
 	local sp = irandom(400,900)			--random spacing of spawned group
 	local deployConfig = random(1,100)	--randomly choose between squarish formation and hexagonish formation
 	local enemyList = {}
+	local prefix = generateCallSignPrefix(1)
 	-- Reminder: stsl and stnl are ship template score and name list
 	while enemyStrength > 0 do
 		local shipTemplateType = irandom(1,#stsl)
@@ -6180,12 +6802,13 @@ function spawnEnemies(xOrigin, yOrigin, danger, enemyFaction)
 		end
 		ship:setCommsScript(""):setCommsFunction(commsShip)
 		table.insert(enemyList, ship)
+		ship:setCallSign(generateCallSign(prefix))
 		enemyStrength = enemyStrength - stsl[shipTemplateType]
 	end
 	return enemyList
 end
---evaluate the players for enemy strength and size spawning purposes
 function playerPower()
+--evaluate the players for enemy strength and size spawning purposes
 	local playerShipScore = 0
 	for p5idx=1,8 do
 		local p5obj = getPlayerShip(p5idx)
@@ -6199,6 +6822,259 @@ function playerPower()
 	end
 	return playerShipScore
 end
+function setPlayers()
+--set up players with name, goods, cargo space, reputation and either a warp drive or a jump drive if applicable
+	concurrentPlayerCount = 0
+	for p1idx=1,8 do
+		pobj = getPlayerShip(p1idx)
+		if pobj ~= nil and pobj:isValid() then
+			concurrentPlayerCount = concurrentPlayerCount + 1
+			if pobj.goods == nil then
+				pobj.goods = {}
+			end
+			if pobj.initialRep == nil then
+				pobj:addReputationPoints(500-(difficulty*20))
+				pobj.initialRep = true
+			end
+			if not pobj.nameAssigned then
+				pobj.nameAssigned = true
+				local tempPlayerType = pobj:getTypeName()
+				if tempPlayerType == "MP52 Hornet" then
+					if #playerShipNamesForMP52Hornet > 0 then
+						local ni = math.random(1,#playerShipNamesForMP52Hornet)
+						pobj:setCallSign(playerShipNamesForMP52Hornet[ni])
+						table.remove(playerShipNamesForMP52Hornet,ni)
+					end
+					pobj.shipScore = 7
+					pobj.maxCargo = 3
+					pobj.autoCoolant = false
+					pobj:setWarpDrive(true)
+				elseif tempPlayerType == "Piranha" then
+					if #playerShipNamesForPiranha > 0 then
+						ni = math.random(1,#playerShipNamesForPiranha)
+						pobj:setCallSign(playerShipNamesForPiranha[ni])
+						table.remove(playerShipNamesForPiranha,ni)
+					end
+					pobj.shipScore = 16
+					pobj.maxCargo = 8
+				elseif tempPlayerType == "Flavia P.Falcon" then
+					if #playerShipNamesForFlaviaPFalcon > 0 then
+						ni = math.random(1,#playerShipNamesForFlaviaPFalcon)
+						pobj:setCallSign(playerShipNamesForFlaviaPFalcon[ni])
+						table.remove(playerShipNamesForFlaviaPFalcon,ni)
+					end
+					pobj.shipScore = 13
+					pobj.maxCargo = 15
+				elseif tempPlayerType == "Phobos M3P" then
+					if #playerShipNamesForPhobosM3P > 0 then
+						ni = math.random(1,#playerShipNamesForPhobosM3P)
+						pobj:setCallSign(playerShipNamesForPhobosM3P[ni])
+						table.remove(playerShipNamesForPhobosM3P,ni)
+					end
+					pobj.shipScore = 19
+					pobj.maxCargo = 10
+					pobj:setWarpDrive(true)
+				elseif tempPlayerType == "Atlantis" then
+					if #playerShipNamesForAtlantis > 0 then
+						ni = math.random(1,#playerShipNamesForAtlantis)
+						pobj:setCallSign(playerShipNamesForAtlantis[ni])
+						table.remove(playerShipNamesForAtlantis,ni)
+					end
+					pobj.shipScore = 52
+					pobj.maxCargo = 6
+				elseif tempPlayerType == "Player Cruiser" then
+					if #playerShipNamesForCruiser > 0 then
+						ni = math.random(1,#playerShipNamesForCruiser)
+						pobj:setCallSign(playerShipNamesForCruiser[ni])
+						table.remove(playerShipNamesForCruiser,ni)
+					end
+					pobj.shipScore = 40
+					pobj.maxCargo = 6
+				elseif tempPlayerType == "Player Missile Cr." then
+					if #playerShipNamesForMissileCruiser > 0 then
+						ni = math.random(1,#playerShipNamesForMissileCruiser)
+						pobj:setCallSign(playerShipNamesForMissileCruiser[ni])
+						table.remove(playerShipNamesForMissileCruiser,ni)
+					end
+					pobj.shipScore = 45
+					pobj.maxCargo = 8
+				elseif tempPlayerType == "Player Fighter" then
+					if #playerShipNamesForFighter > 0 then
+						ni = math.random(1,#playerShipNamesForFighter)
+						pobj:setCallSign(playerShipNamesForFighter[ni])
+						table.remove(playerShipNamesForFighter,ni)
+					end
+					pobj.shipScore = 7
+					pobj.maxCargo = 3
+					pobj.autoCoolant = false
+					pobj:setJumpDrive(true)
+					pobj:setJumpDriveRange(3000,40000)
+				elseif tempPlayerType == "Benedict" then
+					if #playerShipNamesForBenedict > 0 then
+						ni = math.random(1,#playerShipNamesForBenedict)
+						pobj:setCallSign(playerShipNamesForBenedict[ni])
+						table.remove(playerShipNamesForBenedict,ni)
+					end
+					pobj.shipScore = 10
+					pobj.maxCargo = 9
+				elseif tempPlayerType == "Kiriya" then
+					if #playerShipNamesForKiriya > 0 then
+						ni = math.random(1,#playerShipNamesForKiriya)
+						pobj:setCallSign(playerShipNamesForKiriya[ni])
+						table.remove(playerShipNamesForKiriya,ni)
+					end
+					pobj.shipScore = 10
+					pobj.maxCargo = 9
+				elseif tempPlayerType == "Striker" then
+					if #playerShipNamesForStriker > 0 then
+						ni = math.random(1,#playerShipNamesForStriker)
+						pobj:setCallSign(playerShipNamesForStriker[ni])
+						table.remove(playerShipNamesForStriker,ni)
+					end
+					if pobj:getImpulseMaxSpeed() == 45 then
+						pobj:setImpulseMaxSpeed(90)
+					end
+					if pobj:getBeamWeaponCycleTime(0) == 6 then
+						local bi = 0
+						repeat
+							local tempArc = pobj:getBeamWeaponArc(bi)
+							local tempDir = pobj:getBeamWeaponDirection(bi)
+							local tempRng = pobj:getBeamWeaponRange(bi)
+							local tempDmg = pobj:getBeamWeaponDamage(bi)
+							pobj:setBeamWeapon(bi,tempArc,tempDir,tempRng,5,tempDmg)
+							bi = bi + 1
+						until(pobj:getBeamWeaponRange(bi) < 1)
+					end
+					pobj.shipScore = 8
+					pobj.maxCargo = 4
+					pobj:setJumpDrive(true)
+					pobj:setJumpDriveRange(3000,40000)
+				elseif tempPlayerType == "ZX-Lindworm" then
+					if #playerShipNamesForLindworm > 0 then
+						ni = math.random(1,#playerShipNamesForLindworm)
+						pobj:setCallSign(playerShipNamesForLindworm[ni])
+						table.remove(playerShipNamesForLindworm,ni)
+					end
+					pobj.shipScore = 8
+					pobj.maxCargo = 3
+					pobj.autoCoolant = false
+					pobj:setWarpDrive(true)
+				elseif tempPlayerType == "Repulse" then
+					if #playerShipNamesForRepulse > 0 then
+						ni = math.random(1,#playerShipNamesForRepulse)
+						pobj:setCallSign(playerShipNamesForRepulse[ni])
+						table.remove(playerShipNamesForRepulse,ni)
+					end
+					pobj.shipScore = 14
+					pobj.maxCargo = 12
+				elseif tempPlayerType == "Ender" then
+					if #playerShipNamesForEnder > 0 then
+						ni = math.random(1,#playerShipNamesForEnder)
+						pobj:setCallSign(playerShipNamesForEnder[ni])
+						table.remove(playerShipNamesForEnder,ni)
+					end
+					pobj.shipScore = 100
+					pobj.maxCargo = 20
+				elseif tempPlayerType == "Nautilus" then
+					if #playerShipNamesForNautilus > 0 then
+						ni = math.random(1,#playerShipNamesForNautilus)
+						pobj:setCallSign(playerShipNamesForNautilus[ni])
+						table.remove(playerShipNamesForNautilus,ni)
+					end
+					pobj.shipScore = 12
+					pobj.maxCargo = 7
+				elseif tempPlayerType == "Hathcock" then
+					if #playerShipNamesForHathcock > 0 then
+						ni = math.random(1,#playerShipNamesForHathcock)
+						pobj:setCallSign(playerShipNamesForHathcock[ni])
+						table.remove(playerShipNamesForHathcock,ni)
+					end
+					pobj.shipScore = 30
+					pobj.maxCargo = 6
+				elseif tempPlayerType == "Proto-Atlantis" then
+					if #playerShipNamesForProtoAtlantis > 0 then
+						ni = math.random(1,#playerShipNamesForProtoAtlantis)
+						pobj:setCallSign(playerShipNamesForProtoAtlantis[ni])
+						table.remove(playerShipNamesForProtoAtlantis,ni)
+					end
+					pobj.shipScore = 40
+					pobj.maxCargo = 4
+				elseif tempPlayerType == "Atlantis II" then
+					if #playerShipNamesForAtlantisII > 0 then
+						ni = math.random(1,#playerShipNamesForAtlantisII)
+						pobj:setCallSign(playerShipNamesForAtlantisII[ni])
+						table.remove(playerShipNamesForAtlantisII,ni)
+					end
+					pobj.shipScore = 60
+					pobj.maxCargo = 5
+				elseif tempPlayerType == "Surkov" then
+					if #playerShipNamesForSurkov > 0 then
+						ni = math.random(1,#playerShipNamesForSurkov)
+						pobj:setCallSign(playerShipNamesForSurkov[ni])
+						table.remove(playerShipNamesForSurkov,ni)
+					end
+					pobj.shipScore = 35
+					pobj.maxCargo = 6
+				elseif tempPlayerType == "Stricken" then
+					if #playerShipNamesForStricken > 0 then
+						ni = math.random(1,#playerShipNamesForStricken)
+						pobj:setCallSign(playerShipNamesForStricken[ni])
+						table.remove(playerShipNamesForStricken,ni)
+					end
+					pobj.shipScore = 40
+					pobj.maxCargo = 4
+				elseif tempPlayerType == "Redhook" then
+					if #playerShipNamesForRedhook > 0 then
+						ni = math.random(1,#playerShipNamesForRedhook)
+						pobj:setCallSign(playerShipNamesForRedhook[ni])
+						table.remove(playerShipNamesForRedhook,ni)
+					end
+					pobj.shipScore = 18
+					pobj.maxCargo = 8
+				else
+					if #playerShipNamesForLeftovers > 0 then
+						ni = math.random(1,#playerShipNamesForLeftovers)
+						pobj:setCallSign(playerShipNamesForLeftovers[ni])
+						table.remove(playerShipNamesForLeftovers,ni)
+					end
+					pobj.shipScore = 24
+					pobj.maxCargo = 5
+					pobj:setWarpDrive(true)
+				end
+				if pobj.cargo == nil then
+					pobj.cargo = pobj.maxCargo
+					pobj.maxRepairCrew = pobj:getRepairCrewCount()
+					pobj.healthyShield = 1.0
+					pobj.prevShield = 1.0
+					pobj.healthyReactor = 1.0
+					pobj.prevReactor = 1.0
+					pobj.healthyManeuver = 1.0
+					pobj.prevManeuver = 1.0
+					pobj.healthyImpulse = 1.0
+					pobj.prevImpulse = 1.0
+					if pobj:getBeamWeaponRange(0) > 0 then
+						pobj.healthyBeam = 1.0
+						pobj.prevBeam = 1.0
+					end
+					if pobj:getWeaponTubeCount() > 0 then
+						pobj.healthyMissile = 1.0
+						pobj.prevMissile = 1.0
+					end
+					if pobj:hasWarpDrive() then
+						pobj.healthyWarp = 1.0
+						pobj.prevWarp = 1.0
+					end
+					if pobj:hasJumpDrive() then
+						pobj.healthyJump = 1.0
+						pobj.prevJump = 1.0
+					end
+				end
+			end
+			pobj.initialCoolant = pobj:getMaxCoolant()
+		end
+	end
+end
+--		Mortal repair crew functions. Includes coolant loss as option to losing repair crew
 function healthCheck(delta)
 	healthCheckTimer = healthCheckTimer - delta
 	if healthCheckTimer < 0 then
@@ -6275,6 +7151,19 @@ function healthCheck(delta)
 					if fatalityChance > 0 then
 						crewFate(p,fatalityChance)
 					end
+				else	--no repair crew left
+					if random(1,100) <= (4 - dificulty) then
+						p:setRepairCrewCount(1)
+						if p:hasPlayerAtPosition("Engineering") then
+							local repairCrewRecovery = "repairCrewRecovery"
+							p:addCustomMessage("Engineering",repairCrewRecovery,"Medical team has revived one of your repair crew")
+						end
+						if p:hasPlayerAtPosition("Engineering+") then
+							local repairCrewRecoveryPlus = "repairCrewRecoveryPlus"
+							p:addCustomMessage("Engineering+",repairCrewRecoveryPlus,"Medical team has revived one of your repair crew")
+						end
+						resetPreviousSystemHealth(p)
+					end
 				end
 			end
 		end
@@ -6283,45 +7172,55 @@ function healthCheck(delta)
 end
 function crewFate(p, fatalityChance)
 	if math.random() < (fatalityChance) then
-		p:setRepairCrewCount(p:getRepairCrewCount() - 1)
-		if p:hasPlayerAtPosition("Engineering") then
-			local repairCrewFatality = "repairCrewFatality"
-			p:addCustomMessage("Engineering",repairCrewFatality,"One of your repair crew has perished")
-		end
-		if p:hasPlayerAtPosition("Engineering+") then
-			local repairCrewFatalityPlus = "repairCrewFatalityPlus"
-			p:addCustomMessage("Engineering+",repairCrewFatalityPlus,"One of your repair crew has perished")
+		if p.initialCoolant == nil then
+			p:setRepairCrewCount(p:getRepairCrewCount() - 1)
+			if p:hasPlayerAtPosition("Engineering") then
+				local repairCrewFatality = "repairCrewFatality"
+				p:addCustomMessage("Engineering",repairCrewFatality,"One of your repair crew has perished")
+			end
+			if p:hasPlayerAtPosition("Engineering+") then
+				local repairCrewFatalityPlus = "repairCrewFatalityPlus"
+				p:addCustomMessage("Engineering+",repairCrewFatalityPlus,"One of your repair crew has perished")
+			end
+		else
+			if random(1,100) < 50 then
+				p:setRepairCrewCount(p:getRepairCrewCount() - 1)
+				if p:hasPlayerAtPosition("Engineering") then
+					local repairCrewFatality = "repairCrewFatality"
+					p:addCustomMessage("Engineering",repairCrewFatality,"One of your repair crew has perished")
+				end
+				if p:hasPlayerAtPosition("Engineering+") then
+					local repairCrewFatalityPlus = "repairCrewFatalityPlus"
+					p:addCustomMessage("Engineering+",repairCrewFatalityPlus,"One of your repair crew has perished")
+				end
+			else
+				p:setMaxCoolant(p:getMaxCoolant()*.5)
+				if p:hasPlayerAtPosition("Engineering") then
+					local coolantLoss = "coolantLoss"
+					p:addCustomMessage("Engineering",coolantLoss,"Damage has caused a loss of coolant")
+				end
+				if p:hasPlayerAtPosition("Engineering+") then
+					local coolantLossPlus = "coolantLossPlus"
+					p:addCustomMessage("Engineering+",coolantLossPlus,"Damage has caused a loss of coolant")
+				end
+			end
 		end
 	end
 end
---[[-----------------------------------------------------------------
-      Inventory button for relay/operations 
------------------------------------------------------------------]]--
+--      Inventory button and functions for relay/operations 
 function cargoInventory(delta)
-	if cargoInventoryList == nil then
-		cargoInventoryList = {}
-		table.insert(cargoInventoryList,cargoInventory1)
-		table.insert(cargoInventoryList,cargoInventory2)
-		table.insert(cargoInventoryList,cargoInventory3)
-		table.insert(cargoInventoryList,cargoInventory4)
-		table.insert(cargoInventoryList,cargoInventory5)
-		table.insert(cargoInventoryList,cargoInventory6)
-		table.insert(cargoInventoryList,cargoInventory7)
-		table.insert(cargoInventoryList,cargoInventory8)
-	end
 	for pidx=1,8 do
 		p = getPlayerShip(pidx)
 		if p ~= nil and p:isValid() then
-			gi = 1
-			cargoHoldEmpty = true
-			repeat
-				playerGoodsType = goods[p][gi][1]
-				playerGoodsQuantity = goods[p][gi][2]
-				if playerGoodsQuantity > 0 then
-					cargoHoldEmpty = false
+			local cargoHoldEmpty = true
+			if p.goods ~= nil then
+				for good, quantity in pairs(p.goods) do
+					if quantity ~= nil and quantity > 0 then
+						cargoHoldEmpty = false
+						break
+					end
 				end
-				gi = gi + 1
-			until(gi > #goods[p])
+			end
 			if not cargoHoldEmpty then
 				if p:hasPlayerAtPosition("Relay") then
 					if p.inventoryButton == nil then
@@ -6341,161 +7240,55 @@ function cargoInventory(delta)
 		end
 	end
 end
-function cargoInventory1()
-	local p = getPlayerShip(1)
+function cargoInventoryGivenShip(p)
 	p:addToShipLog(string.format("%s Current cargo:",p:getCallSign()),"Yellow")
-	gi = 1
 	local cargoHoldEmpty = true
-	repeat
-		local playerGoodsType = goods[p][gi][1]
-		local playerGoodsQuantity = goods[p][gi][2]
-		if playerGoodsQuantity > 0 then
-			p:addToShipLog(string.format("     %s: %i",playerGoodsType,playerGoodsQuantity),"Yellow")
-			cargoHoldEmpty = false
+	if p.goods ~= nil then
+		for good, quantity in pairs(p.goods) do
+			if quantity ~= nil and quantity > 0 then
+				p:addToShipLog(string.format("     %s: %i",good,math.floor(quantity)),"Yellow")
+				cargoHoldEmpty = false
+			end
 		end
-		gi = gi + 1
-	until(gi > #goods[p])
+	end
 	if cargoHoldEmpty then
 		p:addToShipLog("     Empty\n","Yellow")
 	end
 	p:addToShipLog(string.format("Available space: %i",p.cargo),"Yellow")
+end
+function cargoInventory1()
+	local p = getPlayerShip(1)
+	cargoInventoryGivenShip(p)
 end
 function cargoInventory2()
 	local p = getPlayerShip(2)
-	p:addToShipLog(string.format("%s Current cargo:",p:getCallSign()),"Yellow")
-	gi = 1
-	local cargoHoldEmpty = true
-	repeat
-		local playerGoodsType = goods[p][gi][1]
-		local playerGoodsQuantity = goods[p][gi][2]
-		if playerGoodsQuantity > 0 then
-			p:addToShipLog(string.format("     %s: %i",playerGoodsType,playerGoodsQuantity),"Yellow")
-			cargoHoldEmpty = false
-		end
-		gi = gi + 1
-	until(gi > #goods[p])
-	if cargoHoldEmpty then
-		p:addToShipLog("     Empty\n","Yellow")
-	end
-	p:addToShipLog(string.format("Available space: %i",p.cargo),"Yellow")
+	cargoInventoryGivenShip(p)
 end
 function cargoInventory3()
 	local p = getPlayerShip(3)
-	p:addToShipLog(string.format("%s Current cargo:",p:getCallSign()),"Yellow")
-	gi = 1
-	local cargoHoldEmpty = true
-	repeat
-		local playerGoodsType = goods[p][gi][1]
-		local playerGoodsQuantity = goods[p][gi][2]
-		if playerGoodsQuantity > 0 then
-			p:addToShipLog(string.format("     %s: %i",playerGoodsType,playerGoodsQuantity),"Yellow")
-			cargoHoldEmpty = false
-		end
-		gi = gi + 1
-	until(gi > #goods[p])
-	if cargoHoldEmpty then
-		p:addToShipLog("     Empty\n","Yellow")
-	end
-	p:addToShipLog(string.format("Available space: %i",p.cargo),"Yellow")
+	cargoInventoryGivenShip(p)
 end
 function cargoInventory4()
 	local p = getPlayerShip(4)
-	p:addToShipLog(string.format("%s Current cargo:",p:getCallSign()),"Yellow")
-	gi = 1
-	local cargoHoldEmpty = true
-	repeat
-		local playerGoodsType = goods[p][gi][1]
-		local playerGoodsQuantity = goods[p][gi][2]
-		if playerGoodsQuantity > 0 then
-			p:addToShipLog(string.format("     %s: %i",playerGoodsType,playerGoodsQuantity),"Yellow")
-			cargoHoldEmpty = false
-		end
-		gi = gi + 1
-	until(gi > #goods[p])
-	if cargoHoldEmpty then
-		p:addToShipLog("     Empty\n","Yellow")
-	end
-	p:addToShipLog(string.format("Available space: %i",p.cargo),"Yellow")
+	cargoInventoryGivenShip(p)
 end
 function cargoInventory5()
 	local p = getPlayerShip(5)
-	p:addToShipLog(string.format("%s Current cargo:",p:getCallSign()),"Yellow")
-	gi = 1
-	local cargoHoldEmpty = true
-	repeat
-		local playerGoodsType = goods[p][gi][1]
-		local playerGoodsQuantity = goods[p][gi][2]
-		if playerGoodsQuantity > 0 then
-			p:addToShipLog(string.format("     %s: %i",playerGoodsType,playerGoodsQuantity),"Yellow")
-			cargoHoldEmpty = false
-		end
-		gi = gi + 1
-	until(gi > #goods[p])
-	if cargoHoldEmpty then
-		p:addToShipLog("     Empty\n","Yellow")
-	end
-	p:addToShipLog(string.format("Available space: %i",p.cargo),"Yellow")
+	cargoInventoryGivenShip(p)
 end
 function cargoInventory6()
 	local p = getPlayerShip(6)
-	p:addToShipLog(string.format("%s Current cargo:",p:getCallSign()),"Yellow")
-	gi = 1
-	local cargoHoldEmpty = true
-	repeat
-		local playerGoodsType = goods[p][gi][1]
-		local playerGoodsQuantity = goods[p][gi][2]
-		if playerGoodsQuantity > 0 then
-			p:addToShipLog(string.format("     %s: %i",playerGoodsType,playerGoodsQuantity),"Yellow")
-			cargoHoldEmpty = false
-		end
-		gi = gi + 1
-	until(gi > #goods[p])
-	if cargoHoldEmpty then
-		p:addToShipLog("     Empty\n","Yellow")
-	end
-	p:addToShipLog(string.format("Available space: %i",p.cargo),"Yellow")
+	cargoInventoryGivenShip(p)
 end
 function cargoInventory7()
 	local p = getPlayerShip(7)
-	p:addToShipLog(string.format("%s Current cargo:",p:getCallSign()),"Yellow")
-	gi = 1
-	local cargoHoldEmpty = true
-	repeat
-		local playerGoodsType = goods[p][gi][1]
-		local playerGoodsQuantity = goods[p][gi][2]
-		if playerGoodsQuantity > 0 then
-			p:addToShipLog(string.format("     %s: %i",playerGoodsType,playerGoodsQuantity),"Yellow")
-			cargoHoldEmpty = false
-		end
-		gi = gi + 1
-	until(gi > #goods[p])
-	if cargoHoldEmpty then
-		p:addToShipLog("     Empty\n","Yellow")
-	end
-	p:addToShipLog(string.format("Available space: %i",p.cargo),"Yellow")
+	cargoInventoryGivenShip(p)
 end
 function cargoInventory8()
 	local p = getPlayerShip(8)
-	p:addToShipLog(string.format("%s Current cargo:",p:getCallSign()),"Yellow")
-	gi = 1
-	local cargoHoldEmpty = true
-	repeat
-		local playerGoodsType = goods[p][gi][1]
-		local playerGoodsQuantity = goods[p][gi][2]
-		if playerGoodsQuantity > 0 then
-			p:addToShipLog(string.format("     %s: %i",playerGoodsType,playerGoodsQuantity),"Yellow")
-			cargoHoldEmpty = false
-		end
-		gi = gi + 1
-	until(gi > #goods[p])
-	if cargoHoldEmpty then
-		p:addToShipLog("     Empty\n","Yellow")
-	end
-	p:addToShipLog(string.format("Available space: %i",p.cargo),"Yellow")
+	cargoInventoryGivenShip(p)
 end
---[[-----------------------------------------------------------------
-      Enable and disable auto-cooling on a ship 
------------------------------------------------------------------]]--
+--      Enable and disable auto-cooling on a ship functions
 function autoCoolant(delta)
 	if enableAutoCoolFunctionList == nil then
 		enableAutoCoolFunctionList = {}
@@ -6625,203 +7418,182 @@ function disableAutoCool8()
 	p:setAutoCoolant(false)
 	p.autoCoolant = false
 end
---set up players with name, goods, cargo space, reputation and either a warp drive or a jump drive if applicable
-function setPlayers()
-	concurrentPlayerCount = 0
-	for p1idx=1,8 do
-		pobj = getPlayerShip(p1idx)
-		if pobj ~= nil and pobj:isValid() then
-			concurrentPlayerCount = concurrentPlayerCount + 1
-			if goods[pobj] == nil then
-				goods[pobj] = goodsList
-			end
-			if pobj.initialRep == nil then
-				pobj:addReputationPoints(500-(difficulty*20))
-				pobj.initialRep = true
-			end
-			if not pobj.nameAssigned then
-				pobj.nameAssigned = true
-				local tempPlayerType = pobj:getTypeName()
-				if tempPlayerType == "MP52 Hornet" then
-					if #playerShipNamesForMP52Hornet > 0 then
-						local ni = math.random(1,#playerShipNamesForMP52Hornet)
-						pobj:setCallSign(playerShipNamesForMP52Hornet[ni])
-						table.remove(playerShipNamesForMP52Hornet,ni)
+--		Gain or lose coolant from nebula functions
+function coolantNebulae(delta)
+	for pidx=1,8 do
+		local p = getPlayerShip(pidx)
+		if p ~= nil and p:isValid() then
+			local inside_gain_coolant_nebula = false
+			for i=1,#coolant_nebula do
+				if distance(p,coolant_nebula[i]) < 5000 then
+					if coolant_nebula[i].lose then
+						p:setMaxCoolant(p:getMaxCoolant()*coolant_loss)
 					end
-					pobj.shipScore = 7
-					pobj.maxCargo = 3
-					pobj.autoCoolant = false
-					pobj:setWarpDrive(true)
-				elseif tempPlayerType == "Piranha" then
-					if #playerShipNamesForPiranha > 0 then
-						ni = math.random(1,#playerShipNamesForPiranha)
-						pobj:setCallSign(playerShipNamesForPiranha[ni])
-						table.remove(playerShipNamesForPiranha,ni)
+					if coolant_nebula[i].gain then
+						inside_gain_coolant_nebula = true
 					end
-					pobj.shipScore = 16
-					pobj.maxCargo = 8
-				elseif tempPlayerType == "Flavia P.Falcon" then
-					if #playerShipNamesForFlaviaPFalcon > 0 then
-						ni = math.random(1,#playerShipNamesForFlaviaPFalcon)
-						pobj:setCallSign(playerShipNamesForFlaviaPFalcon[ni])
-						table.remove(playerShipNamesForFlaviaPFalcon,ni)
-					end
-					pobj.shipScore = 13
-					pobj.maxCargo = 15
-				elseif tempPlayerType == "Phobos M3P" then
-					if #playerShipNamesForPhobosM3P > 0 then
-						ni = math.random(1,#playerShipNamesForPhobosM3P)
-						pobj:setCallSign(playerShipNamesForPhobosM3P[ni])
-						table.remove(playerShipNamesForPhobosM3P,ni)
-					end
-					pobj.shipScore = 19
-					pobj.maxCargo = 10
-					pobj:setWarpDrive(true)
-				elseif tempPlayerType == "Atlantis" then
-					if #playerShipNamesForAtlantis > 0 then
-						ni = math.random(1,#playerShipNamesForAtlantis)
-						pobj:setCallSign(playerShipNamesForAtlantis[ni])
-						table.remove(playerShipNamesForAtlantis,ni)
-					end
-					pobj.shipScore = 52
-					pobj.maxCargo = 6
-				elseif tempPlayerType == "Player Cruiser" then
-					if #playerShipNamesForCruiser > 0 then
-						ni = math.random(1,#playerShipNamesForCruiser)
-						pobj:setCallSign(playerShipNamesForCruiser[ni])
-						table.remove(playerShipNamesForCruiser,ni)
-					end
-					pobj.shipScore = 40
-					pobj.maxCargo = 6
-				elseif tempPlayerType == "Player Missile Cr." then
-					if #playerShipNamesForMissileCruiser > 0 then
-						ni = math.random(1,#playerShipNamesForMissileCruiser)
-						pobj:setCallSign(playerShipNamesForMissileCruiser[ni])
-						table.remove(playerShipNamesForMissileCruiser,ni)
-					end
-					pobj.shipScore = 45
-					pobj.maxCargo = 8
-				elseif tempPlayerType == "Player Fighter" then
-					if #playerShipNamesForFighter > 0 then
-						ni = math.random(1,#playerShipNamesForFighter)
-						pobj:setCallSign(playerShipNamesForFighter[ni])
-						table.remove(playerShipNamesForFighter,ni)
-					end
-					pobj.shipScore = 7
-					pobj.maxCargo = 3
-					pobj.autoCoolant = false
-					pobj:setJumpDrive(true)
-					pobj:setJumpDriveRange(3000,40000)
-				elseif tempPlayerType == "Benedict" then
-					if #playerShipNamesForBenedict > 0 then
-						ni = math.random(1,#playerShipNamesForBenedict)
-						pobj:setCallSign(playerShipNamesForBenedict[ni])
-						table.remove(playerShipNamesForBenedict,ni)
-					end
-					pobj.shipScore = 10
-					pobj.maxCargo = 9
-				elseif tempPlayerType == "Kiriya" then
-					if #playerShipNamesForKiriya > 0 then
-						ni = math.random(1,#playerShipNamesForKiriya)
-						pobj:setCallSign(playerShipNamesForKiriya[ni])
-						table.remove(playerShipNamesForKiriya,ni)
-					end
-					pobj.shipScore = 10
-					pobj.maxCargo = 9
-				elseif tempPlayerType == "Striker" then
-					if #playerShipNamesForStriker > 0 then
-						ni = math.random(1,#playerShipNamesForStriker)
-						pobj:setCallSign(playerShipNamesForStriker[ni])
-						table.remove(playerShipNamesForStriker,ni)
-					end
-					pobj.shipScore = 8
-					pobj.maxCargo = 4
-					pobj:setJumpDrive(true)
-					pobj:setJumpDriveRange(3000,40000)
-				elseif tempPlayerType == "ZX-Lindworm" then
-					if #playerShipNamesForLindworm > 0 then
-						ni = math.random(1,#playerShipNamesForLindworm)
-						pobj:setCallSign(playerShipNamesForLindworm[ni])
-						table.remove(playerShipNamesForLindworm,ni)
-					end
-					pobj.shipScore = 8
-					pobj.maxCargo = 3
-					pobj.autoCoolant = false
-					pobj:setWarpDrive(true)
-				elseif tempPlayerType == "Repulse" then
-					if #playerShipNamesForRepulse > 0 then
-						ni = math.random(1,#playerShipNamesForRepulse)
-						pobj:setCallSign(playerShipNamesForRepulse[ni])
-						table.remove(playerShipNamesForRepulse,ni)
-					end
-					pobj.shipScore = 14
-					pobj.maxCargo = 12
-				elseif tempPlayerType == "Ender" then
-					if #playerShipNamesForEnder > 0 then
-						ni = math.random(1,#playerShipNamesForEnder)
-						pobj:setCallSign(playerShipNamesForEnder[ni])
-						table.remove(playerShipNamesForEnder,ni)
-					end
-					pobj.shipScore = 100
-					pobj.maxCargo = 20
-				elseif tempPlayerType == "Nautilus" then
-					if #playerShipNamesForNautilus > 0 then
-						ni = math.random(1,#playerShipNamesForNautilus)
-						pobj:setCallSign(playerShipNamesForNautilus[ni])
-						table.remove(playerShipNamesForNautilus,ni)
-					end
-					pobj.shipScore = 12
-					pobj.maxCargo = 7
-				elseif tempPlayerType == "Hathcock" then
-					if #playerShipNamesForHathcock > 0 then
-						ni = math.random(1,#playerShipNamesForHathcock)
-						pobj:setCallSign(playerShipNamesForHathcock[ni])
-						table.remove(playerShipNamesForHathcock,ni)
-					end
-					pobj.shipScore = 30
-					pobj.maxCargo = 6
-				else
-					if #playerShipNamesForLeftovers > 0 then
-						ni = math.random(1,#playerShipNamesForLeftovers)
-						pobj:setCallSign(playerShipNamesForLeftovers[ni])
-						table.remove(playerShipNamesForLeftovers,ni)
-					end
-					pobj.shipScore = 24
-					pobj.maxCargo = 5
-					pobj:setWarpDrive(true)
 				end
-				if pobj.cargo == nil then
-					pobj.cargo = pobj.maxCargo
-					pobj.maxRepairCrew = pobj:getRepairCrewCount()
-					pobj.healthyShield = 1.0
-					pobj.prevShield = 1.0
-					pobj.healthyReactor = 1.0
-					pobj.prevReactor = 1.0
-					pobj.healthyManeuver = 1.0
-					pobj.prevManeuver = 1.0
-					pobj.healthyImpulse = 1.0
-					pobj.prevImpulse = 1.0
-					if pobj:getBeamWeaponRange(0) > 0 then
-						pobj.healthyBeam = 1.0
-						pobj.prevBeam = 1.0
+			end
+			if inside_gain_coolant_nebula then
+				if p.get_coolant then
+					if p.coolant_trigger then
+						updateCoolantGivenPlayer(p, delta)
 					end
-					if pobj:getWeaponTubeCount() > 0 then
-						pobj.healthyMissile = 1.0
-						pobj.prevMissile = 1.0
+				else
+					if p:hasPlayerAtPosition("Engineering") then
+						p.get_coolant_button = "get_coolant_button"
+						p:addCustomButton("Engineering",p.get_coolant_button,"Get Coolant",get_coolant_function[pidx])
+						p.get_coolant = true
 					end
-					if pobj:hasWarpDrive() then
-						pobj.healthyWarp = 1.0
-						pobj.prevWarp = 1.0
+					if p:hasPlayerAtPosition("Engineering+") then
+						p.get_coolant_button_plus = "get_coolant_button_plus"
+						p:addCustomButton("Engineering+",p.get_coolant_button_plus,"Get Coolant",get_coolant_function[pidx])
+						p.get_coolant = true
 					end
-					if pobj:hasJumpDrive() then
-						pobj.healthyJump = 1.0
-						pobj.prevJump = 1.0
+				end
+			else
+				p.get_coolant = false
+				p.coolant_trigger = false
+				p.configure_coolant_timer = nil
+				p.deploy_coolant_timer = nil
+				if p:hasPlayerAtPosition("Engineering") then
+					if p.get_coolant_button ~= nil then
+						p:removeCustom(p.get_coolant_button)
+						p.get_coolant_button = nil
+					end
+					if p.gather_coolant ~= nil then
+						p:removeCustom(p.gather_coolant)
+						p.gather_coolant = nil
+					end
+				end
+				if p:hasPlayerAtPosition("Engineering+") then
+					if p.get_coolant_button_plus ~= nil then
+						p:removeCustom(p.get_coolant_button_plus)
+						p.get_coolant_button_plus = nil
+					end
+					if p.gather_coolant_plus ~= nil then
+						p:removeCustom(p.gather_coolant_plus)
+						p.gather_coolant_plus = nil
 					end
 				end
 			end
 		end
 	end
-	setConcurrenetPlayerCount = concurrentPlayerCount
+end
+function updateCoolantGivenPlayer(p, delta)
+	if p.configure_coolant_timer == nil then
+		p.configure_coolant_timer = delta + 5
+	end
+	p.configure_coolant_timer = p.configure_coolant_timer - delta
+	if p.configure_coolant_timer < 0 then
+		if p.deploy_coolant_timer == nil then
+			p.deploy_coolant_timer = delta + 5
+		end
+		p.deploy_coolant_timer = p.deploy_coolant_timer - delta
+		if p.deploy_coolant_timer < 0 then
+			gather_coolant_status = "Gathering Coolant"
+			p:setMaxCoolant(p:getMaxCoolant() + coolant_gain)
+		else
+			gather_coolant_status = string.format("Deploying Collectors %i",math.ceil(p.deploy_coolant_timer - delta))
+		end
+	else
+		gather_coolant_status = string.format("Configuring Collectors %i",math.ceil(p.configure_coolant_timer - delta))
+	end
+	if p:hasPlayerAtPosition("Engineering") then
+		p.gather_coolant = "gather_coolant"
+		p:addCustomInfo("Engineering",p.gather_coolant,gather_coolant_status)
+	end
+	if p:hasPlayerAtPosition("Engineering+") then
+		p.gather_coolant_plus = "gather_coolant_plus"
+		p:addCustomInfo("Engineering",p.gather_coolant_plus,gather_coolant_status)
+	end
+end
+function getCoolantGivenPlayer(p)
+	if p:hasPlayerAtPosition("Engineering") then
+		if p.get_coolant_button ~= nil then
+			p:removeCustom(p.get_coolant_button)
+			p.get_coolant_button = nil
+		end
+	end
+	if p:hasPlayerAtPosition("Engineering+") then
+		if p.get_coolant_button_plus ~= nil then
+			p:removeCustom(p.get_coolant_button_plus)
+			p.get_coolant_button_plus = nil
+		end
+	end
+	p.coolant_trigger = true
+end
+function getCoolant1()
+	local p = getPlayerShip(1)
+	getCoolantGivenPlayer(p)
+end
+function getCoolant2()
+	local p = getPlayerShip(2)
+	getCoolantGivenPlayer(p)
+end
+function getCoolant3()
+	local p = getPlayerShip(3)
+	getCoolantGivenPlayer(p)
+end
+function getCoolant4()
+	local p = getPlayerShip(4)
+	getCoolantGivenPlayer(p)
+end
+function getCoolant5()
+	local p = getPlayerShip(5)
+	getCoolantGivenPlayer(p)
+end
+function getCoolant6()
+	local p = getPlayerShip(6)
+	getCoolantGivenPlayer(p)
+end
+function getCoolant7()
+	local p = getPlayerShip(7)
+	getCoolantGivenPlayer(p)
+end
+function getCoolant8()
+	local p = getPlayerShip(8)
+	getCoolantGivenPlayer(p)
+end
+--		Generate call sign functions
+function generateCallSign(prefix)
+	if prefix == nil then
+		prefix = generateCallSignPrefix()
+	end
+	suffix_index = suffix_index + math.random(1,3)
+	if suffix_index > 999 then 
+		suffix_index = 1
+	end
+	return string.format("%s%i",prefix,suffix_index)
+end
+function generateCallSignPrefix(length)
+	if call_sign_prefix_pool == nil then
+		call_sign_prefix_pool = {}
+		prefix_length = prefix_length + 1
+		if prefix_length > 3 then
+			prefix_length = 1
+		end
+		fillPrefixPool()
+	end
+	if length == nil then
+		length = prefix_length
+	end
+	local prefix_index = 0
+	local prefix = ""
+	for i=1,length do
+		if #call_sign_prefix_pool < 1 then
+			fillPrefixPool()
+		end
+		prefix_index = math.random(1,#call_sign_prefix_pool)
+		prefix = prefix .. call_sign_prefix_pool[prefix_index]
+		table.remove(call_sign_prefix_pool,prefix_index)
+	end
+	return prefix
+end
+function fillPrefixPool()
+	for i=1,26 do
+		table.insert(call_sign_prefix_pool,string.char(i+64))
+	end
 end
 --[[-------------------------------------------------------------------
 	Transport plot 
@@ -6838,10 +7610,10 @@ function randomStation(randomStations)
 	until(randomlySelectedStation ~= nil or stationAttemptCount > 100)
 	return randomlySelectedStation
 end
+function randomNearStation(pool,nobj,partialStationList)
 --pool = number of nearest stations to randomly choose from
 --nobj = named object for comparison purposes
 --partialStationList = list of station to compare against
-function randomNearStation(pool,nobj,partialStationList)
 	local distanceStations = {}
 	local rs = {}
 	local ni
@@ -7002,13 +7774,6 @@ function independentTransportPlot(delta)
 				obj = CpuShip():setTemplate(name):setFaction('Independent'):setCommsScript(""):setCommsFunction(commsShip)
 				obj.target = target
 				obj.undock_delay = irandom(1,4)
-				rifl = math.floor(random(1,#goodsList))	-- random item from list
-				goodsType = goodsList[rifl][1]
-				if goodsType == nil then
-					goodsType = "nickel"
-				end
-				rcoi = math.floor(random(30,90))	-- random cost of item
-				goods[obj] = {{goodsType,1,rcoi}}
 				obj:orderDock(obj.target)
 				x, y = obj.target:getPosition()
 				xd, yd = vectorFromAngle(random(0, 360), random(25000, 40000))
@@ -7085,13 +7850,6 @@ function friendlyTransportPlot(delta)
 				obj = CpuShip():setTemplate(name):setFaction('Human Navy'):setCommsScript(""):setCommsFunction(commsShip)
 				obj.target = target
 				obj.undock_delay = irandom(1,4)
-				local rifl = math.floor(random(1,#goodsList))	-- random item from list
-				goodsType = goodsList[rifl][1]
-				if goodsType == nil then
-					goodsType = "nickel"
-				end
-				local rcoi = math.floor(random(30,90))	-- random cost of item
-				goods[obj] = {{goodsType,fSize,rcoi}}
 				obj:orderDock(obj.target)
 				x, y = obj.target:getPosition()
 				xd, yd = vectorFromAngle(random(0, 360), random(25000, 40000))
@@ -7431,8 +8189,10 @@ function vengence(delta)
 		if availableVengenceCount > 0 then
 			if plot3diagnostic then print("fleets available") end
 			local vengenceFleet = nil
+			local edfi = 0
 			repeat
-				local candidate = enemyDefensiveFleetList[math.random(1,#enemyDefensiveFleetList)]
+				edfi = math.random(1,#enemyDefensiveFleetList)
+				local candidate = enemyDefensiveFleetList[edfi]
 				local availableVengence = true
 				for _, enemy in ipairs(candidate) do
 					if enemy ~= nil and enemy:isValid() and enemy.vengence then
@@ -7444,6 +8204,7 @@ function vengence(delta)
 					vengenceFleet = candidate
 				end
 			until(vengenceFleet ~= nil)
+			intelGatherArtifacts[edfi]:setDescriptions("Scan to gather intelligence",string.format("Enemy fleet in sector %s is on the move",intelGatherArtifacts[edfi].startSector))
 			for _, enemy in ipairs(vengenceFleet) do
 				if enemy ~= nil and enemy:isValid() then
 					enemy:orderRoaming()
@@ -7912,11 +8673,11 @@ function spawnFighterFleet(originX, originY, fighterCount, faction)
 end
 function spawnJammerFleet(originX, originY)
 	faction = "Kraylor"
-	local shipSpawnCount = 2
+	local shipSpawnCount = 3
 	if difficulty < 1 then
-		shipSpawnCount = 1
+		shipSpawnCount = 2
 	elseif difficulty > 1 then
-		shipSpawnCount = 3
+		shipSpawnCount = 4
 	end
 	--Ship Template Name List
 	local jammerNames  = {"MT52 Hornet","MU52 Hornet","Adder MK5","Adder MK4","WX-Lindworm","Adder MK6","Phobos T3","Phobos M3","Piranha F8","Piranha F12","Fighter","Ktlitan Fighter","Ktlitan Drone","Ktlitan Scout"}
@@ -8174,6 +8935,176 @@ function enemyBorderCheck(delta)
 	end
 end
 --[[-----------------------------------------------------------------
+    Plot ER enemy reinforcements
+-----------------------------------------------------------------]]--
+function enemyReinforcements(delta)
+	if #enemyReinforcementSchedule > 0 then
+		if enemyReinforcementTimer == nil then
+			enemyReinforcementTimer = delta + enemyReinforcementSchedule[1][1]*60 + ersAdj*60 + random(1,100)
+		else
+			enemyReinforcementTimer = enemyReinforcementTimer - delta
+			if enemyReinforcementTimer < 0 then
+				local ta = VisualAsteroid():setPosition(kraylorCentroidX,kraylorCentroidY)
+				local p = closestPlayerTo(ta)
+				ta:destroy()
+				if p == nil then
+					for pidx=1,8 do
+						p = getPlayerShip(pidx)
+						if p ~= nil and p:isValid() then
+							break
+						end
+					end
+				end
+				if p ~= nil then
+					local dirx, diry = vectorFromAngle(random(0,360),random(15000,25000))
+					local fpx, fpy = p:getPosition()
+					local tempFleet = spawnEnemies(fpx+dirx,fpy+diry,enemyReinforcementSchedule[1][2],"Kraylor")
+					for _, enemy in ipairs(tempFleet) do
+						enemy:orderAttack(p)
+					end
+					table.insert(enemyFleetList,tempFleet)
+					table.remove(enemyReinforcementSchedule,1)
+				end
+				enemyReinforcementTimer = nil
+			end
+		end
+	end
+end
+--[[-----------------------------------------------------------------
+    Plot MF muck and flies
+-----------------------------------------------------------------]]--
+function muckAndFlies(delta)
+	if muckFlyCounter == nil then
+		muckFlyCounter = difficulty*2 + 2
+	end
+	if muckFlyTimer == nil then
+--		muckFlyTimer = 10
+		muckFlyTimer = delta + 400 - difficulty * 90 + random(1,200)	--final: 400, 90 and 200
+	end
+	muckFlyTimer = muckFlyTimer - delta
+	if muckFlyTimer < 0 then
+		if treaty and treatyTimer > 0 then
+			muckFlyTimer = delta + 800 - difficulty * 90 + random(1,200)	--final: 800, 90 and 200
+			return
+		end
+		local victimList = {}
+		for pidx=1,8 do
+			p = getPlayerShip(pidx)
+			if p ~= nil and p:isValid() then
+				table.insert(victimList,p)
+			end
+		end
+		if #victimList > 0 then
+			local p = victimList[math.random(1,#victimList)]
+			local px, py = p:getPosition()
+			local jamAngle = random(0,360)
+			local jamDistance = random(6000,10000)
+			local jx, jy = vectorFromAngle(jamAngle,jamDistance)
+			muck = WarpJammer():setRange(jamDistance*2):setPosition(px+jx,py+jy):setFaction("Kraylor"):onDestruction(armoredWarpJammer)
+			muck.jamRange = jamDistance*2
+			if difficulty < 1 then
+				muck.lifeCount = 0
+			elseif difficulty > 1 then
+				muck.lifeCount = 2
+			else
+				muck.lifeCount = 1
+			end
+			local flies = {}
+			local flyCount = 2 * difficulty + math.random(1,3)
+			for i=1,flyCount do
+				local ship = CpuShip():setFaction("Kraylor"):setTemplate("Ktlitan Drone"):setPosition(px+jx,py+jy):orderDefendLocation(px+jx,py+jy):onDestruction(enemyVesselDestroyed):setCommsScript(""):setCommsFunction(commsShip)
+				ship:setCallSign(string.format("F%s%i%i",string.char(math.random(65,90)),muckFlyCounter,i))
+				table.insert(flies,ship)
+				rawKraylorShipStrength = rawKraylorShipStrength + 4
+			end
+			table.insert(enemyFleetList,flies)
+			local stx, sty = vectorFromAngle(jamAngle,jamDistance * .7)
+			local playerShipScore = 24
+			if p.shipScore ~= nil then
+				playerShipScore = p.ShipScore
+			end
+			local stench = spawnEnemies(px+stx,py+sty,1,"Kraylor",playerShipScore)
+			for i, enemy in ipairs(stench) do
+				enemy:orderAttack(p):setCallSign(string.format("MS%s%i%i",string.char(math.random(65,90)),i,muckFlyCounter))
+			end
+			table.insert(enemyFleetList,stench)
+			if difficulty >= 1 then
+				local attemptCount = 0
+				local validCandidate = false
+				local candidate = nil
+				repeat 
+					candidate = humanStationList[math.random(1,#humanStationList)]
+					attemptCount = attemptCount + 1
+					if candidate ~= nil then
+						if candidate:isValid() then
+							if distance(candidate,px+jx,py+jy) > (jamDistance*3 + 10000) then
+								validCandidate = true
+							end
+						end
+					end
+				until(validCandidate or attemptCount > repeatExitBoundary)
+				if validCandidate then
+					local dix, diy = candidate:getPosition()
+					if dix ~= nil then
+						local tempFleet = spawnEnemies(dix+500,diy+500,1,"Kraylor")
+						for i, enemy in ipairs(tempFleet) do
+							enemy:setCallSign(string.format("D%s%i%i",string.char(math.random(65,90)),muckFlyCounter,i))
+						end
+						table.insert(enemyFleetList,tempFleet)
+					end
+				end
+			end
+			if difficulty > 1 then
+				attemptCount = 0
+				validCandidate = false
+				repeat 
+					candidate = humanStationList[math.random(1,#humanStationList)]
+					attemptCount = attemptCount + 1
+					if candidate ~= nil then
+						if candidate:isValid() then
+							if distance(candidate,px+jx,py+jy) > (jamDistance*3 + 10000) then
+								validCandidate = true
+							end
+						end
+					end
+				until(validCandidate or attemptCount > repeatExitBoundary)
+				if validCandidate then
+					local dix, diy = candidate:getPosition()
+					if dix ~= nil then
+						local tempFleet = spawnEnemies(dix+500,diy+500,1,"Kraylor")
+						for i, enemy in ipairs(tempFleet) do
+							enemy:setCallSign(string.format("D%s%i%i",string.char(math.random(65,90)),muckFlyCounter,i))
+						end
+						table.insert(enemyFleetList,tempFleet)
+					end
+				end
+			end
+		end
+		muckFlyCounter = muckFlyCounter - 1
+		if muckFlyCounter <= 0 then
+			plotMF = nil
+		else
+			muckFlyTimer = nil
+		end
+	end
+end
+function armoredWarpJammer(self, instigator)
+	if self.lifeCount < 1 then
+		return
+	end
+	local tempx, tempy = self:getPosition()
+	local redoMuck = WarpJammer():setRange(self.jamRange):setPosition(tempx,tempy):setFaction("Kraylor"):onDestruction(armoredWarpJammer)
+	redoMuck.jamRange = self.jamRange
+	redoMuck.lifeCount = self.lifeCount - 1
+	if difficulty < 1 then
+		instigator:setHull(instigator:getHull()*.9)
+	elseif difficulty > 1 then
+		instigator:setHull(instigator:getHull()*.7)
+	else
+		instigator:setHull(instigator:getHull()*.8)
+	end
+end
+--[[-----------------------------------------------------------------
     Dynamic game master buttons
 -----------------------------------------------------------------]]--
 function dynamicGameMasterButtons(delta)
@@ -8230,7 +9161,7 @@ function fullWarByGM()
 	GMFullWar = nil
 end
 --[[-----------------------------------------------------------------
-    Plot end of war checks
+    Plot end of war checks and functions
 -----------------------------------------------------------------]]--
 function endWar(delta)
 	endWarTimer = endWarTimer - delta
@@ -8522,8 +9453,8 @@ function stationStatus()
 	local npct2 = neutralSurvivedValue/originalNeutralStationValue*100
 	return friendlySurvivedCount, friendlySurvivedValue, fpct1, fpct2, enemySurvivedCount, enemySurvivedValue, epct1, epct2, neutralSurvivedCount, neutralSurvivedValue, npct1, npct2
 end
---final page for victory or defeat on main streen
 function endStatistics()
+--final page for victory or defeat on main streen
 	if endStatDiagnostic then print("starting end statistics") end
 	friendlySurvivedCount, friendlySurvivedValue, fpct1, fpct2, enemySurvivedCount, enemySurvivedValue, epct1, epct2, neutralSurvivedCount, neutralSurvivedValue, npct1, npct2, friendlyShipSurvivedValue, fpct, enemyShipSurvivedValue, epct = listStatuses()
 	if friendlySurvivedCount == nil then
@@ -8551,9 +9482,11 @@ function endStatistics()
 	local friendlyShipComponent = friendlyShipSurvivedValue/rawHumanShipStrength
 	local enemyShipComponent = 1-enemyShipSurvivedValue/rawKraylorShipStrength
 	local evalFriendly = fpct2*friendlyStationComponentWeight + npct2*neutralStationComponentWeight + fpct*friendlyShipComponentWeight
-	gMsg = gMsg .. string.format("Friendly evaluation strength: %.1f%%, weights: friendly station: %.1f, neutral station: %.1f, friendly ship: %.1f\n",evalFriendly, friendlyStationComponentWeight, neutralStationComponentWeight, friendlyShipComponentWeight)
+	gMsg = gMsg .. string.format("Friendly evaluation strength: %.1f%%\n",evalFriendly)
+	gMsg = gMsg .. string.format("   Weights: friendly station: %.2f, neutral station: %.2f, friendly ship: %.2f\n", friendlyStationComponentWeight, neutralStationComponentWeight, friendlyShipComponentWeight)
 	local evalEnemy = epct2*enemyStationComponentWeight + epct*enemyShipComponentWeight
-	gMsg = gMsg .. string.format("Enemy evaluation strength: %.1f%%, weights: enemy station: %.1f, enemy ship: %.1f\n",evalEnemy, enemyStationComponentWeight, enemyShipComponentWeight)
+	gMsg = gMsg .. string.format("Enemy evaluation strength: %.1f%%\n",evalEnemy)
+	gMsg = gMsg .. string.format("   Weights: enemy station: %.2f, enemy ship: %.2f\n", enemyStationComponentWeight, enemyShipComponentWeight)
 	local rankVal = friendlyStationComponent*.4 + friendlyShipComponent*.2 + enemyStationComponent*.2 + enemyShipComponent*.1 + neutralStationComponent*.1 
 	if endStatDiagnostic then print("calculated ranking stats") end
 	if endStatDiagnostic then print("rank value: " .. rankVal) end
@@ -8615,96 +9548,108 @@ function update(delta)
 		setPlayers()
 		return
 	end
-	if updateDiagnostic then print("plot1") end
+	setPlayers()
+--	if updateDiagnostic then print("plot1") end
 	if plot1 ~= nil then	--war/peace
 		plot1(delta)
 	end
-	if updateDiagnostic then print("plot2") end
+--	if updateDiagnostic then print("plot2") end
 	if plot2 ~= nil then	--timed game
 		plot2(delta)
 	end
-	if updateDiagnostic then print("plotEW") end
+--	if updateDiagnostic then print("plotEW") end
 	if plotEW ~= nil then	--end war checks
 		plotEW(delta)
 	end
-	if updateDiagnostic then print("plotPB") end
+--	if updateDiagnostic then print("plotPB") end
 	if plotPB ~= nil then	--player border
 		plotPB(delta)
 	end
-	if updateDiagnostic then print("plotPWC") end
+--	if updateDiagnostic then print("plotPWC") end
 	if plotPWC ~= nil then	--player war crime check
 		plotPWC(delta)
 	end
-	if updateDiagnostic then print("plotED") end
+--	if updateDiagnostic then print("plotED") end
 	if plotED ~= nil then	--enemy defense
 		plotED(delta)
 	end
-	if updateDiagnostic then print("plotDZ") end
+--	if updateDiagnostic then print("plotDZ") end
 	if plotDZ ~= nil then	--enemy defense zone
 		plotDZ(delta)
 	end
-	if updateDiagnostic then print("plotExpTrans") end
+--	if updateDiagnostic then print("plotExpTrans") end
 	if plotExpTrans ~= nil then		--exploding transport
 		plotExpTrans(delta)
 	end
-	if updateDiagnostic then print("plotAW") end
+--	if updateDiagnostic then print("plotAW") end
 	if plotAW ~= nil then	--artifact to worm
 		plotAW(delta)
 	end
-	if updateDiagnostic then print("plotWJ") end
+--	if updateDiagnostic then print("plotWJ") end
 	if plotWJ ~= nil then	--artifact to worm
 		plotWJ(delta)
 	end
-	if updateDiagnostic then print("plotAM") end
+--	if updateDiagnostic then print("plotAM") end
 	if plotAM ~= nil then	--artifact to mine
 		plotAM(delta)
 	end
-	if updateDiagnostic then print("plotWP") end
+--	if updateDiagnostic then print("plotWP") end
 	if plotWP ~= nil then	--weapons platform
 		plotWP(delta)
 	end
-	if updateDiagnostic then print("plotWPO") end
+--	if updateDiagnostic then print("plotWPO") end
 	if plotWPO ~= nil then	--weapons platform orbit
 		plotWPO(delta)
 	end
-	if updateDiagnostic then print("plotH") end
+--	if updateDiagnostic then print("plotH") end
 	if plotH ~= nil then	--health
 		plotH(delta)
 	end
-	if updateDiagnostic then print("plot3") end
+--	if updateDiagnostic then print("plot3") end
 	if plot3 ~= nil then	--kraylor attacks
 		plot3(delta)
 	end
-	if updateDiagnostic then print("plotFT") end
+--	if updateDiagnostic then print("plotFT") end
 	if plotFT ~= nil then	--friendly transport plot
 		plotFT(delta)
 	end
-	if updateDiagnostic then print("plotIT") end
+--	if updateDiagnostic then print("plotIT") end
 	if plotIT ~= nil then	--independent transport plot
 		plotIT(delta)
 	end
-	if updateDiagnostic then print("plotKT") end
+--	if updateDiagnostic then print("plotKT") end
 	if plotKT ~= nil then	--kraylor transport plot
 		plotKT(delta)
 	end
-	if updateDiagnostic then print("plotEB") end
+--	if updateDiagnostic then print("plotEB") end
 	if plotEB ~= nil then	--enemy border
 		plotEB(delta)
 	end
-	if updateDiagnostic then print("plotPA") end
+--	if updateDiagnostic then print("plotPA") end
 	if plotPA ~= nil then	--personal ambush
 		plotPA(delta)
 	end
-	if updateDiagnostic then print("plotCI") end
-	if plotCI ~= nil then	--coolant automation for fighters
+--	if updateDiagnostic then print("plotCI") end
+	if plotCI ~= nil then	--cargo inventory
 		plotCI(delta)
 	end
-	if updateDiagnostic then print("plotC") end
+--	if updateDiagnostic then print("plotC") end
 	if plotC ~= nil then	--coolant automation for fighters
 		plotC(delta)
 	end
-	if updateDiagnostic then print("plotDGM") end
-	if plotDGM ~= nil then
+--	if updateDiagnostic then print("plotDGM") end
+	if plotDGM ~= nil then	--dynamic GM buttons
 		plotDGM(delta)
+	end
+--	if updateDiagnostic then print("plotER") end
+	if plotER ~= nil then	--enemy resupply
+		plotER(delta)
+	end
+--	if updateDiagnostic then print("plotMF") end
+	if plotMF ~= nil then	--muck and flies
+		plotMF(delta)
+	end
+	if plotCN ~= nil then	--coolant via nebula
+		plotCN(delta)
 	end
 end


### PR DESCRIPTION
Things changed/added:
- Call sign generation functions
- Simplified goods handling
- Additional Kraylor strategies
- Coolant variances
- Several player ship options via GM buttons
- Simplified player ship characteristic handling
- Inventory button for Relay
- More closely followed comms data for station paradigm demonstrated in default comms script
- Localized variables for tuning purposes
- Added intelligence gathering sensor buoys
- Hard variation does not get free upgrades until total war declared
- Fixed bug where beams were broken after "upgrade"
- Coolant may be obtained at station (sometimes)
- Change references to variable player to comms_source in communications functions
- Simple ship upgrade data available remotely (sometimes)
- Goods information in the area available without having to "check back later"
- Added defensive fleet group commands once fleet directive authority granted
- Goods purchasable from certain freighters
