### PR TITLE
[WIP] Controllable main camera angle

### DIFF
--- a/src/screenComponents/viewport3d.cpp
+++ b/src/screenComponents/viewport3d.cpp
@@ -26,6 +26,7 @@ GuiViewport3D::GuiViewport3D(GuiContainer* owner, string id)
     show_callsigns = false;
     show_headings = false;
     show_spacedust = false;
+    camera_fov = 60.0f;
 }
 
 void GuiViewport3D::onDraw(sf::RenderTarget& window)
@@ -39,7 +40,6 @@ void GuiViewport3D::onDraw(sf::RenderTarget& window)
 
     ShaderManager::getShader("billboardShader")->setUniform("camera_position", camera_position);
 
-    float camera_fov = 60.0f;
     float sx = window.getSize().x * window.getView().getViewport().width / window.getView().getSize().x;
     float sy = window.getSize().y * window.getView().getViewport().height / window.getView().getSize().y;
     glViewport(rect.left * sx, (float(window.getView().getSize().y) - rect.height - rect.top) * sx, rect.width * sx, rect.height * sy);
@@ -287,7 +287,7 @@ void GuiViewport3D::onDraw(sf::RenderTarget& window)
     foreach(SpaceObject, obj, space_object_list)
     {
         glPushMatrix();
-        glTranslatef(-camera_position.x,-camera_position.y, -camera_position.z);
+        glTranslatef(-camera_position.x, -camera_position.y, -camera_position.z);
         glTranslatef(obj->getPosition().x, obj->getPosition().y, 0);
         glRotatef(obj->getRotation(), 0, 0, 1);
 

--- a/src/screenComponents/viewport3d.h
+++ b/src/screenComponents/viewport3d.h
@@ -9,6 +9,8 @@ class GuiViewport3D : public GuiElement
     bool show_headings;
     bool show_spacedust;
 
+    float camera_fov;
+
     double projection_matrix[16];
     double model_matrix[16];
     double viewport[4];
@@ -16,6 +18,7 @@ public:
     GuiViewport3D(GuiContainer* owner, string id);
 
     virtual void onDraw(sf::RenderTarget& window);
+    virtual void setCameraFOV(float fov) { camera_fov = fov; }
 
     GuiViewport3D* showCallsigns() { show_callsigns = true; return this; }
     GuiViewport3D* showHeadings() { show_headings = true; return this; }

--- a/src/screens/mainScreen.cpp
+++ b/src/screens/mainScreen.cpp
@@ -19,14 +19,18 @@
 
 ScreenMainScreen::ScreenMainScreen()
 {
+    // Initialize a black background.
     new GuiOverlay(this, "", sf::Color::Black);
 
+    // Build the 3D viewport.
     viewport = new GuiViewport3D(this, "VIEWPORT");
     viewport->showCallsigns()->showHeadings()->showSpacedust();
     viewport->setPosition(0, 0, ATopLeft)->setSize(GuiElement::GuiSizeMax, GuiElement::GuiSizeMax);
-    
+
+    // Build, style, size, and position the mini short-range radar view.
     (new GuiRadarView(viewport, "VIEWPORT_RADAR", nullptr))->setStyle(GuiRadarView::CircularMasked)->setSize(200, 200)->setPosition(-20, 20, ATopRight);
-    
+
+    // Build radar views for full-screen short- and long-range radars.
     tactical_radar = new GuiRadarView(this, "TACTICAL", nullptr);
     tactical_radar->setPosition(0, 0, ATopLeft)->setSize(GuiElement::GuiSizeMax, GuiElement::GuiSizeMax);
     tactical_radar->setRangeIndicatorStepSize(1000.0f)->shortRange()->enableCallsigns()->hide();
@@ -34,16 +38,19 @@ ScreenMainScreen::ScreenMainScreen()
     long_range_radar->setPosition(0, 0, ATopLeft)->setSize(GuiElement::GuiSizeMax, GuiElement::GuiSizeMax);
     long_range_radar->setRangeIndicatorStepSize(5000.0f)->longRange()->enableCallsigns()->hide();
     long_range_radar->setFogOfWarStyle(GuiRadarView::NebulaFogOfWar);
+
+    // Initialize and hide the onscreen comms overlay.
     onscreen_comms = new GuiCommsOverlay(this);
     onscreen_comms->setSize(GuiElement::GuiSizeMax, GuiElement::GuiSizeMax)->setVisible(false);
 
-    new GuiShipDestroyedPopup(this);
-    
+    // Initialize indicator and message overlays.
+    new GuiShipDestroyedPopup(this);    
     new GuiJumpIndicator(this);
     new GuiSelfDestructIndicator(this);
     new GuiGlobalMessage(this);
     new GuiIndicatorOverlays(this);
 
+    // Add general keyboard shortcut help.
     keyboard_help = new GuiHelpOverlay(this, "Keyboard Shortcuts");
 
     for (std::pair<string, string> shortcut : hotkeys.listHotkeysByCategory("Main Screen"))
@@ -51,6 +58,8 @@ ScreenMainScreen::ScreenMainScreen()
 
     keyboard_help->setText(keyboard_general);
 
+    // If music is not disabled in preferences, play it based on our ship's
+    // current threat level.
     if (PreferencesManager::get("music_enabled") != "0")
     {
         threat_estimate = new ThreatLevelEstimate();
@@ -63,11 +72,13 @@ ScreenMainScreen::ScreenMainScreen()
         });
     }
 
-    first_person = PreferencesManager::get("first_person") == "1";
+    // Determine whether to start in first-person view from user preferences.
+    first_person = PreferencesManager::get("first_person", "0") == "1";
 }
 
 void ScreenMainScreen::update(float delta)
 {
+    // If we disconnected, stop audio, destroy the screen, and return to main.
     if (game_client && game_client->getStatus() == GameClient::Disconnected)
     {
         soundManager->stopMusic();
@@ -80,14 +91,23 @@ void ScreenMainScreen::update(float delta)
 
     if (my_spaceship)
     {
+        // Remember our ship's current weapons target.
         P<SpaceObject> target_ship = my_spaceship->getTarget();
+
+        // Set the initial camera yaw (direction) to our ship's current facing.
         float target_camera_yaw = my_spaceship->getRotation();
+
+        // Turn the camera based on the current main screen setting.
+        // Each direction is relative to our ship's current facing.
+        // Negative values turn the camera to the left, positive to the right.
         switch(my_spaceship->main_screen_setting)
         {
         case MSS_Back: target_camera_yaw += 180; break;
         case MSS_Left: target_camera_yaw -= 90; break;
         case MSS_Right: target_camera_yaw += 90; break;
         case MSS_Target:
+            // If our ship has a weapons target, calculate the angle required
+            // to turn the camera toward it.
             if (target_ship)
             {
                 sf::Vector2f target_camera_diff = my_spaceship->getPosition() - target_ship->getPosition();
@@ -96,19 +116,36 @@ void ScreenMainScreen::update(float delta)
             break;
         default: break;
         }
-        camera_pitch = 30.0f;
 
-        float camera_ship_distance = 420.0f;
-        float camera_ship_height = 420.0f;
+        // Initialize the camera position.
+        float camera_ship_distance;
+        float camera_ship_height;
+
         if (first_person)
         {
+            // Set first-person camera position by moving it to the front of
+            // its radius (-getRadius) and proportionally slightly elevated.
+            // The proportion is based on a naive assumption that ships tend to
+            // be about 1/10 as tall as their 2D (length/width) radius.
             camera_ship_distance = -my_spaceship->getRadius();
             camera_ship_height = my_spaceship->getRadius() / 10.f;
             camera_pitch = 0;
+        } else {
+            // By default, place the camera 420m behind and above the ship and
+            // point it downward 30 degrees.
+            camera_ship_distance = 420.0f;
+            camera_ship_height = 420.0f;
+            camera_pitch = 30.0f;
         }
+
+        // 2D position is used to calculate the camera's target position based
+        // on its coordinates on the 2D playing field and its height.
         sf::Vector2f cameraPosition2D = my_spaceship->getPosition() + sf::vector2FromAngle(target_camera_yaw) * -camera_ship_distance;
         sf::Vector3f targetCameraPosition(cameraPosition2D.x, cameraPosition2D.y, camera_ship_height);
+
 #ifdef DEBUG
+        // Debug mode view turns the camera into a top-dow view over our ship's
+        // position for as long as main screen holds down the Z key.
         if (sf::Keyboard::isKeyPressed(sf::Keyboard::Z))
         {
             targetCameraPosition.x = my_spaceship->getPosition().x;
@@ -117,17 +154,22 @@ void ScreenMainScreen::update(float delta)
             camera_pitch = 90.0f;
         }
 #endif
+
         if (first_person)
         {
+            // Reposition and redirect the first-person camera and direction to
+            // point at the calculated target position.
             camera_position = targetCameraPosition;
             camera_yaw = target_camera_yaw;
-        }
-        else
-        {
+        } else {
+            // By default, reposition the camera to facter in the target
+            // position, and rotate the camera horizontally to follow it.
             camera_position = camera_position * 0.9f + targetCameraPosition * 0.1f;
             camera_yaw += sf::angleDifference(camera_yaw, target_camera_yaw) * 0.1f;
         }
 
+        // Determine main screen state. Only one state should be active at a
+        // time.
         switch(my_spaceship->main_screen_setting)
         {
         case MSS_Front:
@@ -149,8 +191,14 @@ void ScreenMainScreen::update(float delta)
             tactical_radar->hide();
             long_range_radar->show();
             break;
+        default:
+            viewport->show();
+            tactical_radar->hide();
+            long_range_radar->hide();
+            break;
         }
 
+        // Determine whether to show any overlays on the main screen.
         switch(my_spaceship->main_screen_overlay)
         {
         case MSO_ShowComms:
@@ -158,6 +206,10 @@ void ScreenMainScreen::update(float delta)
             onscreen_comms->show();
             break;
         case MSO_HideComms:
+            onscreen_comms->clearElements();
+            onscreen_comms->hide();
+            break;
+        default:
             onscreen_comms->clearElements();
             onscreen_comms->hide();
             break;
@@ -185,7 +237,6 @@ void ScreenMainScreen::update(float delta)
             // TODO: Play an engine failure sound.
             impulse_sound = -1;
         }
-
     }
 }
 
@@ -194,6 +245,8 @@ void ScreenMainScreen::onClick(sf::Vector2f mouse_position)
     if (!my_spaceship)
         return;
     
+    // Rotate the view to the left on left click, and to the right on right
+    // click. Default to forward view.
     if (InputHandler::mouseIsPressed(sf::Mouse::Left))
     {
         switch(my_spaceship->main_screen_setting)
@@ -216,10 +269,13 @@ void ScreenMainScreen::onClick(sf::Vector2f mouse_position)
         default: my_spaceship->commandMainScreenSetting(MSS_Front); break;
         }
     }
+
+    // Cycle main screen states on middle click.
     if (InputHandler::mouseIsPressed(sf::Mouse::Middle))
     {
         switch(my_spaceship->main_screen_setting)
         {
+        // Default to tactical first unless it's prohibited by server settings.
         default:
             if (gameGlobalInfo->allow_main_screen_tactical_radar)
                 my_spaceship->commandMainScreenSetting(MSS_Tactical);
@@ -240,6 +296,7 @@ void ScreenMainScreen::onClick(sf::Vector2f mouse_position)
 
 void ScreenMainScreen::onHotkey(const HotkeyResult& key)
 {
+    // Set configurable hotkey behaviors.
     if (key.category == "MAIN_SCREEN" && my_spaceship)
     {
         if (key.hotkey == "VIEW_FORWARD")
@@ -263,11 +320,13 @@ void ScreenMainScreen::onHotkey(const HotkeyResult& key)
 
 void ScreenMainScreen::onKey(sf::Event::KeyEvent key, int unicode)
 {
+    // Set non-configurable hotkey behavior.
     switch (key.code)
     {
     //TODO: This is more generic code and is duplicated.
     case sf::Keyboard::Escape:
     case sf::Keyboard::Home:
+        // Exit the view and return to ship selection.
         soundManager->stopMusic();
         soundManager->stopSound(impulse_sound);
         destroy();
@@ -279,6 +338,7 @@ void ScreenMainScreen::onKey(sf::Event::KeyEvent key, int unicode)
         keyboard_help->frame->setVisible(!keyboard_help->frame->isVisible());
         break;
     case sf::Keyboard::P:
+        // Pause the game
         if (game_server)
             engine->setGameSpeed(0.0);
         break;

--- a/src/screens/mainScreen.cpp
+++ b/src/screens/mainScreen.cpp
@@ -52,6 +52,7 @@ ScreenMainScreen::ScreenMainScreen()
 
     // Add general keyboard shortcut help.
     keyboard_help = new GuiHelpOverlay(this, "Keyboard Shortcuts");
+    keyboard_general = "";
 
     for (std::pair<string, string> shortcut : hotkeys.listHotkeysByCategory("Main Screen"))
         keyboard_general += shortcut.second + ":\t" + shortcut.first + "\n";
@@ -94,6 +95,9 @@ void ScreenMainScreen::update(float delta)
         // Remember our ship's current weapons target.
         P<SpaceObject> target_ship = my_spaceship->getTarget();
 
+        float camera_ship_distance = 0.0f;
+        float camera_ship_height = 0.0f;
+
         // Set the initial camera yaw (direction) to our ship's current facing.
         float target_camera_yaw = my_spaceship->getRotation();
 
@@ -117,9 +121,10 @@ void ScreenMainScreen::update(float delta)
         default: break;
         }
 
-        // Initialize the camera position.
-        float camera_ship_distance;
-        float camera_ship_height;
+        // Bound mods
+        camera_ship_distance_modifier = std::min(200.0f, std::max(-100.0f, camera_ship_distance_modifier));
+        camera_ship_height_modifier = std::min(200.0f, std::max(-100.0f, camera_ship_height_modifier));
+        camera_pitch_modifier = std::min(20.0f, std::max(-20.0f, camera_pitch_modifier));
 
         if (first_person)
         {
@@ -127,15 +132,15 @@ void ScreenMainScreen::update(float delta)
             // its radius (-getRadius) and proportionally slightly elevated.
             // The proportion is based on a naive assumption that ships tend to
             // be about 1/10 as tall as their 2D (length/width) radius.
-            camera_ship_distance = -my_spaceship->getRadius();
-            camera_ship_height = my_spaceship->getRadius() / 10.f;
-            camera_pitch = 0;
+            camera_ship_distance = camera_ship_distance_modifier - my_spaceship->getRadius();
+            camera_ship_height = camera_ship_height_modifier + (my_spaceship->getRadius() / 10.f);
+            camera_pitch = camera_pitch_modifier + 0;
         } else {
             // By default, place the camera 420m behind and above the ship and
             // point it downward 30 degrees.
-            camera_ship_distance = 420.0f;
-            camera_ship_height = 420.0f;
-            camera_pitch = 30.0f;
+            camera_ship_distance = camera_ship_distance_modifier + 420.0f;
+            camera_ship_height = camera_ship_height_modifier + 420.0f;
+            camera_pitch = camera_pitch_modifier + 30.0f;
         }
 
         // 2D position is used to calculate the camera's target position based
@@ -331,6 +336,18 @@ void ScreenMainScreen::onKey(sf::Event::KeyEvent key, int unicode)
         soundManager->stopSound(impulse_sound);
         destroy();
         returnToShipSelection();
+        break;
+    case sf::Keyboard::E:
+        camera_ship_height_modifier += 10.0f;
+        break;
+    case sf::Keyboard::D:
+        camera_ship_height_modifier -= 10.0f;
+        break;
+    case sf::Keyboard::W:
+        camera_pitch_modifier -= 5.0f;
+        break;
+    case sf::Keyboard::S:
+        camera_pitch_modifier += 5.0f;
         break;
     case sf::Keyboard::Slash:
     case sf::Keyboard::F1:

--- a/src/screens/mainScreen.h
+++ b/src/screens/mainScreen.h
@@ -17,11 +17,15 @@ class ScreenMainScreen : public GuiCanvas, public Updatable
 private:
     GuiViewport3D* viewport;
     GuiHelpOverlay* keyboard_help;
-    string keyboard_general = "";
+    string keyboard_general;
     GuiRadarView* tactical_radar;
     GuiRadarView* long_range_radar;
     bool first_person;
     GuiCommsOverlay* onscreen_comms;
+    float camera_ship_distance_modifier;
+    float camera_ship_height_modifier;
+    float camera_pitch_modifier;
+
     int impulse_sound = -1;
 public:
     ScreenMainScreen();


### PR DESCRIPTION
Allow changing the main screen camera's height relative to its ship and its pitch.

Neither the input method nor the behavior feels right. The more I poke this, the more it seems like the camera should be an object of its own with its own functions, instead of being sort of universal and controlled by modifying main-scope variables.

Keys used are W/S (pitch up/down) and E/D (raise/lower), which don't align with the cinematic view controls of Up/Down and R/F respectively; those conflict with the existing main screen controls.