### PR TITLE
Require Android to use landscape

### DIFF
--- a/android/AndroidManifest.xml
+++ b/android/AndroidManifest.xml
@@ -18,6 +18,7 @@
     <activity android:name="android.app.NativeActivity"
               android:label="@string/app_name"
               android:icon="@drawable/ic_launcher"
+              android:screenOrientation="userLandscape"
               android:configChanges="keyboardHidden|orientation|screenSize">
 
         <meta-data android:name="android.app.lib_name" android:value="sfml-activity" />


### PR DESCRIPTION
`userLandscape` forces horizontal landscape orientation while respecting the user’s sensor preference for upright or reverse (upside-down) landscape.