### PR TITLE
Fix missing radar traces

### DIFF
--- a/scripts/shipTemplates_Frigates.lua
+++ b/scripts/shipTemplates_Frigates.lua
@@ -12,6 +12,7 @@ They are divided in 3 different sub-classes:
 * Support: Support types come in many variaties. They are simply a frigate hull fitted with whatever was needed. Anything from mine-layers to science vessels.
 ----------------------------------------------------------]]
 template = ShipTemplate():setName("Phobos T3"):setClass("Frigate", "Cruiser"):setModel("AtlasHeavyFighterYellow")
+template:setRadarTrace("radar_cruiser.png")
 template:setDescription([[The Phobos T3, just like the Atlantis, is the workhorse of almost any navy. It's extremely easy to modify, which makes retro-fitting this ship a breeze. Its basic stats aren't impressive, but due to its modular nature, it's fairly easy to produce in large quantities.]])
 template:setHull(70)
 template:setShields(50, 40)
@@ -79,6 +80,7 @@ variation:addDoor(8, 4, false);
 --variation:addDoor(2, 5, false);
 
 template = ShipTemplate():setName("Nirvana R5"):setClass("Frigate", "Cruiser: Anti-fighter"):setModel("small_frigate_5") -- TODO: Better 3D model selection
+template:setRadarTrace("radar_cruiser.png")
 template:setDescription([[The Nirvana R5 is an anti-fighter cruiser. It has several rapid-firing, low-damage point-defense weapons to quickly take out starfighters.]])
 template:setBeamWeapon(0, 90, -15, 1200, 3, 1)
 template:setBeamWeapon(1, 90,  15, 1200, 3, 1)
@@ -97,6 +99,7 @@ variation:setBeamWeapon(3, 90, -50, 1200, 2.9, 1)
 variation:setSpeed(70, 15, 10)
 
 template = ShipTemplate():setName("Storm"):setClass("Frigate", "Cruiser: Heavy Artillery"):setModel("HeavyCorvetteYellow")	--Yellow, Green, Blue, White, Red
+template:setRadarTrace("radar_cruiser.png")
 template:setDescription([[A heavy artillery cruiser, the Storm fires bunches of missiles from forward facing tubes.]])
 template:setBeamWeapon(0, 60, 0, 1200, 3, 2)
 template:setHull(50)
@@ -112,7 +115,7 @@ template:setTubeDirection(3, -2)
 template:setTubeDirection(4,  2)
 template:setDefaultAI('missilevolley')
 
-template = ShipTemplate():setName("Hathcock"):setClass("Frigate", "Sniper"):setModel("HeavyCorvetteGreen"):setType("playership")
+template = ShipTemplate():setName("Hathcock"):setClass("Frigate", "Cruiser: Sniper"):setModel("HeavyCorvetteGreen"):setType("playership")
 template:setDescription("Long range narrow beam and some point defense beams, broadside missiles. Agile for a frigate")
 --						Arc, Dir, Range, CycleTime, Dmg
 template:setBeamWeapon(0, 4,   0, 1400.0, 6.0, 4)
@@ -158,6 +161,7 @@ template:addDoor( 5, 1, false)
 
 
 template = ShipTemplate():setName("Piranha F12"):setClass("Frigate", "Cruiser: Light Artillery"):setModel("HeavyCorvetteRed")
+template:setRadarTrace("radar_cruiser.png")
 template:setDescription([[A light artillery cruiser, the Piranha F12 is the smallest ship to exclusively fire from broadside weapon tubes.]])
 template:setHull(70)
 template:setShields(30, 30)
@@ -250,6 +254,7 @@ variation:addDoor(7, 3, false)
 
 --Cruiser: strike craft (fast in/out)
 template = ShipTemplate():setName("Stalker Q7"):setClass("Frigate", "Cruiser: Strike ship"):setModel("small_frigate_3")
+template:setRadarTrace("radar_cruiser.png")
 template:setDescription([[The Stalker is a strike ship designed to swoop into battle, deal damage quickly, and get out fast. The Q7 model is fitted with a warp drive.]])
 template:setHull(50)
 template:setShields(80, 30, 30, 30)
@@ -264,6 +269,7 @@ variation:setWarpSpeed(0)
 variation:setJumpDrive(true)
 
 template = ShipTemplate():setName("Ranus U"):setClass("Frigate", "Cruiser: Sniper"):setModel("MissileCorvetteGreen")
+template:setRadarTrace("radar_cruiser.png")
 template:setDescription([[The Ranus U sniper is built to deal a large amounts of damage quickly and from a distance before escaping. It's the only basic frigate that carries nuclear weapons, even though it's also the smallest of all frigate-class ships.]])
 template:setHull(30)
 template:setShields(30, 5, 5)

--- a/scripts/shipTemplates_StarFighters.lua
+++ b/scripts/shipTemplates_StarFighters.lua
@@ -62,7 +62,7 @@ variation:addDoor(5, 1, false);
 variation:addDoor(5, 2, false);
 
 template = ShipTemplate():setName("Adder MK5"):setClass("Starfighter", "Gunship"):setModel("AdlerLongRangeScoutYellow")
-template:setRadarTrace("radar_cruiser.png")
+template:setRadarTrace("radar_fighter.png")
 template:setDescription([[The Adder line's fifth iteration proved to be a great success among pirates and law officers alike. It is cheap, fast, and easy to maintain, and it packs a decent punch.]])
 template:setHull(50)
 template:setShields(30)


### PR DESCRIPTION
As of now, some ships don't have any radar traces, basically of the cruiser subtype. This can lead to confusing situations like "is this red arrow a scanned cruiser or an unidentified ship that turned out  to be hostile?"

Curiously, there is already an existing cruiser radar trace, but rarely used.

This PR adds the cruiser radar trace to all ships that don't have one yet. It also changes the radar from the adder ships (I don't see a reason why they have cruiser traces, as they don't differ that much from other starfighters)

Note: 
This PR adresses the same issues as #640 but in a simpler way, as it seems that one is not going to be merged. So it can be seen as an alternative PR. Or as an intermediate one, so if you plan to merge #640 at a later point, I'm fine if my changes will be overwritten.