### PR TITLE
Fix alignment of touchscreen calib button text

### DIFF
--- a/src/menus/mainMenus.cpp
+++ b/src/menus/mainMenus.cpp
@@ -101,10 +101,13 @@ MainMenu::MainMenu()
 
     if (InputHandler::touch_screen)
     {
-        (new GuiButton(this, "TOUCH_CALIB", tr("Calibrate\nTouchscreen"), [this]() {
+        GuiButton* touch_calib = new GuiButton(this, "TOUCH_CALIB", "", [this]() {
             destroy();
             new MouseCalibrator("");
-        }))->setPosition(sf::Vector2f(-50, -50), ABottomRight)->setSize(300, 100);
+        });
+        touch_calib->setPosition(sf::Vector2f(-50, -50), ABottomRight)->setSize(200, 100);
+        (new GuiLabel(touch_calib, "TOUCH_CALIB_LABEL", tr("Calibrate\nTouchscreen"), 30)
+        )->setPosition(0, -15, ACenter);
     }
 
     float y = 100;


### PR DESCRIPTION
Resize and realign the label on the Calibrate Touchscreen button in the main menu

Before:

<img width="348" alt="Screen Shot 2020-03-13 at 1 41 17 AM" src="https://user-images.githubusercontent.com/19192104/76604343-d2714a00-64cb-11ea-9802-f49ae70af08c.png">

After:

<img width="240" alt="Screen Shot 2020-03-13 at 1 40 41 AM" src="https://user-images.githubusercontent.com/19192104/76604350-d604d100-64cb-11ea-90f8-75900cac12b3.png">