### PR TITLE
Log planet radius to game state log

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@
 ### Added
 
 - `SpaceShip:setScanState()` and `setScanStateByFaction()` scripting functions.
+- `Planet:getPlanetRadius()` scripting function.
+- Log planet radius to the game state log and render it in the viewer.
 
 ### Changed
 

--- a/logs/index.html
+++ b/logs/index.html
@@ -429,6 +429,10 @@
                         {
                             this.drawCircle(ctx, x, y, this._zoom_scale, "#FFC864", 1.0, 1)
                         }
+                        else if (entry.type == "Planet")
+                        {
+                            this.drawCircle(ctx, x, y, this._zoom_scale, "#00A", 1.0, Math.floor(entry["planet_radius"] / 20))
+                        }
                         else if (entry.type == "ScanProbe")
                         {
                             // Draw probe scan radius.

--- a/src/gameStateLogger.cpp
+++ b/src/gameStateLogger.cpp
@@ -272,7 +272,13 @@ void GameStateLogger::writeObjectEntry(JSONGenerator& json, P<SpaceObject> obj)
         if (station)
         {
             writeStationEntry(json, station);
-        }
+        }else{
+            P<Planet> planet = obj;
+            if (planet)
+            {
+                writePlanetEntry(json, planet);
+            }
+	}
     }
 }
 

--- a/src/gameStateLogger.cpp
+++ b/src/gameStateLogger.cpp
@@ -11,6 +11,7 @@
 #include "spaceObjects/blackHole.h"
 #include "spaceObjects/nebula.h"
 #include "spaceObjects/spaceship.h"
+#include "spaceObjects/planet.h"
 
 class JSONGenerator
 {
@@ -166,7 +167,7 @@ void GameStateLogger::update(float delta)
    The state entry looke like:
     {
         "type": "state",
-        "time": game time passed sinds start of logging,
+        "time": game time passed since start of logging,
         "new_static": [ list of object entries that are not likely to change, and only send once ],
         "objects": [ list of updated objects, this can include objects that have been created by new_static before ],
         "del_static": [ list of ids that have been added with "new_static" in a previous entry, but have been destroyed now ]
@@ -251,6 +252,8 @@ bool GameStateLogger::isStatic(P<SpaceObject> obj)
         return true;
     if (P<Mine>(obj))
         return true;
+    if (P<Planet>(obj))
+        return true;
     return false;
 }
 
@@ -281,7 +284,6 @@ void GameStateLogger::writeObjectEntry(JSONGenerator& json, P<SpaceObject> obj)
 	}
     }
 }
-
 
 void GameStateLogger::writeShipEntry(JSONGenerator& json, P<SpaceShip> ship)
 {
@@ -508,4 +510,9 @@ void GameStateLogger::writeStationEntry(JSONGenerator& json, P<SpaceStation> sta
             config.endArray();
         }
     }
+}
+
+void GameStateLogger::writePlanetEntry(JSONGenerator& json, P<Planet> planet)
+{
+    json.write("planet_radius", planet->getPlanetRadius());
 }

--- a/src/gameStateLogger.h
+++ b/src/gameStateLogger.h
@@ -6,11 +6,12 @@
 class SpaceObject;
 class SpaceShip;
 class SpaceStation;
+class Planet;
 class JSONGenerator;
 /*
  * The GameStateLogger logs the current state of the game to a log file.
  * It does this every X seconds.
- * This logged data can be used to analize the game afterwards.
+ * This logged data can be used to analyze the game afterwards.
  *
  * The resulting log contains 2 types of records:
  * 1) Periodic game data, update of all the objects in the game with all states.
@@ -39,6 +40,7 @@ private:
     void writeObjectEntry(JSONGenerator& json, P<SpaceObject> obj);
     void writeShipEntry(JSONGenerator& json, P<SpaceShip> obj);
     void writeStationEntry(JSONGenerator& json, P<SpaceStation> obj);
+    void writePlanetEntry(JSONGenerator& json, P<Planet> obj);
 };
 
 #endif//GAME_STATE_LOGGER_H

--- a/src/spaceObjects/planet.cpp
+++ b/src/spaceObjects/planet.cpp
@@ -97,6 +97,7 @@ REGISTER_SCRIPT_SUBCLASS(Planet, SpaceObject)
     REGISTER_SCRIPT_CLASS_FUNCTION(Planet, setPlanetAtmosphereTexture);
     REGISTER_SCRIPT_CLASS_FUNCTION(Planet, setPlanetSurfaceTexture);
     REGISTER_SCRIPT_CLASS_FUNCTION(Planet, setPlanetCloudTexture);
+    REGISTER_SCRIPT_CLASS_FUNCTION(Planet, getPlanetRadius);
     REGISTER_SCRIPT_CLASS_FUNCTION(Planet, setPlanetRadius);
     REGISTER_SCRIPT_CLASS_FUNCTION(Planet, setPlanetCloudRadius);
     REGISTER_SCRIPT_CLASS_FUNCTION(Planet, setDistanceFromMovementPlane);
@@ -158,6 +159,11 @@ void Planet::setPlanetSurfaceTexture(string texture_name)
 void Planet::setPlanetCloudTexture(string texture_name)
 {
     cloud_texture = texture_name;
+}
+
+float Planet::getPlanetRadius()
+{
+    return planet_size;
 }
 
 void Planet::setPlanetRadius(float size)

--- a/src/spaceObjects/planet.h
+++ b/src/spaceObjects/planet.h
@@ -20,6 +20,8 @@ public:
     virtual void collide(Collisionable* target, float force) override;
     virtual bool canHideInNebula()  override { return false; }
     
+    float getPlanetRadius();
+
     void setPlanetAtmosphereColor(float r, float g, float b);
     void setPlanetAtmosphereTexture(string texture_name);
     void setPlanetSurfaceTexture(string texture_name);
@@ -53,5 +55,5 @@ private:
     void updateCollisionSize();
 };
 
-#endif//WORM_HOLE_H
+#endif//PLANET_H
 


### PR DESCRIPTION
- Add a getPlanetRadius function to return the value, and also exposes it for scripting.
- Recognize Planets in the game state logger and log their radius.
- Render the radius in the game state viewer. This renders planets that are not on the same plane as the players (ie. cosmetic Planet objects, like the moon in the Empty scenario) that do _not_ appear in crew radars.

![screenshot](https://user-images.githubusercontent.com/19192104/71887815-b3cd8c00-30f3-11ea-90a2-888ebf0ed7d9.png)
