### PR TITLE
Render AI only on server-side GM/Spectator view

### DIFF
--- a/src/spaceObjects/cpuShip.cpp
+++ b/src/spaceObjects/cpuShip.cpp
@@ -235,7 +235,8 @@ void CpuShip::orderDock(P<SpaceObject> object)
 void CpuShip::drawOnGMRadar(sf::RenderTarget& window, sf::Vector2f position, float scale, bool long_range)
 {
     SpaceShip::drawOnGMRadar(window, position, scale, long_range);
-    ai->drawOnGMRadar(window, position, scale);
+    if (game_server)
+        ai->drawOnGMRadar(window, position, scale);
 }
 
 std::unordered_map<string, string> CpuShip::getGMInfo()


### PR DESCRIPTION
Fixes #813

An alternative fix might be to replicate `ai` to clients, but that seems overkill since (as of now) only the spectator view would use it.