### PR TITLE
Fix Hue lights unresponsiveness when using multiple bulbs, and add Transition between states

### DIFF
--- a/src/hardware/devices/philipsHueDevice.cpp
+++ b/src/hardware/devices/philipsHueDevice.cpp
@@ -171,22 +171,23 @@ bool PhilipsHueDevice::configure(std::unordered_map<string, string> settings)
 
 void PhilipsHueDevice::setChannelData(int channel, float value)
 {
-    int light_idx = channel / 3;
+    int light_idx = channel / 4;
     if (light_idx < 0 || light_idx >= light_count)
         return;
 
     sf::Lock lock(mutex);
-    switch(channel % 3)
+    switch(channel % 4)
     {
     case 0: if (lights[light_idx].brightness != value * 254) lights[light_idx].dirty = true; lights[light_idx].brightness = value * 254; break;
     case 1: if (lights[light_idx].saturation != value * 254) lights[light_idx].dirty = true; lights[light_idx].saturation = value * 254; break;
     case 2: if (lights[light_idx].hue != value * 65535) lights[light_idx].dirty = true; lights[light_idx].hue = value * 65535; break;
+    case 3: if (lights[light_idx].transitiontime != value) lights[light_idx].dirty = true; lights[light_idx].transitiontime = value; break;
     }
 }
 
 int PhilipsHueDevice::getChannelCount()
 {
-    return light_count * 3;
+    return light_count * 4;
 }
 
 void PhilipsHueDevice::updateLoop()
@@ -206,15 +207,19 @@ void PhilipsHueDevice::updateLoop()
                     info = lights[n];
                 }
                 string post_data;
-                if (info.brightness > 0)
-                    post_data = "{\"on\":true, \"sat\":"+string(info.saturation)+", \"bri\":"+string(info.brightness)+",\"hue\":"+string(info.hue)+", \"transitiontime\": 0}";
-                else
-                    post_data = "{\"on\":false, \"transitiontime\": 0}";
-                sf::Http::Response response = http.sendRequest(sf::Http::Request("/api/" + username + "/lights/" + string(n + 1) + "/state", sf::Http::Request::Put, post_data));
-                if (response.getStatus() != sf::Http::Response::Ok)
+                if (info.laststate != "sat-" + string(info.saturation) + "-bri-" + string(info.brightness) + "-hue-" + string(info.hue) + "-transition-" + string(info.transitiontime))
                 {
-                    LOG(WARNING) << "Failed to set light [" << (n + 1) << "] philips hue bridge: " << response.getStatus();
-                    LOG(WARNING) << response.getBody();
+                    lights[n].laststate = "sat-" + string(info.saturation) + "-bri-" + string(info.brightness) + "-hue-" + string(info.hue) + "-transition-" + string(info.transitiontime);
+                    if (info.brightness > 0)
+                        post_data = "{\"on\":true, \"sat\":"+string(info.saturation)+", \"bri\":"+string(info.brightness)+",\"hue\":"+string(info.hue)+", \"transitiontime\": "+string(info.transitiontime)+"}";
+                    else
+                        post_data = "{\"on\":false, \"transitiontime\": "+string(info.transitiontime)+"}";
+                    sf::Http::Response response = http.sendRequest(sf::Http::Request("/api/" + username + "/lights/" + string(n + 1) + "/state", sf::Http::Request::Put, post_data));
+                    if (response.getStatus() != sf::Http::Response::Ok)
+                    {
+                        LOG(WARNING) << "Failed to set light [" << (n + 1) << "] philips hue bridge: " << response.getStatus();
+                        LOG(WARNING) << response.getBody();
+                    }
                 }
             }
         }

--- a/src/hardware/devices/philipsHueDevice.h
+++ b/src/hardware/devices/philipsHueDevice.h
@@ -9,12 +9,13 @@
 //The PhilipsHueDevice talks to a philips hue bridge.
 //Documentation of the philips hue API is at:
 //  https://www.developers.meethue.com/documentation/getting-started
-//The PhilipsHueDevice device creates 3 channels for each connected light.
-//So the amount of available channels is amount of lights x3.
+//The PhilipsHueDevice device creates 4 channels for each connected light.
+//So the amount of available channels is amount of lights x4.
 //The channels are:
 // Brightness
 // Saturation
 // Hue
+// Transition Time
 class PhilipsHueDevice : public HardwareOutputDevice
 {
 public:
@@ -37,12 +38,14 @@ private:
     class LightInfo
     {
     public:
-        LightInfo() : dirty(true), brightness(0), saturation(0), hue(0) {}
+        LightInfo() : dirty(true), brightness(0), saturation(0), hue(0), transitiontime(0), laststate(0) {}
     
         bool dirty;
         int brightness;
         int saturation;
         int hue;
+        int transitiontime;
+        string laststate;
     };
 
     sf::Thread update_thread;


### PR DESCRIPTION
**Changes**
This also adds caching for light state (transitiontime, brightness, saturation, hue) and only makes a request to the Hue hub when the lights change status. This is to allow lights to be more responsive when a change is actually needed. 
It also adds a 4th channel for Hue Transitions, which is useful to fade multiple lights from one state to another so the Hue update delay per light is unnoticeable. Without this, using multiple lights is uncomfortable.
**Stability**
This has been tested on Ubuntu 18.04 LTS, I built it from sources. I did a whole 90 minute game with friends and it worked as expected. I also tested it outside of this. It also worked on another Debian-based Distribution. I have not tested this on Windows, but these changes shouldn't affect the Windows build any differently.

Please let me know if any of my code is not to convention.