### PR TITLE
Change the windows build to a GUI executable

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -381,7 +381,7 @@ endif()
 if(ANDROID)
     add_library(${EXECUTABLE_NAME} SHARED ${SOURCES})
 else()
-    add_executable(${EXECUTABLE_NAME} MACOSX_BUNDLE ${SOURCES})
+    add_executable(${EXECUTABLE_NAME} MACOSX_BUNDLE WIN32 ${SOURCES})
 endif()
 
 include_directories(${CMAKE_SOURCE_DIR}/src)


### PR DESCRIPTION
As commented on discord, otherwise it shows 2 windows (the main GUI window and a console window).

Kilted Klingon has mentioned that he uses the console windows on windows, it would be nice if he had a soultion that worked before merging. (or maybe make sure he has a exe that is built as a console build until his http stuff is done). Regardless of if its decided to merge now or later it being tracked in a pull request seems better than being forgotten about on discord.

I dont know what is meant to happen when WIN32 is defined on non windows platforms.
Experimentally
Windows release build is still not working locally, so I cant test that.
Windows debug is working.
Native Linux build worked as expected (unchanged).
I am unable to test mac builds.