### PR TITLE
Add shield calibration for engineering+

### DIFF
--- a/src/screenComponents/shieldFreqencySelect.cpp
+++ b/src/screenComponents/shieldFreqencySelect.cpp
@@ -7,18 +7,24 @@
 #include "gui/gui2_keyvaluedisplay.h"
 #include "gui/gui2_selector.h"
 #include "gui/gui2_progressbar.h"
+#include "gui/gui2_autolayout.h"
 
 GuiShieldFrequencySelect::GuiShieldFrequencySelect(GuiContainer* owner, string id)
 : GuiElement(owner, id)
 {
     (new GuiShieldsEnableButton(this, "SHIELDS_ENABLE"))->setPosition(0, 0, ATopLeft)->setSize(GuiElement::GuiSizeMax, 50);
-    calibrate_button = new GuiButton(this, "", "Calibrate", [this]() {
+    GuiElement* calibration_row = new GuiAutoLayout(this, "", GuiAutoLayout::LayoutHorizontalRightToLeft);
+    calibration_row->setPosition(0, 50, ATopLeft)->setSize(GuiElement::GuiSizeMax, 50);
+
+    new_frequency = new GuiSelector(calibration_row, "", nullptr);
+    new_frequency->setSize(120, 50);
+
+    calibrate_button = new GuiButton(calibration_row, "", "Calibrate", [this]() {
         if (my_spaceship)
             my_spaceship->commandSetShieldFrequency(new_frequency->getSelectionIndex());
     });
-    calibrate_button->setPosition(0, 50, ATopLeft)->setSize(280 * 0.55, 50);
-    new_frequency = new GuiSelector(this, "", nullptr);
-    new_frequency->setPosition(280 * 0.55, 50, ATopLeft)->setSize(280 * 0.45, 50);
+    calibrate_button->setSize(GuiElement::GuiSizeMax, 50);
+
     for(int n=0; n<=SpaceShip::max_frequency; n++)
     {
         new_frequency->addEntry(frequencyToString(n), string(n));

--- a/src/screens/crew4/engineeringAdvancedScreen.cpp
+++ b/src/screens/crew4/engineeringAdvancedScreen.cpp
@@ -1,9 +1,17 @@
 #include "engineeringAdvancedScreen.h"
 
+#include "gameGlobalInfo.h"
+#include "screenComponents/shieldFreqencySelect.h"
 #include "screenComponents/shieldsEnableButton.h"
 
 EngineeringAdvancedScreen::EngineeringAdvancedScreen(GuiContainer* owner)
 : EngineeringScreen(owner, engineeringAdvanced)
 {
-    (new GuiShieldsEnableButton(this, "SHIELDS_ENABLE"))->setPosition(20, 370, ATopLeft)->setSize(240, 50);
+	if (gameGlobalInfo->use_beam_shield_frequencies)
+    {
+        //The shield frequency selection includes a shield enable button.
+        (new GuiShieldFrequencySelect(this, "SHIELD_FREQ"))->setPosition(20, 310, ATopLeft)->setSize(240, 100);
+    }else{
+        (new GuiShieldsEnableButton(this, "SHIELDS_ENABLE"))->setPosition(20, 310, ABottomRight)->setSize(240, 50);
+    }
 }

--- a/src/screens/crew4/engineeringAdvancedScreen.cpp
+++ b/src/screens/crew4/engineeringAdvancedScreen.cpp
@@ -12,6 +12,6 @@ EngineeringAdvancedScreen::EngineeringAdvancedScreen(GuiContainer* owner)
         //The shield frequency selection includes a shield enable button.
         (new GuiShieldFrequencySelect(this, "SHIELD_FREQ"))->setPosition(20, 310, ATopLeft)->setSize(240, 100);
     }else{
-        (new GuiShieldsEnableButton(this, "SHIELDS_ENABLE"))->setPosition(20, 310, ABottomRight)->setSize(240, 50);
+        (new GuiShieldsEnableButton(this, "SHIELDS_ENABLE"))->setPosition(20, 310, ATopLeft)->setSize(240, 50);
     }
 }

--- a/src/screens/crew6/engineeringScreen.cpp
+++ b/src/screens/crew6/engineeringScreen.cpp
@@ -38,7 +38,7 @@ EngineeringScreen::EngineeringScreen(GuiContainer* owner, ECrewPosition crew_pos
     coolant_display = new GuiKeyValueDisplay(this, "COOLANT_DISPLAY", 0.45, "Coolant", "");
     coolant_display->setIcon("gui/icons/coolant")->setTextSize(20)->setPosition(20, 260, ATopLeft)->setSize(240, 40);
 
-    (new GuiSelfDestructButton(this, "SELF_DESTRUCT"))->setPosition(20, 300, ATopLeft)->setSize(240, 100);
+    (new GuiSelfDestructButton(this, "SELF_DESTRUCT"))->setPosition(20, 20, ATopLeft)->setSize(240, 100);
 
     GuiElement* system_config_container = new GuiElement(this, "");
     system_config_container->setPosition(0, -20, ABottomCenter)->setSize(750 + 300, GuiElement::GuiSizeMax);


### PR DESCRIPTION
Also moves self destruct button to the top left for better space distribution.
This complements #747

![engplusfreq](https://user-images.githubusercontent.com/25465934/75177158-e9771480-5735-11ea-8f0e-15ba2394cb0c.jpg)
