### PR TITLE
Combat maneuver hotkeys

### DIFF
--- a/src/gui/hotkeyConfig.cpp
+++ b/src/gui/hotkeyConfig.cpp
@@ -210,6 +210,18 @@ void HotkeyConfig::load()
     }
 }
 
+sf::Keyboard::Key HotkeyConfig::stringToKeycode(string hotkey_name)
+{
+	for(auto key_name : sfml_key_names)
+    {
+		if (key_name.first == hotkey_name)
+		{
+			return key_name.second;
+		}
+	}
+	return sf::Keyboard::Unknown;
+}
+
 std::vector<HotkeyResult> HotkeyConfig::getHotkey(sf::Event::KeyEvent key)
 {
     std::vector<HotkeyResult> results;

--- a/src/gui/hotkeyConfig.cpp
+++ b/src/gui/hotkeyConfig.cpp
@@ -35,9 +35,9 @@ HotkeyConfig::HotkeyConfig()
     newKey("INC_JUMP", std::make_tuple("Increase jump distance", ""));
     newKey("DEC_JUMP", std::make_tuple("Decrease jump distance", ""));
     newKey("JUMP", std::make_tuple("Initiate jump", ""));
-    //newKey("COMBAT_LEFT", "Combat maneuver left");
-    //newKey("COMBAT_RIGHT", "Combat maneuver right");
-    //newKey("COMBAT_BOOST", "Combat maneuver boost");
+    newKey("COMBAT_LEFT", "Combat maneuver left");
+    newKey("COMBAT_RIGHT", "Combat maneuver right");
+    newKey("COMBAT_BOOST", "Combat maneuver boost");
 
     newCategory("WEAPONS", "Weapons");
     newKey("SELECT_MISSILE_TYPE_HOMING", std::make_tuple("Select homing", "Num1"));

--- a/src/gui/hotkeyConfig.cpp
+++ b/src/gui/hotkeyConfig.cpp
@@ -35,9 +35,9 @@ HotkeyConfig::HotkeyConfig()
     newKey("INC_JUMP", std::make_tuple("Increase jump distance", ""));
     newKey("DEC_JUMP", std::make_tuple("Decrease jump distance", ""));
     newKey("JUMP", std::make_tuple("Initiate jump", ""));
-    newKey("COMBAT_LEFT", "Combat maneuver left");
-    newKey("COMBAT_RIGHT", "Combat maneuver right");
-    newKey("COMBAT_BOOST", "Combat maneuver boost");
+    newKey("COMBAT_LEFT",  std::make_tuple( "Combat maneuver left", ""));
+    newKey("COMBAT_RIGHT", std::make_tuple( "Combat maneuver right", ""));
+    newKey("COMBAT_BOOST", std::make_tuple( "Combat maneuver boost", ""));
 
     newCategory("WEAPONS", "Weapons");
     newKey("SELECT_MISSILE_TYPE_HOMING", std::make_tuple("Select homing", "Num1"));

--- a/src/gui/hotkeyConfig.h
+++ b/src/gui/hotkeyConfig.h
@@ -44,6 +44,7 @@ public:
     std::vector<std::pair<string, string>> listHotkeysByCategory(string hotkey_category);
     
     std::vector<HotkeyResult> getHotkey(sf::Event::KeyEvent key);
+    static sf::Keyboard::Key stringToKeycode(string hotkey_name);
 private:
     std::vector<HotkeyConfigCategory> categories;
     

--- a/src/screenComponents/combatManeuver.cpp
+++ b/src/screenComponents/combatManeuver.cpp
@@ -3,12 +3,133 @@
 #include "combatManeuver.h"
 #include "powerDamageIndicator.h"
 #include "snapSlider.h"
-
+#include "preferenceManager.h"
 #include "gui/gui2_progressbar.h"
 
 GuiCombatManeuver::GuiCombatManeuver(GuiContainer* owner, string id)
 : GuiElement(owner, id)
 {
+	static std::vector<std::pair<string, sf::Keyboard::Key> > sfml_key_names = {
+	    {"A", sf::Keyboard::A},
+	    {"B", sf::Keyboard::B},
+	    {"C", sf::Keyboard::C},
+	    {"D", sf::Keyboard::D},
+	    {"E", sf::Keyboard::E},
+	    {"F", sf::Keyboard::F},
+	    {"G", sf::Keyboard::G},
+	    {"H", sf::Keyboard::H},
+	    {"I", sf::Keyboard::I},
+	    {"J", sf::Keyboard::J},
+	    {"K", sf::Keyboard::K},
+	    {"L", sf::Keyboard::L},
+	    {"M", sf::Keyboard::M},
+	    {"N", sf::Keyboard::N},
+	    {"O", sf::Keyboard::O},
+	    {"P", sf::Keyboard::P},
+	    {"Q", sf::Keyboard::Q},
+	    {"R", sf::Keyboard::R},
+	    {"S", sf::Keyboard::S},
+	    {"T", sf::Keyboard::T},
+	    {"U", sf::Keyboard::U},
+	    {"V", sf::Keyboard::V},
+	    {"W", sf::Keyboard::W},
+	    {"X", sf::Keyboard::X},
+	    {"Y", sf::Keyboard::Y},
+	    {"Z", sf::Keyboard::Z},
+	    {"Num0", sf::Keyboard::Num0},
+	    {"Num1", sf::Keyboard::Num1},
+	    {"Num2", sf::Keyboard::Num2},
+	    {"Num3", sf::Keyboard::Num3},
+	    {"Num4", sf::Keyboard::Num4},
+	    {"Num5", sf::Keyboard::Num5},
+	    {"Num6", sf::Keyboard::Num6},
+	    {"Num7", sf::Keyboard::Num7},
+	    {"Num8", sf::Keyboard::Num8},
+	    {"Num9", sf::Keyboard::Num9},
+	    {"Escape", sf::Keyboard::Escape},
+	    {"LControl", sf::Keyboard::LControl},
+	    {"LShift", sf::Keyboard::LShift},
+	    {"LAlt", sf::Keyboard::LAlt},
+	    {"LSystem", sf::Keyboard::LSystem},
+	    {"RControl", sf::Keyboard::RControl},
+	    {"RShift", sf::Keyboard::RShift},
+	    {"RAlt", sf::Keyboard::RAlt},
+	    {"RSystem", sf::Keyboard::RSystem},
+	    {"Menu", sf::Keyboard::Menu},
+	    {"LBracket", sf::Keyboard::LBracket},
+	    {"RBracket", sf::Keyboard::RBracket},
+	    {"SemiColon", sf::Keyboard::SemiColon},
+	    {"Comma", sf::Keyboard::Comma},
+	    {"Period", sf::Keyboard::Period},
+	    {"Quote", sf::Keyboard::Quote},
+	    {"Slash", sf::Keyboard::Slash},
+	    {"BackSlash", sf::Keyboard::BackSlash},
+	    {"Tilde", sf::Keyboard::Tilde},
+	    {"Equal", sf::Keyboard::Equal},
+	    {"Dash", sf::Keyboard::Dash},
+	    {"Space", sf::Keyboard::Space},
+	    {"Return", sf::Keyboard::Return},
+	    {"BackSpace", sf::Keyboard::BackSpace},
+	    {"Tab", sf::Keyboard::Tab},
+	    {"PageUp", sf::Keyboard::PageUp},
+	    {"PageDown", sf::Keyboard::PageDown},
+	    {"End", sf::Keyboard::End},
+	    {"Home", sf::Keyboard::Home},
+	    {"Insert", sf::Keyboard::Insert},
+	    {"Delete", sf::Keyboard::Delete},
+	    {"Add", sf::Keyboard::Add},
+	    {"Subtract", sf::Keyboard::Subtract},
+	    {"Multiply", sf::Keyboard::Multiply},
+	    {"Divide", sf::Keyboard::Divide},
+	    {"Left", sf::Keyboard::Left},
+	    {"Right", sf::Keyboard::Right},
+	    {"Up", sf::Keyboard::Up},
+	    {"Down", sf::Keyboard::Down},
+	    {"Numpad0", sf::Keyboard::Numpad0},
+	    {"Numpad1", sf::Keyboard::Numpad1},
+	    {"Numpad2", sf::Keyboard::Numpad2},
+	    {"Numpad3", sf::Keyboard::Numpad3},
+	    {"Numpad4", sf::Keyboard::Numpad4},
+	    {"Numpad5", sf::Keyboard::Numpad5},
+	    {"Numpad6", sf::Keyboard::Numpad6},
+	    {"Numpad7", sf::Keyboard::Numpad7},
+	    {"Numpad8", sf::Keyboard::Numpad8},
+	    {"Numpad9", sf::Keyboard::Numpad9},
+	    {"F1", sf::Keyboard::F1},
+	    {"F2", sf::Keyboard::F2},
+	    {"F3", sf::Keyboard::F3},
+	    {"F4", sf::Keyboard::F4},
+	    {"F5", sf::Keyboard::F5},
+	    {"F6", sf::Keyboard::F6},
+	    {"F7", sf::Keyboard::F7},
+	    {"F8", sf::Keyboard::F8},
+	    {"F9", sf::Keyboard::F9},
+	    {"F10", sf::Keyboard::F10},
+	    {"F11", sf::Keyboard::F11},
+	    {"F12", sf::Keyboard::F12},
+	    {"F13", sf::Keyboard::F13},
+	    {"F14", sf::Keyboard::F14},
+	    {"F15", sf::Keyboard::F15},
+	    {"Pause", sf::Keyboard::Pause},
+	};
+
+	combat_left_key=PreferencesManager::get("HOTKEY.HELMS.COMBAT_LEFT");
+	combat_right_key=PreferencesManager::get("HOTKEY.HELMS.COMBAT_RIGHT");
+	combat_boost_key=PreferencesManager::get("HOTKEY.HELMS.COMBAT_BOOST");
+
+	for(auto key_name : sfml_key_names)
+    {
+		if (key_name.first == combat_left_key){
+			combat_left_keycode=key_name.second;
+		}
+		if (key_name.first == combat_right_key){
+			combat_right_keycode=key_name.second;
+		}
+		if (key_name.first == combat_boost_key){
+			combat_boost_keycode=key_name.second;
+		}
+	}
+
     charge_bar = new GuiProgressbar(this, id + "_CHARGE", 0.0, 1.0, 0.0);
     charge_bar->setColor(sf::Color(192, 192, 192, 64));
     charge_bar->setPosition(0, 0, ABottomCenter)->setSize(GuiElement::GuiSizeMax, 50);
@@ -29,6 +150,23 @@ GuiCombatManeuver::GuiCombatManeuver(GuiContainer* owner, string id)
 
 void GuiCombatManeuver::onDraw(sf::RenderTarget& window)
 {
+	float strafe_amount=0.0;
+	float boost_amount=0.0;
+	if (sf::Keyboard::isKeyPressed(combat_left_keycode)){
+		strafe_amount=-1.0;
+	}
+	if (sf::Keyboard::isKeyPressed(combat_right_keycode)){
+		strafe_amount=1.0;
+	}
+	if (sf::Keyboard::isKeyPressed(combat_boost_keycode)){
+		boost_amount=1.0;
+	}
+	setStrafeValue(strafe_amount);
+	my_spaceship->commandCombatManeuverStrafe(strafe_amount);
+	setBoostValue(boost_amount);
+	my_spaceship->commandCombatManeuverBoost(boost_amount);
+
+
     if (my_spaceship)
     {
         if (my_spaceship->combat_maneuver_boost_speed <= 0.0 && my_spaceship->combat_maneuver_strafe_speed <= 0.0)

--- a/src/screenComponents/combatManeuver.cpp
+++ b/src/screenComponents/combatManeuver.cpp
@@ -37,22 +37,40 @@ GuiCombatManeuver::GuiCombatManeuver(GuiContainer* owner, string id)
 
 void GuiCombatManeuver::onDraw(sf::RenderTarget& window)
 {
+	// combat maneuver keycodes
 	if (slider->getValue().x ==0 && slider->getValue().y==0)
 	{
-		float strafe_amount=0.0;
-		float boost_amount=0.0;
+		if (!strafing)
+		{
+			if (sf::Keyboard::isKeyPressed(combat_left_keycode))
+			{
+				strafing=true;
+				my_spaceship->commandCombatManeuverStrafe(-1.0);
+			}
+			else if (sf::Keyboard::isKeyPressed(combat_right_keycode))
+			{
+				strafing=true;
+				my_spaceship->commandCombatManeuverStrafe(1.0);
+			}
+		}
+		else if (!sf::Keyboard::isKeyPressed(combat_right_keycode) && !sf::Keyboard::isKeyPressed(combat_left_keycode))
+		{
+			strafing=false;
+			my_spaceship->commandCombatManeuverStrafe(0.0);
+		}
 
-		if (sf::Keyboard::isKeyPressed(combat_left_keycode)){
-			strafe_amount=-1.0;
+		if (sf::Keyboard::isKeyPressed(combat_boost_keycode) && !boosting)
+		{
+			boosting=true;
+			my_spaceship->commandCombatManeuverBoost(1.0);
 		}
-		if (sf::Keyboard::isKeyPressed(combat_right_keycode)){
-			strafe_amount=1.0;
+
+		if (!sf::Keyboard::isKeyPressed(combat_boost_keycode) && boosting){
+			boosting=false;
+			my_spaceship->commandCombatManeuverBoost(0.0);
 		}
-		if (sf::Keyboard::isKeyPressed(combat_boost_keycode)){
-			boost_amount=1.0;
-	}
-		my_spaceship->commandCombatManeuverStrafe(strafe_amount);
-	my_spaceship->commandCombatManeuverBoost(boost_amount);
+
+
 	}
 
     if (my_spaceship)

--- a/src/screenComponents/combatManeuver.cpp
+++ b/src/screenComponents/combatManeuver.cpp
@@ -113,9 +113,9 @@ GuiCombatManeuver::GuiCombatManeuver(GuiContainer* owner, string id)
 	    {"Pause", sf::Keyboard::Pause},
 	};
 
-	combat_left_key=PreferencesManager::get("HOTKEY.HELMS.COMBAT_LEFT");
-	combat_right_key=PreferencesManager::get("HOTKEY.HELMS.COMBAT_RIGHT");
-	combat_boost_key=PreferencesManager::get("HOTKEY.HELMS.COMBAT_BOOST");
+	string combat_left_key=PreferencesManager::get("HOTKEY.HELMS.COMBAT_LEFT");
+	string combat_right_key=PreferencesManager::get("HOTKEY.HELMS.COMBAT_RIGHT");
+	string combat_boost_key=PreferencesManager::get("HOTKEY.HELMS.COMBAT_BOOST");
 
 	for(auto key_name : sfml_key_names)
     {

--- a/src/screenComponents/combatManeuver.cpp
+++ b/src/screenComponents/combatManeuver.cpp
@@ -37,7 +37,7 @@ GuiCombatManeuver::GuiCombatManeuver(GuiContainer* owner, string id)
 
 void GuiCombatManeuver::onDraw(sf::RenderTarget& window)
 {
-	// combat maneuver keycodes
+	// combat maneuver hotkeys
 	if (slider->getValue().x ==0 && slider->getValue().y==0)
 	{
 		if (!strafing)
@@ -69,8 +69,6 @@ void GuiCombatManeuver::onDraw(sf::RenderTarget& window)
 			boosting=false;
 			my_spaceship->commandCombatManeuverBoost(0.0);
 		}
-
-
 	}
 
     if (my_spaceship)

--- a/src/screenComponents/combatManeuver.cpp
+++ b/src/screenComponents/combatManeuver.cpp
@@ -9,126 +9,13 @@
 GuiCombatManeuver::GuiCombatManeuver(GuiContainer* owner, string id)
 : GuiElement(owner, id)
 {
-	static std::vector<std::pair<string, sf::Keyboard::Key> > sfml_key_names = {
-	    {"A", sf::Keyboard::A},
-	    {"B", sf::Keyboard::B},
-	    {"C", sf::Keyboard::C},
-	    {"D", sf::Keyboard::D},
-	    {"E", sf::Keyboard::E},
-	    {"F", sf::Keyboard::F},
-	    {"G", sf::Keyboard::G},
-	    {"H", sf::Keyboard::H},
-	    {"I", sf::Keyboard::I},
-	    {"J", sf::Keyboard::J},
-	    {"K", sf::Keyboard::K},
-	    {"L", sf::Keyboard::L},
-	    {"M", sf::Keyboard::M},
-	    {"N", sf::Keyboard::N},
-	    {"O", sf::Keyboard::O},
-	    {"P", sf::Keyboard::P},
-	    {"Q", sf::Keyboard::Q},
-	    {"R", sf::Keyboard::R},
-	    {"S", sf::Keyboard::S},
-	    {"T", sf::Keyboard::T},
-	    {"U", sf::Keyboard::U},
-	    {"V", sf::Keyboard::V},
-	    {"W", sf::Keyboard::W},
-	    {"X", sf::Keyboard::X},
-	    {"Y", sf::Keyboard::Y},
-	    {"Z", sf::Keyboard::Z},
-	    {"Num0", sf::Keyboard::Num0},
-	    {"Num1", sf::Keyboard::Num1},
-	    {"Num2", sf::Keyboard::Num2},
-	    {"Num3", sf::Keyboard::Num3},
-	    {"Num4", sf::Keyboard::Num4},
-	    {"Num5", sf::Keyboard::Num5},
-	    {"Num6", sf::Keyboard::Num6},
-	    {"Num7", sf::Keyboard::Num7},
-	    {"Num8", sf::Keyboard::Num8},
-	    {"Num9", sf::Keyboard::Num9},
-	    {"Escape", sf::Keyboard::Escape},
-	    {"LControl", sf::Keyboard::LControl},
-	    {"LShift", sf::Keyboard::LShift},
-	    {"LAlt", sf::Keyboard::LAlt},
-	    {"LSystem", sf::Keyboard::LSystem},
-	    {"RControl", sf::Keyboard::RControl},
-	    {"RShift", sf::Keyboard::RShift},
-	    {"RAlt", sf::Keyboard::RAlt},
-	    {"RSystem", sf::Keyboard::RSystem},
-	    {"Menu", sf::Keyboard::Menu},
-	    {"LBracket", sf::Keyboard::LBracket},
-	    {"RBracket", sf::Keyboard::RBracket},
-	    {"SemiColon", sf::Keyboard::SemiColon},
-	    {"Comma", sf::Keyboard::Comma},
-	    {"Period", sf::Keyboard::Period},
-	    {"Quote", sf::Keyboard::Quote},
-	    {"Slash", sf::Keyboard::Slash},
-	    {"BackSlash", sf::Keyboard::BackSlash},
-	    {"Tilde", sf::Keyboard::Tilde},
-	    {"Equal", sf::Keyboard::Equal},
-	    {"Dash", sf::Keyboard::Dash},
-	    {"Space", sf::Keyboard::Space},
-	    {"Return", sf::Keyboard::Return},
-	    {"BackSpace", sf::Keyboard::BackSpace},
-	    {"Tab", sf::Keyboard::Tab},
-	    {"PageUp", sf::Keyboard::PageUp},
-	    {"PageDown", sf::Keyboard::PageDown},
-	    {"End", sf::Keyboard::End},
-	    {"Home", sf::Keyboard::Home},
-	    {"Insert", sf::Keyboard::Insert},
-	    {"Delete", sf::Keyboard::Delete},
-	    {"Add", sf::Keyboard::Add},
-	    {"Subtract", sf::Keyboard::Subtract},
-	    {"Multiply", sf::Keyboard::Multiply},
-	    {"Divide", sf::Keyboard::Divide},
-	    {"Left", sf::Keyboard::Left},
-	    {"Right", sf::Keyboard::Right},
-	    {"Up", sf::Keyboard::Up},
-	    {"Down", sf::Keyboard::Down},
-	    {"Numpad0", sf::Keyboard::Numpad0},
-	    {"Numpad1", sf::Keyboard::Numpad1},
-	    {"Numpad2", sf::Keyboard::Numpad2},
-	    {"Numpad3", sf::Keyboard::Numpad3},
-	    {"Numpad4", sf::Keyboard::Numpad4},
-	    {"Numpad5", sf::Keyboard::Numpad5},
-	    {"Numpad6", sf::Keyboard::Numpad6},
-	    {"Numpad7", sf::Keyboard::Numpad7},
-	    {"Numpad8", sf::Keyboard::Numpad8},
-	    {"Numpad9", sf::Keyboard::Numpad9},
-	    {"F1", sf::Keyboard::F1},
-	    {"F2", sf::Keyboard::F2},
-	    {"F3", sf::Keyboard::F3},
-	    {"F4", sf::Keyboard::F4},
-	    {"F5", sf::Keyboard::F5},
-	    {"F6", sf::Keyboard::F6},
-	    {"F7", sf::Keyboard::F7},
-	    {"F8", sf::Keyboard::F8},
-	    {"F9", sf::Keyboard::F9},
-	    {"F10", sf::Keyboard::F10},
-	    {"F11", sf::Keyboard::F11},
-	    {"F12", sf::Keyboard::F12},
-	    {"F13", sf::Keyboard::F13},
-	    {"F14", sf::Keyboard::F14},
-	    {"F15", sf::Keyboard::F15},
-	    {"Pause", sf::Keyboard::Pause},
-	};
-
 	string combat_left_key=PreferencesManager::get("HOTKEY.HELMS.COMBAT_LEFT");
 	string combat_right_key=PreferencesManager::get("HOTKEY.HELMS.COMBAT_RIGHT");
 	string combat_boost_key=PreferencesManager::get("HOTKEY.HELMS.COMBAT_BOOST");
 
-	for(auto key_name : sfml_key_names)
-    {
-		if (key_name.first == combat_left_key){
-			combat_left_keycode=key_name.second;
-		}
-		if (key_name.first == combat_right_key){
-			combat_right_keycode=key_name.second;
-		}
-		if (key_name.first == combat_boost_key){
-			combat_boost_keycode=key_name.second;
-		}
-	}
+	combat_left_keycode=HotkeyConfig::stringToKeycode(combat_left_key);
+	combat_right_keycode=HotkeyConfig::stringToKeycode(combat_right_key);
+	combat_boost_keycode=HotkeyConfig::stringToKeycode(combat_boost_key);
 
     charge_bar = new GuiProgressbar(this, id + "_CHARGE", 0.0, 1.0, 0.0);
     charge_bar->setColor(sf::Color(192, 192, 192, 64));
@@ -150,22 +37,23 @@ GuiCombatManeuver::GuiCombatManeuver(GuiContainer* owner, string id)
 
 void GuiCombatManeuver::onDraw(sf::RenderTarget& window)
 {
-	float strafe_amount=0.0;
-	float boost_amount=0.0;
-	if (sf::Keyboard::isKeyPressed(combat_left_keycode)){
-		strafe_amount=-1.0;
-	}
-	if (sf::Keyboard::isKeyPressed(combat_right_keycode)){
-		strafe_amount=1.0;
-	}
-	if (sf::Keyboard::isKeyPressed(combat_boost_keycode)){
-		boost_amount=1.0;
-	}
-	setStrafeValue(strafe_amount);
-	my_spaceship->commandCombatManeuverStrafe(strafe_amount);
-	setBoostValue(boost_amount);
-	my_spaceship->commandCombatManeuverBoost(boost_amount);
+	if (slider->getValue().x ==0 && slider->getValue().y==0)
+	{
+		float strafe_amount=0.0;
+		float boost_amount=0.0;
 
+		if (sf::Keyboard::isKeyPressed(combat_left_keycode)){
+			strafe_amount=-1.0;
+		}
+		if (sf::Keyboard::isKeyPressed(combat_right_keycode)){
+			strafe_amount=1.0;
+		}
+		if (sf::Keyboard::isKeyPressed(combat_boost_keycode)){
+			boost_amount=1.0;
+	}
+		my_spaceship->commandCombatManeuverStrafe(strafe_amount);
+	my_spaceship->commandCombatManeuverBoost(boost_amount);
+	}
 
     if (my_spaceship)
     {
@@ -179,6 +67,7 @@ void GuiCombatManeuver::onDraw(sf::RenderTarget& window)
         }
     }
 }
+
 
 void GuiCombatManeuver::onHotkey(const HotkeyResult& key)
 {

--- a/src/screenComponents/combatManeuver.h
+++ b/src/screenComponents/combatManeuver.h
@@ -11,6 +11,12 @@ class GuiCombatManeuver : public GuiElement
 private:
     GuiSnapSlider2D* slider;
     GuiProgressbar* charge_bar;
+	string combat_left_key;
+	string combat_right_key;
+	string combat_boost_key;
+	sf::Keyboard::Key combat_left_keycode;
+	sf::Keyboard::Key combat_right_keycode;
+	sf::Keyboard::Key combat_boost_keycode;
 public:
     GuiCombatManeuver(GuiContainer* owner, string id);
     

--- a/src/screenComponents/combatManeuver.h
+++ b/src/screenComponents/combatManeuver.h
@@ -14,6 +14,8 @@ private:
 	sf::Keyboard::Key combat_left_keycode;
 	sf::Keyboard::Key combat_right_keycode;
 	sf::Keyboard::Key combat_boost_keycode;
+	bool strafing=false;
+	bool boosting=false;
 public:
     GuiCombatManeuver(GuiContainer* owner, string id);
     

--- a/src/screenComponents/combatManeuver.h
+++ b/src/screenComponents/combatManeuver.h
@@ -11,9 +11,6 @@ class GuiCombatManeuver : public GuiElement
 private:
     GuiSnapSlider2D* slider;
     GuiProgressbar* charge_bar;
-	string combat_left_key;
-	string combat_right_key;
-	string combat_boost_key;
 	sf::Keyboard::Key combat_left_keycode;
 	sf::Keyboard::Key combat_right_keycode;
 	sf::Keyboard::Key combat_boost_keycode;

--- a/src/screens/crew1/singlePilotScreen.cpp
+++ b/src/screens/crew1/singlePilotScreen.cpp
@@ -90,10 +90,12 @@ SinglePilotScreen::SinglePilotScreen(GuiContainer* owner)
                     value = (y_position+20) * 1.25 / 100;
 
                 my_spaceship->commandCombatManeuverBoost(-value);
+                combat_maneuver->setBoostValue(fabs(value));
             }
             else if (my_spaceship)
             {
                 my_spaceship->commandCombatManeuverBoost(0.0);
+                combat_maneuver->setBoostValue(0.0);
             }
         },
         [this](float z_position) {
@@ -102,12 +104,16 @@ SinglePilotScreen::SinglePilotScreen(GuiContainer* owner)
         },
         [this](float r_position) {
             if (my_spaceship)
+			{
                 my_spaceship->commandCombatManeuverStrafe(r_position / 100);
+                combat_maneuver->setStrafeValue(r_position/100);
+            }
         }
     );
 
     // Ship stats and combat maneuver at bottom right corner of left panel.
-    (new GuiCombatManeuver(left_panel, "COMBAT_MANEUVER"))->setPosition(-20, -180, ABottomRight)->setSize(200, 150);
+    combat_maneuver = new GuiCombatManeuver(left_panel, "COMBAT_MANEUVER");
+    combat_maneuver->setPosition(-20, -180, ABottomRight)->setSize(200, 150);
 
     energy_display = new GuiKeyValueDisplay(left_panel, "ENERGY_DISPLAY", 0.45, "Energy", "");
     energy_display->setIcon("gui/icons/energy")->setTextSize(20)->setPosition(-20, -140, ABottomRight)->setSize(240, 40);

--- a/src/screens/crew1/singlePilotScreen.h
+++ b/src/screens/crew1/singlePilotScreen.h
@@ -3,6 +3,7 @@
 
 #include "gui/gui2_overlay.h"
 #include "screenComponents/targetsContainer.h"
+#include "screenComponents/combatManeuver.h"
 
 class GuiViewport3D;
 class GuiMissileTubeControls;
@@ -32,6 +33,7 @@ private:
     GuiRotationDial* missile_aim;
     GuiMissileTubeControls* tube_controls;
     GuiToggleButton* lock_aim;
+	GuiCombatManeuver* combat_maneuver;
 public:
     SinglePilotScreen(GuiContainer* owner);
     

--- a/src/screens/crew4/tacticalScreen.cpp
+++ b/src/screens/crew4/tacticalScreen.cpp
@@ -77,10 +77,12 @@ TacticalScreen::TacticalScreen(GuiContainer* owner)
                     value = (y_position+20) * 1.25 / 100;
 
                 my_spaceship->commandCombatManeuverBoost(-value);
+                combat_maneuver->setBoostValue(fabs(value));
             }
             else if (my_spaceship)
             {
                 my_spaceship->commandCombatManeuverBoost(0.0);
+                combat_maneuver->setBoostValue(0.0);
             }
         },
         [this](float z_position) {
@@ -89,7 +91,10 @@ TacticalScreen::TacticalScreen(GuiContainer* owner)
         },
         [this](float r_position) {
             if (my_spaceship)
+            {
                 my_spaceship->commandCombatManeuverStrafe(r_position / 100);
+                combat_maneuver->setStrafeValue(r_position/100);
+            }
         }
     );
 
@@ -117,7 +122,8 @@ TacticalScreen::TacticalScreen(GuiContainer* owner)
     lock_aim->setPosition(250, 20, ATopCenter)->setSize(110, 50);
 
     // Combat maneuver and propulsion controls in the bottom right corner.
-    (new GuiCombatManeuver(this, "COMBAT_MANEUVER"))->setPosition(-20, -390, ABottomRight)->setSize(200, 150);
+    combat_maneuver = new GuiCombatManeuver(this, "COMBAT_MANEUVER");
+    combat_maneuver->setPosition(-20, -390, ABottomRight)->setSize(200, 150);
     GuiAutoLayout* engine_layout = new GuiAutoLayout(this, "ENGINE_LAYOUT", GuiAutoLayout::LayoutHorizontalRightToLeft);
     engine_layout->setPosition(-20, -80, ABottomRight)->setSize(GuiElement::GuiSizeMax, 300);
     (new GuiImpulseControls(engine_layout, "IMPULSE"))->setSize(100, GuiElement::GuiSizeMax);

--- a/src/screens/crew4/tacticalScreen.h
+++ b/src/screens/crew4/tacticalScreen.h
@@ -3,6 +3,7 @@
 
 #include "gui/gui2_overlay.h"
 #include "screenComponents/targetsContainer.h"
+#include "screenComponents/combatManeuver.h"
 
 class GuiMissileTubeControls;
 class GuiRadarView;
@@ -28,6 +29,7 @@ private:
     GuiRotationDial* missile_aim;
     GuiMissileTubeControls* tube_controls;
     GuiToggleButton* lock_aim;
+	GuiCombatManeuver* combat_maneuver;
 public:
     TacticalScreen(GuiContainer* owner);
     


### PR DESCRIPTION
This adds hotkeys for combat maneuvering (which were already present as a placeholder).

_Unfortunately D is already predefined, and S could be accidentally pressed, otherwise defaulting them to WAD would have been nice._

You may wonder why I didn't use the onHotkey events. I did at first, and then realized I also need a way to recognize whether the keys were released, to stop the maneuver. So I had to manually check anyway, and checking via onHotkey became redundant.