### PR TITLE
Add red, green, blue colorConfig profiles for buttons

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@
 - `ScanProbe:onExpiration`, `ScanProbe:onDestruction`, and
   `PlayerSpaceship:onProbeLaunch` callback scripting functions.
 - Scan object and cycle selected object hotkeys added to Science.
+- `setColors()` and `getColors()` GUI functions, and R/G/B color profiles, for
+  GuiButtons.
 
 ### Changed
 

--- a/resources/gui/colors.ini
+++ b/resources/gui/colors.ini
@@ -9,6 +9,30 @@ button.forground.hover = #FFFFFF
 button.forground.active = #120A00
 button.forground.disabled = #FFFFFF4D
 
+button_red.background = #FF0000
+button_red.background.disabled = #A08080
+
+button_red.forground = #FF0000
+button_red.forground.hover = #FF0000
+button_red.forground.active = #120000
+button_red.forground.disabled = #FF00004D
+
+button_green.background = #00FF00
+button_green.background.disabled = #80A080
+
+button_green.forground = #00FF00
+button_green.forground.hover = #00FF00
+button_green.forground.active = #001200
+button_green.forground.disabled = #00FF004D
+
+button_blue.background = #0000FF
+button_blue.background.disabled = #8080A0
+
+button_blue.forground = #0000FF
+button_blue.forground.hover = #0000FF
+button_blue.forground.active = #000012
+button_blue.forground.disabled = #0000FF4D
+
 text_entry = #FFFFFF
 
 slider = #FFFFFF

--- a/src/gui/colorConfig.cpp
+++ b/src/gui/colorConfig.cpp
@@ -42,6 +42,9 @@ void ColorConfig::load()
     DEF_COLOR(log_receive_enemy);
     DEF_COLOR(log_receive_neutral);
     DEF_WIDGETCOLORSET(button);
+    DEF_WIDGETCOLORSET(button_red);
+    DEF_WIDGETCOLORSET(button_green);
+    DEF_WIDGETCOLORSET(button_blue);
     DEF_WIDGETCOLORSET(label);
     DEF_WIDGETCOLORSET(text_entry);
     DEF_WIDGETCOLORSET(slider);

--- a/src/gui/colorConfig.h
+++ b/src/gui/colorConfig.h
@@ -32,6 +32,9 @@ public:
     sf::Color log_receive_neutral;
     
     WidgetColorSet button;
+    WidgetColorSet button_red;
+    WidgetColorSet button_green;
+    WidgetColorSet button_blue;
     WidgetColorSet label;
     WidgetColorSet text_entry;
     WidgetColorSet slider;

--- a/src/gui/gui2_button.cpp
+++ b/src/gui/gui2_button.cpp
@@ -7,12 +7,13 @@ GuiButton::GuiButton(GuiContainer* owner, string id, string text, func_t func)
 : GuiElement(owner, id), text(text), func(func)
 {
     text_size = 30;
+    color_set = colorConfig.button;
 }
 
 void GuiButton::onDraw(sf::RenderTarget& window)
 {
-    sf::Color color = selectColor(colorConfig.button.background);
-    sf::Color text_color = selectColor(colorConfig.button.forground);
+    sf::Color color = selectColor(color_set.background);
+    sf::Color text_color = selectColor(color_set.forground);
     
     if (!enabled)
         drawStretched(window, rect, "gui/ButtonBackground.disabled", color);
@@ -96,7 +97,18 @@ GuiButton* GuiButton::setIcon(string icon_name, EGuiAlign icon_alignment, float 
     return this;
 }
 
+GuiButton* GuiButton::setColors(WidgetColorSet color_set)
+{
+    this->color_set = color_set;
+    return this;
+}
+
 string GuiButton::getIcon() const
 {
     return icon_name;
+}
+
+WidgetColorSet GuiButton::getColors() const
+{
+    return color_set;
 }

--- a/src/gui/gui2_button.h
+++ b/src/gui/gui2_button.h
@@ -16,6 +16,7 @@ protected:
     string icon_name;
     EGuiAlign icon_alignment;
     float icon_rotation;
+    WidgetColorSet color_set;
 public:
     GuiButton(GuiContainer* owner, string id, string text, func_t func);
 
@@ -25,9 +26,11 @@ public:
     
     GuiButton* setText(string text);
     GuiButton* setTextSize(float size);
-    GuiButton* setIcon(string icon_name, EGuiAlign icon_alignment = ACenterLeft, float rotation=0);
+    GuiButton* setIcon(string icon_name, EGuiAlign icon_alignment = ACenterLeft, float rotation = 0);
+    GuiButton* setColors(WidgetColorSet color_set);
     string getText() const;
     string getIcon() const;
+    WidgetColorSet getColors() const;
 };
 
 #endif//GUI2_BUTTON_H

--- a/src/screenComponents/selfDestructButton.cpp
+++ b/src/screenComponents/selfDestructButton.cpp
@@ -1,4 +1,5 @@
 #include "selfDestructButton.h"
+#include "gui/colorConfig.h"
 #include "playerInfo.h"
 #include "spaceObjects/playerSpaceship.h"
 
@@ -12,7 +13,7 @@ GuiSelfDestructButton::GuiSelfDestructButton(GuiContainer* owner, string id)
         confirm_button->show();
         cancel_button->show();
     });
-    activate_button->setIcon("gui/icons/self-destruct")->setSize(GuiElement::GuiSizeMax, 50);
+    activate_button->setColors(colorConfig.button_red)->setIcon("gui/icons/self-destruct")->setSize(GuiElement::GuiSizeMax, 50);
 
     confirm_button = new GuiButton(this, id + "_CONFIRM", "Confirm!", [this](){
         confirm_button->hide();


### PR DESCRIPTION
- Add WidgetColorSets for red, green, and blue buttons
- Add color codes for those sets to colors.ini
- Add `setColors()` and `getColors()` functions to GuiButton to configure a button's colorSet
- Set the self-destruct button's colorSet to Red

Supports re-implementing the signal details PR. Default behavior/colorSet is unchanged.

![buttoncolor](https://user-images.githubusercontent.com/19192104/75101039-76ca3580-558b-11ea-87ec-4e01edd1d0ef.png)
