### PR TITLE
Allow setting custom master registry server URLs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@
 
 - _Shoreline_ scenario refactored to fix errors.
 - Add planet radius to GM screen scripting exports.
+- Added `registry_registration_url` and `registry_list_url` to optionally use a
+  custom Internet master registry server. Only `http://` URLs are allowed.
 
 ### Fixed
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -323,7 +323,7 @@ void returnToMainMenu()
         new EpsilonServer();
         if (PreferencesManager::get("headless_name") != "") game_server->setServerName(PreferencesManager::get("headless_name"));
         if (PreferencesManager::get("headless_password") != "") game_server->setPassword(PreferencesManager::get("headless_password"));
-        if (PreferencesManager::get("headless_internet") == "1") game_server->registerOnMasterServer("http://daid.eu/ee/register.php");
+        if (PreferencesManager::get("headless_internet") == "1") game_server->registerOnMasterServer(PreferencesManager::get("registry_registration_url", "http://daid.eu/ee/register.php"));
         if (PreferencesManager::get("variation") != "") gameGlobalInfo->variation = PreferencesManager::get("variation");
         gameGlobalInfo->startScenario(PreferencesManager::get("headless"));
 

--- a/src/menus/serverBrowseMenu.cpp
+++ b/src/menus/serverBrowseMenu.cpp
@@ -12,10 +12,11 @@
 ServerBrowserMenu::ServerBrowserMenu(SearchSource source)
 {
     scanner = new ServerScanner(VERSION_NUMBER);
+
     if (source == Local)
         scanner->scanLocalNetwork();
     else
-        scanner->scanMasterServer("http://daid.eu/ee/list.php");
+        scanner->scanMasterServer(PreferencesManager::get("registry_list_url", "http://daid.eu/ee/list.php"));
 
     new GuiOverlay(this, "", colorConfig.background);
     (new GuiOverlay(this, "", sf::Color::White))->setTextureTiled("gui/BackgroundCrosses");
@@ -29,7 +30,7 @@ ServerBrowserMenu::ServerBrowserMenu(SearchSource source)
         if (index == 0)
             scanner->scanLocalNetwork();
         else
-            scanner->scanMasterServer("http://daid.eu/ee/list.php");
+            scanner->scanMasterServer(PreferencesManager::get("registry_list_url", "http://daid.eu/ee/list.php"));
     });
     lan_internet_selector->setOptions({"LAN", "Internet"})->setSelectionIndex(source == Local ? 0 : 1)->setPosition(0, -50, ABottomCenter)->setSize(300, 50);
 

--- a/src/menus/serverCreationScreen.cpp
+++ b/src/menus/serverCreationScreen.cpp
@@ -74,7 +74,7 @@ ServerCreationScreen::ServerCreationScreen()
     (new GuiLabel(row, "LAN_INTERNET_LABEL", "Server visibility: ", 30))->setAlignment(ACenterRight)->setSize(250, GuiElement::GuiSizeMax);
     (new GuiSelector(row, "LAN_INTERNET_SELECT", [](int index, string value) {
         if (index == 1)
-            game_server->registerOnMasterServer("http://daid.eu/ee/register.php");
+            game_server->registerOnMasterServer(PreferencesManager::get("registry_registration_url", "http://daid.eu/ee/register.php"));
         else
             game_server->stopMasterServerRegistry();
     }))->setOptions({"LAN only", "Internet"})->setSelectionIndex(0)->setSize(GuiElement::GuiSizeMax, GuiElement::GuiSizeMax);


### PR DESCRIPTION
Adds two options, `registry_registration_url` and
`registry_list_url`, that allow the URLs to the registry server
to be configured. Defaults to the existing behavior
(`http://daid.eu/ee/list.php` and `register.php)`.