### PR TITLE
Cast integer in Engineering crew ID to string

### DIFF
--- a/src/screenComponents/shipInternalView.cpp
+++ b/src/screenComponents/shipInternalView.cpp
@@ -72,10 +72,10 @@ void GuiShipInternalView::onDraw(sf::RenderTarget& window)
                 c->destroy();
             crew_list.clear();
 
-            foreach(RepairCrew, rc, crew)
+            for(P<RepairCrew> rc : crew)
             {
                 int id = rc->getMultiplayerId();
-                crew_list.push_back(new GuiShipCrew(room_container, id + "_CREW", rc, [this](P<RepairCrew> crew_member){
+                crew_list.push_back(new GuiShipCrew(room_container, std::to_string(id) + "_CREW", rc, [this](P<RepairCrew> crew_member){
                     if (selected_crew_member)
                         selected_crew_member->selected = false;
                     selected_crew_member = crew_member;


### PR DESCRIPTION
When compiling, these lines would throw a -Wstring-plus-int warning:

```
/Users/gguillotte/git/EmptyEpsilon-build-scripts/EmptyEpsilon/src/screenComponents/shipInternalView.cpp:81:72: warning:
      adding 'int' to a string does not append to the string [-Wstring-plus-int]
                crew_list.push_back(new GuiShipCrew(room_container, id + "_CREW", rc, [this](P<RepairCrew> c...
                                                                    ~~~^~~~~~~~~
/Users/gguillotte/git/EmptyEpsilon-build-scripts/EmptyEpsilon/src/screenComponents/shipInternalView.cpp:81:72: note:
      use array indexing to silence this warning
```

However, the game would crash upon entering the Engineering station of a ship
with a `terminating with uncaught exception of type std::length_error:
basic_string` error.

```
10  libc++.1.dylib                    0x00007fff68b5a290 std::__1::__basic_string_common<true>::__throw_length_error() const + 16
11                                    0x0000000102430951 GuiShipInternalView::onDraw(sf::RenderTarget&) + 1601
12                                    0x00000001024b45a1 GuiContainer::drawElements(sf::Rect<float>, sf::RenderTarget&) + 353
13                                    0x00000001024b45b9 GuiContainer::drawElements(sf::Rect<float>, sf::RenderTarget&) + 377
14                                    0x00000001024b45b9 GuiContainer::drawElements(sf::Rect<float>, sf::RenderTarget&) + 377
15                                    0x00000001024b45b9 GuiContainer::drawElements(sf::Rect<float>, sf::RenderTarget&) + 377
16                                    0x00000001024a37be GuiCanvas::render(sf::RenderTarget&) + 78
```

Stepping through with a debugger would catch the failure occurring during this
`foreach(RepairCrew, rc, crew)` loop.

After casting the `id` to a string, the game no longer crashes.