### PR TITLE
Radar Lock for rotating radars to have ship pointing up.

### DIFF
--- a/src/menus/optionsMenu.cpp
+++ b/src/menus/optionsMenu.cpp
@@ -6,6 +6,7 @@
 
 #include "gui/gui2_overlay.h"
 #include "gui/gui2_button.h"
+#include "gui/gui2_togglebutton.h"
 #include "gui/gui2_selector.h"
 #include "gui/gui2_label.h"
 #include "gui/gui2_slider.h"
@@ -99,6 +100,31 @@ OptionsMenu::OptionsMenu()
         // 2: On if main screen, off otherwise (default)
         PreferencesManager::set("music_enabled", string(index));
     }))->setOptions({"Disabled", "Enabled", "Main Screen only"})->setSelectionIndex(music_enabled_index)->setPosition(50, top, ATopLeft)->setSize(300, 50);
+
+    // Interface options.
+    top += 60;
+    (new GuiLabel(this, "INTERFACE_OPTIONS_LABEL", tr("Interface Options"), 30))->addBackground()->setPosition(50, top, ATopLeft)->setSize(300, 50);
+
+    // Helms rotation lock.
+    top += 50;
+    (new GuiToggleButton(this, "HEMS_RADAR_LOCK", tr("Helms Radar Lock"), [](bool value)
+    {
+        PreferencesManager::set("helms_radar_lock", value?"1":"");
+    }))->setValue(PreferencesManager::get("helms_radar_lock","0")=="1")->setPosition(50, top, ATopLeft)->setSize(300, 50);
+
+    // Helms rotation lock.
+    top += 50;
+    (new GuiToggleButton(this, "WEAPONS_RADAR_LOCK", tr("Weapons Radar Lock"), [](bool value)
+    {
+        PreferencesManager::set("weapons_radar_lock", value?"1":"");
+    }))->setValue(PreferencesManager::get("weapons_radar_lock","0")=="1")->setPosition(50, top, ATopLeft)->setSize(300, 50);
+
+    // Helms rotation lock.
+    top += 50;
+    (new GuiToggleButton(this, "SCIENCE_RADAR_LOCK", tr("Science Radar Lock"), [](bool value)
+    {
+        PreferencesManager::set("science_radar_lock", value?"1":"");
+    }))->setValue(PreferencesManager::get("science_radar_lock","0")=="1")->setPosition(50, top, ATopLeft)->setSize(300, 50);
 
     // Right column, manual layout. Draw first element 50px from top.
     top = 50;

--- a/src/menus/optionsMenu.cpp
+++ b/src/menus/optionsMenu.cpp
@@ -158,6 +158,14 @@ OptionsMenu::OptionsMenu()
         soundManager->stopMusic();
         returnToMainMenu();
     }))->setPosition(50, -50, ABottomLeft)->setSize(300, 50);
+    // Save options button.
+    (new GuiButton(this, "SAVE_OPTIONS", "Save Options", [this]()
+    {
+        if (getenv("HOME"))
+            PreferencesManager::save(string(getenv("HOME")) + "/.emptyepsilon/options.ini");
+        else
+            PreferencesManager::save("options.ini");
+    }))->setPosition(370, -50, ABottomLeft)->setSize(300, 50);
 }
 
 void OptionsMenu::onKey(sf::Event::KeyEvent key, int unicode)

--- a/src/screenComponents/aimLock.cpp
+++ b/src/screenComponents/aimLock.cpp
@@ -52,3 +52,70 @@ void AimLockButton::setAimLock(bool value)
         this->tube_controls->setMissileTargetAngle(my_spaceship->getRotation());
     }
 }
+
+
+AimLock::AimLock(GuiContainer* owner, string id, GuiRadarView* radar, float min_value, float max_value, float start_value, func_t func)
+: GuiRotationDial(owner, id, min_value, max_value, start_value, func), radar(radar)
+{
+}
+
+void AimLock::onDraw(sf::RenderTarget& window)
+{
+    sf::Vector2f center = getCenterPoint();
+    float view_rotation = radar->getViewRotation();
+    float radius = std::min(rect.width, rect.height) / 2.0f;
+    
+    sf::Sprite sprite;
+    textureManager.setTexture(sprite, "dial_background.png");
+    sprite.setPosition(center);
+    sprite.setScale(radius * 2 / sprite.getTextureRect().height, radius * 2 / sprite.getTextureRect().height);
+    window.draw(sprite);
+
+    textureManager.setTexture(sprite, "dial_button.png");
+    sprite.setPosition(center);
+    sprite.setScale(radius * 2 / sprite.getTextureRect().height, radius * 2 / sprite.getTextureRect().height);
+    sprite.setRotation((value - min_value) / (max_value - min_value) * 360.0f - view_rotation);
+    window.draw(sprite);
+}
+
+bool AimLock::onMouseDown(sf::Vector2f position)
+{
+    return GuiRotationDial::onMouseDown(position);
+}
+
+void AimLock::onMouseDrag(sf::Vector2f position)
+{
+    float view_rotation = radar->getViewRotation();
+
+    sf::Vector2f center = getCenterPoint();
+    
+    sf::Vector2f diff = position - center;
+
+    float new_value = ((sf::vector2ToAngle(diff) + 90.0f) + view_rotation) / 360.0f;
+    if (new_value < 0.0f)
+        new_value += 1.0f;
+    new_value = min_value + (max_value - min_value) * new_value;
+    if (min_value < max_value)
+    {
+        if (new_value < min_value)
+            new_value = min_value;
+        if (new_value > max_value)
+            new_value = max_value;
+    }else{
+        if (new_value > min_value)
+            new_value = min_value;
+        if (new_value < max_value)
+            new_value = max_value;
+    }
+    if (value != new_value)
+    {
+        value = new_value;
+        if (func)
+            func(value);
+    }
+}
+
+void AimLock::onMouseUp(sf::Vector2f position)
+{
+}
+

--- a/src/screenComponents/aimLock.h
+++ b/src/screenComponents/aimLock.h
@@ -2,9 +2,10 @@
 #define AIM_LOCK_H
 
 #include "gui/gui2_togglebutton.h"
+#include "gui/gui2_rotationdial.h"
+#include "screenComponents/radarView.h"
 
 class GuiMissileTubeControls;
-class GuiRotationDial;
 
 class AimLockButton : public GuiToggleButton
 {
@@ -17,6 +18,19 @@ private:
     GuiRotationDial* missile_aim;
     
     void setAimLock(bool value);
+};
+
+
+class AimLock : public GuiRotationDial {
+public:
+    AimLock(GuiContainer* owner, string id, GuiRadarView* radar, float min_value, float max_value, float start_value, func_t func);
+
+    virtual void onDraw(sf::RenderTarget& window);
+    virtual bool onMouseDown(sf::Vector2f position);
+    virtual void onMouseDrag(sf::Vector2f position);
+    virtual void onMouseUp(sf::Vector2f position);
+private:
+    GuiRadarView* radar;
 };
 
 #endif//AIM_LOCK_H

--- a/src/screenComponents/radarView.cpp
+++ b/src/screenComponents/radarView.cpp
@@ -239,16 +239,8 @@ void GuiRadarView::drawSectorGrid(sf::RenderTarget& window)
         for(int sector_y = sector_y_min - 1; sector_y <= sector_y_max; sector_y++)
         {
             float y = sector_y * sector_size;
-            if (view_rotation==0)
-            {
-                sf::Vector2f pos = worldToScreen(sf::Vector2f(x,y));
-                drawText(window, sf::FloatRect(pos.x, pos.y, 30, 30), getSectorName(sf::Vector2f(sector_x * sector_size + sub_sector_size, sector_y * sector_size + sub_sector_size)), ATopLeft, 30, bold_font, color);
-            }
-            else
-            {
-                sf::Vector2f pos = worldToScreen(sf::Vector2f(x+(30/scale),y+(30/scale)));
-                drawText(window, sf::FloatRect(pos.x-10, pos.y-10, 20, 20), getSectorName(sf::Vector2f(sector_x * sector_size + sub_sector_size, sector_y * sector_size + sub_sector_size)), ACenter, 30, bold_font, color);
-             }
+            sf::Vector2f pos = worldToScreen(sf::Vector2f(x+(30/scale),y+(30/scale)));
+            drawText(window, sf::FloatRect(pos.x-10, pos.y-10, 20, 20), getSectorName(sf::Vector2f(sector_x * sector_size + sub_sector_size, sector_y * sector_size + sub_sector_size)), ACenter, 30, bold_font, color);
         }
     }
     sf::VertexArray lines_x(sf::Lines, 2 * (sector_x_max - sector_x_min + 1));

--- a/src/screenComponents/radarView.cpp
+++ b/src/screenComponents/radarView.cpp
@@ -452,8 +452,10 @@ void GuiRadarView::drawTargetProjections(sf::RenderTarget& window)
                 a[cnt + 1].position = fire_draw_position + (turn_center + sf::vector2FromAngle(fire_angle - angle_diff / 10.0f * cnt - left_or_right) * turn_radius) * scale;
             a[11].position = fire_draw_position + turn_exit * scale;
             a[12].position = fire_draw_position + (turn_exit + sf::vector2FromAngle(missile_target_angle) * length_after_turn) * scale;
-            for(int cnt=0; cnt<13; cnt++)
+            for(int cnt=0; cnt<13; cnt++) {
+                a[cnt].position = sf::rotateVector(a[cnt].position-radar_screen_center, -view_rotation)+radar_screen_center;
                 a[cnt].color = sf::Color(255, 255, 255, 128);
+            }
             window.draw(a);
 
             float offset = seconds_per_distance_tick * data.speed;
@@ -470,8 +472,8 @@ void GuiRadarView::drawTargetProjections(sf::RenderTarget& window)
                     n = sf::vector2FromAngle(missile_target_angle + 90.0f);
                 }
                 sf::VertexArray a(sf::Lines, 2);
-                a[0].position = fire_draw_position + p - n * 10.0f;
-                a[1].position = fire_draw_position + p + n * 10.0f;
+                a[0].position = sf::rotateVector((fire_draw_position + p - n * 10.0f)-radar_screen_center, -view_rotation)+radar_screen_center;
+                a[1].position = sf::rotateVector((fire_draw_position + p + n * 10.0f)-radar_screen_center, -view_rotation)+radar_screen_center;
                 window.draw(a);
 
                 offset += seconds_per_distance_tick * data.speed;
@@ -487,14 +489,14 @@ void GuiRadarView::drawTargetProjections(sf::RenderTarget& window)
                 continue;
 
             sf::VertexArray a(sf::Lines, 12);
-            a[0].position = radar_screen_center + (obj->getPosition() - view_position) * scale;
+            a[0].position = worldToScreen(obj->getPosition());
             a[0].color = sf::Color(255, 255, 255, 128);
-            a[1].position = a[0].position + (obj->getVelocity() * 60.0f) * scale;
+            a[1].position = worldToScreen(obj->getPosition() + obj->getVelocity() * 60.0f);
             a[1].color = sf::Color(255, 255, 255, 0);
             sf::Vector2f n = sf::normalize(sf::Vector2f(-obj->getVelocity().y, obj->getVelocity().x));
             for(int cnt=0; cnt<5; cnt++)
             {
-                sf::Vector2f p = (obj->getVelocity() * (seconds_per_distance_tick + seconds_per_distance_tick * cnt)) * scale;
+                sf::Vector2f p = sf::rotateVector(obj->getVelocity() * (seconds_per_distance_tick * (cnt + 1.0f) * scale), -view_rotation);
                 a[2 + cnt * 2].position = a[0].position + p + n * 10.0f;
                 a[3 + cnt * 2].position = a[0].position + p - n * 10.0f;
                 a[2 + cnt * 2].color = a[3 + cnt * 2].color = sf::Color(255, 255, 255, 128 - cnt * 20);

--- a/src/screenComponents/radarView.cpp
+++ b/src/screenComponents/radarView.cpp
@@ -12,6 +12,7 @@
 GuiRadarView::GuiRadarView(GuiContainer* owner, string id, float distance, TargetsContainer* targets)
 : GuiElement(owner, id), next_ghost_dot_update(0.0), targets(targets), missile_tube_controls(nullptr), distance(distance), long_range(false), show_ghost_dots(false)
 , show_waypoints(false), show_target_projection(false), show_missile_tubes(false), show_callsigns(false), show_heading_indicators(false), show_game_master_data(false)
+, view_position(sf::Vector2f(0.0f,0.0f)), view_rotation(0)
 , range_indicator_step_size(0.0f), style(Circular), fog_style(NoFogOfWar), mouse_down_func(nullptr), mouse_drag_func(nullptr), mouse_up_func(nullptr)
 {
     auto_center_on_my_ship = true;
@@ -39,8 +40,10 @@ void GuiRadarView::onDraw(sf::RenderTarget& window)
     // Render texture to screen
 
     //Hacky, when not relay and we have a ship, center on it.
-    if (my_spaceship && auto_center_on_my_ship)
+    if (my_spaceship && auto_center_on_my_ship) {
         view_position = my_spaceship->getPosition();
+        view_rotation = my_spaceship->getRotation();
+    }
 
     //Setup our textures for rendering
     adjustRenderTexture(background_texture);
@@ -170,7 +173,6 @@ void GuiRadarView::drawNoneFriendlyBlockedAreas(sf::RenderTarget& window)
     window.clear(sf::Color(0, 0, 0, 255));
     if (my_spaceship)
     {
-        sf::Vector2f radar_screen_center(rect.left + rect.width / 2.0f, rect.top + rect.height / 2.0f);
         float scale = std::min(rect.width, rect.height) / 2.0f / distance;
 
         float r = 5000.0 * scale;
@@ -182,13 +184,13 @@ void GuiRadarView::drawNoneFriendlyBlockedAreas(sf::RenderTarget& window)
         {
             if ((P<SpaceShip>(obj) || P<SpaceStation>(obj)) && obj->isFriendly(my_spaceship))
             {
-                circle.setPosition(radar_screen_center + (obj->getPosition() - view_position) * scale);
+                circle.setPosition(worldToScreen(obj->getPosition()));
                 window.draw(circle);
             }
             P<ScanProbe> sp = obj;
             if (sp && sp->owner_id == my_spaceship->getMultiplayerId())
             {
-                circle.setPosition(radar_screen_center + (obj->getPosition() - view_position) * scale);
+                circle.setPosition(worldToScreen(obj->getPosition()));
                 window.draw(circle);
             }
         }
@@ -198,11 +200,11 @@ void GuiRadarView::drawNoneFriendlyBlockedAreas(sf::RenderTarget& window)
 void GuiRadarView::drawSectorGrid(sf::RenderTarget& window)
 {
     sf::Vector2f radar_screen_center(rect.left + rect.width / 2.0f, rect.top + rect.height / 2.0f);
+    float scale = std::min(rect.width, rect.height) / 2.0 / distance;
 
     constexpr float sector_size = 20000;
     const float sub_sector_size = sector_size / 8;
 
-    float scale = std::min(rect.width, rect.height) / 2.0 / distance;
     int sector_x_min = floor((view_position.x - (radar_screen_center.x - rect.left) / scale) / sector_size) + 1;
     int sector_x_max = floor((view_position.x + (rect.left + rect.width - radar_screen_center.x) / scale) / sector_size);
     int sector_y_min = floor((view_position.y - (radar_screen_center.y - rect.top) / scale) / sector_size) + 1;
@@ -210,29 +212,38 @@ void GuiRadarView::drawSectorGrid(sf::RenderTarget& window)
     sf::Color color(64, 64, 128, 128);
     for(int sector_x = sector_x_min - 1; sector_x <= sector_x_max; sector_x++)
     {
-        float x = radar_screen_center.x + ((sector_x * sector_size) - view_position.x) * scale;
+        float x = sector_x * sector_size;
         for(int sector_y = sector_y_min - 1; sector_y <= sector_y_max; sector_y++)
         {
-            float y = radar_screen_center.y + ((sector_y * sector_size) - view_position.y) * scale;
-            drawText(window, sf::FloatRect(x, y, 30, 30), getSectorName(sf::Vector2f(sector_x * sector_size + sub_sector_size, sector_y * sector_size + sub_sector_size)), ATopLeft, 30, bold_font, color);
+            float y = sector_y * sector_size;
+            if (view_rotation==0)
+            {
+                sf::Vector2f pos = worldToScreen(sf::Vector2f(x,y));
+                drawText(window, sf::FloatRect(pos.x, pos.y, 30, 30), getSectorName(sf::Vector2f(sector_x * sector_size + sub_sector_size, sector_y * sector_size + sub_sector_size)), ATopLeft, 30, bold_font, color);
+            }
+            else
+            {
+                sf::Vector2f pos = worldToScreen(sf::Vector2f(x+(30/scale),y+(30/scale)));
+                drawText(window, sf::FloatRect(pos.x-10, pos.y-10, 20, 20), getSectorName(sf::Vector2f(sector_x * sector_size + sub_sector_size, sector_y * sector_size + sub_sector_size)), ACenter, 30, bold_font, color);
+             }
         }
     }
     sf::VertexArray lines_x(sf::Lines, 2 * (sector_x_max - sector_x_min + 1));
     sf::VertexArray lines_y(sf::Lines, 2 * (sector_y_max - sector_y_min + 1));
     for(int sector_x = sector_x_min; sector_x <= sector_x_max; sector_x++)
     {
-        float x = radar_screen_center.x + ((sector_x * sector_size) - view_position.x) * scale;
-        lines_x[(sector_x - sector_x_min)*2].position = sf::Vector2f(x, rect.top);
+        float x = sector_x * sector_size;
+        lines_x[(sector_x - sector_x_min)*2].position = worldToScreen(sf::Vector2f(x, (sector_y_min-1)*sector_size));
         lines_x[(sector_x - sector_x_min)*2].color = color;
-        lines_x[(sector_x - sector_x_min)*2+1].position = sf::Vector2f(x, rect.top + rect.height);
+        lines_x[(sector_x - sector_x_min)*2+1].position = worldToScreen(sf::Vector2f(x, (sector_y_max+1)*sector_size));
         lines_x[(sector_x - sector_x_min)*2+1].color = color;
     }
     for(int sector_y = sector_y_min; sector_y <= sector_y_max; sector_y++)
     {
-        float y = radar_screen_center.y + ((sector_y * sector_size) - view_position.y) * scale;
-        lines_y[(sector_y - sector_y_min)*2].position = sf::Vector2f(rect.left, y);
+        float y = sector_y * sector_size;
+        lines_y[(sector_y - sector_y_min)*2].position = worldToScreen(sf::Vector2f((sector_x_min-1)*sector_size, y));
         lines_y[(sector_y - sector_y_min)*2].color = color;
-        lines_y[(sector_y - sector_y_min)*2+1].position = sf::Vector2f(rect.left + rect.width, y);
+        lines_y[(sector_y - sector_y_min)*2+1].position = worldToScreen(sf::Vector2f((sector_x_max+1)*sector_size, y));
         lines_y[(sector_y - sector_y_min)*2+1].color = color;
     }
     window.draw(lines_x);
@@ -246,11 +257,11 @@ void GuiRadarView::drawSectorGrid(sf::RenderTarget& window)
     sf::VertexArray points(sf::Points, (sub_sector_x_max - sub_sector_x_min + 1) * (sub_sector_y_max - sub_sector_y_min + 1));
     for(int sector_x = sub_sector_x_min; sector_x <= sub_sector_x_max; sector_x++)
     {
-        float x = radar_screen_center.x + ((sector_x * sub_sector_size) - view_position.x) * scale;
+        float x = sector_x * sub_sector_size;
         for(int sector_y = sub_sector_y_min; sector_y <= sub_sector_y_max; sector_y++)
         {
-            float y = radar_screen_center.y + ((sector_y * sub_sector_size) - view_position.y) * scale;
-            points[(sector_x - sub_sector_x_min) + (sector_y - sub_sector_y_min) * (sub_sector_x_max - sub_sector_x_min + 1)].position = sf::Vector2f(x, y);
+            float y = sector_y * sub_sector_size;
+            points[(sector_x - sub_sector_x_min) + (sector_y - sub_sector_y_min) * (sub_sector_x_max - sub_sector_x_min + 1)].position = worldToScreen(sf::Vector2f(x,y));
             points[(sector_x - sub_sector_x_min) + (sector_y - sub_sector_y_min) * (sub_sector_x_max - sub_sector_x_min + 1)].color = color;
         }
     }
@@ -288,7 +299,7 @@ void GuiRadarView::drawNebulaBlockedAreas(sf::RenderTarget& window)
                 float r = n->getRadius() * scale;
                 sf::CircleShape circle(r, 32);
                 circle.setOrigin(r, r);
-                circle.setPosition(radar_screen_center + (n->getPosition() - view_position) * scale);
+                circle.setPosition(worldToScreen(n->getPosition()));
                 circle.setFillColor(sf::Color(0, 0, 0, 255));
                 window.draw(circle, blend);
 
@@ -302,11 +313,11 @@ void GuiRadarView::drawNebulaBlockedAreas(sf::RenderTarget& window)
                 sf::Vector2f pos_e = scan_center + diff / diff_len * distance * 3.0f;
 
                 sf::VertexArray a(sf::TrianglesStrip, 5);
-                a[0].position = radar_screen_center + (pos_a - view_position) * scale;
-                a[1].position = radar_screen_center + (pos_b - view_position) * scale;
-                a[2].position = radar_screen_center + (pos_c - view_position) * scale;
-                a[3].position = radar_screen_center + (pos_d - view_position) * scale;
-                a[4].position = radar_screen_center + (pos_e - view_position) * scale;
+                a[0].position = worldToScreen(pos_a - view_position);
+                a[1].position = worldToScreen(pos_b - view_position);
+                a[2].position = worldToScreen(pos_c - view_position);
+                a[3].position = worldToScreen(pos_d - view_position);
+                a[4].position = worldToScreen(pos_e - view_position);
                 for(int n=0; n<5;n++)
                     a[n].color = sf::Color(0, 0, 0, 255);
                 window.draw(a, blend);
@@ -326,13 +337,10 @@ void GuiRadarView::drawNebulaBlockedAreas(sf::RenderTarget& window)
 
 void GuiRadarView::drawGhostDots(sf::RenderTarget& window)
 {
-    sf::Vector2f radar_screen_center(rect.left + rect.width / 2.0f, rect.top + rect.height / 2.0f);
-    float scale = std::min(rect.width, rect.height) / 2.0f / distance;
-
     sf::VertexArray ghost_points(sf::Points, ghost_dots.size());
     for(unsigned int n=0; n<ghost_dots.size(); n++)
     {
-        ghost_points[n].position = radar_screen_center + (ghost_dots[n].position - view_position) * scale;
+        ghost_points[n].position = worldToScreen(ghost_dots[n].position);
         ghost_points[n].color = sf::Color(255, 255, 255, 255 * ((ghost_dots[n].end_of_life - engine->getElapsedTime()) / GhostDot::total_lifetime));
     }
     window.draw(ghost_points);
@@ -344,11 +352,10 @@ void GuiRadarView::drawWaypoints(sf::RenderTarget& window)
         return;
 
     sf::Vector2f radar_screen_center(rect.left + rect.width / 2.0f, rect.top + rect.height / 2.0f);
-    float scale = std::min(rect.width, rect.height) / 2.0f / distance;
 
     for(unsigned int n=0; n<my_spaceship->waypoints.size(); n++)
     {
-        sf::Vector2f screen_position = radar_screen_center + (my_spaceship->waypoints[n] - view_position) * scale;
+        sf::Vector2f screen_position = worldToScreen(my_spaceship->waypoints[n]);
 
         sf::Sprite object_sprite;
         textureManager.setTexture(object_sprite, "waypoint");
@@ -360,11 +367,10 @@ void GuiRadarView::drawWaypoints(sf::RenderTarget& window)
 
         if (style != Rectangular && sf::length(screen_position - radar_screen_center) > std::min(rect.width, rect.height) * 0.5f)
         {
-            sf::Vector2f offset = my_spaceship->waypoints[n] - view_position;
-            screen_position = radar_screen_center + (offset / sf::length(offset) * std::min(rect.width, rect.height) * 0.4f);
+            screen_position = radar_screen_center + ((screen_position - radar_screen_center) / sf::length(screen_position - radar_screen_center) * std::min(rect.width, rect.height) * 0.4f);
 
             object_sprite.setPosition(screen_position);
-            object_sprite.setRotation(sf::vector2ToAngle(offset) - 90);
+            object_sprite.setRotation(sf::vector2ToAngle(screen_position - radar_screen_center) - 90);
             window.draw(object_sprite);
 
             drawText(window, sf::FloatRect(screen_position.x, screen_position.y, 0, 0), string(n + 1), ACenter, 18, bold_font, colorConfig.ship_waypoint_text);
@@ -407,10 +413,10 @@ void GuiRadarView::drawTargetProjections(sf::RenderTarget& window)
             if (!my_spaceship->weapon_tube[n].isLoaded())
                 continue;
             sf::Vector2f fire_position = my_spaceship->getPosition() + sf::rotateVector(my_spaceship->ship_template->model_data->getTubePosition2D(n), my_spaceship->getRotation());
-            sf::Vector2f fire_draw_position = radar_screen_center - (view_position - fire_position) * scale;
+            sf::Vector2f fire_draw_position = worldToScreen(fire_position);
 
             const MissileWeaponData& data = MissileWeaponData::getDataFor(my_spaceship->weapon_tube[n].getLoadType());
-            float fire_angle = my_spaceship->getRotation() + my_spaceship->weapon_tube[n].getDirection();
+            float fire_angle = my_spaceship->weapon_tube[n].getDirection() + (my_spaceship->getRotation());
             float missile_target_angle = fire_angle;
             if (data.turnrate > 0.0f)
             {
@@ -500,7 +506,6 @@ void GuiRadarView::drawTargetProjections(sf::RenderTarget& window)
 
 void GuiRadarView::drawMissileTubes(sf::RenderTarget& window)
 {
-    sf::Vector2f radar_screen_center(rect.left + rect.width / 2.0f, rect.top + rect.height / 2.0f);
     float scale = std::min(rect.width, rect.height) / 2.0f / distance;
 
     if (my_spaceship)
@@ -509,9 +514,9 @@ void GuiRadarView::drawMissileTubes(sf::RenderTarget& window)
         for(int n=0; n<my_spaceship->weapon_tube_count; n++)
         {
             sf::Vector2f fire_position = my_spaceship->getPosition() + sf::rotateVector(my_spaceship->ship_template->model_data->getTubePosition2D(n), my_spaceship->getRotation());
-            sf::Vector2f fire_draw_position = radar_screen_center - (view_position - fire_position) * scale;
+            sf::Vector2f fire_draw_position = worldToScreen(fire_position);
 
-            float fire_angle = my_spaceship->getRotation() + my_spaceship->weapon_tube[n].getDirection();
+            float fire_angle = my_spaceship->getRotation() + my_spaceship->weapon_tube[n].getDirection() - view_rotation;
             
             a[n * 2].position = fire_draw_position;
             a[n * 2 + 1].position = fire_draw_position + (sf::vector2FromAngle(fire_angle) * 1000.0f) * scale;
@@ -524,7 +529,6 @@ void GuiRadarView::drawMissileTubes(sf::RenderTarget& window)
 
 void GuiRadarView::drawObjects(sf::RenderTarget& window_normal, sf::RenderTarget& window_alpha)
 {
-    sf::Vector2f radar_screen_center(rect.left + rect.width / 2.0f, rect.top + rect.height / 2.0f);
     float scale = std::min(rect.width, rect.height) / 2.0f / distance;
 
     std::set<SpaceObject*> visible_objects;
@@ -577,7 +581,7 @@ void GuiRadarView::drawObjects(sf::RenderTarget& window_normal, sf::RenderTarget
 
     for(SpaceObject* obj : visible_objects)
     {
-        sf::Vector2f object_position_on_screen = radar_screen_center + (obj->getPosition() - view_position) * scale;
+        sf::Vector2f object_position_on_screen = worldToScreen(obj->getPosition());
         float r = obj->getRadius() * scale;
         sf::FloatRect object_rect(object_position_on_screen.x - r, object_position_on_screen.y - r, r * 2, r * 2);
         if (obj != *my_spaceship && rect.intersects(object_rect))
@@ -585,49 +589,46 @@ void GuiRadarView::drawObjects(sf::RenderTarget& window_normal, sf::RenderTarget
             sf::RenderTarget* window = &window_normal;
             if (!obj->canHideInNebula())
                 window = &window_alpha;
-            obj->drawOnRadar(*window, object_position_on_screen, scale, long_range);
+            obj->drawOnRadar(*window, object_position_on_screen, scale, view_rotation, long_range);
             if (show_callsigns && obj->getCallSign() != "")
                 drawText(*window, sf::FloatRect(object_position_on_screen.x, object_position_on_screen.y - 15, 0, 0), obj->getCallSign(), ACenter, 15, bold_font);
         }
     }
     if (my_spaceship)
     {
-        sf::Vector2f object_position_on_screen = radar_screen_center + (my_spaceship->getPosition() - view_position) * scale;
-        my_spaceship->drawOnRadar(window_normal, object_position_on_screen, scale, long_range);
+        sf::Vector2f object_position_on_screen = worldToScreen(my_spaceship->getPosition());
+        my_spaceship->drawOnRadar(window_normal, object_position_on_screen, scale, view_rotation, long_range);
     }
 }
 
 void GuiRadarView::drawObjectsGM(sf::RenderTarget& window)
 {
-    sf::Vector2f radar_screen_center(rect.left + rect.width / 2.0f, rect.top + rect.height / 2.0f);
     float scale = std::min(rect.width, rect.height) / 2.0f / distance;
 
     foreach(SpaceObject, obj, space_object_list)
     {
-        sf::Vector2f object_position_on_screen = radar_screen_center + (obj->getPosition() - view_position) * scale;
+        sf::Vector2f object_position_on_screen = worldToScreen(obj->getPosition());
         float r = obj->getRadius() * scale;
         sf::FloatRect object_rect(object_position_on_screen.x - r, object_position_on_screen.y - r, r * 2, r * 2);
         if (rect.intersects(object_rect))
         {
-            obj->drawOnGMRadar(window, object_position_on_screen, scale, long_range);
+            obj->drawOnGMRadar(window, object_position_on_screen, scale, view_rotation, long_range);
         }
     }
 }
 
 void GuiRadarView::drawTargets(sf::RenderTarget& window)
 {
-    if (!targets)
-        return;
-
-    sf::Vector2f radar_screen_center(rect.left + rect.width / 2.0f, rect.top + rect.height / 2.0f);
     float scale = std::min(rect.width, rect.height) / 2.0f / distance;
 
+    if (!targets)
+        return;
     sf::Sprite target_sprite;
     textureManager.setTexture(target_sprite, "redicule.png");
 
     for(P<SpaceObject> obj : targets->getTargets())
     {
-        sf::Vector2f object_position_on_screen = radar_screen_center + (obj->getPosition() - view_position) * scale;
+        sf::Vector2f object_position_on_screen = worldToScreen(obj->getPosition());
         float r = obj->getRadius() * scale;
         sf::FloatRect object_rect(object_position_on_screen.x - r, object_position_on_screen.y - r, r * 2, r * 2);
         if (obj != my_spaceship && rect.intersects(object_rect))
@@ -639,7 +640,7 @@ void GuiRadarView::drawTargets(sf::RenderTarget& window)
 
     if (my_spaceship && targets->getWaypointIndex() > -1 && targets->getWaypointIndex() < my_spaceship->getWaypointCount())
     {
-        sf::Vector2f object_position_on_screen = radar_screen_center + (my_spaceship->waypoints[targets->getWaypointIndex()] - view_position) * scale;
+        sf::Vector2f object_position_on_screen = worldToScreen(my_spaceship->waypoints[targets->getWaypointIndex()]);
 
         target_sprite.setPosition(object_position_on_screen - sf::Vector2f(0, 10));
         window.draw(target_sprite);
@@ -654,23 +655,23 @@ void GuiRadarView::drawHeadingIndicators(sf::RenderTarget& window)
     sf::VertexArray tigs(sf::Lines, 360/20*2);
     for(unsigned int n=0; n<360; n+=20)
     {
-        tigs[n/20*2].position = radar_screen_center + sf::vector2FromAngle(float(n) - 90) * (scale - 20);
-        tigs[n/20*2+1].position = radar_screen_center + sf::vector2FromAngle(float(n) - 90) * (scale - 40);
+        tigs[n/20*2].position = radar_screen_center + sf::vector2FromAngle(float(n) - 90 - view_rotation) * (scale - 20);
+        tigs[n/20*2+1].position = radar_screen_center + sf::vector2FromAngle(float(n) - 90 - view_rotation) * (scale - 40);
     }
     window.draw(tigs);
     sf::VertexArray small_tigs(sf::Lines, 360/5*2);
     for(unsigned int n=0; n<360; n+=5)
     {
-        small_tigs[n/5*2].position = radar_screen_center + sf::vector2FromAngle(float(n) - 90) * (scale - 20);
-        small_tigs[n/5*2+1].position = radar_screen_center + sf::vector2FromAngle(float(n) - 90) * (scale - 30);
+        small_tigs[n/5*2].position = radar_screen_center + sf::vector2FromAngle(float(n) - 90 - view_rotation) * (scale - 20);
+        small_tigs[n/5*2+1].position = radar_screen_center + sf::vector2FromAngle(float(n) - 90 - view_rotation) * (scale - 30);
     }
     window.draw(small_tigs);
     for(unsigned int n=0; n<360; n+=20)
     {
         sf::Text text(string(n), *main_font, 15);
-        text.setPosition(radar_screen_center + sf::vector2FromAngle(float(n) - 90) * (scale - 45));
+        text.setPosition(radar_screen_center + sf::vector2FromAngle(float(n) - 90 - view_rotation) * (scale - 45));
         text.setOrigin(text.getLocalBounds().width / 2.0, text.getLocalBounds().height / 2.0);
-        text.setRotation(n);
+        text.setRotation(n-view_rotation);
         window.draw(text);
     }
 }
@@ -709,14 +710,18 @@ sf::Vector2f GuiRadarView::worldToScreen(sf::Vector2f world_position)
 {
     sf::Vector2f radar_screen_center(rect.left + rect.width / 2.0f, rect.top + rect.height / 2.0f);
     float scale = std::min(rect.width, rect.height) / 2.0f / distance;
-    return radar_screen_center + (world_position - view_position) * scale;
+
+    sf::Vector2f radar_position = sf::rotateVector((world_position - view_position) * scale, -view_rotation);
+    return radar_position + radar_screen_center;
 }
 
 sf::Vector2f GuiRadarView::screenToWorld(sf::Vector2f screen_position)
 {
     sf::Vector2f radar_screen_center(rect.left + rect.width / 2.0f, rect.top + rect.height / 2.0f);
     float scale = std::min(rect.width, rect.height) / 2.0f / distance;
-    return view_position + (screen_position - radar_screen_center) / scale;
+    
+    sf::Vector2f radar_position = sf::rotateVector((screen_position - radar_screen_center) / scale, view_rotation);
+    return view_position + radar_position;
 }
 
 bool GuiRadarView::onMouseDown(sf::Vector2f position)

--- a/src/screenComponents/radarView.cpp
+++ b/src/screenComponents/radarView.cpp
@@ -16,7 +16,7 @@ GuiRadarView::GuiRadarView(GuiContainer* owner, string id, float distance, Targe
 , range_indicator_step_size(0.0f), style(Circular), fog_style(NoFogOfWar), mouse_down_func(nullptr), mouse_drag_func(nullptr), mouse_up_func(nullptr)
 {
     auto_center_on_my_ship = true;
-    auto_rotate_on_my_ship = true;
+    auto_rotate_on_my_ship = false;
 }
 
 void GuiRadarView::onDraw(sf::RenderTarget& window)

--- a/src/screenComponents/radarView.cpp
+++ b/src/screenComponents/radarView.cpp
@@ -16,6 +16,7 @@ GuiRadarView::GuiRadarView(GuiContainer* owner, string id, float distance, Targe
 , range_indicator_step_size(0.0f), style(Circular), fog_style(NoFogOfWar), mouse_down_func(nullptr), mouse_drag_func(nullptr), mouse_up_func(nullptr)
 {
     auto_center_on_my_ship = true;
+    auto_rotate_on_my_ship = true;
 }
 
 void GuiRadarView::onDraw(sf::RenderTarget& window)
@@ -42,7 +43,9 @@ void GuiRadarView::onDraw(sf::RenderTarget& window)
     //Hacky, when not relay and we have a ship, center on it.
     if (my_spaceship && auto_center_on_my_ship) {
         view_position = my_spaceship->getPosition();
-        view_rotation = my_spaceship->getRotation();
+    }
+    if (my_spaceship && auto_rotate_on_my_ship) {
+        view_rotation = my_spaceship->getRotation() + 90;
     }
 
     //Setup our textures for rendering
@@ -493,7 +496,7 @@ void GuiRadarView::drawTargetProjections(sf::RenderTarget& window)
             a[0].color = sf::Color(255, 255, 255, 128);
             a[1].position = worldToScreen(obj->getPosition() + obj->getVelocity() * 60.0f);
             a[1].color = sf::Color(255, 255, 255, 0);
-            sf::Vector2f n = sf::normalize(sf::Vector2f(-obj->getVelocity().y, obj->getVelocity().x));
+            sf::Vector2f n = sf::normalize(sf::rotateVector(sf::Vector2f(-obj->getVelocity().y, obj->getVelocity().x), -view_rotation));
             for(int cnt=0; cnt<5; cnt++)
             {
                 sf::Vector2f p = sf::rotateVector(obj->getVelocity() * (seconds_per_distance_tick * (cnt + 1.0f) * scale), -view_rotation);

--- a/src/screenComponents/radarView.cpp
+++ b/src/screenComponents/radarView.cpp
@@ -316,11 +316,11 @@ void GuiRadarView::drawNebulaBlockedAreas(sf::RenderTarget& window)
                 sf::Vector2f pos_e = scan_center + diff / diff_len * distance * 3.0f;
 
                 sf::VertexArray a(sf::TrianglesStrip, 5);
-                a[0].position = worldToScreen(pos_a - view_position);
-                a[1].position = worldToScreen(pos_b - view_position);
-                a[2].position = worldToScreen(pos_c - view_position);
-                a[3].position = worldToScreen(pos_d - view_position);
-                a[4].position = worldToScreen(pos_e - view_position);
+                a[0].position = worldToScreen(pos_a);
+                a[1].position = worldToScreen(pos_b);
+                a[2].position = worldToScreen(pos_c);
+                a[3].position = worldToScreen(pos_d);
+                a[4].position = worldToScreen(pos_e);
                 for(int n=0; n<5;n++)
                     a[n].color = sf::Color(0, 0, 0, 255);
                 window.draw(a, blend);

--- a/src/screenComponents/radarView.h
+++ b/src/screenComponents/radarView.h
@@ -47,6 +47,7 @@ private:
 
     float distance;
     sf::Vector2f view_position;
+    float view_rotation;
     bool long_range;
     bool show_ghost_dots;
     bool show_waypoints;
@@ -94,6 +95,8 @@ public:
     GuiRadarView* setCallbacks(func_t mouse_down_func, func_t mouse_drag_func, func_t mouse_up_func) { this->mouse_down_func = mouse_down_func; this->mouse_drag_func = mouse_drag_func; this->mouse_up_func = mouse_up_func; return this; }
     GuiRadarView* setViewPosition(sf::Vector2f view_position) { this->view_position = view_position; return this; }
     sf::Vector2f getViewPosition() { return view_position; }
+    GuiRadarView* setViewRotation(float view_rotation) { this->view_rotation = view_rotation; return this; }
+    float getViewRotation() { return view_rotation; }
 
     sf::Vector2f worldToScreen(sf::Vector2f world_position);
     sf::Vector2f screenToWorld(sf::Vector2f screen_position);

--- a/src/screenComponents/radarView.h
+++ b/src/screenComponents/radarView.h
@@ -57,6 +57,7 @@ private:
     bool show_heading_indicators;
     bool show_game_master_data;
     bool auto_center_on_my_ship;
+    bool auto_rotate_on_my_ship;
     float range_indicator_step_size;
     ERadarStyle style;
     EFogOfWarStyle fog_style;
@@ -92,6 +93,8 @@ public:
     GuiRadarView* setFogOfWarStyle(EFogOfWarStyle style) { this->fog_style = style; return this; }
     bool getAutoCentering() { return auto_center_on_my_ship; }
     GuiRadarView* setAutoCentering(bool value) { this->auto_center_on_my_ship = value; return this; }
+    bool getAutoRotating() { return auto_rotate_on_my_ship; }
+    GuiRadarView* setAutoRotating(bool value) { this->auto_rotate_on_my_ship = value; return this; }
     GuiRadarView* setCallbacks(func_t mouse_down_func, func_t mouse_drag_func, func_t mouse_up_func) { this->mouse_down_func = mouse_down_func; this->mouse_drag_func = mouse_drag_func; this->mouse_up_func = mouse_up_func; return this; }
     GuiRadarView* setViewPosition(sf::Vector2f view_position) { this->view_position = view_position; return this; }
     sf::Vector2f getViewPosition() { return view_position; }

--- a/src/screenComponents/rawScannerDataRadarOverlay.cpp
+++ b/src/screenComponents/rawScannerDataRadarOverlay.cpp
@@ -15,6 +15,7 @@ void RawScannerDataRadarOverlay::onDraw(sf::RenderTarget& window)
         return;
 
     sf::Vector2f view_position = radar->getViewPosition();
+    float view_rotation = radar->getViewRotation();
 
     // Cap the number of signature points, which determines the raw data's
     // resolution.
@@ -151,17 +152,17 @@ void RawScannerDataRadarOverlay::onDraw(sf::RenderTarget& window)
         // ... and add vectors for each point.
         a_r[n].position.x = rect.left + rect.width / 2.0f;
         a_r[n].position.y = rect.top + rect.height / 2.0f;
-        a_r[n].position += sf::vector2FromAngle(float(n) / float(point_count) * 360.0f) * (radius * (0.95f - r / 500));
+        a_r[n].position += sf::vector2FromAngle(float(n) / float(point_count) * 360.0f - view_rotation) * (radius * (0.95f - r / 500));
         a_r[n].color = sf::Color(255, 0, 0);
 
         a_g[n].position.x = rect.left + rect.width / 2.0f;
         a_g[n].position.y = rect.top + rect.height / 2.0f;
-        a_g[n].position += sf::vector2FromAngle(float(n) / float(point_count) * 360.0f) * (radius * (0.92f - g / 500));
+        a_g[n].position += sf::vector2FromAngle(float(n) / float(point_count) * 360.0f - view_rotation) * (radius * (0.92f - g / 500));
         a_g[n].color = sf::Color(0, 255, 0);
 
         a_b[n].position.x = rect.left + rect.width / 2.0f;
         a_b[n].position.y = rect.top + rect.height / 2.0f;
-        a_b[n].position += sf::vector2FromAngle(float(n) / float(point_count) * 360.0f) * (radius * (0.89f - b / 500));
+        a_b[n].position += sf::vector2FromAngle(float(n) / float(point_count) * 360.0f - view_rotation) * (radius * (0.89f - b / 500));
         a_b[n].color = sf::Color(0, 0, 255);
     }
 

--- a/src/screens/crew6/helmsScreen.cpp
+++ b/src/screens/crew6/helmsScreen.cpp
@@ -2,6 +2,7 @@
 #include "playerInfo.h"
 #include "spaceObjects/playerSpaceship.h"
 #include "helmsScreen.h"
+#include "preferenceManager.h"
 
 #include "screenComponents/radarView.h"
 #include "screenComponents/impulseControls.h"
@@ -60,6 +61,7 @@ HelmsScreen::HelmsScreen(GuiContainer* owner)
             heading_hint->hide();
         }
     );
+    radar->setAutoRotating(PreferencesManager::get("helms_radar_lock","0")=="1");
     
     heading_hint = new GuiLabel(this, "HEADING_HINT", "", 30);
     heading_hint->setAlignment(ACenter)->setSize(0, 0);

--- a/src/screens/crew6/scienceScreen.cpp
+++ b/src/screens/crew6/scienceScreen.cpp
@@ -3,6 +3,7 @@
 #include "scienceScreen.h"
 #include "scienceDatabase.h"
 #include "spaceObjects/nebula.h"
+#include "preferenceManager.h"
 
 #include "screenComponents/radarView.h"
 #include "screenComponents/rawScannerDataRadarOverlay.h"
@@ -52,6 +53,7 @@ ScienceScreen::ScienceScreen(GuiContainer* owner, ECrewPosition crew_position)
             targets.setToClosestTo(position, 1000, TargetsContainer::Selectable);
         }, nullptr, nullptr
     );
+    science_radar->setAutoRotating(PreferencesManager::get("science_radar_lock","0")=="1");
     new RawScannerDataRadarOverlay(science_radar, "", my_spaceship->getLongRangeRadarRange());
 
     // Draw and hide the probe radar.

--- a/src/screens/crew6/weaponsScreen.cpp
+++ b/src/screens/crew6/weaponsScreen.cpp
@@ -2,6 +2,7 @@
 #include "playerInfo.h"
 #include "gameGlobalInfo.h"
 #include "weaponsScreen.h"
+#include "preferenceManager.h"
 
 #include "screenComponents/missileTubeControls.h"
 #include "screenComponents/aimLock.h"
@@ -42,6 +43,8 @@ WeaponsScreen::WeaponsScreen(GuiContainer* owner)
                 my_spaceship->commandSetTarget(NULL);
         }, nullptr, nullptr
     );
+    radar->setAutoRotating(PreferencesManager::get("weapons_radar_lock","0")=="1");
+
     missile_aim = new AimLock(this, "MISSILE_AIM", radar, -90, 360 - 90, 0, [this](float value){
         tube_controls->setMissileTargetAngle(value);
     });

--- a/src/screens/crew6/weaponsScreen.cpp
+++ b/src/screens/crew6/weaponsScreen.cpp
@@ -42,7 +42,7 @@ WeaponsScreen::WeaponsScreen(GuiContainer* owner)
                 my_spaceship->commandSetTarget(NULL);
         }, nullptr, nullptr
     );
-    missile_aim = new GuiRotationDial(this, "MISSILE_AIM", -90, 360 - 90, 0, [this](float value){
+    missile_aim = new AimLock(this, "MISSILE_AIM", radar, -90, 360 - 90, 0, [this](float value){
         tube_controls->setMissileTargetAngle(value);
     });
     missile_aim->setPosition(0, 0, ACenter)->setSize(GuiElement::GuiSizeMatchHeight, 850);

--- a/src/screens/gm/tweak.cpp
+++ b/src/screens/gm/tweak.cpp
@@ -470,7 +470,7 @@ GuiShipTweakBeamweapons::GuiShipTweakBeamweapons(GuiContainer* owner)
 
 void GuiShipTweakBeamweapons::onDraw(sf::RenderTarget& window)
 {
-    target->drawOnRadar(window, sf::Vector2f(rect.left - 150.0f + rect.width / 2.0f, rect.top + rect.height * 0.66), 300.0f / 5000.0f, false);
+    target->drawOnRadar(window, sf::Vector2f(rect.left - 150.0f + rect.width / 2.0f, rect.top + rect.height * 0.66), 300.0f / 5000.0f, 0, false);
 
     arc_slider->setValue(target->beam_weapons[beam_index].getArc());
     direction_slider->setValue(sf::angleDifference(0.0f, target->beam_weapons[beam_index].getDirection()));

--- a/src/spaceObjects/artifact.cpp
+++ b/src/spaceObjects/artifact.cpp
@@ -60,7 +60,7 @@ void Artifact::draw3D()
 #endif//FEATURE_3D_RENDERING
 }
 
-void Artifact::drawOnRadar(sf::RenderTarget& window, sf::Vector2f position, float scale, bool long_range)
+void Artifact::drawOnRadar(sf::RenderTarget& window, sf::Vector2f position, float scale, float rotation, bool long_range)
 {
     sf::Sprite object_sprite;
     textureManager.setTexture(object_sprite, "RadarBlip.png");

--- a/src/spaceObjects/artifact.h
+++ b/src/spaceObjects/artifact.h
@@ -18,7 +18,7 @@ public:
 
     virtual void draw3D();
 
-    virtual void drawOnRadar(sf::RenderTarget& window, sf::Vector2f position, float scale, bool long_range) override;
+    virtual void drawOnRadar(sf::RenderTarget& window, sf::Vector2f position, float scale, float rotation, bool long_range) override;
 
     virtual void collide(Collisionable* target, float force) override;
 

--- a/src/spaceObjects/asteroid.cpp
+++ b/src/spaceObjects/asteroid.cpp
@@ -48,7 +48,7 @@ void Asteroid::draw3D()
 #endif//FEATURE_3D_RENDERING
 }
 
-void Asteroid::drawOnRadar(sf::RenderTarget& window, sf::Vector2f position, float scale, bool long_range)
+void Asteroid::drawOnRadar(sf::RenderTarget& window, sf::Vector2f position, float scale, float rotation, bool long_range)
 {
     if (size != getRadius())
         setRadius(size);

--- a/src/spaceObjects/asteroid.h
+++ b/src/spaceObjects/asteroid.h
@@ -15,7 +15,7 @@ public:
     
     virtual void draw3D();
 
-    virtual void drawOnRadar(sf::RenderTarget& window, sf::Vector2f position, float scale, bool long_range) override;
+    virtual void drawOnRadar(sf::RenderTarget& window, sf::Vector2f position, float scale, float rotation, bool long_range) override;
 
     virtual void collide(Collisionable* target, float force) override;
     

--- a/src/spaceObjects/blackHole.cpp
+++ b/src/spaceObjects/blackHole.cpp
@@ -46,7 +46,7 @@ void BlackHole::draw3DTransparent()
 }
 #endif
 
-void BlackHole::drawOnRadar(sf::RenderTarget& window, sf::Vector2f position, float scale, bool long_range)
+void BlackHole::drawOnRadar(sf::RenderTarget& window, sf::Vector2f position, float scale, float rotation, bool long_range)
 {
     sf::Sprite object_sprite;
     textureManager.setTexture(object_sprite, "blackHole.png");

--- a/src/spaceObjects/blackHole.h
+++ b/src/spaceObjects/blackHole.h
@@ -14,7 +14,7 @@ public:
 #if FEATURE_3D_RENDERING
     virtual void draw3DTransparent() override;
 #endif
-    virtual void drawOnRadar(sf::RenderTarget& window, sf::Vector2f position, float scale, bool long_range) override;
+    virtual void drawOnRadar(sf::RenderTarget& window, sf::Vector2f position, float scale, float rotation, bool long_range) override;
 
     virtual bool canHideInNebula()  override { return false; }
 

--- a/src/spaceObjects/cpuShip.cpp
+++ b/src/spaceObjects/cpuShip.cpp
@@ -232,9 +232,9 @@ void CpuShip::orderDock(P<SpaceObject> object)
     this->addBroadcast(FVF_Friendly, "Docking to " + object->getCallSign() + ".");
 }
 
-void CpuShip::drawOnGMRadar(sf::RenderTarget& window, sf::Vector2f position, float scale, bool long_range)
+void CpuShip::drawOnGMRadar(sf::RenderTarget& window, sf::Vector2f position, float scale, float rotation, bool long_range)
 {
-    SpaceShip::drawOnGMRadar(window, position, scale, long_range);
+    SpaceShip::drawOnGMRadar(window, position, scale, rotation, long_range);
     if (game_server)
         ai->drawOnGMRadar(window, position, scale);
 }

--- a/src/spaceObjects/cpuShip.h
+++ b/src/spaceObjects/cpuShip.h
@@ -55,7 +55,7 @@ public:
     sf::Vector2f getOrderTargetLocation() { return order_target_location; }
     P<SpaceObject> getOrderTarget() { return order_target; }
 
-    virtual void drawOnGMRadar(sf::RenderTarget& window, sf::Vector2f position, float scale, bool long_range) override;
+    virtual void drawOnGMRadar(sf::RenderTarget& window, sf::Vector2f position, float scale, float rotation, bool long_range) override;
     virtual std::unordered_map<string, string> getGMInfo() override;
 
     virtual string getExportLine() override;

--- a/src/spaceObjects/electricExplosionEffect.cpp
+++ b/src/spaceObjects/electricExplosionEffect.cpp
@@ -79,7 +79,7 @@ void ElectricExplosionEffect::draw3DTransparent()
 }
 #endif//FEATURE_3D_RENDERING
 
-void ElectricExplosionEffect::drawOnRadar(sf::RenderTarget& window, sf::Vector2f position, float scale, bool long_range)
+void ElectricExplosionEffect::drawOnRadar(sf::RenderTarget& window, sf::Vector2f position, float scale, float rotation, bool long_range)
 {
     if (!on_radar)
         return;

--- a/src/spaceObjects/electricExplosionEffect.h
+++ b/src/spaceObjects/electricExplosionEffect.h
@@ -19,7 +19,7 @@ public:
 #if FEATURE_3D_RENDERING
     virtual void draw3DTransparent();
 #endif
-    virtual void drawOnRadar(sf::RenderTarget& window, sf::Vector2f position, float scale, bool longRange);
+    virtual void drawOnRadar(sf::RenderTarget& window, sf::Vector2f position, float scale, float rotation, bool longRange);
     virtual void update(float delta);
     
     void setSize(float size) { this->size = size; }

--- a/src/spaceObjects/explosionEffect.cpp
+++ b/src/spaceObjects/explosionEffect.cpp
@@ -97,7 +97,7 @@ void ExplosionEffect::draw3DTransparent()
 }
 #endif//FEATURE_3D_RENDERING
 
-void ExplosionEffect::drawOnRadar(sf::RenderTarget& window, sf::Vector2f position, float scale, bool long_range)
+void ExplosionEffect::drawOnRadar(sf::RenderTarget& window, sf::Vector2f position, float scale, float rotation, bool long_range)
 {
     if (!on_radar)
         return;

--- a/src/spaceObjects/explosionEffect.h
+++ b/src/spaceObjects/explosionEffect.h
@@ -20,7 +20,7 @@ public:
 #if FEATURE_3D_RENDERING
     virtual void draw3DTransparent();
 #endif
-    virtual void drawOnRadar(sf::RenderTarget& window, sf::Vector2f position, float scale, bool longRange);
+    virtual void drawOnRadar(sf::RenderTarget& window, sf::Vector2f position, float scale, float rotation, bool longRange);
     virtual void update(float delta);
     
     void setSize(float size) { this->size = size; }

--- a/src/spaceObjects/mine.cpp
+++ b/src/spaceObjects/mine.cpp
@@ -37,7 +37,7 @@ void Mine::draw3DTransparent()
 {
 }
 
-void Mine::drawOnRadar(sf::RenderTarget& window, sf::Vector2f position, float scale, bool long_range)
+void Mine::drawOnRadar(sf::RenderTarget& window, sf::Vector2f position, float scale, float rotation, bool long_range)
 {
     sf::Sprite objectSprite;
     textureManager.setTexture(objectSprite, "RadarBlip.png");
@@ -47,7 +47,7 @@ void Mine::drawOnRadar(sf::RenderTarget& window, sf::Vector2f position, float sc
     window.draw(objectSprite);
 }
 
-void Mine::drawOnGMRadar(sf::RenderTarget& window, sf::Vector2f position, float scale, bool long_range)
+void Mine::drawOnGMRadar(sf::RenderTarget& window, sf::Vector2f position, float scale, float rotation, bool long_range)
 {
     sf::CircleShape hitRadius(trigger_range * scale);
     hitRadius.setOrigin(trigger_range * scale, trigger_range * scale);

--- a/src/spaceObjects/mine.h
+++ b/src/spaceObjects/mine.h
@@ -24,8 +24,8 @@ public:
 
     virtual void draw3D();
     virtual void draw3DTransparent();
-    virtual void drawOnRadar(sf::RenderTarget& window, sf::Vector2f position, float scale, bool long_range);
-    virtual void drawOnGMRadar(sf::RenderTarget& window, sf::Vector2f position, float scale, bool long_range);
+    virtual void drawOnRadar(sf::RenderTarget& window, sf::Vector2f position, float scale, float rotation, bool long_range);
+    virtual void drawOnGMRadar(sf::RenderTarget& window, sf::Vector2f position, float scale, float rotation, bool long_range);
     virtual void update(float delta);
 
     virtual void collide(Collisionable* target, float force);

--- a/src/spaceObjects/missiles/missileWeapon.cpp
+++ b/src/spaceObjects/missiles/missileWeapon.cpp
@@ -17,13 +17,13 @@ MissileWeapon::MissileWeapon(string multiplayer_name, const MissileWeaponData& d
     launch_sound_played = false;
 }
 
-void MissileWeapon::drawOnRadar(sf::RenderTarget& window, sf::Vector2f position, float scale, bool long_range)
+void MissileWeapon::drawOnRadar(sf::RenderTarget& window, sf::Vector2f position, float scale, float rotation, bool long_range)
 {
     if (long_range) return;
 
     sf::Sprite object_sprite;
     textureManager.setTexture(object_sprite, "RadarArrow.png");
-    object_sprite.setRotation(getRotation());
+    object_sprite.setRotation(getRotation()-rotation);
     object_sprite.setPosition(position);
     object_sprite.setColor(data.color);
     object_sprite.setScale(0.25 + 0.25 * category_modifier, 0.25 + 0.25 * category_modifier);

--- a/src/spaceObjects/missiles/missileWeapon.h
+++ b/src/spaceObjects/missiles/missileWeapon.h
@@ -23,7 +23,7 @@ public:
 
     MissileWeapon(string multiplayer_name, const MissileWeaponData& data);
 
-    virtual void drawOnRadar(sf::RenderTarget& window, sf::Vector2f position, float scale, bool long_range) override;
+    virtual void drawOnRadar(sf::RenderTarget& window, sf::Vector2f position, float scale, float rotation, bool long_range) override;
     virtual void update(float delta) override;
 
     virtual void collide(Collisionable* target, float force) override;

--- a/src/spaceObjects/nebula.cpp
+++ b/src/spaceObjects/nebula.cpp
@@ -72,11 +72,11 @@ void Nebula::draw3DTransparent()
 }
 #endif//FEATURE_3D_RENDERING
 
-void Nebula::drawOnRadar(sf::RenderTarget& window, sf::Vector2f position, float scale, bool long_range)
+void Nebula::drawOnRadar(sf::RenderTarget& window, sf::Vector2f position, float scale, float rotation, bool long_range)
 {
     sf::Sprite object_sprite;
     textureManager.setTexture(object_sprite, "Nebula" + string(radar_visual) + ".png");
-    object_sprite.setRotation(getRotation());
+    object_sprite.setRotation(getRotation()-rotation);
     object_sprite.setPosition(position);
     float size = getRadius() * scale / object_sprite.getTextureRect().width * 3.0;
     object_sprite.setScale(size, size);
@@ -84,7 +84,7 @@ void Nebula::drawOnRadar(sf::RenderTarget& window, sf::Vector2f position, float 
     window.draw(object_sprite, sf::BlendAdd);
 }
 
-void Nebula::drawOnGMRadar(sf::RenderTarget& window, sf::Vector2f position, float scale, bool long_range)
+void Nebula::drawOnGMRadar(sf::RenderTarget& window, sf::Vector2f position, float scale, float rotation, bool long_range)
 {
     sf::CircleShape range_circle(getRadius() * scale);
     range_circle.setOrigin(getRadius() * scale, getRadius() * scale);

--- a/src/spaceObjects/nebula.h
+++ b/src/spaceObjects/nebula.h
@@ -23,8 +23,8 @@ public:
 #if FEATURE_3D_RENDERING
     virtual void draw3DTransparent();
 #endif
-    virtual void drawOnRadar(sf::RenderTarget& window, sf::Vector2f position, float scale, bool long_range);
-    virtual void drawOnGMRadar(sf::RenderTarget& window, sf::Vector2f position, float scale, bool long_range);
+    virtual void drawOnRadar(sf::RenderTarget& window, sf::Vector2f position, float scale, float rotation, bool long_range);
+    virtual void drawOnGMRadar(sf::RenderTarget& window, sf::Vector2f position, float scale, float rotation, bool long_range);
     virtual bool canHideInNebula() { return false; }
     
     static bool inNebula(sf::Vector2f position);

--- a/src/spaceObjects/planet.cpp
+++ b/src/spaceObjects/planet.cpp
@@ -314,7 +314,7 @@ void Planet::draw3DTransparent()
 }
 #endif
 
-void Planet::drawOnRadar(sf::RenderTarget& window, sf::Vector2f position, float scale, bool long_range)
+void Planet::drawOnRadar(sf::RenderTarget& window, sf::Vector2f position, float scale, float rotation, bool long_range)
 {
     if (collision_size > 0)
     {
@@ -326,7 +326,7 @@ void Planet::drawOnRadar(sf::RenderTarget& window, sf::Vector2f position, float 
     }
 }
 
-void Planet::drawOnGMRadar(sf::RenderTarget& window, sf::Vector2f position, float scale, bool long_range)
+void Planet::drawOnGMRadar(sf::RenderTarget& window, sf::Vector2f position, float scale, float rotation, bool long_range)
 {
     sf::CircleShape radar_radius(planet_size * scale);
     radar_radius.setOrigin(planet_size * scale, planet_size * scale);

--- a/src/spaceObjects/planet.h
+++ b/src/spaceObjects/planet.h
@@ -14,8 +14,8 @@ public:
     virtual void draw3D() override;
     virtual void draw3DTransparent() override;
 #endif//FEATURE_3D_RENDERING
-    virtual void drawOnRadar(sf::RenderTarget& window, sf::Vector2f position, float scale, bool long_range) override;
-    virtual void drawOnGMRadar(sf::RenderTarget& window, sf::Vector2f draw_position, float scale, bool long_range) override;
+    virtual void drawOnRadar(sf::RenderTarget& window, sf::Vector2f position, float scale, float rotation, bool long_range) override;
+    virtual void drawOnGMRadar(sf::RenderTarget& window, sf::Vector2f draw_position, float scale, float rotation, bool long_range) override;
     virtual void update(float delta) override;
     virtual void collide(Collisionable* target, float force) override;
     virtual bool canHideInNebula()  override { return false; }

--- a/src/spaceObjects/playerSpaceship.cpp
+++ b/src/spaceObjects/playerSpaceship.cpp
@@ -1896,9 +1896,9 @@ void PlayerSpaceship::onReceiveServerCommand(sf::Packet& packet)
     }
 }
 
-void PlayerSpaceship::drawOnGMRadar(sf::RenderTarget& window, sf::Vector2f position, float scale, bool long_range)
+void PlayerSpaceship::drawOnGMRadar(sf::RenderTarget& window, sf::Vector2f position, float scale, float rotation, bool long_range)
 {
-    SpaceShip::drawOnGMRadar(window, position, scale, long_range);
+    SpaceShip::drawOnGMRadar(window, position, scale, rotation, long_range);
     if (long_range)
     {
         sf::CircleShape radar_radius(long_range_radar_range * scale);

--- a/src/spaceObjects/playerSpaceship.h
+++ b/src/spaceObjects/playerSpaceship.h
@@ -298,7 +298,7 @@ public:
     void setControlCode(string code) { control_code = code; }
 
     // Radar function
-    virtual void drawOnGMRadar(sf::RenderTarget& window, sf::Vector2f position, float scale, bool long_range) override;
+    virtual void drawOnGMRadar(sf::RenderTarget& window, sf::Vector2f position, float scale, float rotation, bool long_range) override;
 
     // Radar range
     float getLongRangeRadarRange();

--- a/src/spaceObjects/scanProbe.cpp
+++ b/src/spaceObjects/scanProbe.cpp
@@ -83,7 +83,7 @@ void ScanProbe::takeDamage(float damage_amount, DamageInfo info)
     destroy();
 }
 
-void ScanProbe::drawOnRadar(sf::RenderTarget& window, sf::Vector2f position, float scale, bool long_range)
+void ScanProbe::drawOnRadar(sf::RenderTarget& window, sf::Vector2f position, float scale, float rotation, bool long_range)
 {
     sf::Sprite object_sprite;
     textureManager.setTexture(object_sprite, "ProbeBlip.png");

--- a/src/spaceObjects/scanProbe.h
+++ b/src/spaceObjects/scanProbe.h
@@ -21,7 +21,7 @@ public:
     virtual void update(float delta) override;
     virtual bool canBeTargetedBy(P<SpaceObject> other) override;
     virtual void takeDamage(float damage_amount, DamageInfo info) override;
-    virtual void drawOnRadar(sf::RenderTarget& window, sf::Vector2f position, float scale, bool long_range) override;
+    virtual void drawOnRadar(sf::RenderTarget& window, sf::Vector2f position, float scale, float rotation, bool long_range) override;
 
     void setTarget(sf::Vector2f target) { target_position = target; }
     sf::Vector2f getTarget() { return target_position; }

--- a/src/spaceObjects/shipTemplateBasedObject.cpp
+++ b/src/spaceObjects/shipTemplateBasedObject.cpp
@@ -103,7 +103,7 @@ ShipTemplateBasedObject::ShipTemplateBasedObject(float collision_range, string m
     registerMemberReplication(&can_be_destroyed);
 }
 
-void ShipTemplateBasedObject::drawShieldsOnRadar(sf::RenderTarget& window, sf::Vector2f position, float scale, float sprite_scale, bool show_levels)
+void ShipTemplateBasedObject::drawShieldsOnRadar(sf::RenderTarget& window, sf::Vector2f position, float scale, float rotation, float sprite_scale, bool show_levels)
 {
     if (!getShieldsActive())
         return;
@@ -129,7 +129,7 @@ void ShipTemplateBasedObject::drawShieldsOnRadar(sf::RenderTarget& window, sf::V
         
         window.draw(objectSprite);
     }else if (shield_count > 1) {
-        float rotation = getRotation();
+        float direction = getRotation()-rotation;
         float arc = 360.0f / float(shield_count);
         
         for(int n=0; n<shield_count; n++)
@@ -145,9 +145,9 @@ void ShipTemplateBasedObject::drawShieldsOnRadar(sf::RenderTarget& window, sf::V
                 color = Tween<sf::Color>::linear(shield_hit_effect[n], 0.0f, 1.0f, color, sf::Color(255, 0, 0, 128));
             }
             sf::VertexArray a(sf::TrianglesFan, 4);
-            sf::Vector2f delta_a = sf::vector2FromAngle(rotation - arc / 2.0f);
-            sf::Vector2f delta_b = sf::vector2FromAngle(rotation);
-            sf::Vector2f delta_c = sf::vector2FromAngle(rotation + arc / 2.0f);
+            sf::Vector2f delta_a = sf::vector2FromAngle(direction - arc / 2.0f);
+            sf::Vector2f delta_b = sf::vector2FromAngle(direction);
+            sf::Vector2f delta_c = sf::vector2FromAngle(direction + arc / 2.0f);
             a[0].position = position + delta_b * sprite_scale * 32.0f * 0.05f;
             a[1].position = a[0].position + delta_a * sprite_scale * 32.0f * 1.5f;
             a[2].position = a[0].position + delta_b * sprite_scale * 32.0f * 1.5f;
@@ -162,7 +162,7 @@ void ShipTemplateBasedObject::drawShieldsOnRadar(sf::RenderTarget& window, sf::V
             a[3].color = color;
             window.draw(a, textureManager.getTexture("shield_circle.png"));
 
-            rotation += arc;
+            direction += arc;
         }
     }
 }

--- a/src/spaceObjects/shipTemplateBasedObject.h
+++ b/src/spaceObjects/shipTemplateBasedObject.h
@@ -40,7 +40,7 @@ public:
 #if FEATURE_3D_RENDERING
     virtual void draw3DTransparent() override;
 #endif
-    virtual void drawShieldsOnRadar(sf::RenderTarget& window, sf::Vector2f position, float scale, float sprite_scale, bool show_levels);
+    virtual void drawShieldsOnRadar(sf::RenderTarget& window, sf::Vector2f position, float scale, float rotation, float sprite_scale, bool show_levels);
     virtual void update(float delta) override;
 
     virtual std::unordered_map<string, string> getGMInfo() override;

--- a/src/spaceObjects/spaceObject.cpp
+++ b/src/spaceObjects/spaceObject.cpp
@@ -292,11 +292,11 @@ void SpaceObject::draw3D()
 }
 #endif//FEATURE_3D_RENDERING
 
-void SpaceObject::drawOnRadar(sf::RenderTarget& window, sf::Vector2f position, float scale, bool longRange)
+void SpaceObject::drawOnRadar(sf::RenderTarget& window, sf::Vector2f position, float scale, float rotation, bool longRange)
 {
 }
 
-void SpaceObject::drawOnGMRadar(sf::RenderTarget& window, sf::Vector2f position, float scale, bool longRange)
+void SpaceObject::drawOnGMRadar(sf::RenderTarget& window, sf::Vector2f position, float scale, float rotation, bool longRange)
 {
 }
 

--- a/src/spaceObjects/spaceObject.h
+++ b/src/spaceObjects/spaceObject.h
@@ -166,8 +166,8 @@ public:
     virtual void draw3D();
     virtual void draw3DTransparent() {}
 #endif//FEATURE_3D_RENDERING
-    virtual void drawOnRadar(sf::RenderTarget& window, sf::Vector2f position, float scale, bool longRange);
-    virtual void drawOnGMRadar(sf::RenderTarget& window, sf::Vector2f position, float scale, bool longRange);
+    virtual void drawOnRadar(sf::RenderTarget& window, sf::Vector2f position, float scale, float rotation, bool longRange);
+    virtual void drawOnGMRadar(sf::RenderTarget& window, sf::Vector2f position, float scale, float rotation, bool longRange);
     virtual void destroy();
 
     virtual void setCallSign(string new_callsign) { callsign = new_callsign; }

--- a/src/spaceObjects/spaceStation.cpp
+++ b/src/spaceObjects/spaceStation.cpp
@@ -25,7 +25,7 @@ SpaceStation::SpaceStation()
     callsign = "DS" + string(getMultiplayerId());
 }
 
-void SpaceStation::drawOnRadar(sf::RenderTarget& window, sf::Vector2f position, float scale, bool long_range)
+void SpaceStation::drawOnRadar(sf::RenderTarget& window, sf::Vector2f position, float scale, float rotation, bool long_range)
 {
     sf::Sprite objectSprite;
     textureManager.setTexture(objectSprite, radar_trace);

--- a/src/spaceObjects/spaceStation.cpp
+++ b/src/spaceObjects/spaceStation.cpp
@@ -35,7 +35,7 @@ void SpaceStation::drawOnRadar(sf::RenderTarget& window, sf::Vector2f position, 
     if (!long_range)
     {
         sprite_scale *= 0.7;
-        drawShieldsOnRadar(window, position, scale, sprite_scale, true);
+        drawShieldsOnRadar(window, position, scale, rotation, sprite_scale, true);
     }
     sprite_scale = std::max(0.15f, sprite_scale);
     objectSprite.setScale(sprite_scale, sprite_scale);

--- a/src/spaceObjects/spaceStation.h
+++ b/src/spaceObjects/spaceStation.h
@@ -8,7 +8,7 @@ class SpaceStation : public ShipTemplateBasedObject
 public:
     SpaceStation();
     
-    virtual void drawOnRadar(sf::RenderTarget& window, sf::Vector2f position, float scale, bool long_range);
+    virtual void drawOnRadar(sf::RenderTarget& window, sf::Vector2f position, float scale, float rotation, bool long_range);
     virtual bool canBeDockedBy(P<SpaceObject> obj);
     virtual void destroyedByDamage(DamageInfo& info);
     virtual void applyTemplateValues();

--- a/src/spaceObjects/spaceship.cpp
+++ b/src/spaceObjects/spaceship.cpp
@@ -452,10 +452,10 @@ void SpaceShip::drawOnRadar(sf::RenderTarget& window, sf::Vector2f position, flo
         if (!my_spaceship || getScannedStateFor(my_spaceship) >= SS_SimpleScan)
         {
             // ... draw and show shield indicators on our radar.
-            drawShieldsOnRadar(window, position, scale, 1.0, true);
+            drawShieldsOnRadar(window, position, scale, rotation, 1.0, true);
         } else {
             // Otherwise, draw the indicators, but don't show them.
-            drawShieldsOnRadar(window, position, scale, 1.0, false);
+            drawShieldsOnRadar(window, position, scale, rotation, 1.0, false);
         }
     }
 

--- a/src/spaceObjects/spaceship.cpp
+++ b/src/spaceObjects/spaceship.cpp
@@ -347,7 +347,7 @@ RawRadarSignatureInfo SpaceShip::getDynamicRadarSignatureInfo()
     return info;
 }
 
-void SpaceShip::drawOnRadar(sf::RenderTarget& window, sf::Vector2f position, float scale, bool long_range)
+void SpaceShip::drawOnRadar(sf::RenderTarget& window, sf::Vector2f position, float scale, float rotation, bool long_range)
 {
     // Draw beam arcs on short-range radar only, and only for fully scanned
     // ships.
@@ -375,7 +375,7 @@ void SpaceShip::drawOnRadar(sf::RenderTarget& window, sf::Vector2f position, flo
 
             // Set the beam's origin on radar to its relative position on the
             // mesh.
-            sf::Vector2f beam_offset = sf::rotateVector(ship_template->model_data->getBeamPosition2D(n) * scale, getRotation());
+            sf::Vector2f beam_offset = sf::rotateVector(ship_template->model_data->getBeamPosition2D(n) * scale, getRotation()-rotation);
 
             // Configure an array to hold each point of the arc. Each point in
             // the array draws a line to the next point. If the color between
@@ -390,13 +390,13 @@ void SpaceShip::drawOnRadar(sf::RenderTarget& window, sf::Vector2f position, flo
             a[0].position = beam_offset + position;
 
             // Draw the beam's left bound.
-            a[1].position = beam_offset + position + sf::vector2FromAngle(getRotation() + (beam_direction + beam_arc / 2.0f)) * beam_range * scale;
-            a[2].position = beam_offset + position + sf::vector2FromAngle(getRotation() + (beam_direction + beam_arc / 2.0f)) * beam_range * scale * 1.3f;
+            a[1].position = beam_offset + position + sf::vector2FromAngle(getRotation()-rotation + (beam_direction + beam_arc / 2.0f)) * beam_range * scale;
+            a[2].position = beam_offset + position + sf::vector2FromAngle(getRotation()-rotation + (beam_direction + beam_arc / 2.0f)) * beam_range * scale * 1.3f;
             window.draw(a);
 
             // Draw the beam's right bound.
-            a[1].position = beam_offset + position + sf::vector2FromAngle(getRotation() + (beam_direction - beam_arc / 2.0f)) * beam_range * scale;
-            a[2].position = beam_offset + position + sf::vector2FromAngle(getRotation() + (beam_direction - beam_arc / 2.0f)) * beam_range * scale * 1.3f;
+            a[1].position = beam_offset + position + sf::vector2FromAngle(getRotation()-rotation + (beam_direction - beam_arc / 2.0f)) * beam_range * scale;
+            a[2].position = beam_offset + position + sf::vector2FromAngle(getRotation()-rotation + (beam_direction - beam_arc / 2.0f)) * beam_range * scale * 1.3f;
             window.draw(a);
 
             // Draw the beam's arc.
@@ -405,9 +405,9 @@ void SpaceShip::drawOnRadar(sf::RenderTarget& window, sf::Vector2f position, flo
             for(int i=0; i<arcPoints; i++)
             {
                 arc_line[i].color = color;
-                arc_line[i].position = beam_offset + position + sf::vector2FromAngle(getRotation() + (beam_direction - beam_arc / 2.0f + 10 * i)) * beam_range * scale;
+                arc_line[i].position = beam_offset + position + sf::vector2FromAngle(getRotation()-rotation + (beam_direction - beam_arc / 2.0f + 10 * i)) * beam_range * scale;
             }
-            arc_line[arcPoints-1].position = beam_offset + position + sf::vector2FromAngle(getRotation() + (beam_direction + beam_arc / 2.0f)) * beam_range * scale;
+            arc_line[arcPoints-1].position = beam_offset + position + sf::vector2FromAngle(getRotation()-rotation + (beam_direction + beam_arc / 2.0f)) * beam_range * scale;
             window.draw(arc_line);
 
             // If the beam is turreted, draw the turret's arc. Otherwise, exit.
@@ -423,13 +423,13 @@ void SpaceShip::drawOnRadar(sf::RenderTarget& window, sf::Vector2f position, flo
             a[1].color = sf::Color(color.r, color.g, color.b, color.a / 2);
 
             // Draw the turret's left bound. (We're reusing the beam's origin.)
-            a[1].position = beam_offset + position + sf::vector2FromAngle(getRotation() + (turret_direction + turret_arc / 2.0f)) * beam_range * scale;
-            a[2].position = beam_offset + position + sf::vector2FromAngle(getRotation() + (turret_direction + turret_arc / 2.0f)) * beam_range * scale * 1.3f;
+            a[1].position = beam_offset + position + sf::vector2FromAngle(getRotation()-rotation + (turret_direction + turret_arc / 2.0f)) * beam_range * scale;
+            a[2].position = beam_offset + position + sf::vector2FromAngle(getRotation()-rotation + (turret_direction + turret_arc / 2.0f)) * beam_range * scale * 1.3f;
             window.draw(a);
 
             // Draw the turret's right bound.
-            a[1].position = beam_offset + position + sf::vector2FromAngle(getRotation() + (turret_direction - turret_arc / 2.0f)) * beam_range * scale;
-            a[2].position = beam_offset + position + sf::vector2FromAngle(getRotation() + (turret_direction - turret_arc / 2.0f)) * beam_range * scale * 1.3f;
+            a[1].position = beam_offset + position + sf::vector2FromAngle(getRotation()-rotation + (turret_direction - turret_arc / 2.0f)) * beam_range * scale;
+            a[2].position = beam_offset + position + sf::vector2FromAngle(getRotation()-rotation + (turret_direction - turret_arc / 2.0f)) * beam_range * scale * 1.3f;
             window.draw(a);
 
             // Draw the turret's arc.
@@ -438,9 +438,9 @@ void SpaceShip::drawOnRadar(sf::RenderTarget& window, sf::Vector2f position, flo
             for(int i = 0; i < turret_points; i++)
             {
                 turret_line[i].color = sf::Color(color.r, color.g, color.b, color.a / 2);
-                turret_line[i].position = beam_offset + position + sf::vector2FromAngle(getRotation() + (turret_direction - turret_arc / 2.0f + 10 * i)) * beam_range * scale;
+                turret_line[i].position = beam_offset + position + sf::vector2FromAngle(getRotation()-rotation + (turret_direction - turret_arc / 2.0f + 10 * i)) * beam_range * scale;
             }
-            turret_line[turret_points-1].position = beam_offset + position + sf::vector2FromAngle(getRotation() + (turret_direction + turret_arc / 2.0f)) * beam_range * scale;
+            turret_line[turret_points-1].position = beam_offset + position + sf::vector2FromAngle(getRotation()-rotation + (turret_direction + turret_arc / 2.0f)) * beam_range * scale;
             window.draw(turret_line);
         }
     }
@@ -473,7 +473,7 @@ void SpaceShip::drawOnRadar(sf::RenderTarget& window, sf::Vector2f position, flo
         textureManager.setTexture(objectSprite, radar_trace);
     }
 
-    objectSprite.setRotation(getRotation());
+    objectSprite.setRotation(getRotation()-rotation);
     objectSprite.setPosition(position);
     if (long_range)
     {
@@ -501,7 +501,7 @@ void SpaceShip::drawOnRadar(sf::RenderTarget& window, sf::Vector2f position, flo
     window.draw(objectSprite);
 }
 
-void SpaceShip::drawOnGMRadar(sf::RenderTarget& window, sf::Vector2f position, float scale, bool long_range)
+void SpaceShip::drawOnGMRadar(sf::RenderTarget& window, sf::Vector2f position, float scale, float rotation, bool long_range)
 {
     if (!long_range)
     {

--- a/src/spaceObjects/spaceship.h
+++ b/src/spaceObjects/spaceship.h
@@ -191,8 +191,8 @@ public:
     /*!
      * Draw this ship on the radar.
      */
-    virtual void drawOnRadar(sf::RenderTarget& window, sf::Vector2f position, float scale, bool long_range) override;
-    virtual void drawOnGMRadar(sf::RenderTarget& window, sf::Vector2f position, float scale, bool long_range) override;
+    virtual void drawOnRadar(sf::RenderTarget& window, sf::Vector2f position, float scale, float rotation, bool long_range) override;
+    virtual void drawOnGMRadar(sf::RenderTarget& window, sf::Vector2f position, float scale, float rotation, bool long_range) override;
 
     virtual void update(float delta) override;
     virtual float getShieldRechargeRate(int shield_index) override;

--- a/src/spaceObjects/supplyDrop.cpp
+++ b/src/spaceObjects/supplyDrop.cpp
@@ -28,7 +28,7 @@ SupplyDrop::SupplyDrop()
     model_info.setData("ammo_box");
 }
 
-void SupplyDrop::drawOnRadar(sf::RenderTarget& window, sf::Vector2f position, float scale, bool long_range)
+void SupplyDrop::drawOnRadar(sf::RenderTarget& window, sf::Vector2f position, float scale, float rotation, bool long_range)
 {
     sf::Sprite object_sprite;
     textureManager.setTexture(object_sprite, "RadarBlip.png");

--- a/src/spaceObjects/supplyDrop.h
+++ b/src/spaceObjects/supplyDrop.h
@@ -14,7 +14,7 @@ public:
 
     SupplyDrop();
 
-    virtual void drawOnRadar(sf::RenderTarget& window, sf::Vector2f position, float scale, bool long_range) override;
+    virtual void drawOnRadar(sf::RenderTarget& window, sf::Vector2f position, float scale, float rotation, bool long_range) override;
 
     virtual void collide(Collisionable* target, float force) override;
 

--- a/src/spaceObjects/warpJammer.cpp
+++ b/src/spaceObjects/warpJammer.cpp
@@ -34,7 +34,7 @@ WarpJammer::WarpJammer()
     model_info.setData("shield_generator");
 }
 
-void WarpJammer::drawOnRadar(sf::RenderTarget& window, sf::Vector2f position, float scale, bool long_range)
+void WarpJammer::drawOnRadar(sf::RenderTarget& window, sf::Vector2f position, float scale, float rotation, bool long_range)
 {
     sf::Sprite object_sprite;
     textureManager.setTexture(object_sprite, "RadarBlip.png");

--- a/src/spaceObjects/warpJammer.h
+++ b/src/spaceObjects/warpJammer.h
@@ -17,7 +17,7 @@ public:
     
     void setRange(float range) { this->range = range; }
 
-    virtual void drawOnRadar(sf::RenderTarget& window, sf::Vector2f position, float scale, bool long_range) override;
+    virtual void drawOnRadar(sf::RenderTarget& window, sf::Vector2f position, float scale, float rotation, bool long_range) override;
 
     virtual bool canBeTargetedBy(P<SpaceObject> other)  override { return true; }
     virtual void takeDamage(float damage_amount, DamageInfo info) override;

--- a/src/spaceObjects/wormHole.cpp
+++ b/src/spaceObjects/wormHole.cpp
@@ -81,7 +81,7 @@ void WormHole::draw3DTransparent()
 #endif//FEATURE_3D_RENDERING
 
 
-void WormHole::drawOnRadar(sf::RenderTarget& window, sf::Vector2f position, float scale, bool long_range)
+void WormHole::drawOnRadar(sf::RenderTarget& window, sf::Vector2f position, float scale, float rotation, bool long_range)
 {
     sf::Sprite object_sprite;
     textureManager.setTexture(object_sprite, "wormHole" + string(radar_visual) + ".png");
@@ -94,7 +94,7 @@ void WormHole::drawOnRadar(sf::RenderTarget& window, sf::Vector2f position, floa
 }
 
 // Draw a line toward the target position
-void WormHole::drawOnGMRadar(sf::RenderTarget& window, sf::Vector2f position, float scale, bool long_range)
+void WormHole::drawOnGMRadar(sf::RenderTarget& window, sf::Vector2f position, float scale, float rotation, bool long_range)
 {    
     sf::VertexArray a(sf::Lines, 2);
     a[0].position = position;

--- a/src/spaceObjects/wormHole.h
+++ b/src/spaceObjects/wormHole.h
@@ -22,8 +22,8 @@ public:
 #if FEATURE_3D_RENDERING
     virtual void draw3DTransparent() override;
 #endif//FEATURE_3D_RENDERING
-    virtual void drawOnRadar(sf::RenderTarget& window, sf::Vector2f position, float scale, bool long_range) override;
-    virtual void drawOnGMRadar(sf::RenderTarget& window, sf::Vector2f position, float scale, bool long_range) override;
+    virtual void drawOnRadar(sf::RenderTarget& window, sf::Vector2f position, float scale, float rotation, bool long_range) override;
+    virtual void drawOnGMRadar(sf::RenderTarget& window, sf::Vector2f position, float scale, float rotation, bool long_range) override;
     virtual void update(float delta) override;
     virtual void collide(Collisionable* target, float force) override;
     

--- a/src/spaceObjects/zone.cpp
+++ b/src/spaceObjects/zone.cpp
@@ -31,7 +31,7 @@ Zone::Zone()
     registerMemberReplication(&label);
 }
 
-void Zone::drawOnRadar(sf::RenderTarget& window, sf::Vector2f position, float scale, bool long_range)
+void Zone::drawOnRadar(sf::RenderTarget& window, sf::Vector2f position, float scale, float rotation, bool long_range)
 {
     if (!long_range || color.a == 0)
         return;
@@ -67,12 +67,12 @@ void Zone::drawOnRadar(sf::RenderTarget& window, sf::Vector2f position, float sc
     }
 }
 
-void Zone::drawOnGMRadar(sf::RenderTarget& window, sf::Vector2f position, float scale, bool long_range)
+void Zone::drawOnGMRadar(sf::RenderTarget& window, sf::Vector2f position, float scale, float rotation, bool long_range)
 {
     if (long_range && color.a == 0)
     {
         color.a = 255;
-        drawOnRadar(window, position, scale, long_range);
+        drawOnRadar(window, position, scale, rotation, long_range);
         color.a = 0;
     }
 }

--- a/src/spaceObjects/zone.h
+++ b/src/spaceObjects/zone.h
@@ -8,8 +8,8 @@ class Zone : public SpaceObject
 public:
     Zone();
 
-    virtual void drawOnRadar(sf::RenderTarget& window, sf::Vector2f position, float scale, bool long_range) override;
-    virtual void drawOnGMRadar(sf::RenderTarget& window, sf::Vector2f position, float scale, bool long_range) override;
+    virtual void drawOnRadar(sf::RenderTarget& window, sf::Vector2f position, float scale, float rotation, bool long_range) override;
+    virtual void drawOnGMRadar(sf::RenderTarget& window, sf::Vector2f position, float scale, float rotation, bool long_range) override;
 
     virtual bool canHideInNebula()  override { return false; }
 


### PR DESCRIPTION
`RadarView` `view_position` now has a twin `view_rotation`.

`SpaceObject`'s render to radar functions now take a rotation argument as well.

Most of the draw functions in `RadarView` now  use the preexisting but updated `worldToScreen` function rather than calculating the position individually.  It may be appropriate to have `radar_screen_center` and `scale` be member variables since they are used all over the place so they do not need to be recalculated all the time.

The options for whether to radar lock are in the options menu.  I also added a save button to the options menu so that players are not annoyed that they have to reset the options every-time.