### PR TITLE
Add main screen first person preference

### DIFF
--- a/src/screens/mainScreen.cpp
+++ b/src/screens/mainScreen.cpp
@@ -55,7 +55,7 @@ ScreenMainScreen::ScreenMainScreen()
         });
     }
 
-    first_person = false;
+    first_person = PreferencesManager::get("first_person") == "1";
 }
 
 void ScreenMainScreen::update(float delta)


### PR DESCRIPTION
Add `first_person` to PreferencesManager.

- A value of `1` uses first-person view by default on main screen
- Any other value uses third-person view by default

If unset or not present, no default behavior is changed and main
screen uses third-person view.