### PR TITLE
Make 3D view in single-pilot respect first_person option

### DIFF
--- a/src/screens/crew1/singlePilotScreen.h
+++ b/src/screens/crew1/singlePilotScreen.h
@@ -14,6 +14,8 @@ class GuiRotationDial;
 class SinglePilotScreen : public GuiOverlay
 {
 private:
+    bool first_person;
+
     GuiOverlay* background_gradient;
     GuiOverlay* background_crosses;
 


### PR DESCRIPTION
Allow the single-pilot 3D viewport to enter first-person mode, and do so by respecting the `first_person` option in the preferences file (`options.ini`).