### PR TITLE
Allow spaceObject visibility to be toggled

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@
 - `ScanProbe:onExpiration`, `ScanProbe:onDestruction`, and
   `PlayerSpaceship:onProbeLaunch` callback scripting functions.
 - Scan object and cycle selected object hotkeys added to Science.
+- SpaceObjects can be invisible, hiding them from radar and 3D views.
+- `SpaceObject:setVisibility` and `isVisible` scripting functions.
 
 ### Changed
 

--- a/src/screenComponents/radarView.cpp
+++ b/src/screenComponents/radarView.cpp
@@ -585,9 +585,14 @@ void GuiRadarView::drawObjects(sf::RenderTarget& window_normal, sf::RenderTarget
             sf::RenderTarget* window = &window_normal;
             if (!obj->canHideInNebula())
                 window = &window_alpha;
-            obj->drawOnRadar(*window, object_position_on_screen, scale, long_range);
-            if (show_callsigns && obj->getCallSign() != "")
-                drawText(*window, sf::FloatRect(object_position_on_screen.x, object_position_on_screen.y - 15, 0, 0), obj->getCallSign(), ACenter, 15, bold_font);
+
+            // Draw only visible objects.
+            if (obj->isVisible())
+            {
+                obj->drawOnRadar(*window, object_position_on_screen, scale, long_range);
+                if (show_callsigns && obj->getCallSign() != "")
+                    drawText(*window, sf::FloatRect(object_position_on_screen.x, object_position_on_screen.y - 15, 0, 0), obj->getCallSign(), ACenter, 15, bold_font);
+            }
         }
     }
     if (my_spaceship)
@@ -632,8 +637,12 @@ void GuiRadarView::drawTargets(sf::RenderTarget& window)
         sf::FloatRect object_rect(object_position_on_screen.x - r, object_position_on_screen.y - r, r * 2, r * 2);
         if (obj != my_spaceship && rect.intersects(object_rect))
         {
-            target_sprite.setPosition(object_position_on_screen);
-            window.draw(target_sprite);
+            // Draw objects only if they're visible.
+            if (obj != my_spaceship && obj->isVisible())
+            {
+                target_sprite.setPosition(object_position_on_screen);
+                window.draw(target_sprite);
+            }
         }
     }
 

--- a/src/screenComponents/radarView.cpp
+++ b/src/screenComponents/radarView.cpp
@@ -67,12 +67,13 @@ void GuiRadarView::onDraw(sf::RenderTarget& window)
 
     ///Start drawing of foreground
     forground_texture.clear(sf::Color::Transparent);
-    //Draw things that are masked out by fog-of-war
+    //Draw the trails of visible objects
     if (show_ghost_dots)
     {
         updateGhostDots();
         drawGhostDots(forground_texture);
     }
+    //Draw things that are masked out by fog-of-war
     drawObjects(forground_texture, background_texture);
     if (show_game_master_data)
         drawObjectsGM(forground_texture);
@@ -143,7 +144,7 @@ void GuiRadarView::updateGhostDots()
         foreach(SpaceObject, obj, space_object_list)
         {
             P<SpaceShip> ship = obj;
-            if (ship && sf::length(obj->getPosition() - view_position) < distance)
+            if (ship && ship->isVisible() == true && sf::length(obj->getPosition() - view_position) < distance)
             {
                 ghost_dots.push_back(GhostDot(obj->getPosition()));
             }

--- a/src/screenComponents/targetsContainer.cpp
+++ b/src/screenComponents/targetsContainer.cpp
@@ -29,7 +29,7 @@ void TargetsContainer::set(P<SpaceObject> obj)
             entries[0] = obj;
             if (entries.size() > 1)
                 entries.resize(1);
-        }else{
+        }else if (obj->isVisible()){
             entries.push_back(obj);
         }
     }
@@ -58,11 +58,11 @@ void TargetsContainer::setToClosestTo(sf::Vector2f position, float max_range, ES
             switch(selection_type)
             {
             case Selectable:
-                if (!spaceObject->canBeSelectedBy(my_spaceship))
+                if (!spaceObject->canBeSelectedBy(my_spaceship) || !spaceObject->isVisible())
                     continue;
                 break;
             case Targetable:
-                if (!spaceObject->canBeTargetedBy(my_spaceship))
+                if (!spaceObject->canBeTargetedBy(my_spaceship) || !spaceObject->isVisible())
                     continue;
                 break;
             }

--- a/src/spaceObjects/spaceObject.cpp
+++ b/src/spaceObjects/spaceObject.cpp
@@ -210,6 +210,14 @@ REGISTER_SCRIPT_CLASS_NO_CREATE(SpaceObject)
     REGISTER_SCRIPT_CLASS_FUNCTION(SpaceObject, getRadarSignatureGravity);
     REGISTER_SCRIPT_CLASS_FUNCTION(SpaceObject, getRadarSignatureElectrical);
     REGISTER_SCRIPT_CLASS_FUNCTION(SpaceObject, getRadarSignatureBiological);
+    /// Sets this object's visibility, both on radar and in 3D rendering.
+    /// Requires a boolean value.
+    /// Example: obj:setVisibility(false)
+    REGISTER_SCRIPT_CLASS_FUNCTION(SpaceObject, setVisibility);
+    /// Gets this object's visibility.
+    /// Returns a boolean value.
+    /// Example: local is_visible = obj:isVisible()
+    REGISTER_SCRIPT_CLASS_FUNCTION(SpaceObject, isVisible);
     /// Sets this object's scanning complexity (number of bars in the scanning
     /// minigame) and depth (number of scanning minigames to complete).
     /// Requires two integer values.
@@ -260,6 +268,7 @@ SpaceObject::SpaceObject(float collision_range, string multiplayer_name, float m
     space_object_list.push_back(this);
     faction_id = 0;
 
+    is_visible = true;
     scanning_complexity_value = 0;
     scanning_depth_value = 0;
 
@@ -273,6 +282,7 @@ SpaceObject::SpaceObject(float collision_range, string multiplayer_name, float m
     registerMemberReplication(&radar_signature.gravity);
     registerMemberReplication(&radar_signature.electrical);
     registerMemberReplication(&radar_signature.biological);
+    registerMemberReplication(&is_visible);
     registerMemberReplication(&scanning_complexity_value);
     registerMemberReplication(&scanning_depth_value);
     registerCollisionableReplication(multiplayer_significant_range);
@@ -285,7 +295,9 @@ SpaceObject::~SpaceObject()
 #if FEATURE_3D_RENDERING
 void SpaceObject::draw3D()
 {
-    model_info.render(getPosition(), getRotation());
+    // Draw only visible objects.
+    if (is_visible)
+      model_info.render(getPosition(), getRotation());
 }
 #endif//FEATURE_3D_RENDERING
 

--- a/src/spaceObjects/spaceObject.h
+++ b/src/spaceObjects/spaceObject.h
@@ -89,6 +89,7 @@ class SpaceObject : public Collisionable, public MultiplayerObject
         string full_scan;
     } object_description;
     RawRadarSignatureInfo radar_signature;
+    bool is_visible;
 
     /*!
      * Scan state per faction. Implementation wise, this vector is resized when
@@ -112,12 +113,16 @@ public:
     float getRadius() { return object_radius; }
     void setRadius(float radius) { object_radius = radius; setCollisionRadius(radius); }
 
-    // Return the object's raw radar signature. The default signature is 0,0,0.
+    // Return the object's raw radar signature. The default signature is 0 grav, 0 elec, 0 bio.
     virtual RawRadarSignatureInfo getRadarSignatureInfo() { return radar_signature; }
     void setRadarSignatureInfo(float grav, float elec, float bio) { radar_signature = RawRadarSignatureInfo(grav, elec, bio); }
     float getRadarSignatureGravity() { return radar_signature.gravity; }
     float getRadarSignatureElectrical() { return radar_signature.electrical; }
     float getRadarSignatureBiological() { return radar_signature.biological; }
+
+    // Return the object's radar visibility.
+    void setVisibility(bool visibility) { is_visible = visibility; }
+    bool isVisible() { return is_visible; }
 
     string getDescription(EScannedState state)
     {


### PR DESCRIPTION
Add `setVisibility()` scripting function to spaceObjects to toggle their visibility on radar and in 3D rendering, and `isVisible()` (returns bool) to check visibility in scripting.

Invisible objects can't be targeted, and invisible ships don't leave a trail of ghost dots.