### PR TITLE
Check getenv before assigning it

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -185,9 +185,12 @@ int main(int argc, char** argv)
     hotkeys.load();
 
     if (PreferencesManager::get("username", "") == "")
-        PreferencesManager::set("username", getenv("USERNAME"));
-    if (PreferencesManager::get("username", "") == "")
-        PreferencesManager::set("username", getenv("USER"));
+    {
+        if (getenv("USERNAME"))
+            PreferencesManager::set("username", getenv("USERNAME"));
+        else if (getenv("USER"))
+            PreferencesManager::set("username", getenv("USER"));
+    }
 
     if (PreferencesManager::get("headless") == "")
     {


### PR DESCRIPTION
This should fix #800 on systems were the `USERNAME` environment variable isn't set (ie. not Windows).