### PR TITLE
Revert some overrides that broke linux builds

### DIFF
--- a/src/spaceObjects/artifact.h
+++ b/src/spaceObjects/artifact.h
@@ -16,7 +16,7 @@ public:
 
     virtual void update(float delta) override;
 
-    virtual void draw3D() override;
+    virtual void draw3D();
 
     virtual void drawOnRadar(sf::RenderTarget& window, sf::Vector2f position, float scale, bool long_range) override;
 

--- a/src/spaceObjects/asteroid.h
+++ b/src/spaceObjects/asteroid.h
@@ -13,7 +13,7 @@ public:
 
     Asteroid();
     
-    virtual void draw3D() override;
+    virtual void draw3D();
 
     virtual void drawOnRadar(sf::RenderTarget& window, sf::Vector2f position, float scale, bool long_range) override;
 
@@ -34,7 +34,7 @@ public:
 
     VisualAsteroid();
 
-    virtual void draw3D() override;
+    virtual void draw3D();
     
     void setSize(float size);
 


### PR DESCRIPTION
Building on macOS, or on Linux targeting Windows or Android, with `-Winconsistent-missing-overrides` results in warnings like:

```
EmptyEpsilon/src/spaceObjects/asteroid.h:37:18: warning: 'draw3D' overrides a member function but is not marked 'override' [-Winconsistent-missing-override]
```

Adding the `override` doesn't affect builds... except when targeting Linux, which treats it as an error:

```
EmptyEpsilon/src/spaceObjects/asteroid.h:37:18: error: 'draw3D' marked 'override' but does not override any member functions
```

Removing the overrides brings the warning back on other builds, but doesn't block Linux builds.