### PR TITLE
Change ship signatures based on system states

### DIFF
--- a/src/spaceObjects/spaceship.cpp
+++ b/src/spaceObjects/spaceship.cpp
@@ -189,7 +189,7 @@ SpaceShip::SpaceShip(string multiplayerClassName, float multiplayer_significant_
     scanning_complexity_value = -1;
     scanning_depth_value = -1;
 
-    setRadarSignatureInfo(0.05, 0.3, 0.3);
+    setRadarSignatureInfo(signature_baseline.gravity, signature_baseline.electrical, signature_baseline.biological);
 
     if (game_server)
         setCallSign(gameGlobalInfo->getNextShipCallsign());
@@ -646,10 +646,22 @@ void SpaceShip::update(float delta)
         weapon_tube[n].update(delta);
     }
 
+    RawRadarSignatureInfo signature_delta;
+
     for(int n=0; n<SYS_COUNT; n++)
     {
+        ESystem this_system = static_cast<ESystem>(n);
         systems[n].hacked_level = std::max(0.0f, systems[n].hacked_level - delta / unhack_time);
+        signature_delta.biological += std::min(0.0f, getSystemHeat(this_system) - getSystemCoolant(this_system) / SYS_COUNT); // Divide by SYS_COUNT? Or let ships with more systems emit more heat?
+        signature_delta.electrical += (getSystemPower(this_system) - 1.0f);
     }
+    signature_delta.gravity += (1.0f / jump_delay + 1.0f) + (current_warp * 0.25f);
+ 
+    RawRadarSignatureInfo new_signature;
+    new_signature += signature_baseline;
+    new_signature += signature_delta;
+
+    setRadarSignatureInfo(new_signature.gravity, new_signature.electrical, new_signature.biological);
 
     model_info.engine_scale = std::min(1.0f, (float) std::max(fabs(getAngularVelocity() / turn_speed), fabs(current_impulse)));
     if (has_jump_drive && jump_delay > 0.0f)

--- a/src/spaceObjects/spaceship.h
+++ b/src/spaceObjects/spaceship.h
@@ -403,6 +403,8 @@ public:
 
     void setRadarTrace(string trace) { radar_trace = trace; }
 
+    const RawRadarSignatureInfo signature_baseline = RawRadarSignatureInfo(0.05, 0.3, 0.3);
+
     void addBroadcast(int threshold, string message);
 
     //Return a string that can be appended to an object create function in the lua scripting.

--- a/src/spaceObjects/spaceship.h
+++ b/src/spaceObjects/spaceship.h
@@ -403,11 +403,9 @@ public:
 
     void setRadarTrace(string trace) { radar_trace = trace; }
 
-    const RawRadarSignatureInfo signature_baseline = RawRadarSignatureInfo(0.05, 0.3, 0.3);
-
     void addBroadcast(int threshold, string message);
 
-    //Return a string that can be appended to an object create function in the lua scripting.
+    // Return a string that can be appended to an object create function in the lua scripting.
     // This function is used in getScriptExport calls to adjust for tweaks done in the GM screen.
     string getScriptExportModificationsOnTemplate();
 };


### PR DESCRIPTION
Ship signatures can change based on their heat, power level, and
usage.

- Systems that generate heat increase the biological band; coolant
  offsets this effect even if the system maintains heat.
- Systems that use energy increase the electrical band.
- Ships that are jumping or warping spike the gravity band.

This allows Science to predict when a ship is going to warp/jump,
and in stealth missions can give away the positions of ships that
run hot.

CPU ships do not manage heat/energy but still exhibit jump/warp
spikes.

Example of a jump spike before and after:

![jumping](https://user-images.githubusercontent.com/19192104/72344532-4f2ba780-3686-11ea-8dd0-1ecf073d6f95.png)
![jumping2](https://user-images.githubusercontent.com/19192104/72344533-4f2ba780-3686-11ea-8b65-f62d5b012d6a.png)

Progress toward #14 