### PR TITLE
Use GUI hotkeys for main screen keyboard shortcuts

### DIFF
--- a/src/gui/hotkeyConfig.cpp
+++ b/src/gui/hotkeyConfig.cpp
@@ -1,3 +1,4 @@
+#include <i18n.h>
 #include "hotkeyConfig.h"
 #include "preferenceManager.h"
 #include "shipTemplate.h"
@@ -14,6 +15,16 @@ HotkeyConfig::HotkeyConfig()
     newKey("STATION_ENGINEERING", std::make_tuple("Switch to engineering station", "F4"));
     newKey("STATION_SCIENCE", std::make_tuple("Switch to science station", "F5"));
     newKey("STATION_RELAY", std::make_tuple("Switch to relay station", "F6"));
+
+    newCategory("MAIN_SCREEN", "Main Screen");
+    newKey("VIEW_FORWARD", std::make_tuple("View forward", "Up"));
+    newKey("VIEW_LEFT", std::make_tuple("View left", "Left"));
+    newKey("VIEW_RIGHT", std::make_tuple("View right", "Right"));
+    newKey("VIEW_BACK", std::make_tuple("View backward", "Down"));
+    newKey("VIEW_TARGET", std::make_tuple("Lock view on weapons target", "T"));
+    newKey("TACTICAL_RADAR", std::make_tuple("View tactical radar", "Tab"));
+    newKey("LONG_RANGE_RADAR", std::make_tuple("View long-range radar", "Q"));
+    newKey("FIRST_PERSON", std::make_tuple("Toggle first-person view", "F"));
     
     newCategory("HELMS", "Helms");
     newKey("INC_IMPULSE", std::make_tuple("Increase impulse", "Up"));

--- a/src/screens/crewStationScreen.cpp
+++ b/src/screens/crewStationScreen.cpp
@@ -8,6 +8,7 @@
 #include "screenComponents/indicatorOverlays.h"
 #include "screenComponents/noiseOverlay.h"
 #include "screenComponents/shipDestroyedPopup.h"
+#include "screenComponents/helpOverlay.h"
 
 #include "gui/gui2_togglebutton.h"
 #include "gui/gui2_panel.h"
@@ -180,9 +181,6 @@ void CrewStationScreen::onKey(sf::Event::KeyEvent key, int unicode)
         returnToShipSelection();
         break;
     case sf::Keyboard::Slash:
-        // Toggle keyboard help.
-        keyboard_help->frame->setVisible(!keyboard_help->frame->isVisible());
-        break;
     case sf::Keyboard::F1:
         // Toggle keyboard help.
         keyboard_help->frame->setVisible(!keyboard_help->frame->isVisible());

--- a/src/screens/mainScreen.cpp
+++ b/src/screens/mainScreen.cpp
@@ -14,6 +14,7 @@
 #include "screenComponents/radarView.h"
 #include "screenComponents/shipDestroyedPopup.h"
 
+#include "gui/gui2_panel.h"
 #include "gui/gui2_overlay.h"
 
 ScreenMainScreen::ScreenMainScreen()
@@ -42,6 +43,13 @@ ScreenMainScreen::ScreenMainScreen()
     new GuiSelfDestructIndicator(this);
     new GuiGlobalMessage(this);
     new GuiIndicatorOverlays(this);
+
+    keyboard_help = new GuiHelpOverlay(this, "Keyboard Shortcuts");
+
+    for (std::pair<string, string> shortcut : hotkeys.listHotkeysByCategory("Main Screen"))
+        keyboard_general += shortcut.second + ":\t" + shortcut.first + "\n";
+
+    keyboard_help->setText(keyboard_general);
 
     if (PreferencesManager::get("music_enabled") != "0")
     {
@@ -230,42 +238,33 @@ void ScreenMainScreen::onClick(sf::Vector2f mouse_position)
     }
 }
 
+void ScreenMainScreen::onHotkey(const HotkeyResult& key)
+{
+    if (key.category == "MAIN_SCREEN" && my_spaceship)
+    {
+        if (key.hotkey == "VIEW_FORWARD")
+            my_spaceship->commandMainScreenSetting(MSS_Front);
+        else if (key.hotkey == "VIEW_LEFT")
+            my_spaceship->commandMainScreenSetting(MSS_Left);
+        else if (key.hotkey == "VIEW_RIGHT")
+            my_spaceship->commandMainScreenSetting(MSS_Right);
+        else if (key.hotkey == "VIEW_BACK")
+            my_spaceship->commandMainScreenSetting(MSS_Back);
+        else if (key.hotkey == "VIEW_TARGET")
+            my_spaceship->commandMainScreenSetting(MSS_Target);
+        else if (key.hotkey == "TACTICAL_RADAR")
+            my_spaceship->commandMainScreenSetting(MSS_Tactical);
+        else if (key.hotkey == "LONG_RANGE_RADAR")
+            my_spaceship->commandMainScreenSetting(MSS_LongRange);
+        else if (key.hotkey == "FIRST_PERSON")
+            first_person = !first_person;
+    }
+}
+
 void ScreenMainScreen::onKey(sf::Event::KeyEvent key, int unicode)
 {
-    switch(key.code)
+    switch (key.code)
     {
-    case sf::Keyboard::Up:
-        if (my_spaceship)
-            my_spaceship->commandMainScreenSetting(MSS_Front);
-        break;
-    case sf::Keyboard::Left:
-        if (my_spaceship)
-            my_spaceship->commandMainScreenSetting(MSS_Left);
-        break;
-    case sf::Keyboard::Right:
-        if (my_spaceship)
-            my_spaceship->commandMainScreenSetting(MSS_Right);
-        break;
-    case sf::Keyboard::Down:
-        if (my_spaceship)
-            my_spaceship->commandMainScreenSetting(MSS_Back);
-        break;
-    case sf::Keyboard::T:
-        if (my_spaceship)
-            my_spaceship->commandMainScreenSetting(MSS_Target);
-        break;
-    case sf::Keyboard::Tab:
-        if (my_spaceship && gameGlobalInfo->allow_main_screen_tactical_radar)
-            my_spaceship->commandMainScreenSetting(MSS_Tactical);
-        break;
-    case sf::Keyboard::Q:
-        if (my_spaceship && gameGlobalInfo->allow_main_screen_long_range_radar)
-            my_spaceship->commandMainScreenSetting(MSS_LongRange);
-        break;
-    case sf::Keyboard::F:
-        first_person = !first_person;
-        break;
-    
     //TODO: This is more generic code and is duplicated.
     case sf::Keyboard::Escape:
     case sf::Keyboard::Home:
@@ -273,6 +272,11 @@ void ScreenMainScreen::onKey(sf::Event::KeyEvent key, int unicode)
         soundManager->stopSound(impulse_sound);
         destroy();
         returnToShipSelection();
+        break;
+    case sf::Keyboard::Slash:
+    case sf::Keyboard::F1:
+        // Toggle keyboard help.
+        keyboard_help->frame->setVisible(!keyboard_help->frame->isVisible());
         break;
     case sf::Keyboard::P:
         if (game_server)

--- a/src/screens/mainScreen.h
+++ b/src/screens/mainScreen.h
@@ -2,18 +2,22 @@
 #define MAIN_SCREEN_H
 
 #include "engine.h"
+#include "screenComponents/helpOverlay.h"
 #include "gui/gui2_canvas.h"
 #include "threatLevelEstimate.h"
 
 class GuiViewport3D;
 class GuiRadarView;
 class GuiCommsOverlay;
+class GuiHelpOverlay;
 
 class ScreenMainScreen : public GuiCanvas, public Updatable
 {
     P<ThreatLevelEstimate> threat_estimate;
 private:
     GuiViewport3D* viewport;
+    GuiHelpOverlay* keyboard_help;
+    string keyboard_general = "";
     GuiRadarView* tactical_radar;
     GuiRadarView* long_range_radar;
     bool first_person;
@@ -25,6 +29,7 @@ public:
     virtual void update(float delta) override;
     
     virtual void onClick(sf::Vector2f mouse_position) override;
+    virtual void onHotkey(const HotkeyResult& key) override;
     virtual void onKey(sf::Event::KeyEvent key, int unicode) override;
 };
 


### PR DESCRIPTION
Convert main screen to use GUI hotkeys and add a F1/slash key help
overlay. Hotkeys are in the new MAIN_SCREEN category.

<img width="447" alt="Screen Shot 2020-03-18 at 3 47 04 AM" src="https://user-images.githubusercontent.com/19192104/76952968-2a90bd80-68cb-11ea-8f4b-738121d95591.png">
