### PR TITLE
Mirror model rendering

### DIFF
--- a/src/mesh.cpp
+++ b/src/mesh.cpp
@@ -173,10 +173,10 @@ Mesh* Mesh::getMesh(string filename)
         {
             ret->vertices[n].position[0] = -vertices[indices[n].v].x;
             ret->vertices[n].position[1] = vertices[indices[n].v].z;
-            ret->vertices[n].position[2] = vertices[indices[n].v].y;
+            ret->vertices[n].position[2] = -vertices[indices[n].v].y;
             ret->vertices[n].normal[0] = -normals[indices[n].n].x;
             ret->vertices[n].normal[1] = normals[indices[n].n].z;
-            ret->vertices[n].normal[2] = normals[indices[n].n].y;
+            ret->vertices[n].normal[2] = -normals[indices[n].n].y;
             ret->vertices[n].uv[0] = texCoords[indices[n].t].x;
             ret->vertices[n].uv[1] = 1.0 - texCoords[indices[n].t].y;
         }
@@ -185,6 +185,9 @@ Mesh* Mesh::getMesh(string filename)
         ret->vertexCount = readInt(stream);
         ret->vertices = new MeshVertex[ret->vertexCount];
         stream->read(ret->vertices, sizeof(MeshVertex) * ret->vertexCount);
+        // Flip the Y coordinate on every mesh
+        for(unsigned int n = 0; n < ret->vertexCount; n++)
+            ret->vertices[n].position[1] = -ret->vertices[n].position[1];
     }else{
         LOG(ERROR) << "Unknown mesh format: " << filename;
     }

--- a/src/mesh.cpp
+++ b/src/mesh.cpp
@@ -186,8 +186,11 @@ Mesh* Mesh::getMesh(string filename)
         ret->vertices = new MeshVertex[ret->vertexCount];
         stream->read(ret->vertices, sizeof(MeshVertex) * ret->vertexCount);
         // Flip the Y coordinate on every mesh
-        for(unsigned int n = 0; n < ret->vertexCount; n++)
+        for(int n = 0; n < ret->vertexCount; n++)
+        {
             ret->vertices[n].position[1] = -ret->vertices[n].position[1];
+            ret->vertices[n].normal[1] = -ret->vertices[n].normal[1];
+        }
     }else{
         LOG(ERROR) << "Unknown mesh format: " << filename;
     }

--- a/src/screenComponents/rotatingModelView.cpp
+++ b/src/screenComponents/rotatingModelView.cpp
@@ -13,6 +13,8 @@ static void _glPerspective(double fovY, double aspect, double zNear, double zFar
     fW = fH * aspect;
 
     glFrustum(-fW, fW, -fH, fH, zNear, zFar);
+    // Reverse face culling from default GL_CCW order
+    glFrontFace(GL_CW);
 }
 #endif//FEATURE_3D_RENDERING
 

--- a/src/screenComponents/viewport3d.cpp
+++ b/src/screenComponents/viewport3d.cpp
@@ -17,6 +17,8 @@ static void _glPerspective(double fovY, double aspect, double zNear, double zFar
     fW = fH * aspect;
 
     glFrustum(-fW, fW, -fH, fH, zNear, zFar);
+    // Reverse face culling from default GL_CCW order
+    glFrontFace(GL_CW);
 }
 #endif//FEATURE_3D_RENDERING
 
@@ -68,45 +70,45 @@ void GuiViewport3D::onDraw(sf::RenderTarget& window)
     glDepthMask(false);
     sf::Texture::bind(textureManager.getTexture("StarsBack"), sf::Texture::Normalized);
     glBegin(GL_TRIANGLE_STRIP);
-    glTexCoord2f(0.0, 0.0); glVertex3f( 100, 100, 100);
-    glTexCoord2f(0.0, 1.0); glVertex3f( 100, 100,-100);
-    glTexCoord2f(1.0, 0.0); glVertex3f(-100, 100, 100);
-    glTexCoord2f(1.0, 1.0); glVertex3f(-100, 100,-100);
-    glEnd();
-    sf::Texture::bind(textureManager.getTexture("StarsLeft"), sf::Texture::Normalized);
-    glBegin(GL_TRIANGLE_STRIP);
-    glTexCoord2f(0.0, 0.0); glVertex3f(-100, 100, 100);
-    glTexCoord2f(0.0, 1.0); glVertex3f(-100, 100,-100);
+    glTexCoord2f(0.0, 0.0); glVertex3f( 100,-100, 100);
+    glTexCoord2f(0.0, 1.0); glVertex3f( 100,-100,-100);
     glTexCoord2f(1.0, 0.0); glVertex3f(-100,-100, 100);
     glTexCoord2f(1.0, 1.0); glVertex3f(-100,-100,-100);
     glEnd();
-    sf::Texture::bind(textureManager.getTexture("StarsFront"), sf::Texture::Normalized);
+    sf::Texture::bind(textureManager.getTexture("StarsLeft"), sf::Texture::Normalized);
     glBegin(GL_TRIANGLE_STRIP);
     glTexCoord2f(0.0, 0.0); glVertex3f(-100,-100, 100);
     glTexCoord2f(0.0, 1.0); glVertex3f(-100,-100,-100);
-    glTexCoord2f(1.0, 0.0); glVertex3f( 100,-100, 100);
-    glTexCoord2f(1.0, 1.0); glVertex3f( 100,-100,-100);
+    glTexCoord2f(1.0, 0.0); glVertex3f(-100, 100, 100);
+    glTexCoord2f(1.0, 1.0); glVertex3f(-100, 100,-100);
+    glEnd();
+    sf::Texture::bind(textureManager.getTexture("StarsFront"), sf::Texture::Normalized);
+    glBegin(GL_TRIANGLE_STRIP);
+    glTexCoord2f(0.0, 0.0); glVertex3f(-100, 100, 100);
+    glTexCoord2f(0.0, 1.0); glVertex3f(-100, 100,-100);
+    glTexCoord2f(1.0, 0.0); glVertex3f( 100, 100, 100);
+    glTexCoord2f(1.0, 1.0); glVertex3f( 100, 100,-100);
     glEnd();
     sf::Texture::bind(textureManager.getTexture("StarsRight"), sf::Texture::Normalized);
     glBegin(GL_TRIANGLE_STRIP);
-    glTexCoord2f(0.0, 0.0); glVertex3f( 100,-100, 100);
-    glTexCoord2f(0.0, 1.0); glVertex3f( 100,-100,-100);
-    glTexCoord2f(1.0, 0.0); glVertex3f( 100, 100, 100);
-    glTexCoord2f(1.0, 1.0); glVertex3f( 100, 100,-100);
+    glTexCoord2f(0.0, 0.0); glVertex3f( 100, 100, 100);
+    glTexCoord2f(0.0, 1.0); glVertex3f( 100, 100,-100);
+    glTexCoord2f(1.0, 0.0); glVertex3f( 100,-100, 100);
+    glTexCoord2f(1.0, 1.0); glVertex3f( 100,-100,-100);
     glEnd();
     sf::Texture::bind(textureManager.getTexture("StarsTop"), sf::Texture::Normalized);
     glBegin(GL_TRIANGLE_STRIP);
-    glTexCoord2f(0.0, 0.0); glVertex3f(-100, 100, 100);
-    glTexCoord2f(0.0, 1.0); glVertex3f(-100,-100, 100);
-    glTexCoord2f(1.0, 0.0); glVertex3f( 100, 100, 100);
-    glTexCoord2f(1.0, 1.0); glVertex3f( 100,-100, 100);
+    glTexCoord2f(0.0, 0.0); glVertex3f(-100,-100, 100);
+    glTexCoord2f(0.0, 1.0); glVertex3f(-100, 100, 100);
+    glTexCoord2f(1.0, 0.0); glVertex3f( 100,-100, 100);
+    glTexCoord2f(1.0, 1.0); glVertex3f( 100, 100, 100);
     glEnd();
     sf::Texture::bind(textureManager.getTexture("StarsBottom"), sf::Texture::Normalized);
     glBegin(GL_TRIANGLE_STRIP);
-    glTexCoord2f(1.0, 0.0); glVertex3f( 100,-100,-100);
-    glTexCoord2f(0.0, 0.0); glVertex3f(-100,-100,-100);
-    glTexCoord2f(1.0, 1.0); glVertex3f( 100, 100,-100);
-    glTexCoord2f(0.0, 1.0); glVertex3f(-100, 100,-100);
+    glTexCoord2f(1.0, 0.0); glVertex3f( 100, 100,-100);
+    glTexCoord2f(0.0, 0.0); glVertex3f(-100, 100,-100);
+    glTexCoord2f(1.0, 1.0); glVertex3f( 100,-100,-100);
+    glTexCoord2f(0.0, 1.0); glVertex3f(-100,-100,-100);
     glEnd();
 
     if (gameGlobalInfo)


### PR DESCRIPTION
Scale models across the Y axis, which also inverts winding order. To mitigate the inverted order, cull front faces instead of the default back faces and invert the skybox.

Fixes #294 