### PR TITLE
Add missing tactical radar lock handling.

### DIFF
--- a/src/menus/optionsMenu.cpp
+++ b/src/menus/optionsMenu.cpp
@@ -110,6 +110,7 @@ OptionsMenu::OptionsMenu()
     (new GuiToggleButton(this, "HEMS_RADAR_LOCK", tr("Helms Radar Lock"), [](bool value)
     {
         PreferencesManager::set("helms_radar_lock", value?"1":"");
+        PreferencesManager::set("tactical_radar_lock", value?"1":"");
     }))->setValue(PreferencesManager::get("helms_radar_lock","0")=="1")->setPosition(50, top, ATopLeft)->setSize(300, 50);
 
     // Helms rotation lock.

--- a/src/screens/crew4/tacticalScreen.cpp
+++ b/src/screens/crew4/tacticalScreen.cpp
@@ -2,6 +2,7 @@
 #include "gameGlobalInfo.h"
 #include "spaceObjects/playerSpaceship.h"
 #include "tacticalScreen.h"
+#include "preferenceManager.h"
 
 #include "screenComponents/combatManeuver.h"
 #include "screenComponents/radarView.h"
@@ -59,6 +60,7 @@ TacticalScreen::TacticalScreen(GuiContainer* owner)
                 my_spaceship->commandTargetRotation(sf::vector2ToAngle(position - my_spaceship->getPosition()));
         }
     );
+    radar->setAutoRotating(PreferencesManager::get("tactical_radar_lock","0")=="1");
 
     // Ship statistics in the top left corner.
     energy_display = new GuiKeyValueDisplay(this, "ENERGY_DISPLAY", 0.45, "Energy", "");


### PR DESCRIPTION
Wow, I am dumb, I forgot to make tactical handle the radar lock (operations is based on science, so it already works).

I made it a separate "tactical_radar_lock" option in the .ini but in the options menu, I just paired it with helms.