### PR TITLE
Fixed game completion condition for Minesweeper

### DIFF
--- a/src/screenComponents/mineSweeper.cpp
+++ b/src/screenComponents/mineSweeper.cpp
@@ -74,6 +74,13 @@ float MineSweeper::getProgress()
     return (float)correct_count / (float)(field_size * field_size - bomb_count);
 }
 
+void MineSweeper::gameComplete()
+{
+    bool success = correct_count == (field_size * field_size) - bomb_count;
+    parent->onMiniGameComplete(success);
+    game_complete = success;
+}
+
 sf::Vector2f MineSweeper::getBoardSize()
 {
     return sf::Vector2f(field_size*50, field_size*50);

--- a/src/screenComponents/mineSweeper.h
+++ b/src/screenComponents/mineSweeper.h
@@ -16,6 +16,8 @@ class MineSweeper : public MiniGame {
     virtual void disable() override;
     virtual float getProgress() override;
     virtual sf::Vector2f getBoardSize() override;
+  protected:
+    virtual void gameComplete() override;
   private:
     void onFieldClick(int x, int y);
     int error_count;

--- a/src/screenComponents/miniGame.h
+++ b/src/screenComponents/miniGame.h
@@ -34,7 +34,7 @@ class MiniGame : public sf::NonCopyable
     GuiHackingDialog* parent;
     bool game_complete;
     std::vector<GuiElement*> board;
-    void gameComplete();
+    virtual void gameComplete();
 };
 
 #endif//MINIGAME_H


### PR DESCRIPTION
This fixes an issue where the Minesweeper hacking is successful even if you click on a bomb if more than 50% of the tiles are revealed.