### PR TITLE
[PROPOSAL/POC] Detailed signal visualization on Science

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@
 - `ScanProbe:onExpiration`, `ScanProbe:onDestruction`, and
   `PlayerSpaceship:onProbeLaunch` callback scripting functions.
 - Scan object and cycle selected object hotkeys added to Science.
+- `Spaceship:getDynamicRadarSignatureGravity`, `...Electrical`, and
+  `...Biological` scripting functions.
+- Detailed radar signal data visualizations as a toggleable view on the Science
+  station's radar.
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,13 +4,19 @@
 
 ### Added
 
-- `ScanProbe:onExpiration`, `ScanProbe:onDestruction`, and
+- `ScanProbe:onExpiration`, `...onDestruction`, and
   `PlayerSpaceship:onProbeLaunch` callback scripting functions.
 - Scan object and cycle selected object hotkeys added to Science.
 - `Spaceship:getDynamicRadarSignatureGravity`, `...Electrical`, and
   `...Biological` scripting functions.
+- `SpaceObject:setRadarSignatureGravity`, `...Electrical`, and `...Biological`
+  scripting functions.
+- `SpaceObject:setVisibility` and `...isVisible` scripting functions, allowing
+  SpaceObject visibility to be toggled.
 - Detailed radar signal data visualizations as a toggleable view on the Science
   station's radar.
+- GM tweak features for radar signatures.
+- Scan object, cycle selected object, and signal detail hotkeys added to Science.
 
 ### Changed
 

--- a/src/gui/gui2_button.cpp
+++ b/src/gui/gui2_button.cpp
@@ -6,14 +6,18 @@
 GuiButton::GuiButton(GuiContainer* owner, string id, string text, func_t func)
 : GuiElement(owner, id), text(text), func(func)
 {
+    override_color = false;
+    override_text_color = false;
     text_size = 30;
 }
 
 void GuiButton::onDraw(sf::RenderTarget& window)
 {
-    sf::Color color = selectColor(colorConfig.button.background);
-    sf::Color text_color = selectColor(colorConfig.button.forground);
-    
+    if (!override_color)
+        color = selectColor(colorConfig.button.background);
+    if (!override_text_color)
+        text_color = selectColor(colorConfig.button.forground);
+
     if (!enabled)
         drawStretched(window, rect, "gui/ButtonBackground.disabled", color);
     else if (active)
@@ -71,9 +75,11 @@ void GuiButton::onMouseUp(sf::Vector2f position)
     }
 }
 
-string GuiButton::getText() const
+GuiButton* GuiButton::setColor(sf::Color color)
 {
-    return text;
+    this->override_color = true;
+    this->color = color;
+    return this;
 }
 
 GuiButton* GuiButton::setText(string text)
@@ -88,12 +94,24 @@ GuiButton* GuiButton::setTextSize(float size)
     return this;
 }
 
+GuiButton* GuiButton::setTextColor(sf::Color color)
+{
+    this->override_text_color = true;
+    this->text_color = color;
+    return this;
+}
+
 GuiButton* GuiButton::setIcon(string icon_name, EGuiAlign icon_alignment, float rotation)
 {
     this->icon_name = icon_name;
     this->icon_alignment = icon_alignment;
     this->icon_rotation = rotation;
     return this;
+}
+
+string GuiButton::getText() const
+{
+    return text;
 }
 
 string GuiButton::getIcon() const

--- a/src/gui/gui2_button.h
+++ b/src/gui/gui2_button.h
@@ -11,6 +11,10 @@ public:
 protected:
     string text;
     float text_size;
+    bool override_color;
+    sf::Color color;
+    bool override_text_color;
+    sf::Color text_color;
     EGuiAlign text_alignment;
     func_t func;
     string icon_name;
@@ -23,8 +27,10 @@ public:
     virtual bool onMouseDown(sf::Vector2f position);
     virtual void onMouseUp(sf::Vector2f position);
     
+    GuiButton* setColor(sf::Color button_color);
     GuiButton* setText(string text);
     GuiButton* setTextSize(float size);
+    GuiButton* setTextColor(sf::Color text_color);
     GuiButton* setIcon(string icon_name, EGuiAlign icon_alignment = ACenterLeft, float rotation=0);
     string getText() const;
     string getIcon() const;

--- a/src/gui/hotkeyConfig.cpp
+++ b/src/gui/hotkeyConfig.cpp
@@ -72,6 +72,11 @@ HotkeyConfig::HotkeyConfig()
     newCategory("SCIENCE", "Science");
     newKey("SCAN_OBJECT", std::make_tuple("Scan object", "S"));
     newKey("NEXT_SCANNABLE_OBJECT", std::make_tuple("Select next scannable object", "C"));
+    newKey("TOGGLE_SIGNAL_DETAILS", std::make_tuple("Toggle signal details", "W"));
+    newKey("TOGGLE_VISUAL_DETAILS", std::make_tuple("Toggle visual radar traces", "V"));
+    newKey("TOGGLE_ELECTRICAL_DETAILS", std::make_tuple("Toggle electrical signal details", "E"));
+    newKey("TOGGLE_GRAVITY_DETAILS", std::make_tuple("Toggle gravity signal details", "G"));
+    newKey("TOGGLE_BIOLOGICAL_DETAILS", std::make_tuple("Toggle biological signal details", "B"));
 
     newCategory("ENGINEERING", "Engineering");
     newKey("SELECT_REACTOR", std::make_tuple("Select reactor system", "Num1"));

--- a/src/screenComponents/radarView.cpp
+++ b/src/screenComponents/radarView.cpp
@@ -608,14 +608,6 @@ void GuiRadarView::drawObjects(sf::RenderTarget& window_normal, sf::RenderTarget
             if (!obj->canHideInNebula())
                 window = &window_alpha;
 
-            // Visual objects can be filtered out. Low signatures don't appear.
-            if (show_visual_objects)
-            {
-                obj->drawOnRadar(*window, object_position_on_screen, scale, long_range);
-                if (show_callsigns && obj->getCallSign() != "")
-                    drawText(*window, sf::FloatRect(object_position_on_screen.x, object_position_on_screen.y - 15, 0, 0), obj->getCallSign(), ACenter, 15, bold_font);
-            }
-
             // Signal details can be visualized.
             if (show_signal_details && (show_gravity || show_electrical || show_biological))
             {
@@ -649,8 +641,16 @@ void GuiRadarView::drawObjects(sf::RenderTarget& window_normal, sf::RenderTarget
                 band_radius += band_radius_delta;
                 circle.setRadius(band_radius);
                 circle.setOrigin(band_radius, band_radius);
-                circle.setFillColor(band_color + sf::Color(0, 0, 0, 128));
+                circle.setFillColor(band_color + sf::Color(0, 0, 0, 255));
                 window->draw(circle);
+            }
+
+            // Visual objects can be filtered out. Low signatures don't appear.
+            if (show_visual_objects)
+            {
+                obj->drawOnRadar(*window, object_position_on_screen, scale, long_range);
+                if (show_callsigns && obj->getCallSign() != "")
+                    drawText(*window, sf::FloatRect(object_position_on_screen.x, object_position_on_screen.y - 15, 0, 0), obj->getCallSign(), ACenter, 15, bold_font);
             }
         }
     }

--- a/src/screenComponents/radarView.cpp
+++ b/src/screenComponents/radarView.cpp
@@ -621,11 +621,10 @@ void GuiRadarView::drawObjects(sf::RenderTarget& window_normal, sf::RenderTarget
             {
                 // Draw proportional circles for each radar band.
                 sf::CircleShape circle(0.1, rand() % 5 + 10);
-                circle.setOutlineThickness(1.0);
                 circle.setPosition(object_position_on_screen);
 
                 float band_radius = 2.0f + r;
-                float band_radius_delta = 0;
+                float band_radius_delta = 0.0f;
                 sf::Color band_color(0, 0, 0, 0);
 
                 if (show_gravity)
@@ -650,7 +649,6 @@ void GuiRadarView::drawObjects(sf::RenderTarget& window_normal, sf::RenderTarget
                 band_radius += band_radius_delta;
                 circle.setRadius(band_radius);
                 circle.setOrigin(band_radius, band_radius);
-                circle.setOutlineColor(band_color + sf::Color(0, 0, 0, 255));
                 circle.setFillColor(band_color + sf::Color(0, 0, 0, 128));
                 window->draw(circle);
             }

--- a/src/screenComponents/radarView.cpp
+++ b/src/screenComponents/radarView.cpp
@@ -17,11 +17,8 @@ GuiRadarView::GuiRadarView(GuiContainer* owner, string id, float distance, Targe
 {
     auto_center_on_my_ship = true;
     show_gravity = false;
-    gr = 0.0f;
     show_electrical = false;
-    er = 0.0f;
     show_biological = false;
-    br = 0.0f;
 }
 
 void GuiRadarView::onDraw(sf::RenderTarget& window)
@@ -623,37 +620,41 @@ void GuiRadarView::drawObjects(sf::RenderTarget& window_normal, sf::RenderTarget
             {
                 // Draw proportional circles for each radar band.
                 sf::CircleShape circle(0.1, rand() % 5 + 10);
-                circle.setOutlineThickness(0.0);
+                circle.setOutlineThickness(1.0);
 
-                gr = 2.0f + (r * info.gravity);
-                er = 2.0f + (r * info.electrical);
-                br = 2.0f + (r * info.biological);
+                float band_radius = 0.0f;
 
                 if (show_gravity)
                 {
                     // Gravitational
-                    circle.setRadius(gr);
-                    circle.setOrigin(gr, gr);
+                    band_radius = 2.0f + (r * info.gravity);
+                    circle.setRadius(band_radius);
+                    circle.setOrigin(band_radius, band_radius);
                     circle.setPosition(object_position_on_screen);
-                    circle.setFillColor(sf::Color(0,0,255,224));
+                    circle.setOutlineColor(sf::Color(0,0,255,255));
+                    circle.setFillColor(sf::Color(0,0,255,128));
                     window->draw(circle);
                 }
                 if (show_electrical)
                 {
                     // Electrical
-                    circle.setRadius(er);
-                    circle.setOrigin(er, er);
+                    band_radius = 2.0f + (r * info.electrical);
+                    circle.setRadius(band_radius);
+                    circle.setOrigin(band_radius, band_radius);
                     circle.setPosition(object_position_on_screen);
-                    circle.setFillColor(sf::Color(0,255,0,224));
+                    circle.setOutlineColor(sf::Color(0,255,0,255));
+                    circle.setFillColor(sf::Color(0,255,0,128));
                     window->draw(circle);
                 }
                 if (show_biological)
                 {
                     // Biological
-                    circle.setRadius(br);
-                    circle.setOrigin(br, br);
+                    band_radius = 2.0f + (r * info.biological);
+                    circle.setRadius(band_radius);
+                    circle.setOrigin(band_radius, band_radius);
                     circle.setPosition(object_position_on_screen);
-                    circle.setFillColor(sf::Color(255,0,0,224));
+                    circle.setOutlineColor(sf::Color(255,0,0,255));
+                    circle.setFillColor(sf::Color(255,0,0,128));
                     window->draw(circle);
                 }
             }
@@ -722,6 +723,8 @@ void GuiRadarView::drawTargets(sf::RenderTarget& window)
                     // Otherwise, use the baseline only.
                     info = obj->getRadarSignatureInfo();
                 }
+
+                LOG(INFO) << obj->getCallSign() << " g" << info.gravity << " e" << info.electrical << " b" << info.biological << " r" << r;
 
                 drawText(window,
                     sf::FloatRect(

--- a/src/screenComponents/radarView.cpp
+++ b/src/screenComponents/radarView.cpp
@@ -616,12 +616,12 @@ void GuiRadarView::drawObjects(sf::RenderTarget& window_normal, sf::RenderTarget
             if (show_signal_details && (show_electrical || show_gravity || show_biological))
             {
                 float band_radius = r;
-                sf::Color band_color(0, 0, 0, 223);
+                sf::Color band_color(32, 32, 32, 223);
 
                 // Electrical (red)
                 if (show_electrical && info.electrical > 0)
                 {
-                    band_color.r += 64 + std::min(1.0f, info.electrical) * 164;
+                    band_color.r += 32 + std::min(1.0f, info.electrical) * 132;
 
                     // If the band exceeds 1.0, increase the signal effect's
                     // radius.
@@ -632,7 +632,7 @@ void GuiRadarView::drawObjects(sf::RenderTarget& window_normal, sf::RenderTarget
                 // Gravity (green)
                 if (show_gravity && info.gravity > 0)
                 {
-                    band_color.g += 64 + std::min(1.0f, info.gravity) * 164;
+                    band_color.g += 32 + std::min(1.0f, info.gravity) * 132;
 
                     if (info.gravity > 1.0f)
                         band_radius += r * (info.gravity - 1.0f);
@@ -641,14 +641,14 @@ void GuiRadarView::drawObjects(sf::RenderTarget& window_normal, sf::RenderTarget
                 // Biological (blue)
                 if (show_biological && info.biological > 0)
                 {
-                    band_color.b += 64 + std::min(1.0f, info.biological) * 164;
+                    band_color.b += 32 + std::min(1.0f, info.biological) * 132;
 
                     if (info.biological > 1.0f)
                         band_radius += r * (info.biological - 1.0f);
                 }
 
                 // Floor band_radius to 2.0; don't draw if it's <= 0.
-                if (band_radius > 0.0f && band_color.r + band_color.g + band_color.b > 0)
+                if (band_radius > 0.0f && band_color.r + band_color.g + band_color.b > 96)
                 {
                     band_radius = std::max(2.0f, band_radius);
 

--- a/src/screenComponents/radarView.cpp
+++ b/src/screenComponents/radarView.cpp
@@ -707,17 +707,20 @@ void GuiRadarView::drawTargets(sf::RenderTarget& window)
 
         // If the object is not the controlling ship, and the object is visible
         // on radar, draw the reticule around it.
-        if (obj != my_spaceship && rect.intersects(object_rect))
+        if (rect.intersects(object_rect))
         {
-            target_sprite.setPosition(object_position_on_screen);
-            window.draw(target_sprite);
+            if (obj != my_spaceship)
+            {
+                target_sprite.setPosition(object_position_on_screen);
+                window.draw(target_sprite);
+            }
 
             // Add numeric radar signal values if signal details are enabled.
             if (show_signal_details)
             {
                 P<SpaceShip> ship = obj;
                 RawRadarSignatureInfo info;
-                float r = obj->getRadius();
+                float object_radius = obj->getRadius();
                 sf::Vector2f diff = my_spaceship->getPosition() - obj->getPosition();
                 float distance_to_target = sf::length(diff);
 
@@ -732,10 +735,10 @@ void GuiRadarView::drawTargets(sf::RenderTarget& window)
                         object_position_on_screen.x + 15,
                         object_position_on_screen.y, 0, 0
                     ),
-                    std::to_string(static_cast<int>(
+                    "E" + std::to_string(static_cast<int>(
                         // Larger objects emit larger values.
                         // Distant objects emit less stable values.
-                        info.electrical * r * 10 + random(0, distance_to_target / 100))
+                        info.electrical * object_radius * 10 + random(0, distance_to_target / 100))
                     ),
                     ATopLeft, 15, bold_font, sf::Color(255, 0, 0, 255)
                 );
@@ -746,8 +749,8 @@ void GuiRadarView::drawTargets(sf::RenderTarget& window)
                         object_position_on_screen.x + 15,
                         object_position_on_screen.y + 15, 0, 0
                     ),
-                    std::to_string(static_cast<int>(
-                        info.gravity * r * 10 + random(0, distance_to_target / 100))
+                    "G" + std::to_string(static_cast<int>(
+                        info.gravity * object_radius * 10 + random(0, distance_to_target / 100))
                     ),
                     ATopLeft, 15, bold_font, sf::Color(0, 255, 0, 255)
                 );
@@ -758,8 +761,8 @@ void GuiRadarView::drawTargets(sf::RenderTarget& window)
                         object_position_on_screen.x + 15,
                         object_position_on_screen.y + 30, 0, 0
                     ),
-                    std::to_string(static_cast<int>(
-                        info.biological * r * 10 + random(0, distance_to_target / 100))
+                    "B" + std::to_string(static_cast<int>(
+                        info.biological * object_radius * 10 + random(0, distance_to_target / 100))
                     ),
                     ATopLeft, 15, bold_font, sf::Color(0, 0, 255, 255)
                 );

--- a/src/screenComponents/radarView.cpp
+++ b/src/screenComponents/radarView.cpp
@@ -626,32 +626,32 @@ void GuiRadarView::drawObjects(sf::RenderTarget& window_normal, sf::RenderTarget
                 float band_radius_delta = 0.0f;
                 sf::Color band_color(0, 0, 0, 0);
 
-                if (show_gravity)
-                {
-                    // Gravitational
-                    if (info.gravity > 1.0f)
-                        band_radius_delta += (r * info.gravity) + (info.gravity - 1.0f);
-                    else
-                        band_radius_delta += std::max(0.0f, r * info.gravity);
-                    band_color += sf::Color(0, 0, 255, 0);
-                }
+                // Electrical (red)
                 if (show_electrical)
                 {
-                    // Electrical
                     if (info.electrical > 1.0f)
                         band_radius_delta += (r * info.electrical) + (info.electrical - 1.0f);
                     else
                         band_radius_delta += std::max(0.0f, r * info.electrical);
+                    band_color += sf::Color(255, 0, 0, 0);
+                }
+                // Gravitational (green)
+                if (show_gravity)
+                {
+                    if (info.gravity > 1.0f)
+                        band_radius_delta += (r * info.gravity) + (info.gravity - 1.0f);
+                    else
+                        band_radius_delta += std::max(0.0f, r * info.gravity);
                     band_color += sf::Color(0, 255, 0, 0);
                 }
+                // Biological (blue)
                 if (show_biological)
                 {
-                    // Biological
                     if (info.biological > 1.0f)
                         band_radius_delta += (r * info.biological) + (info.biological - 1.0f);
                     else
                     band_radius_delta += std::max(0.0f, r * info.biological);
-                    band_color += sf::Color(255, 0, 0, 0);
+                    band_color += sf::Color(0, 0, 255, 0);
                 }
 
                 band_radius += band_radius_delta;
@@ -735,35 +735,38 @@ void GuiRadarView::drawTargets(sf::RenderTarget& window)
                     info = obj->getRadarSignatureInfo();
                 }
 
-                drawText(window,
-                    sf::FloatRect(
-                        object_position_on_screen.x + 15,
-                        object_position_on_screen.y, 0, 0
-                    ),
-                    std::to_string(static_cast<int>(
-                        info.gravity * r * 10 + random(0, distance_to_target / 1000))
-                    ),
-                    ATopLeft, 15, bold_font, sf::Color(0, 0, 255, 255)
-                );
+                // Electrical (red)
                 drawText(window,
                     sf::FloatRect(
                         object_position_on_screen.x + 15,
                         object_position_on_screen.y + 15, 0, 0
                     ),
                     std::to_string(static_cast<int>(
-                        info.electrical * r * 10 + random(0, distance_to_target / 1000))
+                        info.electrical * r * 10 + random(0, distance_to_target / 100))
+                    ),
+                    ATopLeft, 15, bold_font, sf::Color(255, 0, 0, 255)
+                );
+                // Gravity (green)
+                drawText(window,
+                    sf::FloatRect(
+                        object_position_on_screen.x + 15,
+                        object_position_on_screen.y, 0, 0
+                    ),
+                    std::to_string(static_cast<int>(
+                        info.gravity * r * 10 + random(0, distance_to_target / 100))
                     ),
                     ATopLeft, 15, bold_font, sf::Color(0, 255, 0, 255)
                 );
+                // Biological (blue)
                 drawText(window,
                     sf::FloatRect(
                         object_position_on_screen.x + 15,
                         object_position_on_screen.y + 30, 0, 0
                     ),
                     std::to_string(static_cast<int>(
-                        info.biological * r * 10 + random(0, distance_to_target / 1000))
+                        info.biological * r * 10 + random(0, distance_to_target / 100))
                     ),
-                    ATopLeft, 15, bold_font, sf::Color(255, 0, 0, 255)
+                    ATopLeft, 15, bold_font, sf::Color(0, 0, 255, 255)
                 );
             }
         }

--- a/src/screenComponents/radarView.cpp
+++ b/src/screenComponents/radarView.cpp
@@ -624,38 +624,35 @@ void GuiRadarView::drawObjects(sf::RenderTarget& window_normal, sf::RenderTarget
                 circle.setOutlineThickness(1.0);
                 circle.setPosition(object_position_on_screen);
 
-                float band_radius = 0.0f;
+                float band_radius = 2.0f + r;
+                float band_radius_delta = 0;
+                sf::Color band_color(0, 0, 0, 0);
 
                 if (show_gravity)
                 {
                     // Gravitational
-                    band_radius = 2.0f + (r * info.gravity);
-                    circle.setRadius(band_radius);
-                    circle.setOrigin(band_radius, band_radius);
-                    circle.setOutlineColor(sf::Color(0,0,255,255));
-                    circle.setFillColor(sf::Color(0,0,255,128));
-                    window->draw(circle);
+                    band_radius_delta += band_radius * info.gravity;
+                    band_color += sf::Color(0, 0, 255, 0);
                 }
                 if (show_electrical)
                 {
                     // Electrical
-                    band_radius = 2.0f + (r * info.electrical);
-                    circle.setRadius(band_radius);
-                    circle.setOrigin(band_radius, band_radius);
-                    circle.setOutlineColor(sf::Color(0,255,0,255));
-                    circle.setFillColor(sf::Color(0,255,0,128));
-                    window->draw(circle);
+                    band_radius_delta += band_radius * info.electrical;
+                    band_color += sf::Color(0, 255, 0, 0);
                 }
                 if (show_biological)
                 {
                     // Biological
-                    band_radius = 2.0f + (r * info.biological);
-                    circle.setRadius(band_radius);
-                    circle.setOrigin(band_radius, band_radius);
-                    circle.setOutlineColor(sf::Color(255,0,0,255));
-                    circle.setFillColor(sf::Color(255,0,0,128));
-                    window->draw(circle);
+                    band_radius_delta += band_radius * info.biological;
+                    band_color += sf::Color(255, 0, 0, 0);
                 }
+
+                band_radius += band_radius_delta;
+                circle.setRadius(band_radius);
+                circle.setOrigin(band_radius, band_radius);
+                circle.setOutlineColor(band_color + sf::Color(0, 0, 0, 255));
+                circle.setFillColor(band_color + sf::Color(0, 0, 0, 128));
+                window->draw(circle);
             }
         }
     }

--- a/src/screenComponents/radarView.cpp
+++ b/src/screenComponents/radarView.cpp
@@ -721,8 +721,13 @@ void GuiRadarView::drawTargets(sf::RenderTarget& window)
                 P<SpaceShip> ship = obj;
                 RawRadarSignatureInfo info;
                 float object_radius = obj->getRadius();
-                sf::Vector2f diff = my_spaceship->getPosition() - obj->getPosition();
-                float distance_to_target = sf::length(diff);
+                float distance_to_target = sf::length(my_spaceship->getPosition() - obj->getPosition());
+                float distance_variance = 0.0f;
+
+                // Destabilize values if the target is beyond short-range
+                // sensors or has not been scanned.
+                if (distance_to_target > 5000.0f && !obj->isScannedBy(my_spaceship))
+                    distance_variance = random(0, distance_to_target / 100);
 
                 if (ship)
                     info = ship->getDynamicRadarSignatureInfo();    // Use dynamic signatures for ships.
@@ -737,10 +742,9 @@ void GuiRadarView::drawTargets(sf::RenderTarget& window)
                     ),
                     "E" + std::to_string(static_cast<int>(
                         // Larger objects emit larger values.
-                        // Distant objects emit less stable values.
-                        info.electrical * object_radius * 10 + random(0, distance_to_target / 100))
+                        info.electrical * object_radius * 10 + distance_variance)
                     ),
-                    ATopLeft, 15, bold_font, sf::Color(255, 0, 0, 255)
+                    ATopLeft, 15, bold_font, sf::Color::Red
                 );
 
                 // Gravity (green)
@@ -750,9 +754,9 @@ void GuiRadarView::drawTargets(sf::RenderTarget& window)
                         object_position_on_screen.y + 15, 0, 0
                     ),
                     "G" + std::to_string(static_cast<int>(
-                        info.gravity * object_radius * 10 + random(0, distance_to_target / 100))
+                        info.gravity * object_radius * 10 + distance_variance)
                     ),
-                    ATopLeft, 15, bold_font, sf::Color(0, 255, 0, 255)
+                    ATopLeft, 15, bold_font, sf::Color::Green
                 );
 
                 // Biological (blue)
@@ -762,9 +766,9 @@ void GuiRadarView::drawTargets(sf::RenderTarget& window)
                         object_position_on_screen.y + 30, 0, 0
                     ),
                     "B" + std::to_string(static_cast<int>(
-                        info.biological * object_radius * 10 + random(0, distance_to_target / 100))
+                        info.biological * object_radius * 10 + distance_variance)
                     ),
-                    ATopLeft, 15, bold_font, sf::Color(0, 0, 255, 255)
+                    ATopLeft, 15, bold_font, sf::Color::Blue
                 );
             }
         }

--- a/src/screenComponents/radarView.cpp
+++ b/src/screenComponents/radarView.cpp
@@ -593,13 +593,13 @@ void GuiRadarView::drawObjects(sf::RenderTarget& window_normal, sf::RenderTarget
             if (!obj->canHideInNebula())
                 window = &window_alpha;
             if (show_visual_objects)
-	    {
+            {
                 obj->drawOnRadar(*window, object_position_on_screen, scale, long_range);
                 if (show_callsigns && obj->getCallSign() != "")
                     drawText(*window, sf::FloatRect(object_position_on_screen.x, object_position_on_screen.y - 15, 0, 0), obj->getCallSign(), ACenter, 15, bold_font);
             }
             if (show_signal_details && (show_gravity || show_electrical || show_biological))
-	    {
+            {
                 RawRadarSignatureInfo info;
                 P<SpaceShip> ship = obj;
 
@@ -646,7 +646,7 @@ void GuiRadarView::drawObjects(sf::RenderTarget& window_normal, sf::RenderTarget
                     circle.setFillColor(sf::Color(255,0,0,128));
                     window->draw(circle);
                 }
-	    }
+            }
         }
     }
     if (my_spaceship)
@@ -698,7 +698,8 @@ void GuiRadarView::drawTargets(sf::RenderTarget& window)
             window.draw(target_sprite);
 
             // Add numeric radar signal values if signal details are enabled.
-            if (show_signal_details) {
+            if (show_signal_details)
+            {
                 P<SpaceShip> ship = obj;
                 RawRadarSignatureInfo info;
 

--- a/src/screenComponents/radarView.cpp
+++ b/src/screenComponents/radarView.cpp
@@ -587,17 +587,24 @@ void GuiRadarView::drawObjects(sf::RenderTarget& window_normal, sf::RenderTarget
         sf::Vector2f object_position_on_screen = radar_screen_center + (obj->getPosition() - view_position) * scale;
         float r = obj->getRadius() * scale;
         sf::FloatRect object_rect(object_position_on_screen.x - r, object_position_on_screen.y - r, r * 2, r * 2);
+
+        // Draw visible objects within radar range.
         if (obj != *my_spaceship && rect.intersects(object_rect))
         {
             sf::RenderTarget* window = &window_normal;
+
             if (!obj->canHideInNebula())
                 window = &window_alpha;
+
+            // Visual objects can be filtered out.
             if (show_visual_objects)
             {
                 obj->drawOnRadar(*window, object_position_on_screen, scale, long_range);
                 if (show_callsigns && obj->getCallSign() != "")
                     drawText(*window, sf::FloatRect(object_position_on_screen.x, object_position_on_screen.y - 15, 0, 0), obj->getCallSign(), ACenter, 15, bold_font);
             }
+
+            // Signal details can be visualized.
             if (show_signal_details && (show_gravity || show_electrical || show_biological))
             {
                 RawRadarSignatureInfo info;
@@ -613,42 +620,46 @@ void GuiRadarView::drawObjects(sf::RenderTarget& window_normal, sf::RenderTarget
                     // Otherwise, use the baseline only.
                     info = obj->getRadarSignatureInfo();
                 }
+
+                // Draw proportional circles for each radar band.
                 sf::CircleShape circle(0.1, rand() % 5 + 10);
                 circle.setOutlineThickness(0.0);
-                // Draw proportional circles for each radar band.
-                if (show_gravity)
+
+                gr = 2.0f + (r * info.gravity);
+                er = 2.0f + (r * info.electrical);
+                br = 2.0f + (r * info.biological);
+
+                if (show_gravity && gr > 2.0f)
                 {
                     // Gravitational
-                    gr = 2.0f + (r * info.gravity);
                     circle.setRadius(gr);
                     circle.setOrigin(gr, gr);
                     circle.setPosition(object_position_on_screen);
-                    circle.setFillColor(sf::Color(0,0,255,128));
+                    circle.setFillColor(sf::Color(0,0,255,224));
                     window->draw(circle);
                 }
-                if (show_electrical)
+                if (show_electrical && er > 2.0f)
                 {
                     // Electrical
-                    er = 2.0f + (r * info.electrical);
                     circle.setRadius(er);
                     circle.setOrigin(er, er);
                     circle.setPosition(object_position_on_screen);
-                    circle.setFillColor(sf::Color(0,255,0,128));
+                    circle.setFillColor(sf::Color(0,255,0,224));
                     window->draw(circle);
                 }
-                if (show_biological)
+                if (show_biological && br > 2.0f)
                 {
                     // Biological
-                    br = 2.0f + (r * info.biological);
                     circle.setRadius(br);
                     circle.setOrigin(br, br);
                     circle.setPosition(object_position_on_screen);
-                    circle.setFillColor(sf::Color(255,0,0,128));
+                    circle.setFillColor(sf::Color(255,0,0,224));
                     window->draw(circle);
                 }
             }
         }
     }
+
     if (my_spaceship)
     {
         sf::Vector2f object_position_on_screen = radar_screen_center + (my_spaceship->getPosition() - view_position) * scale;

--- a/src/screenComponents/radarView.cpp
+++ b/src/screenComponents/radarView.cpp
@@ -598,6 +598,7 @@ void GuiRadarView::drawObjects(sf::RenderTarget& window_normal, sf::RenderTarget
             {
                 // Use dynamic signatures for ships.
                 info = ship->getDynamicRadarSignatureInfo();
+
             } else {
                 // Otherwise, use the baseline only.
                 info = obj->getRadarSignatureInfo();
@@ -621,6 +622,7 @@ void GuiRadarView::drawObjects(sf::RenderTarget& window_normal, sf::RenderTarget
                 // Draw proportional circles for each radar band.
                 sf::CircleShape circle(0.1, rand() % 5 + 10);
                 circle.setOutlineThickness(1.0);
+                circle.setPosition(object_position_on_screen);
 
                 float band_radius = 0.0f;
 
@@ -630,7 +632,6 @@ void GuiRadarView::drawObjects(sf::RenderTarget& window_normal, sf::RenderTarget
                     band_radius = 2.0f + (r * info.gravity);
                     circle.setRadius(band_radius);
                     circle.setOrigin(band_radius, band_radius);
-                    circle.setPosition(object_position_on_screen);
                     circle.setOutlineColor(sf::Color(0,0,255,255));
                     circle.setFillColor(sf::Color(0,0,255,128));
                     window->draw(circle);
@@ -641,7 +642,6 @@ void GuiRadarView::drawObjects(sf::RenderTarget& window_normal, sf::RenderTarget
                     band_radius = 2.0f + (r * info.electrical);
                     circle.setRadius(band_radius);
                     circle.setOrigin(band_radius, band_radius);
-                    circle.setPosition(object_position_on_screen);
                     circle.setOutlineColor(sf::Color(0,255,0,255));
                     circle.setFillColor(sf::Color(0,255,0,128));
                     window->draw(circle);
@@ -652,7 +652,6 @@ void GuiRadarView::drawObjects(sf::RenderTarget& window_normal, sf::RenderTarget
                     band_radius = 2.0f + (r * info.biological);
                     circle.setRadius(band_radius);
                     circle.setOrigin(band_radius, band_radius);
-                    circle.setPosition(object_position_on_screen);
                     circle.setOutlineColor(sf::Color(255,0,0,255));
                     circle.setFillColor(sf::Color(255,0,0,128));
                     window->draw(circle);
@@ -714,6 +713,9 @@ void GuiRadarView::drawTargets(sf::RenderTarget& window)
             {
                 P<SpaceShip> ship = obj;
                 RawRadarSignatureInfo info;
+                float r = obj->getRadius();
+                sf::Vector2f diff = my_spaceship->getPosition() - obj->getPosition();
+                float distance_to_target = sf::length(diff);
 
                 if (ship)
                 {
@@ -724,15 +726,13 @@ void GuiRadarView::drawTargets(sf::RenderTarget& window)
                     info = obj->getRadarSignatureInfo();
                 }
 
-                LOG(INFO) << obj->getCallSign() << " g" << info.gravity << " e" << info.electrical << " b" << info.biological << " r" << r;
-
                 drawText(window,
                     sf::FloatRect(
                         object_position_on_screen.x + 15,
                         object_position_on_screen.y, 0, 0
                     ),
                     std::to_string(static_cast<int>(
-                        info.gravity * obj->getRadius() * 10 + random(0, 5))
+                        info.gravity * r * 10 + random(0, distance_to_target / 1000))
                     ),
                     ATopLeft, 15, bold_font, sf::Color(0, 0, 255, 255)
                 );
@@ -742,7 +742,7 @@ void GuiRadarView::drawTargets(sf::RenderTarget& window)
                         object_position_on_screen.y + 15, 0, 0
                     ),
                     std::to_string(static_cast<int>(
-                        info.electrical * obj->getRadius() * 10 + random(0, 5))
+                        info.electrical * r * 10 + random(0, distance_to_target / 1000))
                     ),
                     ATopLeft, 15, bold_font, sf::Color(0, 255, 0, 255)
                 );
@@ -752,7 +752,7 @@ void GuiRadarView::drawTargets(sf::RenderTarget& window)
                         object_position_on_screen.y + 30, 0, 0
                     ),
                     std::to_string(static_cast<int>(
-                        info.biological * obj->getRadius() * 10 + random(0, 5))
+                        info.biological * r * 10 + random(0, distance_to_target / 1000))
                     ),
                     ATopLeft, 15, bold_font, sf::Color(255, 0, 0, 255)
                 );

--- a/src/screenComponents/radarView.cpp
+++ b/src/screenComponents/radarView.cpp
@@ -604,12 +604,15 @@ void GuiRadarView::drawObjects(sf::RenderTarget& window_normal, sf::RenderTarget
                 window = &window_alpha;
 
             // Visual objects can be filtered out.
-            // If it doesn't emit sensor values, don't draw it.
-            if (show_visual_objects && (info.electrical > 0.0f || info.gravity > 0.0f || info.biological > 0.0f))
+            // If it is invisible, don't draw it.
+            if (show_visual_objects)
             {
-                obj->drawOnRadar(*window, object_position_on_screen, scale, long_range);
-                if (show_callsigns && obj->getCallSign() != "")
-                    drawText(*window, sf::FloatRect(object_position_on_screen.x, object_position_on_screen.y - 15, 0, 0), obj->getCallSign(), ACenter, 15, bold_font);
+                if (obj->isVisible())
+                {
+                    obj->drawOnRadar(*window, object_position_on_screen, scale, long_range);
+                    if (show_callsigns && obj->getCallSign() != "")
+                        drawText(*window, sf::FloatRect(object_position_on_screen.x, object_position_on_screen.y - 15, 0, 0), obj->getCallSign(), ACenter, 15, bold_font);
+                }
             }
 
             // Signal details can be visualized.
@@ -619,6 +622,7 @@ void GuiRadarView::drawObjects(sf::RenderTarget& window_normal, sf::RenderTarget
                 sf::Color band_color(32, 32, 32, 223);
 
                 // Electrical (red)
+                // Show a signal only if its value is > 0.
                 if (show_electrical && info.electrical > 0)
                 {
                     band_color.r += 64 + std::min(1.0f, info.electrical) * 100;
@@ -709,7 +713,7 @@ void GuiRadarView::drawTargets(sf::RenderTarget& window)
         // on radar, draw the reticule around it.
         if (rect.intersects(object_rect))
         {
-            if (obj != my_spaceship)
+            if (obj != my_spaceship && obj->isVisible())
             {
                 target_sprite.setPosition(object_position_on_screen);
                 window.draw(target_sprite);

--- a/src/screenComponents/radarView.cpp
+++ b/src/screenComponents/radarView.cpp
@@ -10,10 +10,18 @@
 #include "targetsContainer.h"
 
 GuiRadarView::GuiRadarView(GuiContainer* owner, string id, float distance, TargetsContainer* targets)
-: GuiElement(owner, id), next_ghost_dot_update(0.0), targets(targets), missile_tube_controls(nullptr), distance(distance), long_range(false), show_ghost_dots(false), show_signal_details(false), show_waypoints(false), show_target_projection(false), show_missile_tubes(false), show_callsigns(false), show_heading_indicators(false), show_game_master_data(false)
-, range_indicator_step_size(0.0f), style(Circular), fog_style(NoFogOfWar), mouse_down_func(nullptr), mouse_drag_func(nullptr), mouse_up_func(nullptr)
+: GuiElement(owner, id), next_ghost_dot_update(0.0), targets(targets), missile_tube_controls(nullptr), distance(distance), long_range(false),
+  show_visual_objects(true), show_ghost_dots(false), show_signal_details(false), show_waypoints(false), show_target_projection(false),
+  show_missile_tubes(false), show_callsigns(false), show_heading_indicators(false), show_game_master_data(false), range_indicator_step_size(0.0f),
+  style(Circular), fog_style(NoFogOfWar), mouse_down_func(nullptr), mouse_drag_func(nullptr), mouse_up_func(nullptr)
 {
     auto_center_on_my_ship = true;
+    show_gravity = false;
+    gr = 0.0f;
+    show_electrical = false;
+    er = 0.0f;
+    show_biological = false;
+    br = 0.0f;
 }
 
 void GuiRadarView::onDraw(sf::RenderTarget& window)
@@ -72,7 +80,8 @@ void GuiRadarView::onDraw(sf::RenderTarget& window)
         updateGhostDots();
         drawGhostDots(forground_texture);
     }
-    drawObjects(forground_texture, background_texture);
+    if (show_visual_objects)
+        drawObjects(forground_texture, background_texture);
     if (show_signal_details)
         drawSignalDetails(forground_texture);
     if (show_game_master_data)
@@ -600,95 +609,73 @@ void GuiRadarView::drawObjects(sf::RenderTarget& window_normal, sf::RenderTarget
 
 void GuiRadarView::drawSignalDetails(sf::RenderTarget& window)
 {
-    sf::Vector2f radar_screen_center(rect.left + rect.width / 2.0f, rect.top + rect.height / 2.0f);
-    float scale = std::min(rect.width, rect.height) / 2.0f / distance;
-
-    for(P<SpaceObject> obj : space_object_list)
+    if (show_gravity || show_electrical || show_biological)
     {
-        // If nebulae cast radar shadows, don't draw details.
-        if (fog_style == NebulaFogOfWar && obj->canHideInNebula() && my_spaceship && Nebula::blockedByNebula(my_spaceship->getPosition(), obj->getPosition()))
-            continue;
+        sf::Vector2f radar_screen_center(rect.left + rect.width / 2.0f, rect.top + rect.height / 2.0f);
+        float scale = std::min(rect.width, rect.height) / 2.0f / distance;
 
-        sf::Vector2f object_position_on_screen = radar_screen_center + (obj->getPosition() - view_position) * scale;
-        float r = obj->getRadius() * scale;
-        sf::FloatRect object_rect(object_position_on_screen.x - r, object_position_on_screen.y - r, r * 2, r * 2);
-
-        // Draw details only for visible objects.
-        if (rect.intersects(object_rect))
+        for(P<SpaceObject> obj : space_object_list)
         {
-            RawRadarSignatureInfo info;
+            // If nebulae cast radar shadows, don't draw details.
+            if (fog_style == NebulaFogOfWar && obj->canHideInNebula() && my_spaceship && Nebula::blockedByNebula(my_spaceship->getPosition(), obj->getPosition()))
+                continue;
 
-            // If the object is a SpaceShip, adjust the signature dynamically
-            // based on its current state and activity.
-            P<SpaceShip> ship = obj;
+            sf::Vector2f object_position_on_screen = radar_screen_center + (obj->getPosition() - view_position) * scale;
+            float r = obj->getRadius() * scale;
+            sf::FloatRect object_rect(object_position_on_screen.x - r, object_position_on_screen.y - r, r * 2, r * 2);
 
-            if (ship)
+            // Draw details only for visible objects.
+            if (rect.intersects(object_rect))
             {
-                // Use dynamic signatures for ships.
-                info = ship->getDynamicRadarSignatureInfo();
-            } else {
-                // Otherwise, use the baseline only.
-                info = obj->getRadarSignatureInfo();
-            }
+                RawRadarSignatureInfo info;
 
-            // Draw proportional circles for each radar band.
-            float gr = 2.0f + (r * info.gravity);
-            float er = 2.0f + (r * info.electrical);
-            float br = 2.0f + (r * info.biological);
+                // If the object is a SpaceShip, adjust the signature dynamically
+                // based on its current state and activity.
+                P<SpaceShip> ship = obj;
 
-            // Gravitational
-            sf::CircleShape circle(gr, rand() % 5 + 10);
-            circle.setOutlineThickness(0.0);
-            circle.setOrigin(gr, gr);
-            circle.setPosition(object_position_on_screen);
-            circle.setFillColor(sf::Color(0,0,255,128));
-            window.draw(circle);
-            // Electrical
-            circle.setRadius(er);
-            circle.setOrigin(er, er);
-            circle.setPosition(object_position_on_screen);
-            circle.setFillColor(sf::Color(0,255,0,128));
-            window.draw(circle);
-            // Biological
-            circle.setRadius(br);
-            circle.setOrigin(br, br);
-            circle.setPosition(object_position_on_screen);
-            circle.setFillColor(sf::Color(255,0,0,128));
-            window.draw(circle);
-            // obj->drawOnGMRadar(window, object_position_on_screen, scale, long_range);
+                if (ship)
+                {
+                    // Use dynamic signatures for ships.
+                    info = ship->getDynamicRadarSignatureInfo();
+                } else {
+                    // Otherwise, use the baseline only.
+                    info = obj->getRadarSignatureInfo();
+                }
 
-            // Add numeric values if the object is targeted.
-            if (my_spaceship->getTarget() == obj) {
-                drawText(window,
-                    sf::FloatRect(
-                        object_position_on_screen.x + 15,
-                        object_position_on_screen.y, 0, 0
-                    ),
-                    std::to_string(static_cast<int>(
-                        info.gravity * obj->getRadius() * 10 + random(0, 5))
-                    ),
-                    ATopLeft, 15, bold_font, sf::Color(0, 0, 255, 255)
-                );
-                drawText(window,
-                    sf::FloatRect(
-                        object_position_on_screen.x + 15,
-                        object_position_on_screen.y + 15, 0, 0
-                    ),
-                    std::to_string(static_cast<int>(
-                        info.electrical * obj->getRadius() * 10 + random(0, 5))
-                    ),
-                    ATopLeft, 15, bold_font, sf::Color(0, 255, 0, 255)
-                );
-                drawText(window,
-                    sf::FloatRect(
-                        object_position_on_screen.x + 15,
-                        object_position_on_screen.y + 30, 0, 0
-                    ),
-                    std::to_string(static_cast<int>(
-                        info.biological * obj->getRadius() * 10 + random(0, 5))
-                    ),
-                    ATopLeft, 15, bold_font, sf::Color(255, 0, 0, 255)
-                );
+                sf::CircleShape circle(0.1, rand() % 5 + 10);
+                circle.setOutlineThickness(0.0);
+                // Draw proportional circles for each radar band.
+                if (show_gravity)
+                {
+                    // Gravitational
+                    gr = 2.0f + (r * info.gravity);
+                    circle.setRadius(gr);
+                    circle.setOrigin(gr, gr);
+                    circle.setPosition(object_position_on_screen);
+                    circle.setFillColor(sf::Color(0,0,255,128));
+                    window.draw(circle);
+                }
+                if (show_electrical)
+                {
+                    // Electrical
+                    er = 2.0f + (r * info.electrical);
+                    circle.setRadius(er);
+                    circle.setOrigin(er, er);
+                    circle.setPosition(object_position_on_screen);
+                    circle.setFillColor(sf::Color(0,255,0,128));
+                    window.draw(circle);
+                }
+                if (show_biological)
+                {
+                    // Biological
+                    br = 2.0f + (r * info.biological);
+                    circle.setRadius(br);
+                    circle.setOrigin(br, br);
+                    circle.setPosition(object_position_on_screen);
+                    circle.setFillColor(sf::Color(255,0,0,128));
+                    window.draw(circle);
+                }
+                // obj->drawOnGMRadar(window, object_position_on_screen, scale, long_range);
             }
         }
     }
@@ -734,6 +721,52 @@ void GuiRadarView::drawTargets(sf::RenderTarget& window)
         {
             target_sprite.setPosition(object_position_on_screen);
             window.draw(target_sprite);
+
+            // Add numeric radar signal values if signal details are enabled.
+            if (show_signal_details) {
+                P<SpaceShip> ship = obj;
+                RawRadarSignatureInfo info;
+
+                if (ship)
+                {
+                    // Use dynamic signatures for ships.
+                    info = ship->getDynamicRadarSignatureInfo();
+                } else {
+                    // Otherwise, use the baseline only.
+                    info = obj->getRadarSignatureInfo();
+                }
+
+                drawText(window,
+                    sf::FloatRect(
+                        object_position_on_screen.x + 15,
+                        object_position_on_screen.y, 0, 0
+                    ),
+                    std::to_string(static_cast<int>(
+                        info.gravity * obj->getRadius() * 10 + random(0, 5))
+                    ),
+                    ATopLeft, 15, bold_font, sf::Color(0, 0, 255, 255)
+                );
+                drawText(window,
+                    sf::FloatRect(
+                        object_position_on_screen.x + 15,
+                        object_position_on_screen.y + 15, 0, 0
+                    ),
+                    std::to_string(static_cast<int>(
+                        info.electrical * obj->getRadius() * 10 + random(0, 5))
+                    ),
+                    ATopLeft, 15, bold_font, sf::Color(0, 255, 0, 255)
+                );
+                drawText(window,
+                    sf::FloatRect(
+                        object_position_on_screen.x + 15,
+                        object_position_on_screen.y + 30, 0, 0
+                    ),
+                    std::to_string(static_cast<int>(
+                        info.biological * obj->getRadius() * 10 + random(0, 5))
+                    ),
+                    ATopLeft, 15, bold_font, sf::Color(255, 0, 0, 255)
+                );
+            }
         }
     }
 

--- a/src/screenComponents/radarView.cpp
+++ b/src/screenComponents/radarView.cpp
@@ -630,28 +630,34 @@ void GuiRadarView::drawObjects(sf::RenderTarget& window_normal, sf::RenderTarget
                 if (show_electrical)
                 {
                     if (info.electrical > 1.0f)
+                    {
                         band_radius_delta += (r * info.electrical) + (info.electrical - 1.0f);
-                    else
+                    } else if (info.electrical > 0.0f) {
                         band_radius_delta += std::max(0.0f, r * info.electrical);
-                    band_color += sf::Color(255, 0, 0, 0);
+                        band_color.r += 128 + (std::min(1.0f, info.electrical) * 128);
+                    }
                 }
                 // Gravitational (green)
                 if (show_gravity)
                 {
                     if (info.gravity > 1.0f)
+                    {
                         band_radius_delta += (r * info.gravity) + (info.gravity - 1.0f);
-                    else
+                    } else if (info.gravity > 0.0f) {
                         band_radius_delta += std::max(0.0f, r * info.gravity);
-                    band_color += sf::Color(0, 255, 0, 0);
+                        band_color.g += 128 + (std::min(1.0f, info.gravity) * 128);
+                    }
                 }
                 // Biological (blue)
                 if (show_biological)
                 {
                     if (info.biological > 1.0f)
+                    {
                         band_radius_delta += (r * info.biological) + (info.biological - 1.0f);
-                    else
-                    band_radius_delta += std::max(0.0f, r * info.biological);
-                    band_color += sf::Color(0, 0, 255, 0);
+                    } else if (info.biological > 0.0f) {
+                        band_radius_delta += std::max(0.0f, r * info.biological);
+                        band_color.b += 128 + (std::min(1.0f, info.biological) * 128);
+                    }
                 }
 
                 band_radius += band_radius_delta;
@@ -663,7 +669,11 @@ void GuiRadarView::drawObjects(sf::RenderTarget& window_normal, sf::RenderTarget
 
                 circle.setRadius(band_radius);
                 circle.setOrigin(band_radius, band_radius);
-                circle.setFillColor(band_color + sf::Color(0, 0, 0, 255));
+                if (band_color.r + band_color.g + band_color.b > 0)
+                    band_color.a = 255;
+                else
+                    band_color.a = 0;
+                circle.setFillColor(band_color);
                 window->draw(circle);
             }
         }

--- a/src/screenComponents/radarView.cpp
+++ b/src/screenComponents/radarView.cpp
@@ -621,7 +621,7 @@ void GuiRadarView::drawObjects(sf::RenderTarget& window_normal, sf::RenderTarget
                 // Electrical (red)
                 if (show_electrical && info.electrical > 0)
                 {
-                    band_color.r += 55 + std::min(1.0f, info.electrical) * 200;
+                    band_color.r += 64 + std::min(1.0f, info.electrical) * 164;
 
                     // If the band exceeds 1.0, increase the signal effect's
                     // radius.
@@ -632,7 +632,7 @@ void GuiRadarView::drawObjects(sf::RenderTarget& window_normal, sf::RenderTarget
                 // Gravity (green)
                 if (show_gravity && info.gravity > 0)
                 {
-                    band_color.g += 55 + std::min(1.0f, info.gravity) * 200;
+                    band_color.g += 64 + std::min(1.0f, info.gravity) * 164;
 
                     if (info.gravity > 1.0f)
                         band_radius += r * (info.gravity - 1.0f);
@@ -641,7 +641,7 @@ void GuiRadarView::drawObjects(sf::RenderTarget& window_normal, sf::RenderTarget
                 // Biological (blue)
                 if (show_biological && info.biological > 0)
                 {
-                    band_color.b += 55 + std::min(1.0f, info.biological) * 200;
+                    band_color.b += 64 + std::min(1.0f, info.biological) * 164;
 
                     if (info.biological > 1.0f)
                         band_radius += r * (info.biological - 1.0f);

--- a/src/screenComponents/radarView.cpp
+++ b/src/screenComponents/radarView.cpp
@@ -592,11 +592,25 @@ void GuiRadarView::drawObjects(sf::RenderTarget& window_normal, sf::RenderTarget
         if (obj != *my_spaceship && rect.intersects(object_rect))
         {
             sf::RenderTarget* window = &window_normal;
+            RawRadarSignatureInfo info;
+            P<SpaceShip> ship = obj;
 
+            // If the object is a SpaceShip, adjust the signature dynamically
+            // based on its current state and activity.
+            if (ship)
+            {
+                // Use dynamic signatures for ships.
+                info = ship->getDynamicRadarSignatureInfo();
+            } else {
+                // Otherwise, use the baseline only.
+                info = obj->getRadarSignatureInfo();
+            }
+
+            // If the object doesn't hide in nebulae, draw it regardless.
             if (!obj->canHideInNebula())
                 window = &window_alpha;
 
-            // Visual objects can be filtered out.
+            // Visual objects can be filtered out. Low signatures don't appear.
             if (show_visual_objects)
             {
                 obj->drawOnRadar(*window, object_position_on_screen, scale, long_range);
@@ -607,20 +621,6 @@ void GuiRadarView::drawObjects(sf::RenderTarget& window_normal, sf::RenderTarget
             // Signal details can be visualized.
             if (show_signal_details && (show_gravity || show_electrical || show_biological))
             {
-                RawRadarSignatureInfo info;
-                P<SpaceShip> ship = obj;
-
-                // If the object is a SpaceShip, adjust the signature dynamically
-                // based on its current state and activity.
-                if (ship)
-                {
-                    // Use dynamic signatures for ships.
-                    info = ship->getDynamicRadarSignatureInfo();
-                } else {
-                    // Otherwise, use the baseline only.
-                    info = obj->getRadarSignatureInfo();
-                }
-
                 // Draw proportional circles for each radar band.
                 sf::CircleShape circle(0.1, rand() % 5 + 10);
                 circle.setOutlineThickness(0.0);
@@ -629,7 +629,7 @@ void GuiRadarView::drawObjects(sf::RenderTarget& window_normal, sf::RenderTarget
                 er = 2.0f + (r * info.electrical);
                 br = 2.0f + (r * info.biological);
 
-                if (show_gravity && gr > 2.0f)
+                if (show_gravity)
                 {
                     // Gravitational
                     circle.setRadius(gr);
@@ -638,7 +638,7 @@ void GuiRadarView::drawObjects(sf::RenderTarget& window_normal, sf::RenderTarget
                     circle.setFillColor(sf::Color(0,0,255,224));
                     window->draw(circle);
                 }
-                if (show_electrical && er > 2.0f)
+                if (show_electrical)
                 {
                     // Electrical
                     circle.setRadius(er);
@@ -647,7 +647,7 @@ void GuiRadarView::drawObjects(sf::RenderTarget& window_normal, sf::RenderTarget
                     circle.setFillColor(sf::Color(0,255,0,224));
                     window->draw(circle);
                 }
-                if (show_biological && br > 2.0f)
+                if (show_biological)
                 {
                     // Biological
                     circle.setRadius(br);

--- a/src/screenComponents/radarView.cpp
+++ b/src/screenComponents/radarView.cpp
@@ -598,7 +598,6 @@ void GuiRadarView::drawObjects(sf::RenderTarget& window_normal, sf::RenderTarget
             {
                 // Use dynamic signatures for ships.
                 info = ship->getDynamicRadarSignatureInfo();
-
             } else {
                 // Otherwise, use the baseline only.
                 info = obj->getRadarSignatureInfo();
@@ -609,7 +608,7 @@ void GuiRadarView::drawObjects(sf::RenderTarget& window_normal, sf::RenderTarget
                 window = &window_alpha;
 
             // Visual objects can be filtered out. Low signatures don't appear.
-            if (show_visual_objects)
+            if (show_visual_objects && (info.gravity > 0.0f || info.electrical > 0.0f || info.biological > 0.0f))
             {
                 obj->drawOnRadar(*window, object_position_on_screen, scale, long_range);
                 if (show_callsigns && obj->getCallSign() != "")

--- a/src/screenComponents/radarView.cpp
+++ b/src/screenComponents/radarView.cpp
@@ -631,9 +631,11 @@ void GuiRadarView::drawSignalDetails(sf::RenderTarget& window)
                 info = obj->getRadarSignatureInfo();
             }
 
+            // Draw proportional circles for each radar band.
             float gr = 2.0f + (r * info.gravity);
             float er = 2.0f + (r * info.electrical);
             float br = 2.0f + (r * info.biological);
+
             // Gravitational
             sf::CircleShape circle(gr, rand() % 5 + 10);
             circle.setOutlineThickness(0.0);
@@ -655,15 +657,15 @@ void GuiRadarView::drawSignalDetails(sf::RenderTarget& window)
             window.draw(circle);
             // obj->drawOnGMRadar(window, object_position_on_screen, scale, long_range);
 
-            // Add numeric values if the object is a ship.
-            if (ship) {
+            // Add numeric values if the object is targeted.
+            if (my_spaceship->getTarget() == obj) {
                 drawText(window,
                     sf::FloatRect(
                         object_position_on_screen.x + 15,
                         object_position_on_screen.y, 0, 0
                     ),
                     std::to_string(static_cast<int>(
-                        info.gravity * ship->getRadius() * 10 + random(0, 5))
+                        info.gravity * obj->getRadius() * 10 + random(0, 5))
                     ),
                     ATopLeft, 15, bold_font, sf::Color(0, 0, 255, 255)
                 );
@@ -673,7 +675,7 @@ void GuiRadarView::drawSignalDetails(sf::RenderTarget& window)
                         object_position_on_screen.y + 15, 0, 0
                     ),
                     std::to_string(static_cast<int>(
-                            info.electrical * ship->getRadius() * 10 + random(0, 5))
+                        info.electrical * obj->getRadius() * 10 + random(0, 5))
                     ),
                     ATopLeft, 15, bold_font, sf::Color(0, 255, 0, 255)
                 );
@@ -683,7 +685,7 @@ void GuiRadarView::drawSignalDetails(sf::RenderTarget& window)
                         object_position_on_screen.y + 30, 0, 0
                     ),
                     std::to_string(static_cast<int>(
-                        info.biological * ship->getRadius() * 10 + random(0, 5))
+                        info.biological * obj->getRadius() * 10 + random(0, 5))
                     ),
                     ATopLeft, 15, bold_font, sf::Color(255, 0, 0, 255)
                 );
@@ -725,6 +727,9 @@ void GuiRadarView::drawTargets(sf::RenderTarget& window)
         sf::Vector2f object_position_on_screen = radar_screen_center + (obj->getPosition() - view_position) * scale;
         float r = obj->getRadius() * scale;
         sf::FloatRect object_rect(object_position_on_screen.x - r, object_position_on_screen.y - r, r * 2, r * 2);
+
+        // If the object is not the controlling ship, and the object is visible
+        // on radar, draw the reticule around it.
         if (obj != my_spaceship && rect.intersects(object_rect))
         {
             target_sprite.setPosition(object_position_on_screen);
@@ -732,6 +737,7 @@ void GuiRadarView::drawTargets(sf::RenderTarget& window)
         }
     }
 
+    // Draw waypoints.
     if (my_spaceship && targets->getWaypointIndex() > -1 && targets->getWaypointIndex() < my_spaceship->getWaypointCount())
     {
         sf::Vector2f object_position_on_screen = radar_screen_center + (my_spaceship->waypoints[targets->getWaypointIndex()] - view_position) * scale;

--- a/src/screenComponents/radarView.cpp
+++ b/src/screenComponents/radarView.cpp
@@ -607,7 +607,7 @@ void GuiRadarView::drawObjects(sf::RenderTarget& window_normal, sf::RenderTarget
             // If it is invisible, don't draw it.
             if (show_visual_objects)
             {
-                if (obj->isVisible())
+                if (obj->isVisible() || show_game_master_data)
                 {
                     obj->drawOnRadar(*window, object_position_on_screen, scale, long_range);
                     if (show_callsigns && obj->getCallSign() != "")
@@ -713,7 +713,7 @@ void GuiRadarView::drawTargets(sf::RenderTarget& window)
         // on radar, draw the reticule around it.
         if (rect.intersects(object_rect))
         {
-            if (obj != my_spaceship && obj->isVisible())
+            if (obj != my_spaceship && (obj->isVisible() || show_game_master_data))
             {
                 target_sprite.setPosition(object_position_on_screen);
                 window.draw(target_sprite);

--- a/src/screenComponents/radarView.cpp
+++ b/src/screenComponents/radarView.cpp
@@ -739,6 +739,7 @@ void GuiRadarView::drawTargets(sf::RenderTarget& window)
                     ),
                     ATopLeft, 15, bold_font, sf::Color(255, 0, 0, 255)
                 );
+
                 // Gravity (green)
                 drawText(window,
                     sf::FloatRect(
@@ -750,6 +751,7 @@ void GuiRadarView::drawTargets(sf::RenderTarget& window)
                     ),
                     ATopLeft, 15, bold_font, sf::Color(0, 255, 0, 255)
                 );
+
                 // Biological (blue)
                 drawText(window,
                     sf::FloatRect(

--- a/src/screenComponents/radarView.cpp
+++ b/src/screenComponents/radarView.cpp
@@ -621,7 +621,7 @@ void GuiRadarView::drawObjects(sf::RenderTarget& window_normal, sf::RenderTarget
                 // Electrical (red)
                 if (show_electrical && info.electrical > 0)
                 {
-                    band_color.r += 32 + std::min(1.0f, info.electrical) * 132;
+                    band_color.r += 64 + std::min(1.0f, info.electrical) * 100;
 
                     // If the band exceeds 1.0, increase the signal effect's
                     // radius.
@@ -632,7 +632,7 @@ void GuiRadarView::drawObjects(sf::RenderTarget& window_normal, sf::RenderTarget
                 // Gravity (green)
                 if (show_gravity && info.gravity > 0)
                 {
-                    band_color.g += 32 + std::min(1.0f, info.gravity) * 132;
+                    band_color.g += 64 + std::min(1.0f, info.gravity) * 100;
 
                     if (info.gravity > 1.0f)
                         band_radius += r * (info.gravity - 1.0f);
@@ -641,7 +641,7 @@ void GuiRadarView::drawObjects(sf::RenderTarget& window_normal, sf::RenderTarget
                 // Biological (blue)
                 if (show_biological && info.biological > 0)
                 {
-                    band_color.b += 32 + std::min(1.0f, info.biological) * 132;
+                    band_color.b += 64 + std::min(1.0f, info.biological) * 100;
 
                     if (info.biological > 1.0f)
                         band_radius += r * (info.biological - 1.0f);

--- a/src/screenComponents/radarView.h
+++ b/src/screenComponents/radarView.h
@@ -85,15 +85,17 @@ public:
     GuiRadarView* setRangeIndicatorStepSize(float step) { range_indicator_step_size = step; return this; }
     GuiRadarView* longRange() { long_range = true; return this; }
     GuiRadarView* shortRange() { long_range = false; return this; }
+    GuiRadarView* setVisualObjects(bool is_enabled) { show_visual_objects = is_enabled; return this; }
     GuiRadarView* enableVisualObjects() { show_visual_objects = true; return this; }
     GuiRadarView* disableVisualObjects() { show_visual_objects = false; return this; }
     GuiRadarView* enableGhostDots() { show_ghost_dots = true; return this; }
     GuiRadarView* disableGhostDots() { show_ghost_dots = false; return this; }
+    GuiRadarView* setSignalDetails(bool is_enabled) { show_signal_details = is_enabled; return this; }
     GuiRadarView* enableSignalDetails() { show_signal_details = true; return this; }
     GuiRadarView* disableSignalDetails() { show_signal_details = false; return this; }
-    void setSignalGravity(bool enabled) { show_gravity = enabled; }
-    void setSignalElectrical(bool enabled) { show_electrical = enabled; }
-    void setSignalBiological(bool enabled) { show_biological = enabled; }
+    void setSignalGravity(bool is_enabled) { show_gravity = is_enabled; }
+    void setSignalElectrical(bool is_enabled) { show_electrical = is_enabled; }
+    void setSignalBiological(bool is_enabled) { show_biological = is_enabled; }
     GuiRadarView* enableWaypoints() { show_waypoints = true; return this; }
     GuiRadarView* disableWaypoints() { show_waypoints = false; return this; }
     GuiRadarView* enableTargetProjections(GuiMissileTubeControls* missile_tube_controls) { show_target_projection = true; this->missile_tube_controls = missile_tube_controls; return this; }

--- a/src/screenComponents/radarView.h
+++ b/src/screenComponents/radarView.h
@@ -37,7 +37,8 @@ private:
         sf::Vector2f position;
         float end_of_life;
 
-        GhostDot(sf::Vector2f pos) : position(pos), end_of_life(engine->getElapsedTime() + total_lifetime) {}
+        GhostDot(sf::Vector2f pos)
+        : position(pos), end_of_life(engine->getElapsedTime() + total_lifetime) {}
     };
     std::vector<GhostDot> ghost_dots;
     float next_ghost_dot_update;
@@ -130,7 +131,7 @@ private:
     void drawTargets(sf::RenderTarget& window);
     void drawHeadingIndicators(sf::RenderTarget& window);
     void drawRadarCutoff(sf::RenderTarget& window);
-    void drawSignalDetails(sf::RenderTarget& window_normal, sf::RenderTarget& window_alpha);
+    void drawSignalDetails(sf::RenderTarget& window);
 };
 
 #endif//RADAR_VIEW_H

--- a/src/screenComponents/radarView.h
+++ b/src/screenComponents/radarView.h
@@ -53,11 +53,8 @@ private:
     bool show_ghost_dots;
     bool show_signal_details;
     bool show_gravity;
-    float gr;
     bool show_electrical;
-    float er;
     bool show_biological;
-    float br;
     bool show_waypoints;
     bool show_target_projection;
     bool show_missile_tubes;
@@ -93,9 +90,9 @@ public:
     GuiRadarView* setSignalDetails(bool is_enabled) { show_signal_details = is_enabled; return this; }
     GuiRadarView* enableSignalDetails() { show_signal_details = true; return this; }
     GuiRadarView* disableSignalDetails() { show_signal_details = false; return this; }
-    void setSignalGravity(bool is_enabled) { show_gravity = is_enabled; }
-    void setSignalElectrical(bool is_enabled) { show_electrical = is_enabled; }
-    void setSignalBiological(bool is_enabled) { show_biological = is_enabled; }
+    GuiRadarView* setSignalGravity(bool is_enabled) { show_gravity = is_enabled; return this; }
+    GuiRadarView* setSignalElectrical(bool is_enabled) { show_electrical = is_enabled; return this; }
+    GuiRadarView* setSignalBiological(bool is_enabled) { show_biological = is_enabled; return this; }
     GuiRadarView* enableWaypoints() { show_waypoints = true; return this; }
     GuiRadarView* disableWaypoints() { show_waypoints = false; return this; }
     GuiRadarView* enableTargetProjections(GuiMissileTubeControls* missile_tube_controls) { show_target_projection = true; this->missile_tube_controls = missile_tube_controls; return this; }

--- a/src/screenComponents/radarView.h
+++ b/src/screenComponents/radarView.h
@@ -49,8 +49,15 @@ private:
     float distance;
     sf::Vector2f view_position;
     bool long_range;
+    bool show_visual_objects;
     bool show_ghost_dots;
     bool show_signal_details;
+    bool show_gravity;
+    float gr;
+    bool show_electrical;
+    float er;
+    bool show_biological;
+    float br;
     bool show_waypoints;
     bool show_target_projection;
     bool show_missile_tubes;
@@ -78,11 +85,15 @@ public:
     GuiRadarView* setRangeIndicatorStepSize(float step) { range_indicator_step_size = step; return this; }
     GuiRadarView* longRange() { long_range = true; return this; }
     GuiRadarView* shortRange() { long_range = false; return this; }
+    GuiRadarView* enableVisualObjects() { show_visual_objects = true; return this; }
+    GuiRadarView* disableVisualObjects() { show_visual_objects = false; return this; }
     GuiRadarView* enableGhostDots() { show_ghost_dots = true; return this; }
     GuiRadarView* disableGhostDots() { show_ghost_dots = false; return this; }
-    bool areSignalDetailsEnabled() { return show_signal_details; }
     GuiRadarView* enableSignalDetails() { show_signal_details = true; return this; }
     GuiRadarView* disableSignalDetails() { show_signal_details = false; return this; }
+    void setSignalGravity(bool enabled) { show_gravity = enabled; }
+    void setSignalElectrical(bool enabled) { show_electrical = enabled; }
+    void setSignalBiological(bool enabled) { show_biological = enabled; }
     GuiRadarView* enableWaypoints() { show_waypoints = true; return this; }
     GuiRadarView* disableWaypoints() { show_waypoints = false; return this; }
     GuiRadarView* enableTargetProjections(GuiMissileTubeControls* missile_tube_controls) { show_target_projection = true; this->missile_tube_controls = missile_tube_controls; return this; }

--- a/src/screenComponents/radarView.h
+++ b/src/screenComponents/radarView.h
@@ -87,6 +87,7 @@ public:
     GuiRadarView* disableVisualObjects() { show_visual_objects = false; return this; }
     GuiRadarView* enableGhostDots() { show_ghost_dots = true; return this; }
     GuiRadarView* disableGhostDots() { show_ghost_dots = false; return this; }
+    bool getSignalDetails() { return show_signal_details; }
     GuiRadarView* setSignalDetails(bool is_enabled) { show_signal_details = is_enabled; return this; }
     GuiRadarView* enableSignalDetails() { show_signal_details = true; return this; }
     GuiRadarView* disableSignalDetails() { show_signal_details = false; return this; }

--- a/src/screenComponents/radarView.h
+++ b/src/screenComponents/radarView.h
@@ -142,7 +142,6 @@ private:
     void drawTargets(sf::RenderTarget& window);
     void drawHeadingIndicators(sf::RenderTarget& window);
     void drawRadarCutoff(sf::RenderTarget& window);
-    void drawSignalDetails(sf::RenderTarget& window);
 };
 
 #endif//RADAR_VIEW_H

--- a/src/screenComponents/radarView.h
+++ b/src/screenComponents/radarView.h
@@ -49,6 +49,7 @@ private:
     sf::Vector2f view_position;
     bool long_range;
     bool show_ghost_dots;
+    bool show_signal_details;
     bool show_waypoints;
     bool show_target_projection;
     bool show_missile_tubes;
@@ -78,6 +79,9 @@ public:
     GuiRadarView* shortRange() { long_range = false; return this; }
     GuiRadarView* enableGhostDots() { show_ghost_dots = true; return this; }
     GuiRadarView* disableGhostDots() { show_ghost_dots = false; return this; }
+    bool areSignalDetailsEnabled() { return show_signal_details; }
+    GuiRadarView* enableSignalDetails() { show_signal_details = true; return this; }
+    GuiRadarView* disableSignalDetails() { show_signal_details = false; return this; }
     GuiRadarView* enableWaypoints() { show_waypoints = true; return this; }
     GuiRadarView* disableWaypoints() { show_waypoints = false; return this; }
     GuiRadarView* enableTargetProjections(GuiMissileTubeControls* missile_tube_controls) { show_target_projection = true; this->missile_tube_controls = missile_tube_controls; return this; }
@@ -126,6 +130,7 @@ private:
     void drawTargets(sf::RenderTarget& window);
     void drawHeadingIndicators(sf::RenderTarget& window);
     void drawRadarCutoff(sf::RenderTarget& window);
+    void drawSignalDetails(sf::RenderTarget& window_normal, sf::RenderTarget& window_alpha);
 };
 
 #endif//RADAR_VIEW_H

--- a/src/screenComponents/targetsContainer.cpp
+++ b/src/screenComponents/targetsContainer.cpp
@@ -53,16 +53,29 @@ void TargetsContainer::setToClosestTo(sf::Vector2f position, float max_range, ES
     foreach(Collisionable, obj, list)
     {
         P<SpaceObject> spaceObject = obj;
+
         if (spaceObject && spaceObject != my_spaceship)
         {
+            // If the object is a SpaceShip, adjust the signature dynamically
+            // based on its current state and activity.
+            P<SpaceShip> ship = obj;
+            RawRadarSignatureInfo info;
+
+            if (ship)
+                info = ship->getDynamicRadarSignatureInfo();    // Use dynamic signatures for ships.
+            else
+                info = spaceObject->getRadarSignatureInfo();    // Otherwise, use the baseline only.
+
+            bool has_signal = info.electrical > 0.0f && info.gravity > 0.0f && info.biological > 0.0f;
+
             switch(selection_type)
             {
             case Selectable:
-                if (!spaceObject->canBeSelectedBy(my_spaceship))
+                if (!spaceObject->canBeSelectedBy(my_spaceship) || !has_signal)
                     continue;
                 break;
             case Targetable:
-                if (!spaceObject->canBeTargetedBy(my_spaceship))
+                if (!spaceObject->canBeTargetedBy(my_spaceship) || !has_signal)
                     continue;
                 break;
             }
@@ -70,8 +83,7 @@ void TargetsContainer::setToClosestTo(sf::Vector2f position, float max_range, ES
                 target = spaceObject;
         }
     }
-    
-    
+
     if (my_spaceship && allow_waypoint_selection)
     {
         for(int n=0; n<my_spaceship->getWaypointCount(); n++)

--- a/src/screenComponents/targetsContainer.cpp
+++ b/src/screenComponents/targetsContainer.cpp
@@ -66,7 +66,7 @@ void TargetsContainer::setToClosestTo(sf::Vector2f position, float max_range, ES
             else
                 info = spaceObject->getRadarSignatureInfo();    // Otherwise, use the baseline only.
 
-            bool has_signal = info.electrical > 0.0f && info.gravity > 0.0f && info.biological > 0.0f;
+            bool has_signal = info.electrical > 0.0f || info.gravity > 0.0f || info.biological > 0.0f;
 
             switch(selection_type)
             {

--- a/src/screens/crew4/operationsScreen.cpp
+++ b/src/screens/crew4/operationsScreen.cpp
@@ -9,6 +9,7 @@
 #include "screenComponents/shipsLogControl.h"
 
 #include "spaceObjects/playerSpaceship.h"
+#include "gui/gui2_togglebutton.h"
 
 OperationScreen::OperationScreen(GuiContainer* owner)
 : GuiOverlay(owner, "", colorConfig.background)
@@ -73,6 +74,13 @@ OperationScreen::OperationScreen(GuiContainer* owner)
         }
     });
     delete_waypoint_button->setPosition(-270, -120, ABottomRight)->setSize(200, 50);
+
+    // Move signal details UI to top left.
+    science->signal_details_toggle->setPosition(20, 20, ATopLeft);
+    science->signal_details_visual_button->setPosition(20, 70, ATopLeft);
+    science->signal_details_electrical_button->setPosition(70, 70, ATopLeft);
+    science->signal_details_gravity_button->setPosition(120, 70, ATopLeft);
+    science->signal_details_biological_button->setPosition(170, 70, ATopLeft);
     
     mode = TargetSelection;
     

--- a/src/screens/crew6/scienceScreen.cpp
+++ b/src/screens/crew6/scienceScreen.cpp
@@ -207,10 +207,10 @@ ScienceScreen::ScienceScreen(GuiContainer* owner, ECrewPosition crew_position)
     signal_details_toggle = new GuiToggleButton(this, "SIGNAL_DETAILS_TOGGLE", "Signal Details", [this](bool value)
     {
         // Toggle visibility of individual radar toggles.
-        signal_details_visual_button->setVisible(value);
-        signal_details_gravity_button->setVisible(value);
-        signal_details_electrical_button->setVisible(value);
-        signal_details_biological_button->setVisible(value);
+        signal_details_visual_button->setValue(true)->setVisible(value);
+        signal_details_gravity_button->setValue(false)->setVisible(value);
+        signal_details_electrical_button->setValue(false)->setVisible(value);
+        signal_details_biological_button->setValue(false)->setVisible(value);
         // Toggle signal details.
         if (value)
             science_radar->enableSignalDetails();
@@ -218,6 +218,7 @@ ScienceScreen::ScienceScreen(GuiContainer* owner, ECrewPosition crew_position)
             science_radar->disableSignalDetails();
     });
     signal_details_toggle->setPosition(-270, -20, ABottomRight)->setSize(200, 50)->setVisible(true);
+
     signal_details_visual_button = new GuiToggleButton(this, "SIGNAL_DETAILS_VISUAL", "V", [this](bool value)
     {
         if (value)
@@ -225,31 +226,32 @@ ScienceScreen::ScienceScreen(GuiContainer* owner, ECrewPosition crew_position)
         else
             science_radar->disableVisualObjects();
     });
-    signal_details_visual_button->setPosition(-420, -70, ABottomRight)->setSize(50, 50)->setVisible(false);
-    signal_details_visual_button->setValue(true);
+    signal_details_visual_button->setValue(true)->setPosition(-420, -70, ABottomRight)->setSize(50, 50)->setVisible(false);
     signal_details_gravity_button = new GuiToggleButton(this, "SIGNAL_DETAILS_GRAVITY", "G", [this](bool value)
     {
         science_radar->setSignalGravity(value);
     });
-    signal_details_gravity_button->setPosition(-370, -70, ABottomRight)->setSize(50, 50)->setVisible(false);
-    signal_details_gravity_button->setValue(false);
+    signal_details_gravity_button->setValue(false)->setPosition(-370, -70, ABottomRight)->setSize(50, 50)->setVisible(false);
     signal_details_electrical_button = new GuiToggleButton(this, "SIGNAL_DETAILS_ELECTRICAL", "E", [this](bool value)
     {
         science_radar->setSignalElectrical(value);
     });
-    signal_details_electrical_button->setPosition(-320, -70, ABottomRight)->setSize(50, 50)->setVisible(false);
-    signal_details_electrical_button->setValue(false);
+    signal_details_electrical_button->setValue(false)->setPosition(-320, -70, ABottomRight)->setSize(50, 50)->setVisible(false);
     signal_details_biological_button = new GuiToggleButton(this, "SIGNAL_DETAILS_BIOLOGICAL", "B", [this](bool value)
     {
         science_radar->setSignalBiological(value);
     });
-    signal_details_biological_button->setPosition(-270, -70, ABottomRight)->setSize(50, 50)->setVisible(false);
-    signal_details_biological_button->setValue(false);
+    signal_details_biological_button->setValue(false)->setPosition(-270, -70, ABottomRight)->setSize(50, 50)->setVisible(false);
 
     // Radar/database view toggle.
     view_mode_selection = new GuiListbox(this, "VIEW_SELECTION", [this](int index, string value) {
         radar_view->setVisible(index == 0);
         background_gradient->setVisible(index == 0);
+        signal_details_toggle->setVisible(index == 0);
+        signal_details_visual_button->setVisible(index == 0);
+        signal_details_gravity_button->setVisible(index == 0);
+        signal_details_electrical_button->setVisible(index == 0);
+        signal_details_biological_button->setVisible(index == 0);
         database_view->setVisible(index == 1);
     });
     view_mode_selection->setOptions({"Radar", "Database"})->setSelectionIndex(0)->setPosition(20, -20, ABottomLeft)->setSize(200, 100);

--- a/src/screens/crew6/scienceScreen.cpp
+++ b/src/screens/crew6/scienceScreen.cpp
@@ -590,46 +590,51 @@ void ScienceScreen::onHotkey(const HotkeyResult& key)
             bool new_value = !signal_details_toggle->getValue();
             setSignalDetailsToggle(new_value);
             signal_details_toggle->setValue(new_value);
+            return;
         }
 
         if (key.hotkey == "TOGGLE_VISUAL_DETAILS")
         {
-            bool new_value = !signal_details_visual_button->getValue();
             if (signal_details_toggle->getValue() == true)
             {
+                bool new_value = !signal_details_visual_button->getValue();
                 setVisualDetailsToggle(new_value);
                 signal_details_visual_button->setValue(new_value);
             }
+            return;
         }
 
         if (key.hotkey == "TOGGLE_ELECTRICAL_DETAILS")
         {
-            bool new_value = !signal_details_electrical_button->getValue();
             if (signal_details_toggle->getValue() == true)
             {
+                bool new_value = !signal_details_electrical_button->getValue();
                 setElectricalDetailsToggle(new_value);
                 signal_details_electrical_button->setValue(new_value);
             }
+            return;
         }
 
         if (key.hotkey == "TOGGLE_GRAVITY_DETAILS")
         {
-            bool new_value = !signal_details_gravity_button->getValue();
             if (signal_details_toggle->getValue() == true)
             {
+                bool new_value = !signal_details_gravity_button->getValue();
                 setGravityDetailsToggle(new_value);
                 signal_details_gravity_button->setValue(new_value);
             }
+            return;
         }
 
         if (key.hotkey == "TOGGLE_BIOLOGICAL_DETAILS")
         {
-            bool new_value = !signal_details_biological_button->getValue();
             if (signal_details_toggle->getValue() == true)
             {
+                bool new_value = !signal_details_biological_button->getValue();
                 setBiologicalDetailsToggle(new_value);
                 signal_details_biological_button->setValue(new_value);
             }
+            return;
         }
     }
 }

--- a/src/screens/crew6/scienceScreen.cpp
+++ b/src/screens/crew6/scienceScreen.cpp
@@ -206,12 +206,45 @@ ScienceScreen::ScienceScreen(GuiContainer* owner, ECrewPosition crew_position)
     // Radar signal details toggle.
     signal_details_toggle = new GuiToggleButton(this, "SIGNAL_DETAILS_TOGGLE", "Signal Details", [this](bool value)
     {
-        if (science_radar->areSignalDetailsEnabled())
-	    science_radar->disableSignalDetails();
-	else
+        // Toggle visibility of individual radar toggles.
+        signal_details_visual_button->setVisible(value);
+        signal_details_gravity_button->setVisible(value);
+        signal_details_electrical_button->setVisible(value);
+        signal_details_biological_button->setVisible(value);
+        // Toggle signal details.
+        if (value)
             science_radar->enableSignalDetails();
+        else
+            science_radar->disableSignalDetails();
     });
-    signal_details_toggle->setPosition(-270, -20, ABottomRight)->setSize(250, 50);
+    signal_details_toggle->setPosition(-270, -20, ABottomRight)->setSize(200, 50)->setVisible(true);
+    signal_details_visual_button = new GuiToggleButton(this, "SIGNAL_DETAILS_VISUAL", "V", [this](bool value)
+    {
+        if (value)
+            science_radar->enableVisualObjects();
+        else
+            science_radar->disableVisualObjects();
+    });
+    signal_details_visual_button->setPosition(-420, -70, ABottomRight)->setSize(50, 50)->setVisible(false);
+    signal_details_visual_button->setValue(true);
+    signal_details_gravity_button = new GuiToggleButton(this, "SIGNAL_DETAILS_GRAVITY", "G", [this](bool value)
+    {
+        science_radar->setSignalGravity(value);
+    });
+    signal_details_gravity_button->setPosition(-370, -70, ABottomRight)->setSize(50, 50)->setVisible(false);
+    signal_details_gravity_button->setValue(false);
+    signal_details_electrical_button = new GuiToggleButton(this, "SIGNAL_DETAILS_ELECTRICAL", "E", [this](bool value)
+    {
+        science_radar->setSignalElectrical(value);
+    });
+    signal_details_electrical_button->setPosition(-320, -70, ABottomRight)->setSize(50, 50)->setVisible(false);
+    signal_details_electrical_button->setValue(false);
+    signal_details_biological_button = new GuiToggleButton(this, "SIGNAL_DETAILS_BIOLOGICAL", "B", [this](bool value)
+    {
+        science_radar->setSignalBiological(value);
+    });
+    signal_details_biological_button->setPosition(-270, -70, ABottomRight)->setSize(50, 50)->setVisible(false);
+    signal_details_biological_button->setValue(false);
 
     // Radar/database view toggle.
     view_mode_selection = new GuiListbox(this, "VIEW_SELECTION", [this](int index, string value) {

--- a/src/screens/crew6/scienceScreen.cpp
+++ b/src/screens/crew6/scienceScreen.cpp
@@ -222,28 +222,28 @@ ScienceScreen::ScienceScreen(GuiContainer* owner, ECrewPosition crew_position)
     {
         science_radar->setVisualObjects(value);
     });
-    signal_details_visual_button->setValue(false)->setPosition(-320, -70, ABottomRight)->setSize(50, 50)->setVisible(false);
+    signal_details_visual_button->setValue(false)->setPosition(-270, -70, ABottomRight)->setSize(50, 50)->setVisible(false);
 
     // Electrical view toggle.
     signal_details_electrical_button = new GuiToggleButton(this, "SIGNAL_DETAILS_ELECTRICAL", "E", [this](bool value)
     {
         science_radar->setSignalElectrical(value);
     });
-    signal_details_electrical_button->setValue(true)->setPosition(-370, -70, ABottomRight)->setSize(50, 50)->setVisible(false);
+    signal_details_electrical_button->setValue(true)->setPosition(-320, -70, ABottomRight)->setSize(50, 50)->setVisible(false);
 
     // Gravity view toggle.
     signal_details_gravity_button = new GuiToggleButton(this, "SIGNAL_DETAILS_GRAVITY", "G", [this](bool value)
     {
         science_radar->setSignalGravity(value);
     });
-    signal_details_gravity_button->setValue(false)->setPosition(-420, -70, ABottomRight)->setSize(50, 50)->setVisible(false);
+    signal_details_gravity_button->setValue(false)->setPosition(-370, -70, ABottomRight)->setSize(50, 50)->setVisible(false);
 
     // Biological view toggle.
     signal_details_biological_button = new GuiToggleButton(this, "SIGNAL_DETAILS_BIOLOGICAL", "B", [this](bool value)
     {
         science_radar->setSignalBiological(value);
     });
-    signal_details_biological_button->setValue(false)->setPosition(-270, -70, ABottomRight)->setSize(50, 50)->setVisible(false);
+    signal_details_biological_button->setValue(false)->setPosition(-420, -70, ABottomRight)->setSize(50, 50)->setVisible(false);
 
     // Radar/database view toggle.
     view_mode_selection = new GuiListbox(this, "VIEW_SELECTION", [this](int index, string value) {

--- a/src/screens/crew6/scienceScreen.cpp
+++ b/src/screens/crew6/scienceScreen.cpp
@@ -108,9 +108,7 @@ ScienceScreen::ScienceScreen(GuiContainer* owner, ECrewPosition crew_position)
             if (database_view->findAndDisplayEntry(ship->getTypeName()))
             {
                 view_mode_selection->setSelectionIndex(1);
-                radar_view->hide();
-                background_gradient->hide();
-                database_view->show();
+                setViewModeSelectionToggle(1);
             }
         }
     });
@@ -227,20 +225,23 @@ ScienceScreen::ScienceScreen(GuiContainer* owner, ECrewPosition crew_position)
     signal_details_biological_button->setColor(sf::Color::Blue);
 
     // Radar/database view toggle.
-    view_mode_selection = new GuiListbox(this, "VIEW_SELECTION", [this](int index, string value) {
-        radar_view->setVisible(index == 0);
-        background_gradient->setVisible(index == 0);
-        signal_details_toggle->setVisible(index == 0);
-        signal_details_visual_button->setVisible(index == 0);
-        signal_details_gravity_button->setVisible(index == 0);
-        signal_details_electrical_button->setVisible(index == 0);
-        signal_details_biological_button->setVisible(index == 0);
-        database_view->setVisible(index == 1);
-    });
+    view_mode_selection = new GuiListbox(this, "VIEW_SELECTION", [this](int index, string value) { setViewModeSelectionToggle(index); });
     view_mode_selection->setOptions({"Radar", "Database"})->setSelectionIndex(0)->setPosition(20, -20, ABottomLeft)->setSize(200, 100);
 
     // Scanning dialog.
     new GuiScanningDialog(this, "SCANNING_DIALOG");
+}
+
+void ScienceScreen::setViewModeSelectionToggle(int index)
+{
+    radar_view->setVisible(index == 0);
+    background_gradient->setVisible(index == 0);
+    signal_details_toggle->setVisible(index == 0);
+    signal_details_visual_button->setVisible(index == 0);
+    signal_details_gravity_button->setVisible(index == 0);
+    signal_details_electrical_button->setVisible(index == 0);
+    signal_details_biological_button->setVisible(index == 0);
+    database_view->setVisible(index == 1);
 }
 
 void ScienceScreen::setSignalDetailsToggle(bool value)
@@ -587,15 +588,18 @@ void ScienceScreen::onHotkey(const HotkeyResult& key)
         // Signal details toggles.
         if (key.hotkey == "TOGGLE_SIGNAL_DETAILS")
         {
-            bool new_value = !signal_details_toggle->getValue();
-            setSignalDetailsToggle(new_value);
-            signal_details_toggle->setValue(new_value);
+            if (science_radar->isVisible() || probe_radar->isVisible())
+            {
+                bool new_value = !signal_details_toggle->getValue();
+                setSignalDetailsToggle(new_value);
+                signal_details_toggle->setValue(new_value);
+            }
             return;
         }
 
         if (key.hotkey == "TOGGLE_VISUAL_DETAILS")
         {
-            if (signal_details_toggle->getValue() == true)
+            if (signal_details_toggle->getValue() == true && (science_radar->isVisible() || probe_radar->isVisible()))
             {
                 bool new_value = !signal_details_visual_button->getValue();
                 setVisualDetailsToggle(new_value);
@@ -606,7 +610,7 @@ void ScienceScreen::onHotkey(const HotkeyResult& key)
 
         if (key.hotkey == "TOGGLE_ELECTRICAL_DETAILS")
         {
-            if (signal_details_toggle->getValue() == true)
+            if (signal_details_toggle->getValue() == true && (science_radar->isVisible() || probe_radar->isVisible()))
             {
                 bool new_value = !signal_details_electrical_button->getValue();
                 setElectricalDetailsToggle(new_value);
@@ -617,7 +621,7 @@ void ScienceScreen::onHotkey(const HotkeyResult& key)
 
         if (key.hotkey == "TOGGLE_GRAVITY_DETAILS")
         {
-            if (signal_details_toggle->getValue() == true)
+            if (signal_details_toggle->getValue() == true && (science_radar->isVisible() || probe_radar->isVisible()))
             {
                 bool new_value = !signal_details_gravity_button->getValue();
                 setGravityDetailsToggle(new_value);
@@ -628,7 +632,7 @@ void ScienceScreen::onHotkey(const HotkeyResult& key)
 
         if (key.hotkey == "TOGGLE_BIOLOGICAL_DETAILS")
         {
-            if (signal_details_toggle->getValue() == true)
+            if (signal_details_toggle->getValue() == true && (science_radar->isVisible() || probe_radar->isVisible()))
             {
                 bool new_value = !signal_details_biological_button->getValue();
                 setBiologicalDetailsToggle(new_value);

--- a/src/screens/crew6/scienceScreen.cpp
+++ b/src/screens/crew6/scienceScreen.cpp
@@ -208,7 +208,7 @@ ScienceScreen::ScienceScreen(GuiContainer* owner, ECrewPosition crew_position)
     {
         // Toggle visibility of individual radar toggles.
         signal_details_visual_button->setValue(true)->setVisible(value);
-        science_radar->setVisualObjects(true);
+        science_radar->setVisualObjects(true)->setSignalGravity(false)->setSignalElectrical(false)->setSignalBiological(false);
         signal_details_gravity_button->setValue(false)->setVisible(value);
         signal_details_electrical_button->setValue(false)->setVisible(value);
         signal_details_biological_button->setValue(false)->setVisible(value);

--- a/src/screens/crew6/scienceScreen.cpp
+++ b/src/screens/crew6/scienceScreen.cpp
@@ -212,14 +212,10 @@ ScienceScreen::ScienceScreen(GuiContainer* owner, ECrewPosition crew_position)
         signal_details_electrical_button->setValue(false)->setVisible(value);
         signal_details_biological_button->setValue(false)->setVisible(value);
         // Toggle signal details.
-        if (science_radar->isVisible())
-        {
-            science_radar->setSignalDetails(value);
-            science_radar->setVisualObjects(true)->setSignalGravity(false)->setSignalElectrical(false)->setSignalBiological(false);
-        } else if (probe_radar->isVisible()) {
-            probe_radar->setSignalDetails(value);
-            probe_radar->setVisualObjects(true)->setSignalGravity(false)->setSignalElectrical(false)->setSignalBiological(false);
-        }
+        science_radar->setSignalDetails(value);
+        probe_radar->setSignalDetails(value);
+        science_radar->setVisualObjects(true)->setSignalGravity(false)->setSignalElectrical(false)->setSignalBiological(false);
+        probe_radar->setVisualObjects(true)->setSignalGravity(false)->setSignalElectrical(false)->setSignalBiological(false);
     });
     signal_details_toggle->setPosition(-270, -20, ABottomRight)->setSize(200, 50)->setVisible(true);
 

--- a/src/screens/crew6/scienceScreen.cpp
+++ b/src/screens/crew6/scienceScreen.cpp
@@ -204,41 +204,25 @@ ScienceScreen::ScienceScreen(GuiContainer* owner, ECrewPosition crew_position)
     zoom_label->setSize(GuiElement::GuiSizeMax, GuiElement::GuiSizeMax);
 
     // Radar signal details toggle.
-    signal_details_toggle = new GuiToggleButton(this, "SIGNAL_DETAILS_TOGGLE", "Signal Details", [this](bool value){ toggleSignalDetails(value); });
+    signal_details_toggle = new GuiToggleButton(this, "SIGNAL_DETAILS_TOGGLE", "Signal Details", [this](bool value){ setSignalDetailsToggle(value); });
     signal_details_toggle->setPosition(-270, -20, ABottomRight)->setSize(200, 50)->setVisible(true);
 
     // Visual objects (radar trace) toggle.
-    signal_details_visual_button = new GuiToggleButton(this, "SIGNAL_DETAILS_VISUAL", "V", [this](bool value)
-    {
-        science_radar->setVisualObjects(value);
-        probe_radar->setVisualObjects(value);
-    });
+    signal_details_visual_button = new GuiToggleButton(this, "SIGNAL_DETAILS_VISUAL", "V", [this](bool value){ setVisualDetailsToggle(value); });
     signal_details_visual_button->setValue(false)->setPosition(-420, -70, ABottomRight)->setSize(50, 50)->setVisible(false);
 
     // Electrical view toggle.
-    signal_details_electrical_button = new GuiToggleButton(this, "SIGNAL_DETAILS_ELECTRICAL", "E", [this](bool value)
-    {
-        science_radar->setSignalElectrical(value);
-        probe_radar->setSignalElectrical(value);
-    });
+    signal_details_electrical_button = new GuiToggleButton(this, "SIGNAL_DETAILS_ELECTRICAL", "E", [this](bool value){ setElectricalDetailsToggle(value); });
     signal_details_electrical_button->setValue(true)->setPosition(-370, -70, ABottomRight)->setSize(50, 50)->setVisible(false);
     signal_details_electrical_button->setColor(sf::Color::Red);
 
     // Gravity view toggle.
-    signal_details_gravity_button = new GuiToggleButton(this, "SIGNAL_DETAILS_GRAVITY", "G", [this](bool value)
-    {
-        science_radar->setSignalGravity(value);
-        probe_radar->setSignalGravity(value);
-    });
+    signal_details_gravity_button = new GuiToggleButton(this, "SIGNAL_DETAILS_GRAVITY", "G", [this](bool value){ setGravityDetailsToggle(value); });
     signal_details_gravity_button->setValue(false)->setPosition(-320, -70, ABottomRight)->setSize(50, 50)->setVisible(false);
     signal_details_gravity_button->setColor(sf::Color::Green);
 
     // Biological view toggle.
-    signal_details_biological_button = new GuiToggleButton(this, "SIGNAL_DETAILS_BIOLOGICAL", "B", [this](bool value)
-    {
-        science_radar->setSignalBiological(value);
-        probe_radar->setSignalBiological(value);
-    });
+    signal_details_biological_button = new GuiToggleButton(this, "SIGNAL_DETAILS_BIOLOGICAL", "B", [this](bool value){ setBiologicalDetailsToggle(value); });
     signal_details_biological_button->setValue(false)->setPosition(-270, -70, ABottomRight)->setSize(50, 50)->setVisible(false);
     signal_details_biological_button->setColor(sf::Color::Blue);
 
@@ -259,7 +243,7 @@ ScienceScreen::ScienceScreen(GuiContainer* owner, ECrewPosition crew_position)
     new GuiScanningDialog(this, "SCANNING_DIALOG");
 }
 
-void ScienceScreen::toggleSignalDetails(bool value)
+void ScienceScreen::setSignalDetailsToggle(bool value)
 {
     // Toggle visibility of signal lens toggles.
     signal_details_visual_button->setValue(true)->setVisible(value);
@@ -271,6 +255,42 @@ void ScienceScreen::toggleSignalDetails(bool value)
     probe_radar->setSignalDetails(value);
     science_radar->setVisualObjects(true)->setSignalGravity(false)->setSignalElectrical(false)->setSignalBiological(false);
     probe_radar->setVisualObjects(true)->setSignalGravity(false)->setSignalElectrical(false)->setSignalBiological(false);
+}
+
+void ScienceScreen::setVisualDetailsToggle(bool value)
+{
+    if (science_radar->getSignalDetails() == true)
+    {
+        science_radar->setVisualObjects(value);
+        probe_radar->setVisualObjects(value);
+    }
+}
+
+void ScienceScreen::setElectricalDetailsToggle(bool value)
+{
+    if (science_radar->getSignalDetails() == true)
+    {
+        science_radar->setSignalElectrical(value);
+        probe_radar->setSignalElectrical(value);
+    }
+}
+
+void ScienceScreen::setGravityDetailsToggle(bool value)
+{
+    if (science_radar->getSignalDetails() == true)
+    {
+        science_radar->setSignalGravity(value);
+        probe_radar->setSignalGravity(value);
+    }
+}
+
+void ScienceScreen::setBiologicalDetailsToggle(bool value)
+{
+    if (science_radar->getSignalDetails() == true)
+    {
+        science_radar->setSignalBiological(value);
+        probe_radar->setSignalBiological(value);
+    }
 }
 
 void ScienceScreen::onDraw(sf::RenderTarget& window)
@@ -564,6 +584,51 @@ void ScienceScreen::onHotkey(const HotkeyResult& key)
                     targets.set(obj);
                     return;
                 }
+        // Signal details toggles.
+        if (key.hotkey == "TOGGLE_SIGNAL_DETAILS")
+        {
+            bool new_value = !signal_details_toggle->getValue();
+            setSignalDetailsToggle(new_value);
+            signal_details_toggle->setValue(new_value);
+        }
+
+        if (key.hotkey == "TOGGLE_VISUAL_DETAILS")
+        {
+            bool new_value = !signal_details_visual_button->getValue();
+            if (signal_details_toggle->getValue() == true)
+            {
+                setVisualDetailsToggle(new_value);
+                signal_details_visual_button->setValue(new_value);
+            }
+        }
+
+        if (key.hotkey == "TOGGLE_ELECTRICAL_DETAILS")
+        {
+            bool new_value = !signal_details_electrical_button->getValue();
+            if (signal_details_toggle->getValue() == true)
+            {
+                setElectricalDetailsToggle(new_value);
+                signal_details_electrical_button->setValue(new_value);
+            }
+        }
+
+        if (key.hotkey == "TOGGLE_GRAVITY_DETAILS")
+        {
+            bool new_value = !signal_details_gravity_button->getValue();
+            if (signal_details_toggle->getValue() == true)
+            {
+                setGravityDetailsToggle(new_value);
+                signal_details_gravity_button->setValue(new_value);
+            }
+        }
+
+        if (key.hotkey == "TOGGLE_BIOLOGICAL_DETAILS")
+        {
+            bool new_value = !signal_details_biological_button->getValue();
+            if (signal_details_toggle->getValue() == true)
+            {
+                setBiologicalDetailsToggle(new_value);
+                signal_details_biological_button->setValue(new_value);
             }
         }
     }

--- a/src/screens/crew6/scienceScreen.cpp
+++ b/src/screens/crew6/scienceScreen.cpp
@@ -223,6 +223,7 @@ ScienceScreen::ScienceScreen(GuiContainer* owner, ECrewPosition crew_position)
     signal_details_visual_button = new GuiToggleButton(this, "SIGNAL_DETAILS_VISUAL", "V", [this](bool value)
     {
         science_radar->setVisualObjects(value);
+        probe_radar->setVisualObjects(value);
     });
     signal_details_visual_button->setValue(false)->setPosition(-420, -70, ABottomRight)->setSize(50, 50)->setVisible(false);
 
@@ -230,6 +231,7 @@ ScienceScreen::ScienceScreen(GuiContainer* owner, ECrewPosition crew_position)
     signal_details_electrical_button = new GuiToggleButton(this, "SIGNAL_DETAILS_ELECTRICAL", "E", [this](bool value)
     {
         science_radar->setSignalElectrical(value);
+        probe_radar->setSignalElectrical(value);
     });
     signal_details_electrical_button->setValue(true)->setPosition(-370, -70, ABottomRight)->setSize(50, 50)->setVisible(false);
 
@@ -237,6 +239,7 @@ ScienceScreen::ScienceScreen(GuiContainer* owner, ECrewPosition crew_position)
     signal_details_gravity_button = new GuiToggleButton(this, "SIGNAL_DETAILS_GRAVITY", "G", [this](bool value)
     {
         science_radar->setSignalGravity(value);
+        probe_radar->setSignalGravity(value);
     });
     signal_details_gravity_button->setValue(false)->setPosition(-320, -70, ABottomRight)->setSize(50, 50)->setVisible(false);
 
@@ -244,6 +247,7 @@ ScienceScreen::ScienceScreen(GuiContainer* owner, ECrewPosition crew_position)
     signal_details_biological_button = new GuiToggleButton(this, "SIGNAL_DETAILS_BIOLOGICAL", "B", [this](bool value)
     {
         science_radar->setSignalBiological(value);
+        probe_radar->setSignalBiological(value);
     });
     signal_details_biological_button->setValue(false)->setPosition(-270, -70, ABottomRight)->setSize(50, 50)->setVisible(false);
 

--- a/src/screens/crew6/scienceScreen.cpp
+++ b/src/screens/crew6/scienceScreen.cpp
@@ -206,32 +206,39 @@ ScienceScreen::ScienceScreen(GuiContainer* owner, ECrewPosition crew_position)
     // Radar signal details toggle.
     signal_details_toggle = new GuiToggleButton(this, "SIGNAL_DETAILS_TOGGLE", "Signal Details", [this](bool value)
     {
-        // Toggle visibility of individual radar toggles.
+        // Toggle visibility of signal lens toggles.
         signal_details_visual_button->setValue(true)->setVisible(value);
-        science_radar->setVisualObjects(true)->setSignalGravity(false)->setSignalElectrical(false)->setSignalBiological(false);
         signal_details_gravity_button->setValue(false)->setVisible(value);
         signal_details_electrical_button->setValue(false)->setVisible(value);
         signal_details_biological_button->setValue(false)->setVisible(value);
         // Toggle signal details.
         science_radar->setSignalDetails(value);
+        science_radar->setVisualObjects(true)->setSignalGravity(false)->setSignalElectrical(false)->setSignalBiological(false);
     });
     signal_details_toggle->setPosition(-270, -20, ABottomRight)->setSize(200, 50)->setVisible(true);
 
+    // Visual objects (radar trace) toggle.
     signal_details_visual_button = new GuiToggleButton(this, "SIGNAL_DETAILS_VISUAL", "V", [this](bool value)
     {
         science_radar->setVisualObjects(value);
     });
-    signal_details_visual_button->setValue(true)->setPosition(-420, -70, ABottomRight)->setSize(50, 50)->setVisible(false);
-    signal_details_gravity_button = new GuiToggleButton(this, "SIGNAL_DETAILS_GRAVITY", "G", [this](bool value)
-    {
-        science_radar->setSignalGravity(value);
-    });
-    signal_details_gravity_button->setValue(false)->setPosition(-370, -70, ABottomRight)->setSize(50, 50)->setVisible(false);
+    signal_details_visual_button->setValue(false)->setPosition(-320, -70, ABottomRight)->setSize(50, 50)->setVisible(false);
+
+    // Electrical view toggle.
     signal_details_electrical_button = new GuiToggleButton(this, "SIGNAL_DETAILS_ELECTRICAL", "E", [this](bool value)
     {
         science_radar->setSignalElectrical(value);
     });
-    signal_details_electrical_button->setValue(false)->setPosition(-320, -70, ABottomRight)->setSize(50, 50)->setVisible(false);
+    signal_details_electrical_button->setValue(true)->setPosition(-370, -70, ABottomRight)->setSize(50, 50)->setVisible(false);
+
+    // Gravity view toggle.
+    signal_details_gravity_button = new GuiToggleButton(this, "SIGNAL_DETAILS_GRAVITY", "G", [this](bool value)
+    {
+        science_radar->setSignalGravity(value);
+    });
+    signal_details_gravity_button->setValue(false)->setPosition(-420, -70, ABottomRight)->setSize(50, 50)->setVisible(false);
+
+    // Biological view toggle.
     signal_details_biological_button = new GuiToggleButton(this, "SIGNAL_DETAILS_BIOLOGICAL", "B", [this](bool value)
     {
         science_radar->setSignalBiological(value);

--- a/src/screens/crew6/scienceScreen.cpp
+++ b/src/screens/crew6/scienceScreen.cpp
@@ -222,28 +222,28 @@ ScienceScreen::ScienceScreen(GuiContainer* owner, ECrewPosition crew_position)
     {
         science_radar->setVisualObjects(value);
     });
-    signal_details_visual_button->setValue(false)->setPosition(-270, -70, ABottomRight)->setSize(50, 50)->setVisible(false);
+    signal_details_visual_button->setValue(false)->setPosition(-420, -70, ABottomRight)->setSize(50, 50)->setVisible(false);
 
     // Electrical view toggle.
     signal_details_electrical_button = new GuiToggleButton(this, "SIGNAL_DETAILS_ELECTRICAL", "E", [this](bool value)
     {
         science_radar->setSignalElectrical(value);
     });
-    signal_details_electrical_button->setValue(true)->setPosition(-320, -70, ABottomRight)->setSize(50, 50)->setVisible(false);
+    signal_details_electrical_button->setValue(true)->setPosition(-370, -70, ABottomRight)->setSize(50, 50)->setVisible(false);
 
     // Gravity view toggle.
     signal_details_gravity_button = new GuiToggleButton(this, "SIGNAL_DETAILS_GRAVITY", "G", [this](bool value)
     {
         science_radar->setSignalGravity(value);
     });
-    signal_details_gravity_button->setValue(false)->setPosition(-370, -70, ABottomRight)->setSize(50, 50)->setVisible(false);
+    signal_details_gravity_button->setValue(false)->setPosition(-320, -70, ABottomRight)->setSize(50, 50)->setVisible(false);
 
     // Biological view toggle.
     signal_details_biological_button = new GuiToggleButton(this, "SIGNAL_DETAILS_BIOLOGICAL", "B", [this](bool value)
     {
         science_radar->setSignalBiological(value);
     });
-    signal_details_biological_button->setValue(false)->setPosition(-420, -70, ABottomRight)->setSize(50, 50)->setVisible(false);
+    signal_details_biological_button->setValue(false)->setPosition(-250, -70, ABottomRight)->setSize(50, 50)->setVisible(false);
 
     // Radar/database view toggle.
     view_mode_selection = new GuiListbox(this, "VIEW_SELECTION", [this](int index, string value) {

--- a/src/screens/crew6/scienceScreen.cpp
+++ b/src/screens/crew6/scienceScreen.cpp
@@ -234,6 +234,7 @@ ScienceScreen::ScienceScreen(GuiContainer* owner, ECrewPosition crew_position)
         probe_radar->setSignalElectrical(value);
     });
     signal_details_electrical_button->setValue(true)->setPosition(-370, -70, ABottomRight)->setSize(50, 50)->setVisible(false);
+    signal_details_electrical_button->setColor(sf::Color::Red);
 
     // Gravity view toggle.
     signal_details_gravity_button = new GuiToggleButton(this, "SIGNAL_DETAILS_GRAVITY", "G", [this](bool value)
@@ -242,6 +243,7 @@ ScienceScreen::ScienceScreen(GuiContainer* owner, ECrewPosition crew_position)
         probe_radar->setSignalGravity(value);
     });
     signal_details_gravity_button->setValue(false)->setPosition(-320, -70, ABottomRight)->setSize(50, 50)->setVisible(false);
+    signal_details_gravity_button->setColor(sf::Color::Green);
 
     // Biological view toggle.
     signal_details_biological_button = new GuiToggleButton(this, "SIGNAL_DETAILS_BIOLOGICAL", "B", [this](bool value)
@@ -250,6 +252,7 @@ ScienceScreen::ScienceScreen(GuiContainer* owner, ECrewPosition crew_position)
         probe_radar->setSignalBiological(value);
     });
     signal_details_biological_button->setValue(false)->setPosition(-270, -70, ABottomRight)->setSize(50, 50)->setVisible(false);
+    signal_details_biological_button->setColor(sf::Color::Blue);
 
     // Radar/database view toggle.
     view_mode_selection = new GuiListbox(this, "VIEW_SELECTION", [this](int index, string value) {

--- a/src/screens/crew6/scienceScreen.cpp
+++ b/src/screens/crew6/scienceScreen.cpp
@@ -221,10 +221,7 @@ ScienceScreen::ScienceScreen(GuiContainer* owner, ECrewPosition crew_position)
 
     signal_details_visual_button = new GuiToggleButton(this, "SIGNAL_DETAILS_VISUAL", "V", [this](bool value)
     {
-        if (value)
-            science_radar->enableVisualObjects();
-        else
-            science_radar->disableVisualObjects();
+        science_radar->setVisualObjects(value);
     });
     signal_details_visual_button->setValue(true)->setPosition(-420, -70, ABottomRight)->setSize(50, 50)->setVisible(false);
     signal_details_gravity_button = new GuiToggleButton(this, "SIGNAL_DETAILS_GRAVITY", "G", [this](bool value)

--- a/src/screens/crew6/scienceScreen.cpp
+++ b/src/screens/crew6/scienceScreen.cpp
@@ -203,6 +203,16 @@ ScienceScreen::ScienceScreen(GuiContainer* owner, ECrewPosition crew_position)
     zoom_label = new GuiLabel(zoom_slider, "", "Zoom: 1.0x", 30);
     zoom_label->setSize(GuiElement::GuiSizeMax, GuiElement::GuiSizeMax);
 
+    // Radar signal details toggle.
+    signal_details_toggle = new GuiToggleButton(this, "SIGNAL_DETAILS_TOGGLE", "Signal Details", [this](bool value)
+    {
+        if (science_radar->areSignalDetailsEnabled())
+	    science_radar->disableSignalDetails();
+	else
+            science_radar->enableSignalDetails();
+    });
+    signal_details_toggle->setPosition(-270, -20, ABottomRight)->setSize(250, 50);
+
     // Radar/database view toggle.
     view_mode_selection = new GuiListbox(this, "VIEW_SELECTION", [this](int index, string value) {
         radar_view->setVisible(index == 0);

--- a/src/screens/crew6/scienceScreen.cpp
+++ b/src/screens/crew6/scienceScreen.cpp
@@ -243,7 +243,7 @@ ScienceScreen::ScienceScreen(GuiContainer* owner, ECrewPosition crew_position)
     {
         science_radar->setSignalBiological(value);
     });
-    signal_details_biological_button->setValue(false)->setPosition(-250, -70, ABottomRight)->setSize(50, 50)->setVisible(false);
+    signal_details_biological_button->setValue(false)->setPosition(-270, -70, ABottomRight)->setSize(50, 50)->setVisible(false);
 
     // Radar/database view toggle.
     view_mode_selection = new GuiListbox(this, "VIEW_SELECTION", [this](int index, string value) {

--- a/src/screens/crew6/scienceScreen.cpp
+++ b/src/screens/crew6/scienceScreen.cpp
@@ -212,8 +212,14 @@ ScienceScreen::ScienceScreen(GuiContainer* owner, ECrewPosition crew_position)
         signal_details_electrical_button->setValue(false)->setVisible(value);
         signal_details_biological_button->setValue(false)->setVisible(value);
         // Toggle signal details.
-        science_radar->setSignalDetails(value);
-        science_radar->setVisualObjects(true)->setSignalGravity(false)->setSignalElectrical(false)->setSignalBiological(false);
+        if (science_radar->isVisible())
+        {
+            science_radar->setSignalDetails(value);
+            science_radar->setVisualObjects(true)->setSignalGravity(false)->setSignalElectrical(false)->setSignalBiological(false);
+        } else if (probe_radar->isVisible()) {
+            probe_radar->setSignalDetails(value);
+            probe_radar->setVisualObjects(true)->setSignalGravity(false)->setSignalElectrical(false)->setSignalBiological(false);
+        }
     });
     signal_details_toggle->setPosition(-270, -20, ABottomRight)->setSize(200, 50)->setVisible(true);
 

--- a/src/screens/crew6/scienceScreen.cpp
+++ b/src/screens/crew6/scienceScreen.cpp
@@ -208,14 +208,12 @@ ScienceScreen::ScienceScreen(GuiContainer* owner, ECrewPosition crew_position)
     {
         // Toggle visibility of individual radar toggles.
         signal_details_visual_button->setValue(true)->setVisible(value);
+        science_radar->setVisualObjects(true);
         signal_details_gravity_button->setValue(false)->setVisible(value);
         signal_details_electrical_button->setValue(false)->setVisible(value);
         signal_details_biological_button->setValue(false)->setVisible(value);
         // Toggle signal details.
-        if (value)
-            science_radar->enableSignalDetails();
-        else
-            science_radar->disableSignalDetails();
+        science_radar->setSignalDetails(value);
     });
     signal_details_toggle->setPosition(-270, -20, ABottomRight)->setSize(200, 50)->setVisible(true);
 

--- a/src/screens/crew6/scienceScreen.cpp
+++ b/src/screens/crew6/scienceScreen.cpp
@@ -204,19 +204,7 @@ ScienceScreen::ScienceScreen(GuiContainer* owner, ECrewPosition crew_position)
     zoom_label->setSize(GuiElement::GuiSizeMax, GuiElement::GuiSizeMax);
 
     // Radar signal details toggle.
-    signal_details_toggle = new GuiToggleButton(this, "SIGNAL_DETAILS_TOGGLE", "Signal Details", [this](bool value)
-    {
-        // Toggle visibility of signal lens toggles.
-        signal_details_visual_button->setValue(true)->setVisible(value);
-        signal_details_gravity_button->setValue(false)->setVisible(value);
-        signal_details_electrical_button->setValue(false)->setVisible(value);
-        signal_details_biological_button->setValue(false)->setVisible(value);
-        // Toggle signal details.
-        science_radar->setSignalDetails(value);
-        probe_radar->setSignalDetails(value);
-        science_radar->setVisualObjects(true)->setSignalGravity(false)->setSignalElectrical(false)->setSignalBiological(false);
-        probe_radar->setVisualObjects(true)->setSignalGravity(false)->setSignalElectrical(false)->setSignalBiological(false);
-    });
+    signal_details_toggle = new GuiToggleButton(this, "SIGNAL_DETAILS_TOGGLE", "Signal Details", [this](bool value){ toggleSignalDetails(value); });
     signal_details_toggle->setPosition(-270, -20, ABottomRight)->setSize(200, 50)->setVisible(true);
 
     // Visual objects (radar trace) toggle.
@@ -269,6 +257,20 @@ ScienceScreen::ScienceScreen(GuiContainer* owner, ECrewPosition crew_position)
 
     // Scanning dialog.
     new GuiScanningDialog(this, "SCANNING_DIALOG");
+}
+
+void ScienceScreen::toggleSignalDetails(bool value)
+{
+    // Toggle visibility of signal lens toggles.
+    signal_details_visual_button->setValue(true)->setVisible(value);
+    signal_details_gravity_button->setValue(false)->setVisible(value);
+    signal_details_electrical_button->setValue(false)->setVisible(value);
+    signal_details_biological_button->setValue(false)->setVisible(value);
+    // Toggle and reset signal details.
+    science_radar->setSignalDetails(value);
+    probe_radar->setSignalDetails(value);
+    science_radar->setVisualObjects(true)->setSignalGravity(false)->setSignalElectrical(false)->setSignalBiological(false);
+    probe_radar->setVisualObjects(true)->setSignalGravity(false)->setSignalElectrical(false)->setSignalBiological(false);
 }
 
 void ScienceScreen::onDraw(sf::RenderTarget& window)

--- a/src/screens/crew6/scienceScreen.h
+++ b/src/screens/crew6/scienceScreen.h
@@ -65,6 +65,7 @@ public:
     P<ScanProbe> observation_point;
     GuiListbox* view_mode_selection;
 private:
+    void setViewModeSelectionToggle(int index);
     void setSignalDetailsToggle(bool value);
     void setVisualDetailsToggle(bool value);
     void setElectricalDetailsToggle(bool value);

--- a/src/screens/crew6/scienceScreen.h
+++ b/src/screens/crew6/scienceScreen.h
@@ -64,6 +64,8 @@ public:
     GuiToggleButton* probe_view_button;
     P<ScanProbe> observation_point;
     GuiListbox* view_mode_selection;
+private:
+    void toggleSignalDetails(bool value);
 public:
     ScienceScreen(GuiContainer* owner, ECrewPosition crew_position=scienceOfficer);
 

--- a/src/screens/crew6/scienceScreen.h
+++ b/src/screens/crew6/scienceScreen.h
@@ -65,11 +65,13 @@ public:
     P<ScanProbe> observation_point;
     GuiListbox* view_mode_selection;
 private:
-    void toggleSignalDetails(bool value);
+    void setSignalDetailsToggle(bool value);
+    void setVisualDetailsToggle(bool value);
+    void setElectricalDetailsToggle(bool value);
+    void setGravityDetailsToggle(bool value);
+    void setBiologicalDetailsToggle(bool value);
 public:
     ScienceScreen(GuiContainer* owner, ECrewPosition crew_position=scienceOfficer);
-
-    void setSignalDetailsGravity(bool value);
 
     virtual void onDraw(sf::RenderTarget& window);
     virtual void onHotkey(const HotkeyResult& key) override;

--- a/src/screens/crew6/scienceScreen.h
+++ b/src/screens/crew6/scienceScreen.h
@@ -56,6 +56,7 @@ public:
     GuiFrequencyCurve* info_beam_frequency;
     GuiKeyValueDisplay* info_system[SYS_COUNT];
 
+    GuiToggleButton* signal_details_toggle;
     GuiToggleButton* probe_view_button;
     P<ScanProbe> observation_point;
     GuiListbox* view_mode_selection;

--- a/src/screens/crew6/scienceScreen.h
+++ b/src/screens/crew6/scienceScreen.h
@@ -57,11 +57,17 @@ public:
     GuiKeyValueDisplay* info_system[SYS_COUNT];
 
     GuiToggleButton* signal_details_toggle;
+    GuiToggleButton* signal_details_visual_button;
+    GuiToggleButton* signal_details_gravity_button;
+    GuiToggleButton* signal_details_electrical_button;
+    GuiToggleButton* signal_details_biological_button;
     GuiToggleButton* probe_view_button;
     P<ScanProbe> observation_point;
     GuiListbox* view_mode_selection;
 public:
     ScienceScreen(GuiContainer* owner, ECrewPosition crew_position=scienceOfficer);
+
+    void setSignalDetailsGravity(bool value);
 
     virtual void onDraw(sf::RenderTarget& window);
     virtual void onHotkey(const HotkeyResult& key) override;

--- a/src/screens/gm/tweak.cpp
+++ b/src/screens/gm/tweak.cpp
@@ -31,6 +31,8 @@ GuiObjectTweak::GuiObjectTweak(GuiContainer* owner, ETweakType tweak_type)
     {
         pages.push_back(new GuiShipTweakBase(this));
         list->addEntry("Base", "");
+        pages.push_back(new GuiObjectTweakRadar(this));
+        list->addEntry("Radar", "");
         pages.push_back(new GuiShipTweakShields(this));
         list->addEntry("Shields", "");
         pages.push_back(new GuiShipTweakMissileTubes(this));

--- a/src/screens/gm/tweak.cpp
+++ b/src/screens/gm/tweak.cpp
@@ -53,6 +53,8 @@ GuiObjectTweak::GuiObjectTweak(GuiContainer* owner, ETweakType tweak_type)
     {
         pages.push_back(new GuiObjectTweakBase(this));
         list->addEntry("Base", "");
+        pages.push_back(new GuiObjectTweakRadar(this));
+        list->addEntry("Radar", "");
     }
 
     for(GuiTweakPage* page : pages)
@@ -536,7 +538,6 @@ GuiShipTweakPlayer::GuiShipTweakPlayer(GuiContainer* owner)
 {
     // TODO: Add more player ship tweaks here.
     // -   Ship-to-ship player transfer
-    // -   Reputation
 
     // Add two columns.
     GuiAutoLayout* left_col = new GuiAutoLayout(this, "LEFT_LAYOUT", GuiAutoLayout::LayoutVerticalTopToBottom);
@@ -711,4 +712,58 @@ void GuiObjectTweakBase::open(P<SpaceObject> target)
     // TODO: Fix long strings in GuiTextEntry, or make a new GUI element for
     // editing long strings.
     description->setText(target->getDescription(SS_NotScanned));
+}
+
+GuiObjectTweakRadar::GuiObjectTweakRadar(GuiContainer* owner)
+: GuiTweakPage(owner)
+{
+    GuiAutoLayout* left_col = new GuiAutoLayout(this, "LEFT_LAYOUT", GuiAutoLayout::LayoutVerticalTopToBottom);
+    left_col->setPosition(50, 25, ATopLeft)->setSize(300, GuiElement::GuiSizeMax);
+
+    GuiAutoLayout* right_col = new GuiAutoLayout(this, "RIGHT_LAYOUT", GuiAutoLayout::LayoutVerticalTopToBottom);
+    right_col->setPosition(-25, 25, ATopRight)->setSize(300, GuiElement::GuiSizeMax);
+
+    // Left column
+    // Toggle object visibility.
+    visibility_toggle = new GuiToggleButton(left_col, "", "Visible", [this](bool value) {
+        target->setVisibility(value);
+    });
+    visibility_toggle->setSize(GuiElement::GuiSizeMax, 40);
+
+    // Edit object's radar signature bands.
+    // For ships, this modifies only the baseline; system usage will also
+    // modify these values.
+    (new GuiLabel(left_col, "", "Electrical signature:", 30))->setSize(GuiElement::GuiSizeMax, 50);
+    electrical_slider = new GuiSlider(left_col, "", -10.0, 10.0, 0.0, [this](float value) {
+        target->setRadarSignatureElectrical(value);
+    });
+    electrical_slider->addOverlay()->setSize(GuiElement::GuiSizeMax, 40);
+
+    (new GuiLabel(left_col, "", "Gravity signature:", 30))->setSize(GuiElement::GuiSizeMax, 50);
+    gravity_slider = new GuiSlider(left_col, "", -10.0, 10.0, 0.0, [this](float value) {
+        target->setRadarSignatureGravity(value);
+    });
+    gravity_slider->addOverlay()->setSize(GuiElement::GuiSizeMax, 40);
+
+    (new GuiLabel(left_col, "", "Biological signature:", 30))->setSize(GuiElement::GuiSizeMax, 50);
+    biological_slider = new GuiSlider(left_col, "", -10.0, 10.0, 0.0, [this](float value) {
+        target->setRadarSignatureBiological(value);
+    });
+    biological_slider->addOverlay()->setSize(GuiElement::GuiSizeMax, 40);
+
+    // Right column
+}
+
+void GuiObjectTweakRadar::onDraw(sf::RenderTarget& window)
+{
+}
+
+void GuiObjectTweakRadar::open(P<SpaceObject> target)
+{
+    this->target = target;
+    
+    visibility_toggle->setValue(target->isVisible());
+    electrical_slider->setValue(target->getRadarSignatureElectrical());
+    gravity_slider->setValue(target->getRadarSignatureGravity());
+    biological_slider->setValue(target->getRadarSignatureBiological());
 }

--- a/src/screens/gm/tweak.h
+++ b/src/screens/gm/tweak.h
@@ -68,6 +68,24 @@ public:
     virtual void open(P<SpaceObject> target) override;
 };
 
+class GuiObjectTweakRadar : public GuiTweakPage
+{
+private:
+    P<SpaceObject> target;
+
+    GuiToggleButton* visibility_toggle;
+    GuiSlider* electrical_slider;
+    GuiSlider* gravity_slider;
+    GuiSlider* biological_slider;
+    // TODO: Radar trace?
+public:
+    GuiObjectTweakRadar(GuiContainer* owner);
+
+    virtual void onDraw(sf::RenderTarget& window) override;
+
+    virtual void open(P<SpaceObject> target) override;
+};
+
 class GuiShipTweakMissileWeapons : public GuiTweakPage
 {
 private:

--- a/src/spaceObjects/asteroid.cpp
+++ b/src/spaceObjects/asteroid.cpp
@@ -79,6 +79,7 @@ void Asteroid::collide(Collisionable* target, float force)
     P<ExplosionEffect> e = new ExplosionEffect();
     e->setSize(getRadius());
     e->setPosition(getPosition());
+    e->setRadarSignatureInfo(0.0, 0.1, 0.2);
     destroy();
 }
 

--- a/src/spaceObjects/beamEffect.cpp
+++ b/src/spaceObjects/beamEffect.cpp
@@ -15,13 +15,13 @@ REGISTER_SCRIPT_SUBCLASS(BeamEffect, SpaceObject)
     REGISTER_SCRIPT_CLASS_FUNCTION(BeamEffect, setBeamFireSoundPower);
     REGISTER_SCRIPT_CLASS_FUNCTION(BeamEffect, setDuration);
     REGISTER_SCRIPT_CLASS_FUNCTION(BeamEffect, setRing);
-
 }
 
 REGISTER_MULTIPLAYER_CLASS(BeamEffect, "BeamEffect");
 BeamEffect::BeamEffect()
 : SpaceObject(1000, "BeamEffect")
 {
+    setRadarSignatureInfo(0.0, 0.3, 0.0);
     setCollisionRadius(1.0);
     lifetime = 1.0;
     sourceId = -1;
@@ -41,7 +41,6 @@ BeamEffect::BeamEffect()
     registerMemberReplication(&beam_fire_sound);
     registerMemberReplication(&beam_fire_sound_power);
     registerMemberReplication(&fire_ring);
-    
 }
 
 #if FEATURE_3D_RENDERING

--- a/src/spaceObjects/mine.cpp
+++ b/src/spaceObjects/mine.cpp
@@ -113,15 +113,16 @@ void Mine::explode()
     e->setSize(blastRange);
     e->setPosition(getPosition());
     e->setOnRadar(true);
+    e->setRadarSignatureInfo(0.0, 0.0, 0.2);
 
     if (on_destruction.isSet())
     {
         if (info.instigator)
-	{
-	    on_destruction.call(P<Mine>(this), P<SpaceObject>(info.instigator));
-	}else{
+        {
+            on_destruction.call(P<Mine>(this), P<SpaceObject>(info.instigator));
+        }else{
             on_destruction.call(P<Mine>(this));
-	}
+        }
     }
     destroy();
 }

--- a/src/spaceObjects/missiles/EMPMissile.cpp
+++ b/src/spaceObjects/missiles/EMPMissile.cpp
@@ -6,6 +6,7 @@ REGISTER_MULTIPLAYER_CLASS(EMPMissile, "EMPMissile");
 EMPMissile::EMPMissile()
 : MissileWeapon("EMPMissile", MissileWeaponData::getDataFor(MW_EMP))
 {
+    setRadarSignatureInfo(0.0, 0.5, 0.1);
 }
 
 void EMPMissile::hitObject(P<SpaceObject> object)
@@ -17,4 +18,5 @@ void EMPMissile::hitObject(P<SpaceObject> object)
     e->setSize(category_modifier * blast_range);
     e->setPosition(getPosition());
     e->setOnRadar(true);
+    e->setRadarSignatureInfo(0.0, 1.0, 0.0);
 }

--- a/src/spaceObjects/missiles/homingMissile.cpp
+++ b/src/spaceObjects/missiles/homingMissile.cpp
@@ -6,6 +6,7 @@ REGISTER_MULTIPLAYER_CLASS(HomingMissile, "HomingMissile");
 HomingMissile::HomingMissile()
 : MissileWeapon("HomingMissile", MissileWeaponData::getDataFor(MW_Homing))
 {
+    setRadarSignatureInfo(0.0, 0.1, 0.2);
 }
 
 void HomingMissile::hitObject(P<SpaceObject> object)
@@ -16,4 +17,5 @@ void HomingMissile::hitObject(P<SpaceObject> object)
     e->setSize(category_modifier * 30);
     e->setPosition(getPosition());
     e->setOnRadar(true);
+    e->setRadarSignatureInfo(0.0, 0.0, 0.5);
 }

--- a/src/spaceObjects/missiles/hvli.cpp
+++ b/src/spaceObjects/missiles/hvli.cpp
@@ -6,6 +6,7 @@ REGISTER_MULTIPLAYER_CLASS(HVLI, "HVLI");
 HVLI::HVLI()
 : MissileWeapon("HVLI", MissileWeaponData::getDataFor(MW_HVLI))
 {
+    setRadarSignatureInfo(0.1, 0.0, 0.0);
 }
 
 void HVLI::hitObject(P<SpaceObject> object)
@@ -20,4 +21,5 @@ void HVLI::hitObject(P<SpaceObject> object)
     e->setSize(category_modifier * 20);
     e->setPosition(getPosition());
     e->setOnRadar(true);
+    setRadarSignatureInfo(0.0, 0.0, 0.1);
 }

--- a/src/spaceObjects/missiles/nuke.cpp
+++ b/src/spaceObjects/missiles/nuke.cpp
@@ -6,6 +6,7 @@ REGISTER_MULTIPLAYER_CLASS(Nuke, "Nuke");
 Nuke::Nuke()
 : MissileWeapon("Nuke", MissileWeaponData::getDataFor(MW_Nuke))
 {
+    setRadarSignatureInfo(0.0, 0.7, 0.1);
 }
 
 void Nuke::hitObject(P<SpaceObject> object)
@@ -18,4 +19,5 @@ void Nuke::hitObject(P<SpaceObject> object)
     e->setPosition(getPosition());
     e->setOnRadar(true);
     e->setExplosionSound("sfx/nuke_explosion.wav");
+    setRadarSignatureInfo(0.0, 0.7, 1.0);
 }

--- a/src/spaceObjects/planet.cpp
+++ b/src/spaceObjects/planet.cpp
@@ -124,7 +124,7 @@ Planet::Planet()
 
     collision_size = -2.0f;
 
-    setRadarSignatureInfo(0.5, 0, 0);
+    setRadarSignatureInfo(0.5, 0, 0.3);
 
     registerMemberReplication(&planet_size);
     registerMemberReplication(&cloud_size);

--- a/src/spaceObjects/playerSpaceship.cpp
+++ b/src/spaceObjects/playerSpaceship.cpp
@@ -485,6 +485,7 @@ void PlayerSpaceship::update(float delta)
             ExplosionEffect* e = new ExplosionEffect();
             e->setSize(1000.0f);
             e->setPosition(getPosition());
+            e->setRadarSignatureInfo(0.0, 0.4, 0.4);
 
             DamageInfo info(this, DT_Kinetic, getPosition());
             SpaceObject::damageArea(getPosition(), 500, 30, 60, info, 0.0);
@@ -560,6 +561,7 @@ void PlayerSpaceship::update(float delta)
                         ExplosionEffect* e = new ExplosionEffect();
                         e->setSize(1000.0f);
                         e->setPosition(getPosition() + sf::rotateVector(sf::Vector2f(0, random(0, 500)), random(0, 360)));
+                        e->setRadarSignatureInfo(0.0, 0.6, 0.6);
                     }
 
                     DamageInfo info(this, DT_Kinetic, getPosition());

--- a/src/spaceObjects/scanProbe.cpp
+++ b/src/spaceObjects/scanProbe.cpp
@@ -25,7 +25,7 @@ ScanProbe::ScanProbe()
     registerMemberReplication(&owner_id);
     registerMemberReplication(&target_position);
     registerMemberReplication(&lifetime, 60.0);
-    setRadarSignatureInfo(0.0, 0.2, 0);
+    setRadarSignatureInfo(0.0, 0.2, 0.0);
     
     switch(irandom(1, 3))
     {

--- a/src/spaceObjects/spaceObject.cpp
+++ b/src/spaceObjects/spaceObject.cpp
@@ -216,8 +216,8 @@ REGISTER_SCRIPT_CLASS_NO_CREATE(SpaceObject)
     REGISTER_SCRIPT_CLASS_FUNCTION(SpaceObject, setVisibility);
     /// Gets this object's visibility.
     /// Returns a boolean value.
-    /// Example: local is_visible = obj:getVisibility()
-    REGISTER_SCRIPT_CLASS_FUNCTION(SpaceObject, getVisibility);
+    /// Example: local is_visible = obj:isVisible()
+    REGISTER_SCRIPT_CLASS_FUNCTION(SpaceObject, isVisible);
     /// Sets this object's scanning complexity (number of bars in the scanning
     /// minigame) and depth (number of scanning minigames to complete).
     /// Requires two integer values.

--- a/src/spaceObjects/spaceObject.cpp
+++ b/src/spaceObjects/spaceObject.cpp
@@ -210,6 +210,14 @@ REGISTER_SCRIPT_CLASS_NO_CREATE(SpaceObject)
     REGISTER_SCRIPT_CLASS_FUNCTION(SpaceObject, getRadarSignatureGravity);
     REGISTER_SCRIPT_CLASS_FUNCTION(SpaceObject, getRadarSignatureElectrical);
     REGISTER_SCRIPT_CLASS_FUNCTION(SpaceObject, getRadarSignatureBiological);
+    /// Sets this object's visibility, both on radar and in 3D rendering.
+    /// Requires a boolean value.
+    /// Example: obj:setVisibility(false)
+    REGISTER_SCRIPT_CLASS_FUNCTION(SpaceObject, setVisibility);
+    /// Gets this object's visibility.
+    /// Returns a boolean value.
+    /// Example: local is_visible = obj:getVisibility()
+    REGISTER_SCRIPT_CLASS_FUNCTION(SpaceObject, getVisibility);
     /// Sets this object's scanning complexity (number of bars in the scanning
     /// minigame) and depth (number of scanning minigames to complete).
     /// Requires two integer values.
@@ -260,6 +268,7 @@ SpaceObject::SpaceObject(float collision_range, string multiplayer_name, float m
     space_object_list.push_back(this);
     faction_id = 0;
 
+    is_visible = true;
     scanning_complexity_value = 0;
     scanning_depth_value = 0;
 
@@ -273,6 +282,7 @@ SpaceObject::SpaceObject(float collision_range, string multiplayer_name, float m
     registerMemberReplication(&radar_signature.gravity);
     registerMemberReplication(&radar_signature.electrical);
     registerMemberReplication(&radar_signature.biological);
+    registerMemberReplication(&is_visible);
     registerMemberReplication(&scanning_complexity_value);
     registerMemberReplication(&scanning_depth_value);
     registerCollisionableReplication(multiplayer_significant_range);
@@ -281,7 +291,8 @@ SpaceObject::SpaceObject(float collision_range, string multiplayer_name, float m
 #if FEATURE_3D_RENDERING
 void SpaceObject::draw3D()
 {
-    model_info.render(getPosition(), getRotation());
+    if (is_visible)
+      model_info.render(getPosition(), getRotation());
 }
 #endif//FEATURE_3D_RENDERING
 

--- a/src/spaceObjects/spaceObject.h
+++ b/src/spaceObjects/spaceObject.h
@@ -89,6 +89,7 @@ class SpaceObject : public Collisionable, public MultiplayerObject
         string full_scan;
     } object_description;
     RawRadarSignatureInfo radar_signature;
+    bool is_visible;
 
     /*!
      * Scan state per faction. Implementation wise, this vector is resized when
@@ -111,12 +112,16 @@ public:
     float getRadius() { return object_radius; }
     void setRadius(float radius) { object_radius = radius; setCollisionRadius(radius); }
 
-    // Return the object's raw radar signature. The default signature is 0,0,0.
+    // Return the object's raw radar signature. The default signature is 0 grav, 0 elec, 0 bio.
     virtual RawRadarSignatureInfo getRadarSignatureInfo() { return radar_signature; }
     void setRadarSignatureInfo(float grav, float elec, float bio) { radar_signature = RawRadarSignatureInfo(grav, elec, bio); }
     float getRadarSignatureGravity() { return radar_signature.gravity; }
     float getRadarSignatureElectrical() { return radar_signature.electrical; }
     float getRadarSignatureBiological() { return radar_signature.biological; }
+
+    // Return the object's radar visibility.
+    void setVisibility(bool visibility) { is_visible = visibility; }
+    bool getVisibility() { return is_visible; }
 
     string getDescription(EScannedState state)
     {

--- a/src/spaceObjects/spaceObject.h
+++ b/src/spaceObjects/spaceObject.h
@@ -115,13 +115,16 @@ public:
     // Return the object's raw radar signature. The default signature is 0 grav, 0 elec, 0 bio.
     virtual RawRadarSignatureInfo getRadarSignatureInfo() { return radar_signature; }
     void setRadarSignatureInfo(float grav, float elec, float bio) { radar_signature = RawRadarSignatureInfo(grav, elec, bio); }
+    void setRadarSignatureGravity(float grav) { radar_signature.gravity = grav; }
     float getRadarSignatureGravity() { return radar_signature.gravity; }
+    void setRadarSignatureElectrical(float elec) { radar_signature.electrical = elec; }
     float getRadarSignatureElectrical() { return radar_signature.electrical; }
+    void setRadarSignatureBiological(float bio) { radar_signature.biological = bio; }
     float getRadarSignatureBiological() { return radar_signature.biological; }
 
     // Return the object's radar visibility.
     void setVisibility(bool visibility) { is_visible = visibility; }
-    bool getVisibility() { return is_visible; }
+    bool isVisible() { return is_visible; }
 
     string getDescription(EScannedState state)
     {

--- a/src/spaceObjects/spaceStation.cpp
+++ b/src/spaceObjects/spaceStation.cpp
@@ -63,6 +63,7 @@ void SpaceStation::destroyedByDamage(DamageInfo& info)
     ExplosionEffect* e = new ExplosionEffect();
     e->setSize(getRadius());
     e->setPosition(getPosition());
+    e->setRadarSignatureInfo(0.0, 0.4, 0.4);
     
     if (info.instigator)
     {

--- a/src/spaceObjects/spaceship.cpp
+++ b/src/spaceObjects/spaceship.cpp
@@ -12,9 +12,9 @@
 #include "scriptInterface.h"
 REGISTER_SCRIPT_SUBCLASS_NO_CREATE(SpaceShip, ShipTemplateBasedObject)
 {
-    //[DEPRICATED]
+    //[DEPRECATED]
     REGISTER_SCRIPT_CLASS_FUNCTION(SpaceShip, isFriendOrFoeIdentified);
-    //[DEPRICATED]
+    //[DEPRECATED]
     REGISTER_SCRIPT_CLASS_FUNCTION(SpaceShip, isFullyScanned);
     REGISTER_SCRIPT_CLASS_FUNCTION(SpaceShip, isFriendOrFoeIdentifiedBy);
     REGISTER_SCRIPT_CLASS_FUNCTION(SpaceShip, isFullyScannedBy);
@@ -76,9 +76,13 @@ REGISTER_SCRIPT_SUBCLASS_NO_CREATE(SpaceShip, ShipTemplateBasedObject)
     /// For example, ship:setRadarTrace("RadarBlip.png") will show a dot instead of an arrow for this ship.
     /// Note: Icon is only shown after scanning, before the ship is scanned it is always shown as an arrow.
     REGISTER_SCRIPT_CLASS_FUNCTION(SpaceShip, setRadarTrace);
-
+    /// Get the dynamic radar signature values for each component band.
+    /// Returns a float.
+    /// Example: obj:getDynamicRadarSignatureGravity()
+    REGISTER_SCRIPT_CLASS_FUNCTION(SpaceShip, getDynamicRadarSignatureGravity);
+    REGISTER_SCRIPT_CLASS_FUNCTION(SpaceShip, getDynamicRadarSignatureElectrical);
+    REGISTER_SCRIPT_CLASS_FUNCTION(SpaceShip, getDynamicRadarSignatureBiological);
     REGISTER_SCRIPT_CLASS_FUNCTION(SpaceShip, addBroadcast);
-
     /// Set the scan state of this ship for every faction.
     REGISTER_SCRIPT_CLASS_FUNCTION(SpaceShip, setScanState);
     /// Set the scane state of this ship for a particular faction.
@@ -265,6 +269,76 @@ void SpaceShip::draw3DTransparent()
     }
 }
 #endif//FEATURE_3D_RENDERING
+
+RawRadarSignatureInfo SpaceShip::getDynamicRadarSignatureInfo()
+{
+    // Adjust radar_signature dynamically based on current state and activity.
+    // radar_signature becomes the ship's baseline radar signature.
+    RawRadarSignatureInfo signature_delta;
+
+    // For each ship system ...
+    for(int n = 0; n < SYS_COUNT; n++)
+    {
+        ESystem ship_system = static_cast<ESystem>(n);
+
+        // ... increase the biological band based on system heat, offset by
+        // coolant.
+        signature_delta.biological += std::max(
+            0.0f,
+            std::min(
+                1.0f,
+                getSystemHeat(ship_system) - (getSystemCoolant(ship_system) / 10.0f)
+            )
+        );
+        
+        // ... adjust the electrical band if system power allocation is not
+        // 100%.
+        if (ship_system == SYS_JumpDrive && jump_drive_charge < jump_drive_max_distance)
+        {
+            // ... elevate electrical after a jump, since recharging jump
+            // consumes energy.
+            signature_delta.electrical += std::max(
+                0.0f,
+                std::min(
+                    1.0f,
+                    getSystemPower(ship_system) * (jump_drive_charge + 0.01f / jump_drive_max_distance)
+                )
+            );
+        } else if (getSystemPower(ship_system) != 1.0f)
+        {
+            // For non-Jump systems, allow underpowered systems to reduce the
+            // total electrical signal output.
+            signature_delta.electrical += std::max(
+                -1.0f,
+                std::min(
+                    1.0f,
+                    getSystemPower(ship_system) - 1.0f
+                )
+            );
+        }
+    }
+
+    // Increase the gravitational band if the ship is about to jump, or is
+    // actively warping.
+    if (jump_delay > 0.0f)
+    {
+        signature_delta.gravity += std::max(
+            0.0f,
+            std::min(
+                (1.0f / jump_delay + 0.01f) + 0.25f,
+                10.0f
+            )
+        );
+    } else if (current_warp > 0.0f)
+    {
+        signature_delta.gravity += current_warp;
+    }
+
+    // Update the signature by adding the delta to its baseline.
+    RawRadarSignatureInfo info = getRadarSignatureInfo();
+    info += signature_delta;
+    return info;
+}
 
 void SpaceShip::drawOnRadar(sf::RenderTarget& window, sf::Vector2f position, float scale, bool long_range)
 {
@@ -851,7 +925,7 @@ void SpaceShip::setScanStateByFaction(string faction_name, EScannedState state)
 
 bool SpaceShip::isFriendOrFoeIdentified()
 {
-    LOG(WARNING) << "Depricated \"isFriendOrFoeIdentified\" function called, use isFriendOrFoeIdentifiedBy or isFriendOrFoeIdentifiedByFaction.";
+    LOG(WARNING) << "Deprecated \"isFriendOrFoeIdentified\" function called, use isFriendOrFoeIdentifiedBy or isFriendOrFoeIdentifiedByFaction.";
     for(unsigned int faction_id = 0; faction_id < factionInfo.size(); faction_id++)
     {
         if (getScannedStateForFaction(faction_id) > SS_NotScanned)
@@ -862,7 +936,7 @@ bool SpaceShip::isFriendOrFoeIdentified()
 
 bool SpaceShip::isFullyScanned()
 {
-    LOG(WARNING) << "Depricated \"isFullyScanned\" function called, use isFullyScannedBy or isFullyScannedByFaction.";
+    LOG(WARNING) << "Deprecated \"isFullyScanned\" function called, use isFullyScannedBy or isFullyScannedByFaction.";
     for(unsigned int faction_id = 0; faction_id < factionInfo.size(); faction_id++)
     {
         if (getScannedStateForFaction(faction_id) >= SS_FullScan)

--- a/src/spaceObjects/spaceship.cpp
+++ b/src/spaceObjects/spaceship.cpp
@@ -1097,6 +1097,7 @@ void SpaceShip::destroyedByDamage(DamageInfo& info)
     ExplosionEffect* e = new ExplosionEffect();
     e->setSize(getRadius() * 1.5);
     e->setPosition(getPosition());
+    e->setRadarSignatureInfo(0.0, 0.2, 0.2);
 
     if (info.instigator)
     {

--- a/src/spaceObjects/spaceship.h
+++ b/src/spaceObjects/spaceship.h
@@ -173,6 +173,15 @@ public:
     virtual void draw3DTransparent() override;
 #endif
     /*!
+     * Get this ship's radar signature dynamically modified by the state of its
+     * systems and current activity.
+     */
+    virtual RawRadarSignatureInfo getDynamicRadarSignatureInfo();
+    float getDynamicRadarSignatureGravity() { return getDynamicRadarSignatureInfo().gravity; }
+    float getDynamicRadarSignatureElectrical() { return getDynamicRadarSignatureInfo().electrical; }
+    float getDynamicRadarSignatureBiological() { return getDynamicRadarSignatureInfo().biological; }
+
+    /*!
      * Draw this ship on the radar.
      */
     virtual void drawOnRadar(sf::RenderTarget& window, sf::Vector2f position, float scale, bool long_range) override;

--- a/src/spaceObjects/supplyDrop.cpp
+++ b/src/spaceObjects/supplyDrop.cpp
@@ -81,6 +81,21 @@ void SupplyDrop::onPickUp(ScriptSimpleCallback callback)
     this->on_pickup_callback = callback;
 }
 
+void SupplyDrop::setEnergy(float amount)
+{
+    energy = amount;
+    setRadarSignatureInfo(getRadarSignatureGravity(), getRadarSignatureElectrical() + (amount / 1000.0f), getRadarSignatureBiological());
+}
+
+void SupplyDrop::setWeaponStorage(EMissileWeapons weapon, int amount)
+{
+    if (weapon != MW_None)
+    {
+        weapon_storage[weapon] = amount;
+        setRadarSignatureInfo(getRadarSignatureGravity() + (0.05f * amount), getRadarSignatureElectrical(), getRadarSignatureBiological());
+    }
+}
+
 string SupplyDrop::getExportLine()
 {
     string ret = "SupplyDrop():setFaction(\"" + getFaction() + "\"):setPosition(" + string(getPosition().x, 0) + ", " + string(getPosition().y, 0) + ")";

--- a/src/spaceObjects/supplyDrop.h
+++ b/src/spaceObjects/supplyDrop.h
@@ -18,8 +18,8 @@ public:
 
     virtual void collide(Collisionable* target, float force) override;
 
-    void setEnergy(float amount) { energy = amount; }
-    void setWeaponStorage(EMissileWeapons weapon, int amount) { if (weapon != MW_None) weapon_storage[weapon] = amount; }
+    void setEnergy(float amount); 
+    void setWeaponStorage(EMissileWeapons weapon, int amount);
 
     void onPickUp(ScriptSimpleCallback callback);
 

--- a/src/spaceObjects/warpJammer.cpp
+++ b/src/spaceObjects/warpJammer.cpp
@@ -73,6 +73,7 @@ void WarpJammer::takeDamage(float damage_amount, DamageInfo info)
         P<ExplosionEffect> e = new ExplosionEffect();
         e->setSize(getRadius());
         e->setPosition(getPosition());
+        e->setRadarSignatureInfo(0.5, 0.5, 0.1);
 
         if (on_destruction.isSet())
         {


### PR DESCRIPTION
Adds toggle to crew6 science (intentionally only this station, for now) to show circular and numerical visualizations of radar signal values. This also exposes VisualAsteroids, and objects with no radar trace but a radar signal value.

![ezgif com-optimize](https://user-images.githubusercontent.com/19192104/73637097-565a2b80-461c-11ea-9821-d2f6056cea23.gif)

Moves the dynamic radar signal visualization previously implemented in rawRadarScannerDataOverlay to a new getter in Spaceship, `getDynamicRadarSignatureInfo`. This makes these dynamic values available to other functions without duplication. Using a separate getter should avoid the potential discrepancy of overloading the spaceObject's `getRadarSignatureInfo` getter and getting different values than the setter's input.

Exposes these component dynamic values to scripts via the `getDynamicRadarSignatureGravity`, `...Electrical`, and `...Biological` functions.