### PR TITLE
Fix view rotation ending up weird bug.

### DIFF
--- a/src/screenComponents/radarView.cpp
+++ b/src/screenComponents/radarView.cpp
@@ -12,9 +12,11 @@
 GuiRadarView::GuiRadarView(GuiContainer* owner, string id, TargetsContainer* targets)
 : GuiElement(owner, id), next_ghost_dot_update(0.0), targets(targets), missile_tube_controls(nullptr), distance(5000.0f), long_range(false), show_ghost_dots(false)
 , show_waypoints(false), show_target_projection(false), show_missile_tubes(false), show_callsigns(false), show_heading_indicators(false), show_game_master_data(false)
+, view_position(sf::Vector2f(0.0f,0.0f)), view_rotation(0)
 , range_indicator_step_size(0.0f), style(Circular), fog_style(NoFogOfWar), mouse_down_func(nullptr), mouse_drag_func(nullptr), mouse_up_func(nullptr)
 {
     auto_center_on_my_ship = true;
+    auto_rotate_on_my_ship = false;
     auto_distance = true;
 }
 


### PR DESCRIPTION
Fixed auto_rotate and view_rotation not being initialized on one of the RenderView constructors