### PR TITLE
Add player ship selector and view lock to spectator

### DIFF
--- a/src/screens/spectatorScreen.h
+++ b/src/screens/spectatorScreen.h
@@ -5,12 +5,16 @@
 #include "gui/gui2_canvas.h"
 #include "screenComponents/targetsContainer.h"
 
-
 class GuiRadarView;
+class GuiSelector;
+class GuiToggleButton;
+
 class SpectatorScreen : public GuiCanvas, public Updatable
 {
 private:
     GuiRadarView* main_radar;
+    GuiSelector* camera_lock_selector;
+    GuiToggleButton* camera_lock_toggle;
 
     sf::Vector2f drag_start_position;
     sf::Vector2f drag_previous_position;


### PR DESCRIPTION
Copied over and modified from top down to lock and move the map view.

![ezgif com-video-to-gif(2)](https://user-images.githubusercontent.com/19192104/78212144-c5f56700-7463-11ea-833d-ad865092dfae.gif)

