### PR TITLE
Optinal rotation for artifacts

### DIFF
--- a/src/spaceObjects/artifact.cpp
+++ b/src/spaceObjects/artifact.cpp
@@ -21,6 +21,8 @@ REGISTER_SCRIPT_SUBCLASS(Artifact, SpaceObject)
     /// Set a function that will be called if a player picks up the artifact.
     /// First argument given to the function will be the artifact, the second the player.
     REGISTER_SCRIPT_CLASS_FUNCTION(Artifact, onPickUp);
+    /// Let the artifact rotate. For reference, normal asteroids in the game have spins between 0.1 and 0.8.
+    REGISTER_SCRIPT_CLASS_FUNCTION(Artifact, setSpin);
 }
 
 REGISTER_MULTIPLAYER_CLASS(Artifact, "Artifact");
@@ -28,6 +30,7 @@ Artifact::Artifact()
 : SpaceObject(120, "Artifact")
 {
     registerMemberReplication(&model_data_name);
+    registerMemberReplication(&artifact_spin);
 
     setRotation(random(0, 360));
     
@@ -45,6 +48,16 @@ void Artifact::update(float delta)
         current_model_data_name = model_data_name;
         model_info.setData(current_model_data_name);
     }
+}
+
+void Artifact::draw3D()
+{
+#if FEATURE_3D_RENDERING
+	if (artifact_spin != 0.0) {
+		glRotatef(engine->getElapsedTime() * artifact_spin, 0, 0, 1);
+	}
+    SpaceObject::draw3D();
+#endif//FEATURE_3D_RENDERING
 }
 
 void Artifact::drawOnRadar(sf::RenderTarget& window, sf::Vector2f position, float scale, bool long_range)
@@ -93,6 +106,11 @@ void Artifact::explode()
 void Artifact::allowPickup(bool allow)
 {
     allow_pickup = allow;
+}
+
+void Artifact::setSpin(float spin)
+{
+    artifact_spin = spin;
 }
 
 void Artifact::onPickUp(ScriptSimpleCallback callback)

--- a/src/spaceObjects/artifact.h
+++ b/src/spaceObjects/artifact.h
@@ -8,6 +8,7 @@ class Artifact : public SpaceObject, public Updatable
 private:
     string current_model_data_name;
     string model_data_name;
+    float artifact_spin=0.0;
     bool allow_pickup;
     ScriptSimpleCallback on_pickup_callback;
 public:
@@ -15,11 +16,14 @@ public:
 
     virtual void update(float delta);
 
+    virtual void draw3D();
+
     virtual void drawOnRadar(sf::RenderTarget& window, sf::Vector2f position, float scale, bool long_range);
 
     virtual void collide(Collisionable* target, float force) override;
 
     void setModel(string name);
+    void setSpin(float spin=0.0);
     void explode();
     void allowPickup(bool allow);
     


### PR DESCRIPTION
After the talk in #729, i realized there is - apart from scaling and a different radar trace - a characteristic of asteroids that artifacts are missing: rotation.
So this adds a setSpin() method, that sets an optional rotation speed for artifacts.