### PR TITLE
Add short range radar range preference

### DIFF
--- a/src/gameGlobalInfo.cpp
+++ b/src/gameGlobalInfo.cpp
@@ -31,7 +31,8 @@ GameGlobalInfo::GameGlobalInfo()
     scanning_complexity = SC_Normal;
     hacking_difficulty = 2;
     hacking_games = HG_All;
-    long_range_radar_range = 30000;
+    short_range_radar_range = 5000.0;
+    long_range_radar_range = 30000.0;
     use_beam_shield_frequencies = true;
     use_system_damage = true;
     allow_main_screen_tactical_radar = true;
@@ -46,6 +47,7 @@ GameGlobalInfo::GameGlobalInfo()
     registerMemberReplication(&global_message_timeout, 1.0);
     registerMemberReplication(&banner_string);
     registerMemberReplication(&victory_faction);
+    registerMemberReplication(&short_range_radar_range);
     registerMemberReplication(&long_range_radar_range);
     registerMemberReplication(&use_beam_shield_frequencies);
     registerMemberReplication(&use_system_damage);
@@ -197,6 +199,12 @@ void GameGlobalInfo::setLongRangeRadarRange(float range)
     // Disallow ranges <= 5000.0f (zoom misbehavior, crashes)
     // or > 125U (unreadable)
     long_range_radar_range = std::max(5000.0f, std::min(125000.0f, range));
+}
+
+void GameGlobalInfo::setShortRangeRadarRange(float range)
+{
+    // Disallow ranges <= 500.0f or > 20U (unusable in weapons)
+    short_range_radar_range = std::max(500.0f, std::min(20000.0f, range));
 }
 
 string playerWarpJumpDriveToString(EPlayerWarpJumpDrive player_warp_jump_drive)
@@ -391,12 +399,20 @@ static int unpauseGame(lua_State* L)
 /// Calling this function will pause the game. Mainly usefull for a headless server setup. As the scenario functions are not called when paused.
 REGISTER_SCRIPT_FUNCTION(unpauseGame);
 
+static int getShortRangeRadarRange(lua_State* L)
+{
+    lua_pushnumber(L, gameGlobalInfo->short_range_radar_range);
+    return 1;
+}
+/// Return the short range radar range, normally 5000.0 (5U), but can be configured per game.
+REGISTER_SCRIPT_FUNCTION(getShortRangeRadarRange);
+
 static int getLongRangeRadarRange(lua_State* L)
 {
     lua_pushnumber(L, gameGlobalInfo->long_range_radar_range);
     return 1;
 }
-/// Return the long range radar range, normally 30.000, but can be configured per game.
+/// Return the long range radar range, normally 30000.0 (30U), but can be configured per game.
 REGISTER_SCRIPT_FUNCTION(getLongRangeRadarRange);
 
 static int playSoundFile(lua_State* L)

--- a/src/gameGlobalInfo.h
+++ b/src/gameGlobalInfo.h
@@ -78,6 +78,10 @@ public:
      * \brief Range of the science radar.
      */
     float long_range_radar_range;
+    /*!
+     * \brief Range of the helm/weapons/tactical radar.
+     */
+    float short_range_radar_range;
     bool use_beam_shield_frequencies;
     bool use_system_damage;
     bool allow_main_screen_tactical_radar;
@@ -117,6 +121,7 @@ public:
     virtual void update(float delta);
     virtual void destroy();
     void setLongRangeRadarRange(float range);
+    void setShortRangeRadarRange(float range);
 
     string getNextShipCallsign();
 };

--- a/src/menus/serverCreationScreen.cpp
+++ b/src/menus/serverCreationScreen.cpp
@@ -28,6 +28,7 @@ ServerCreationScreen::ServerCreationScreen()
     // Set defaults from preferences.
     gameGlobalInfo->player_warp_jump_drive_setting = EPlayerWarpJumpDrive(PreferencesManager::get("server_config_warp_jump_drive_setting", "0").toInt());
     gameGlobalInfo->setLongRangeRadarRange(PreferencesManager::get("server_config_long_range_radar_range", "30000").toInt());
+    gameGlobalInfo->setShortRangeRadarRange(PreferencesManager::get("server_config_short_range_radar_range", "5000").toInt());
     gameGlobalInfo->scanning_complexity = EScanningComplexity(PreferencesManager::get("server_config_scanning_complexity", "2").toInt());
     gameGlobalInfo->hacking_difficulty = PreferencesManager::get("server_config_hacking_difficulty", "1").toInt();
     gameGlobalInfo->hacking_games = EHackingGames(PreferencesManager::get("server_config_hacking_games", "2").toInt());

--- a/src/screenComponents/radarView.cpp
+++ b/src/screenComponents/radarView.cpp
@@ -173,7 +173,7 @@ void GuiRadarView::drawNoneFriendlyBlockedAreas(sf::RenderTarget& window)
         sf::Vector2f radar_screen_center(rect.left + rect.width / 2.0f, rect.top + rect.height / 2.0f);
         float scale = std::min(rect.width, rect.height) / 2.0f / distance;
 
-        float r = 5000.0 * scale;
+        float r = gameGlobalInfo->short_range_radar_range * scale;
         sf::CircleShape circle(r, 50);
         circle.setOrigin(r, r);
         circle.setFillColor(sf::Color(255, 255, 255, 255));
@@ -315,7 +315,7 @@ void GuiRadarView::drawNebulaBlockedAreas(sf::RenderTarget& window)
     }
 
     {
-        float r = 5000.0f * scale;
+        float r = gameGlobalInfo->short_range_radar_range * scale;
         sf::CircleShape circle(r, 32);
         circle.setOrigin(r, r);
         circle.setPosition(radar_screen_center + (scan_center - view_position) * scale);
@@ -554,11 +554,11 @@ void GuiRadarView::drawObjects(sf::RenderTarget& window_normal, sf::RenderTarget
             }
 
             sf::Vector2f position = obj->getPosition();
-            PVector<Collisionable> obj_list = CollisionManager::queryArea(position - sf::Vector2f(5000, 5000), position + sf::Vector2f(5000, 5000));
+            PVector<Collisionable> obj_list = CollisionManager::queryArea(position - sf::Vector2f(gameGlobalInfo->short_range_radar_range, gameGlobalInfo->short_range_radar_range), position + sf::Vector2f(gameGlobalInfo->short_range_radar_range, gameGlobalInfo->short_range_radar_range));
             foreach(Collisionable, c_obj, obj_list)
             {
                 P<SpaceObject> obj2 = c_obj;
-                if (obj2 && (obj->getPosition() - obj2->getPosition()) < 5000.0f + obj2->getRadius())
+                if (obj2 && (obj->getPosition() - obj2->getPosition()) < gameGlobalInfo->short_range_radar_range + obj2->getRadius())
                 {
                     visible_objects.insert(*obj2);
                 }

--- a/src/screens/crew1/singlePilotScreen.cpp
+++ b/src/screens/crew1/singlePilotScreen.cpp
@@ -1,5 +1,6 @@
 #include "main.h"
 #include "playerInfo.h"
+#include "gameGlobalInfo.h"
 #include "spaceObjects/playerSpaceship.h"
 #include "singlePilotScreen.h"
 
@@ -49,9 +50,14 @@ SinglePilotScreen::SinglePilotScreen(GuiContainer* owner)
     (new AlertLevelOverlay(this));
 
     // 5U tactical radar with piloting features.
-    radar = new GuiRadarView(left_panel, "TACTICAL_RADAR", 5000.0, &targets);
+    radar = new GuiRadarView(left_panel, "TACTICAL_RADAR", gameGlobalInfo->short_range_radar_range, &targets);
     radar->setPosition(0, 0, ACenter)->setSize(GuiElement::GuiSizeMatchHeight, 650);
-    radar->setRangeIndicatorStepSize(1000.0)->shortRange()->enableGhostDots()->enableWaypoints()->enableCallsigns()->enableHeadingIndicators()->setStyle(GuiRadarView::Circular);
+    float step_size = 1000.0f;
+    if (gameGlobalInfo->long_range_radar_range >= 15000.0f)
+        step_size = 5000.0f;
+    radar->setRangeIndicatorStepSize(step_size)->shortRange()->enableGhostDots()->enableWaypoints()->enableCallsigns()->enableHeadingIndicators()->setStyle(GuiRadarView::Circular);
+    if (gameGlobalInfo->short_range_radar_range >= 5000.0f)
+        radar->setFogOfWarStyle(GuiRadarView::NebulaFogOfWar);
     radar->setCallbacks(
         [this](sf::Vector2f position) {
             targets.setToClosestTo(position, 250, TargetsContainer::Targetable);
@@ -225,7 +231,7 @@ void SinglePilotScreen::onHotkey(const HotkeyResult& key)
                     current_found = true;
                     continue;
                 }
-                if (current_found && sf::length(obj->getPosition() - my_spaceship->getPosition()) < 5000 && my_spaceship->isEnemy(obj) && my_spaceship->getScannedStateFor(obj) >= SS_FriendOrFoeIdentified && obj->canBeTargetedBy(my_spaceship))
+                if (current_found && sf::length(obj->getPosition() - my_spaceship->getPosition()) < gameGlobalInfo->short_range_radar_range && my_spaceship->isEnemy(obj) && my_spaceship->getScannedStateFor(obj) >= SS_FriendOrFoeIdentified && obj->canBeTargetedBy(my_spaceship))
                 {
                     targets.set(obj);
                     my_spaceship->commandSetTarget(targets.get());
@@ -238,7 +244,7 @@ void SinglePilotScreen::onHotkey(const HotkeyResult& key)
                 {
                     continue;
                 }
-                if (my_spaceship->isEnemy(obj) && sf::length(obj->getPosition() - my_spaceship->getPosition()) < 5000 && my_spaceship->getScannedStateFor(obj) >= SS_FriendOrFoeIdentified && obj->canBeTargetedBy(my_spaceship))
+                if (my_spaceship->isEnemy(obj) && sf::length(obj->getPosition() - my_spaceship->getPosition()) < gameGlobalInfo->short_range_radar_range && my_spaceship->getScannedStateFor(obj) >= SS_FriendOrFoeIdentified && obj->canBeTargetedBy(my_spaceship))
                 {
                     targets.set(obj);
                     my_spaceship->commandSetTarget(targets.get());
@@ -258,7 +264,7 @@ void SinglePilotScreen::onHotkey(const HotkeyResult& key)
                 }
                 if (obj == my_spaceship)
                     continue;
-                if (current_found && sf::length(obj->getPosition() - my_spaceship->getPosition()) < 5000 && obj->canBeTargetedBy(my_spaceship))
+                if (current_found && sf::length(obj->getPosition() - my_spaceship->getPosition()) < gameGlobalInfo->short_range_radar_range && obj->canBeTargetedBy(my_spaceship))
                 {
                     targets.set(obj);
                     my_spaceship->commandSetTarget(targets.get());
@@ -269,7 +275,7 @@ void SinglePilotScreen::onHotkey(const HotkeyResult& key)
             {
                 if (obj == targets.get() || obj == my_spaceship)
                     continue;
-                if (sf::length(obj->getPosition() - my_spaceship->getPosition()) < 5000 && obj->canBeTargetedBy(my_spaceship))
+                if (sf::length(obj->getPosition() - my_spaceship->getPosition()) < gameGlobalInfo->short_range_radar_range && obj->canBeTargetedBy(my_spaceship))
                 {
                     targets.set(obj);
                     my_spaceship->commandSetTarget(targets.get());

--- a/src/screens/crew4/tacticalScreen.cpp
+++ b/src/screens/crew4/tacticalScreen.cpp
@@ -37,9 +37,14 @@ TacticalScreen::TacticalScreen(GuiContainer* owner)
     (new AlertLevelOverlay(this));
 
     // Short-range tactical radar with a 5U range.
-    radar = new GuiRadarView(this, "TACTICAL_RADAR", 5000.0, &targets);
+    radar = new GuiRadarView(this, "TACTICAL_RADAR", gameGlobalInfo->short_range_radar_range, &targets);
     radar->setPosition(0, 0, ACenter)->setSize(GuiElement::GuiSizeMatchHeight, 750);
-    radar->setRangeIndicatorStepSize(1000.0)->shortRange()->enableGhostDots()->enableWaypoints()->enableCallsigns()->enableHeadingIndicators()->setStyle(GuiRadarView::Circular);
+    float step_size = 1000.0f;
+    if (gameGlobalInfo->long_range_radar_range >= 15000.0f)
+        step_size = 5000.0f;
+    radar->setRangeIndicatorStepSize(step_size)->shortRange()->enableGhostDots()->enableWaypoints()->enableCallsigns()->enableHeadingIndicators()->setStyle(GuiRadarView::Circular);
+    if (gameGlobalInfo->short_range_radar_range >= 5000.0f)
+        radar->setFogOfWarStyle(GuiRadarView::NebulaFogOfWar);
 
     // Control targeting and piloting with radar interactions.
     radar->setCallbacks(
@@ -181,7 +186,7 @@ void TacticalScreen::onHotkey(const HotkeyResult& key)
                     current_found = true;
                     continue;
                 }
-                if (current_found && sf::length(obj->getPosition() - my_spaceship->getPosition()) < 5000 && my_spaceship->isEnemy(obj) && my_spaceship->getScannedStateFor(obj) >= SS_FriendOrFoeIdentified && obj->canBeTargetedBy(my_spaceship))
+                if (current_found && sf::length(obj->getPosition() - my_spaceship->getPosition()) < gameGlobalInfo->short_range_radar_range && my_spaceship->isEnemy(obj) && my_spaceship->getScannedStateFor(obj) >= SS_FriendOrFoeIdentified && obj->canBeTargetedBy(my_spaceship))
                 {
                     targets.set(obj);
                     my_spaceship->commandSetTarget(targets.get());
@@ -194,7 +199,7 @@ void TacticalScreen::onHotkey(const HotkeyResult& key)
                 {
                     continue;
                 }
-                if (my_spaceship->isEnemy(obj) && sf::length(obj->getPosition() - my_spaceship->getPosition()) < 5000 && my_spaceship->getScannedStateFor(obj) >= SS_FriendOrFoeIdentified && obj->canBeTargetedBy(my_spaceship))
+                if (my_spaceship->isEnemy(obj) && sf::length(obj->getPosition() - my_spaceship->getPosition()) < gameGlobalInfo->short_range_radar_range && my_spaceship->getScannedStateFor(obj) >= SS_FriendOrFoeIdentified && obj->canBeTargetedBy(my_spaceship))
                 {
                     targets.set(obj);
                     my_spaceship->commandSetTarget(targets.get());
@@ -214,7 +219,7 @@ void TacticalScreen::onHotkey(const HotkeyResult& key)
                 }
                 if (obj == my_spaceship)
                     continue;
-                if (current_found && sf::length(obj->getPosition() - my_spaceship->getPosition()) < 5000 && obj->canBeTargetedBy(my_spaceship))
+                if (current_found && sf::length(obj->getPosition() - my_spaceship->getPosition()) < gameGlobalInfo->short_range_radar_range && obj->canBeTargetedBy(my_spaceship))
                 {
                     targets.set(obj);
                     my_spaceship->commandSetTarget(targets.get());
@@ -225,7 +230,7 @@ void TacticalScreen::onHotkey(const HotkeyResult& key)
             {
                 if (obj == targets.get() || obj == my_spaceship)
                     continue;
-                if (sf::length(obj->getPosition() - my_spaceship->getPosition()) < 5000 && obj->canBeTargetedBy(my_spaceship))
+                if (sf::length(obj->getPosition() - my_spaceship->getPosition()) < gameGlobalInfo->short_range_radar_range && obj->canBeTargetedBy(my_spaceship))
                 {
                     targets.set(obj);
                     my_spaceship->commandSetTarget(targets.get());

--- a/src/screens/crew6/helmsScreen.cpp
+++ b/src/screens/crew6/helmsScreen.cpp
@@ -1,4 +1,5 @@
 #include "playerInfo.h"
+#include "gameGlobalInfo.h"
 #include "spaceObjects/playerSpaceship.h"
 #include "helmsScreen.h"
 
@@ -28,13 +29,18 @@ HelmsScreen::HelmsScreen(GuiContainer* owner)
     // Render the alert level color overlay.
     (new AlertLevelOverlay(this));
 
-    GuiRadarView* radar = new GuiRadarView(this, "HELMS_RADAR", 5000.0, nullptr);
-    
+    GuiRadarView* radar = new GuiRadarView(this, "HELMS_RADAR", gameGlobalInfo->short_range_radar_range, nullptr);
+
     combat_maneuver = new GuiCombatManeuver(this, "COMBAT_MANEUVER");
     combat_maneuver->setPosition(-20, -20, ABottomRight)->setSize(280, 215);
     
     radar->setPosition(0, 0, ACenter)->setSize(GuiElement::GuiSizeMatchHeight, 800);
-    radar->setRangeIndicatorStepSize(1000.0)->shortRange()->enableGhostDots()->enableWaypoints()->enableCallsigns()->enableHeadingIndicators()->setStyle(GuiRadarView::Circular);
+    float step_size = 1000.0f;
+    if (gameGlobalInfo->long_range_radar_range >= 15000.0f)
+        step_size = 5000.0f;
+    radar->setRangeIndicatorStepSize(step_size)->shortRange()->enableGhostDots()->enableWaypoints()->enableCallsigns()->enableHeadingIndicators()->setStyle(GuiRadarView::Circular);
+    if (gameGlobalInfo->short_range_radar_range >= 5000.0f)
+        radar->setFogOfWarStyle(GuiRadarView::NebulaFogOfWar);
     radar->enableMissileTubeIndicators();
     radar->setCallbacks(
         [this](sf::Vector2f position) {

--- a/src/screens/crew6/relayScreen.cpp
+++ b/src/screens/crew6/relayScreen.cpp
@@ -1,5 +1,6 @@
 #include "relayScreen.h"
 #include "playerInfo.h"
+#include "gameGlobalInfo.h"
 #include "spaceObjects/playerSpaceship.h"
 #include "spaceObjects/scanProbe.h"
 #include "scriptInterface.h"
@@ -221,7 +222,7 @@ void RelayScreen::onDraw(sf::RenderTarget& window)
                     continue;
                 }
             }
-            if (obj->getPosition() - target->getPosition() < 5000.0f)
+            if (obj->getPosition() - target->getPosition() < gameGlobalInfo->short_range_radar_range)
             {
                 near_friendly = true;
                 break;

--- a/src/screens/crew6/scienceScreen.cpp
+++ b/src/screens/crew6/scienceScreen.cpp
@@ -43,7 +43,10 @@ ScienceScreen::ScienceScreen(GuiContainer* owner, ECrewPosition crew_position)
     // Draw the science radar.
     science_radar = new GuiRadarView(radar_view, "SCIENCE_RADAR", gameGlobalInfo->long_range_radar_range, &targets);
     science_radar->setPosition(-270, 0, ACenterRight)->setSize(GuiElement::GuiSizeMax, GuiElement::GuiSizeMax);
-    science_radar->setRangeIndicatorStepSize(5000.0)->longRange()->enableWaypoints()->enableCallsigns()->enableHeadingIndicators()->setStyle(GuiRadarView::Circular)->setFogOfWarStyle(GuiRadarView::NebulaFogOfWar);
+    float step_size = 5000.0f;
+    if (gameGlobalInfo->long_range_radar_range >= 50000.0f)
+        step_size = 10000.0f;
+    science_radar->setRangeIndicatorStepSize(step_size)->longRange()->enableWaypoints()->enableCallsigns()->enableHeadingIndicators()->setStyle(GuiRadarView::Circular)->setFogOfWarStyle(GuiRadarView::NebulaFogOfWar);
     science_radar->setCallbacks(
         [this](sf::Vector2f position) {
             if (!my_spaceship || my_spaceship->scanning_delay > 0.0)
@@ -52,10 +55,10 @@ ScienceScreen::ScienceScreen(GuiContainer* owner, ECrewPosition crew_position)
             targets.setToClosestTo(position, 1000, TargetsContainer::Selectable);
         }, nullptr, nullptr
     );
-    new RawScannerDataRadarOverlay(science_radar, "", gameGlobalInfo->long_range_radar_range);
+    new RawScannerDataRadarOverlay(science_radar, "SCIENCE_RADAR_OVERLAY", gameGlobalInfo->long_range_radar_range);
 
     // Draw and hide the probe radar.
-    probe_radar = new GuiRadarView(radar_view, "PROBE_RADAR", 5000, &targets);
+    probe_radar = new GuiRadarView(radar_view, "PROBE_RADAR", gameGlobalInfo->short_range_radar_range, &targets);
     probe_radar->setPosition(-270, 0, ACenterRight)->setSize(GuiElement::GuiSizeMax, GuiElement::GuiSizeMax)->hide();
     probe_radar->setAutoCentering(false)->longRange()->enableWaypoints()->enableCallsigns()->enableHeadingIndicators()->setStyle(GuiRadarView::Circular)->setFogOfWarStyle(GuiRadarView::NoFogOfWar);
     probe_radar->setCallbacks(
@@ -66,7 +69,7 @@ ScienceScreen::ScienceScreen(GuiContainer* owner, ECrewPosition crew_position)
             targets.setToClosestTo(position, 1000, TargetsContainer::Selectable);
         }, nullptr, nullptr
     );
-    new RawScannerDataRadarOverlay(probe_radar, "", 5000);
+    new RawScannerDataRadarOverlay(probe_radar, "PROBE_RADAR_OVERLAY", gameGlobalInfo->short_range_radar_range);
 
     sidebar_selector = new GuiSelector(radar_view, "", [this](int index, string value)
     {
@@ -245,7 +248,7 @@ void ScienceScreen::onDraw(sf::RenderTarget& window)
 
     if (probe_view_button->getValue() && probe)
     {
-        if (targets.get() && (probe->getPosition() - targets.get()->getPosition()) > 5000.0f)
+        if (targets.get() && (probe->getPosition() - targets.get()->getPosition()) > gameGlobalInfo->short_range_radar_range)
             targets.clear();
     }else{
         if (targets.get() && Nebula::blockedByNebula(my_spaceship->getPosition(), targets.get()->getPosition()))

--- a/src/screens/crew6/weaponsScreen.cpp
+++ b/src/screens/crew6/weaponsScreen.cpp
@@ -29,9 +29,14 @@ WeaponsScreen::WeaponsScreen(GuiContainer* owner)
     // Render the alert level color overlay.
     (new AlertLevelOverlay(this));
 
-    radar = new GuiRadarView(this, "HELMS_RADAR", 5000.0, &targets);
+    radar = new GuiRadarView(this, "WEAPONS_RADAR", gameGlobalInfo->short_range_radar_range, &targets);
     radar->setPosition(0, 0, ACenter)->setSize(GuiElement::GuiSizeMatchHeight, 800);
-    radar->setRangeIndicatorStepSize(1000.0)->shortRange()->enableCallsigns()->enableHeadingIndicators()->setStyle(GuiRadarView::Circular);
+    float step_size = 1000.0f;
+    if (gameGlobalInfo->long_range_radar_range >= 15000.0f)
+        step_size = 5000.0f;
+    radar->setRangeIndicatorStepSize(step_size)->shortRange()->enableCallsigns()->enableHeadingIndicators()->setStyle(GuiRadarView::Circular);
+    if (gameGlobalInfo->short_range_radar_range >= 5000.0f)
+        radar->setFogOfWarStyle(GuiRadarView::NebulaFogOfWar);
     radar->setCallbacks(
         [this](sf::Vector2f position) {
             targets.setToClosestTo(position, 250, TargetsContainer::Targetable);
@@ -115,7 +120,7 @@ void WeaponsScreen::onHotkey(const HotkeyResult& key)
                     current_found = true;
                     continue;
                 }
-                if (current_found && sf::length(obj->getPosition() - my_spaceship->getPosition()) < 5000 && my_spaceship->isEnemy(obj) && my_spaceship->getScannedStateFor(obj) >= SS_FriendOrFoeIdentified && obj->canBeTargetedBy(my_spaceship))
+                if (current_found && sf::length(obj->getPosition() - my_spaceship->getPosition()) < gameGlobalInfo->short_range_radar_range && my_spaceship->isEnemy(obj) && my_spaceship->getScannedStateFor(obj) >= SS_FriendOrFoeIdentified && obj->canBeTargetedBy(my_spaceship))
                 {
                     targets.set(obj);
                     my_spaceship->commandSetTarget(targets.get());
@@ -128,7 +133,7 @@ void WeaponsScreen::onHotkey(const HotkeyResult& key)
                 {
                     continue;
                 }
-                if (my_spaceship->isEnemy(obj) && sf::length(obj->getPosition() - my_spaceship->getPosition()) < 5000 && my_spaceship->getScannedStateFor(obj) >= SS_FriendOrFoeIdentified && obj->canBeTargetedBy(my_spaceship))
+                if (my_spaceship->isEnemy(obj) && sf::length(obj->getPosition() - my_spaceship->getPosition()) < gameGlobalInfo->short_range_radar_range && my_spaceship->getScannedStateFor(obj) >= SS_FriendOrFoeIdentified && obj->canBeTargetedBy(my_spaceship))
                 {
                     targets.set(obj);
                     my_spaceship->commandSetTarget(targets.get());
@@ -148,7 +153,7 @@ void WeaponsScreen::onHotkey(const HotkeyResult& key)
                 }
                 if (obj == my_spaceship)
                     continue;
-                if (current_found && sf::length(obj->getPosition() - my_spaceship->getPosition()) < 5000 && obj->canBeTargetedBy(my_spaceship))
+                if (current_found && sf::length(obj->getPosition() - my_spaceship->getPosition()) < gameGlobalInfo->short_range_radar_range && obj->canBeTargetedBy(my_spaceship))
                 {
                     targets.set(obj);
                     my_spaceship->commandSetTarget(targets.get());
@@ -159,7 +164,7 @@ void WeaponsScreen::onHotkey(const HotkeyResult& key)
             {
                 if (obj == targets.get() || obj == my_spaceship)
                     continue;
-                if (sf::length(obj->getPosition() - my_spaceship->getPosition()) < 5000 && obj->canBeTargetedBy(my_spaceship))
+                if (sf::length(obj->getPosition() - my_spaceship->getPosition()) < gameGlobalInfo->short_range_radar_range && obj->canBeTargetedBy(my_spaceship))
                 {
                     targets.set(obj);
                     my_spaceship->commandSetTarget(targets.get());

--- a/src/screens/mainScreen.cpp
+++ b/src/screens/mainScreen.cpp
@@ -24,11 +24,13 @@ ScreenMainScreen::ScreenMainScreen()
     viewport->showCallsigns()->showHeadings()->showSpacedust();
     viewport->setPosition(0, 0, ATopLeft)->setSize(GuiElement::GuiSizeMax, GuiElement::GuiSizeMax);
     
-    (new GuiRadarView(viewport, "VIEWPORT_RADAR", 5000.0f, nullptr))->setStyle(GuiRadarView::CircularMasked)->setSize(200, 200)->setPosition(-20, 20, ATopRight);
+    (new GuiRadarView(viewport, "VIEWPORT_RADAR", gameGlobalInfo->short_range_radar_range, nullptr))->setStyle(GuiRadarView::CircularMasked)->setSize(200, 200)->setPosition(-20, 20, ATopRight);
     
-    tactical_radar = new GuiRadarView(this, "TACTICAL", 5000.0f, nullptr);
+    tactical_radar = new GuiRadarView(this, "TACTICAL", gameGlobalInfo->short_range_radar_range, nullptr);
     tactical_radar->setPosition(0, 0, ATopLeft)->setSize(GuiElement::GuiSizeMax, GuiElement::GuiSizeMax);
     tactical_radar->setRangeIndicatorStepSize(1000.0f)->shortRange()->enableCallsigns()->hide();
+    if (gameGlobalInfo->short_range_radar_range >= 5000.0f)
+        tactical_radar->setFogOfWarStyle(GuiRadarView::NebulaFogOfWar);
     long_range_radar = new GuiRadarView(this, "TACTICAL", gameGlobalInfo->long_range_radar_range, nullptr);
     long_range_radar->setPosition(0, 0, ATopLeft)->setSize(GuiElement::GuiSizeMax, GuiElement::GuiSizeMax);
     long_range_radar->setRangeIndicatorStepSize(5000.0f)->longRange()->enableCallsigns()->hide();

--- a/src/spaceObjects/nebula.cpp
+++ b/src/spaceObjects/nebula.cpp
@@ -3,6 +3,7 @@
 #include "main.h"
 #include "nebula.h"
 #include "playerInfo.h"
+#include "gameGlobalInfo.h"
 
 #include "scriptInterface.h"
 
@@ -109,7 +110,7 @@ bool Nebula::blockedByNebula(sf::Vector2f start, sf::Vector2f end)
 {
     sf::Vector2f startEndDiff = end - start;
     float startEndLength = sf::length(startEndDiff);
-    if (startEndLength < 5000.0f)
+    if (startEndLength < gameGlobalInfo->short_range_radar_range)
         return false;
     
     foreach(Nebula, n, nebula_list)

--- a/src/spaceObjects/playerSpaceship.cpp
+++ b/src/spaceObjects/playerSpaceship.cpp
@@ -1886,8 +1886,8 @@ void PlayerSpaceship::drawOnGMRadar(sf::RenderTarget& window, sf::Vector2f posit
         radar_radius.setOutlineThickness(3.0);
         window.draw(radar_radius);
 
-        sf::CircleShape short_radar_radius(5000 * scale);
-        short_radar_radius.setOrigin(5000 * scale, 5000 * scale);
+        sf::CircleShape short_radar_radius(gameGlobalInfo->short_range_radar_range * scale);
+        short_radar_radius.setOrigin(gameGlobalInfo->short_range_radar_range * scale, gameGlobalInfo->short_range_radar_range * scale);
         short_radar_radius.setPosition(position);
         short_radar_radius.setFillColor(sf::Color::Transparent);
         short_radar_radius.setOutlineColor(sf::Color(255, 255, 255, 64));


### PR DESCRIPTION
Add `server_config_short_range_radar_range` to PreferencesManager
and modify short-range radar view and screens accordingly.

Values are bounded to a range of 500 and 20000 (0.5U to 20U).

The default value remains 5000.

Nebula fog of war behavior now relies on this setting.

- If set to greater than 5000, helm, weapons, tactical, and
  single pilot use NebulaFogOfWar as science does.
- Friendly shared radar ranges on relay scale with the value.
- If close enough to a nebula, science can see through it up to
  the value.

This value also affects probe radar range.

This does _not_ add the setting to the server creation screen.
It is set only in options.ini (for now).

Examples with short-range radar set to 20U (20000) and
long-range radar set to 125U (125000):

<img width="1312" alt="Screen Shot 2020-03-14 at 1 53 55 PM" src="https://user-images.githubusercontent.com/19192104/76690350-64787000-65fc-11ea-9c1d-2d66770a714d.png">
<img width="1312" alt="Screen Shot 2020-03-14 at 1 53 02 PM" src="https://user-images.githubusercontent.com/19192104/76690353-68a48d80-65fc-11ea-975d-ced831d97686.png">
<img width="1312" alt="Screen Shot 2020-03-14 at 1 52 57 PM" src="https://user-images.githubusercontent.com/19192104/76690354-693d2400-65fc-11ea-8d65-1ba51ae00fe9.png">