### PR TITLE
Move dynamic signatures

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@
 - `ScanProbe:onExpiration`, `ScanProbe:onDestruction`, and
   `PlayerSpaceship:onProbeLaunch` callback scripting functions.
 - Scan object and cycle selected object hotkeys added to Science.
+- `SpaceShip:getDynamicRadarSignatureGravity()`, `...Electrical()`, and
+  `...Biological()` scripting functions.
 
 ### Changed
 

--- a/src/spaceObjects/spaceship.h
+++ b/src/spaceObjects/spaceship.h
@@ -174,6 +174,15 @@ public:
     virtual void draw3DTransparent() override;
 #endif
     /*!
+     * Get this ship's radar signature dynamically modified by the state of its
+     * systems and current activity.
+     */
+    virtual RawRadarSignatureInfo getDynamicRadarSignatureInfo();
+    float getDynamicRadarSignatureGravity() { return getDynamicRadarSignatureInfo().gravity; }
+    float getDynamicRadarSignatureElectrical() { return getDynamicRadarSignatureInfo().electrical; }
+    float getDynamicRadarSignatureBiological() { return getDynamicRadarSignatureInfo().biological; }
+
+    /*!
      * Draw this ship on the radar.
      */
     virtual void drawOnRadar(sf::RenderTarget& window, sf::Vector2f position, float scale, bool long_range) override;


### PR DESCRIPTION
Move the dynamic radar signature getter to the SpaceShip object, and replace the implementation in rawScannerDataRadarOverlay with it.

Add `getDynamicRadarSignatureGravity()`, `...Electrical()`, and `...Biological()` scripting functions.

Supports re-implementing the signal details PR.