### PR TITLE
Move DB button to left of info on Science

### DIFF
--- a/src/screens/crew6/scienceScreen.cpp
+++ b/src/screens/crew6/scienceScreen.cpp
@@ -114,7 +114,7 @@ ScienceScreen::ScienceScreen(GuiContainer* owner, ECrewPosition crew_position)
             }
         }
     });
-    info_type_button->setTextSize(20)->setPosition(0, 1, ATopRight)->setSize(50, 28);
+    info_type_button->setTextSize(20)->setPosition(0, 1, ATopLeft)->setSize(50, 28);
     info_shields = new GuiKeyValueDisplay(info_sidebar, "SCIENCE_SHIELDS", 0.4, "Shields", "");
     info_shields->setSize(GuiElement::GuiSizeMax, 30);
     info_hull = new GuiKeyValueDisplay(info_sidebar, "SCIENCE_HULL", 0.4, "Hull", "");


### PR DESCRIPTION
Avoid the button overlapping text when the ship has a long type name

Example after the change:

<img width="279" alt="Screen Shot 2020-03-14 at 10 59 56 PM" src="https://user-images.githubusercontent.com/19192104/76696352-aa0e5a80-6647-11ea-9795-a1c952d97975.png">
