### PR TITLE
Toggle player ship capabilities

### DIFF
--- a/src/gui/gui2_container.cpp
+++ b/src/gui/gui2_container.cpp
@@ -38,6 +38,8 @@ void GuiContainer::drawElements(sf::FloatRect parent_rect, sf::RenderTarget& win
         }else{
             element->updateRect(parent_rect);
             element->hover = element->rect.contains(mouse_position);
+            element->onUpdate();
+
             if (element->visible)
             {
                 element->onDraw(window);

--- a/src/gui/gui2_element.h
+++ b/src/gui/gui2_element.h
@@ -46,6 +46,7 @@ public:
     GuiElement(GuiContainer* owner, string id);
     virtual ~GuiElement();
 
+    virtual void onUpdate() {}
     virtual void onDraw(sf::RenderTarget& window) {}
     virtual bool onMouseDown(sf::Vector2f position);
     virtual void onMouseDrag(sf::Vector2f position);

--- a/src/screenComponents/combatManeuver.cpp
+++ b/src/screenComponents/combatManeuver.cpp
@@ -28,6 +28,11 @@ GuiCombatManeuver::GuiCombatManeuver(GuiContainer* owner, string id)
     (new GuiPowerDamageIndicator(slider, id + "_BOOST_INDICATOR", SYS_Impulse, ABottomLeft))->setPosition(0, 0, ABottomLeft)->setSize(GuiElement::GuiSizeMax, 50);
 }
 
+void GuiCombatManeuver::onUpdate()
+{
+    setVisible(my_spaceship && my_spaceship->getCanCombatManeuver());
+}
+
 void GuiCombatManeuver::onDraw(sf::RenderTarget& window)
 {
     if (my_spaceship)
@@ -45,7 +50,7 @@ void GuiCombatManeuver::onDraw(sf::RenderTarget& window)
 
 void GuiCombatManeuver::onHotkey(const HotkeyResult& key)
 {
-    if (key.category == "HELMS" && my_spaceship)
+    if (key.category == "HELMS" && my_spaceship && isVisible())
     {
         if (key.hotkey == "COMBAT_LEFT")
         {}//TODO

--- a/src/screenComponents/combatManeuver.h
+++ b/src/screenComponents/combatManeuver.h
@@ -14,6 +14,7 @@ private:
 public:
     GuiCombatManeuver(GuiContainer* owner, string id);
     
+    virtual void onUpdate() override;
     virtual void onDraw(sf::RenderTarget& window) override;
     virtual void onHotkey(const HotkeyResult& key) override;
     

--- a/src/screenComponents/dockingButton.cpp
+++ b/src/screenComponents/dockingButton.cpp
@@ -27,6 +27,11 @@ void GuiDockingButton::click()
     }
 }
 
+void GuiDockingButton::onUpdate()
+{
+    setVisible(my_spaceship && my_spaceship->getCanDock());
+}
+
 void GuiDockingButton::onDraw(sf::RenderTarget& window)
 {
     if (my_spaceship)

--- a/src/screenComponents/dockingButton.h
+++ b/src/screenComponents/dockingButton.h
@@ -9,6 +9,7 @@ class GuiDockingButton : public GuiButton
 public:
     GuiDockingButton(GuiContainer* owner, string id);
     
+    virtual void onUpdate() override;
     virtual void onDraw(sf::RenderTarget& window) override;
     virtual void onHotkey(const HotkeyResult& key) override;
 private:

--- a/src/screenComponents/scanTargetButton.cpp
+++ b/src/screenComponents/scanTargetButton.cpp
@@ -17,6 +17,11 @@ GuiScanTargetButton::GuiScanTargetButton(GuiContainer* owner, string id, Targets
     progress->setSize(GuiElement::GuiSizeMax, GuiElement::GuiSizeMax);
 }
     
+void GuiScanTargetButton::onUpdate()
+{
+    setVisible(my_spaceship && my_spaceship->getCanScan());
+}
+
 void GuiScanTargetButton::onDraw(sf::RenderTarget& window)
 {
     if (!my_spaceship)

--- a/src/screenComponents/scanTargetButton.h
+++ b/src/screenComponents/scanTargetButton.h
@@ -16,6 +16,7 @@ private:
 public:
     GuiScanTargetButton(GuiContainer* owner, string id, TargetsContainer* targets);
     
+    virtual void onUpdate() override;
     virtual void onDraw(sf::RenderTarget& window);
 };
 

--- a/src/screenComponents/selfDestructButton.cpp
+++ b/src/screenComponents/selfDestructButton.cpp
@@ -32,6 +32,11 @@ GuiSelfDestructButton::GuiSelfDestructButton(GuiContainer* owner, string id)
     cancel_button->setIcon("gui/icons/self-destruct")->hide()->setSize(GuiElement::GuiSizeMax, 50);
 }
 
+void GuiSelfDestructButton::onUpdate()
+{
+    activate_button->setVisible(my_spaceship && my_spaceship->getCanSelfDestruct());
+}
+
 void GuiSelfDestructButton::onDraw(sf::RenderTarget& window)
 {
 }

--- a/src/screenComponents/selfDestructButton.h
+++ b/src/screenComponents/selfDestructButton.h
@@ -14,6 +14,7 @@ private:
 public:
     GuiSelfDestructButton(GuiContainer* owner, string id);
 
+    virtual void onUpdate() override;
     virtual void onDraw(sf::RenderTarget& window) override;
     virtual void onHotkey(const HotkeyResult& key) override;
 };

--- a/src/screens/crew1/singlePilotScreen.cpp
+++ b/src/screens/crew1/singlePilotScreen.cpp
@@ -74,7 +74,8 @@ SinglePilotScreen::SinglePilotScreen(GuiContainer* owner)
     );
 
     // Ship stats and combat maneuver at bottom right corner of left panel.
-    (new GuiCombatManeuver(left_panel, "COMBAT_MANEUVER"))->setPosition(-20, -180, ABottomRight)->setSize(200, 150);
+    combat_maneuver = new GuiCombatManeuver(left_panel, "COMBAT_MANEUVER");
+    combat_maneuver->setPosition(-20, -180, ABottomRight)->setSize(200, 150)->setVisible(my_spaceship && my_spaceship->getCanCombatManeuver());
 
     energy_display = new GuiKeyValueDisplay(left_panel, "ENERGY_DISPLAY", 0.45, "Energy", "");
     energy_display->setIcon("gui/icons/energy")->setTextSize(20)->setPosition(-20, -140, ABottomRight)->setSize(240, 40);
@@ -120,6 +121,9 @@ void SinglePilotScreen::onDraw(sf::RenderTarget& window)
 {
     if (my_spaceship)
     {
+        // Toggle ship capabilities.
+        combat_maneuver->setVisible(my_spaceship->getCanCombatManeuver());
+
         energy_display->setValue(string(int(my_spaceship->energy_level)));
         heading_display->setValue(string(fmodf(my_spaceship->getRotation() + 360.0 + 360.0 - 270.0, 360.0), 1));
         float velocity = sf::length(my_spaceship->getVelocity()) / 1000 * 60;
@@ -182,6 +186,7 @@ void SinglePilotScreen::onDraw(sf::RenderTarget& window)
         }
     }
 }
+
 bool SinglePilotScreen::onJoystickAxis(const AxisAction& axisAction){
     if(my_spaceship){
         if (axisAction.category == "HELMS"){

--- a/src/screens/crew1/singlePilotScreen.cpp
+++ b/src/screens/crew1/singlePilotScreen.cpp
@@ -121,9 +121,6 @@ void SinglePilotScreen::onDraw(sf::RenderTarget& window)
 {
     if (my_spaceship)
     {
-        // Toggle ship capabilities.
-        combat_maneuver->setVisible(my_spaceship->getCanCombatManeuver());
-
         energy_display->setValue(string(int(my_spaceship->energy_level)));
         heading_display->setValue(string(fmodf(my_spaceship->getRotation() + 360.0 + 360.0 - 270.0, 360.0), 1));
         float velocity = sf::length(my_spaceship->getVelocity()) / 1000 * 60;

--- a/src/screens/crew1/singlePilotScreen.h
+++ b/src/screens/crew1/singlePilotScreen.h
@@ -11,6 +11,7 @@ class GuiRadarView;
 class GuiKeyValueDisplay;
 class GuiToggleButton;
 class GuiRotationDial;
+class GuiCombatManeuver;
 
 class SinglePilotScreen : public GuiOverlay
 {
@@ -29,6 +30,7 @@ private:
     GuiKeyValueDisplay* shields_display;
     GuiElement* warp_controls;
     GuiElement* jump_controls;
+    GuiCombatManeuver* combat_maneuver;
     
     TargetsContainer targets;
     GuiRadarView* radar;

--- a/src/screens/crew6/engineeringScreen.cpp
+++ b/src/screens/crew6/engineeringScreen.cpp
@@ -38,7 +38,8 @@ EngineeringScreen::EngineeringScreen(GuiContainer* owner, ECrewPosition crew_pos
     coolant_display = new GuiKeyValueDisplay(this, "COOLANT_DISPLAY", 0.45, tr("total","Coolant"), "");
     coolant_display->setIcon("gui/icons/coolant")->setTextSize(20)->setPosition(20, 260, ATopLeft)->setSize(240, 40);
 
-    (new GuiSelfDestructButton(this, "SELF_DESTRUCT"))->setPosition(20, 20, ATopLeft)->setSize(240, 100);
+    self_destruct_button = new GuiSelfDestructButton(this, "SELF_DESTRUCT");
+    self_destruct_button->setPosition(20, 20, ATopLeft)->setSize(240, 100)->setVisible(my_spaceship && my_spaceship->getCanSelfDestruct());
 
     GuiElement* system_config_container = new GuiElement(this, "");
     system_config_container->setPosition(0, -20, ABottomCenter)->setSize(750 + 300, GuiElement::GuiSizeMax);
@@ -150,7 +151,10 @@ void EngineeringScreen::onDraw(sf::RenderTarget& window)
 {
     if (my_spaceship)
     {
-        //Update the energy usage.
+        // Toggle ship capabilities.
+        self_destruct_button->setVisible(my_spaceship->getCanSelfDestruct());
+
+        // Update the energy usage.
         if (previous_energy_measurement == 0.0)
         {
             previous_energy_level = my_spaceship->energy_level;

--- a/src/screens/crew6/engineeringScreen.cpp
+++ b/src/screens/crew6/engineeringScreen.cpp
@@ -151,9 +151,6 @@ void EngineeringScreen::onDraw(sf::RenderTarget& window)
 {
     if (my_spaceship)
     {
-        // Toggle ship capabilities.
-        self_destruct_button->setVisible(my_spaceship->getCanSelfDestruct());
-
         // Update the energy usage.
         if (previous_energy_measurement == 0.0)
         {

--- a/src/screens/crew6/engineeringScreen.h
+++ b/src/screens/crew6/engineeringScreen.h
@@ -5,6 +5,7 @@
 #include "shipTemplate.h"
 #include "playerInfo.h"
 
+class GuiSelfDestructButton;
 class GuiKeyValueDisplay;
 class GuiLabel;
 class GuiSlider;
@@ -26,6 +27,7 @@ private:
     GuiKeyValueDisplay* front_shield_display;
     GuiKeyValueDisplay* rear_shield_display;
     GuiKeyValueDisplay* coolant_display;
+    GuiSelfDestructButton* self_destruct_button;
     GuiLabel* power_label;
     GuiSlider* power_slider;
     GuiLabel* coolant_label;

--- a/src/screens/crew6/helmsScreen.cpp
+++ b/src/screens/crew6/helmsScreen.cpp
@@ -90,10 +90,6 @@ void HelmsScreen::onDraw(sf::RenderTarget& window)
 {
     if (my_spaceship)
     {
-        // Toggle ship capabilities.
-        combat_maneuver->setVisible(my_spaceship->getCanCombatManeuver());
-        docking_button->setVisible(my_spaceship->getCanDock());
-
         energy_display->setValue(string(int(my_spaceship->energy_level)));
         heading_display->setValue(string(my_spaceship->getHeading(), 1));
         float velocity = sf::length(my_spaceship->getVelocity()) / 1000 * 60;

--- a/src/screens/crew6/helmsScreen.cpp
+++ b/src/screens/crew6/helmsScreen.cpp
@@ -4,6 +4,7 @@
 #include "helmsScreen.h"
 #include "preferenceManager.h"
 
+#include "screenComponents/combatManeuver.h"
 #include "screenComponents/radarView.h"
 #include "screenComponents/impulseControls.h"
 #include "screenComponents/warpControls.h"
@@ -33,8 +34,8 @@ HelmsScreen::HelmsScreen(GuiContainer* owner)
     GuiRadarView* radar = new GuiRadarView(this, "HELMS_RADAR", nullptr);
     
     combat_maneuver = new GuiCombatManeuver(this, "COMBAT_MANEUVER");
-    combat_maneuver->setPosition(-20, -20, ABottomRight)->setSize(280, 215);
-    
+    combat_maneuver->setPosition(-20, -20, ABottomRight)->setSize(280, 215)->setVisible(my_spaceship && my_spaceship->getCanCombatManeuver());
+
     radar->setPosition(0, 0, ACenter)->setSize(GuiElement::GuiSizeMatchHeight, 800);
     radar->setRangeIndicatorStepSize(1000.0)->shortRange()->enableGhostDots()->enableWaypoints()->enableCallsigns()->enableHeadingIndicators()->setStyle(GuiRadarView::Circular);
     radar->enableMissileTubeIndicators();
@@ -79,7 +80,8 @@ HelmsScreen::HelmsScreen(GuiContainer* owner)
     warp_controls = (new GuiWarpControls(engine_layout, "WARP"))->setSize(100, GuiElement::GuiSizeMax);
     jump_controls = (new GuiJumpControls(engine_layout, "JUMP"))->setSize(100, GuiElement::GuiSizeMax);
     
-    (new GuiDockingButton(this, "DOCKING"))->setPosition(20, -20, ABottomLeft)->setSize(280, 50);
+    docking_button = new GuiDockingButton(this, "DOCKING");
+    docking_button->setPosition(20, -20, ABottomLeft)->setSize(280, 50)->setVisible(my_spaceship && my_spaceship->getCanDock());
 
     (new GuiCustomShipFunctions(this, helmsOfficer, ""))->setPosition(-20, 120, ATopRight)->setSize(250, GuiElement::GuiSizeMax);
 }
@@ -88,6 +90,10 @@ void HelmsScreen::onDraw(sf::RenderTarget& window)
 {
     if (my_spaceship)
     {
+        // Toggle ship capabilities.
+        combat_maneuver->setVisible(my_spaceship->getCanCombatManeuver());
+        docking_button->setVisible(my_spaceship->getCanDock());
+
         energy_display->setValue(string(int(my_spaceship->energy_level)));
         heading_display->setValue(string(my_spaceship->getHeading(), 1));
         float velocity = sf::length(my_spaceship->getVelocity()) / 1000 * 60;

--- a/src/screens/crew6/helmsScreen.cpp
+++ b/src/screens/crew6/helmsScreen.cpp
@@ -106,23 +106,32 @@ void HelmsScreen::onDraw(sf::RenderTarget& window)
 }
 
 bool HelmsScreen::onJoystickAxis(const AxisAction& axisAction){
-    if(my_spaceship){
-        if (axisAction.category == "HELMS"){
-            if (axisAction.action == "IMPULSE"){
-                my_spaceship->commandImpulse(axisAction.value);  
+    if (my_spaceship)
+    {
+        if (axisAction.category == "HELMS")
+        {
+            if (axisAction.action == "IMPULSE")
+            {
+                my_spaceship->commandImpulse(axisAction.value);
                 return true;
-            } 
-            if (axisAction.action == "ROTATE"){
+            }
+            if (axisAction.action == "ROTATE")
+            {
                 my_spaceship->commandTurnSpeed(axisAction.value);
                 return true;
-            } 
-            if (axisAction.action == "STRAFE"){
-                my_spaceship->commandCombatManeuverStrafe(axisAction.value);
-                return true;
-            } 
-            if (axisAction.action == "BOOST"){
-                my_spaceship->commandCombatManeuverBoost(axisAction.value);
-                return true;
+            }
+            if (my_spaceship->getCanCombatManeuver())
+            {
+                if (axisAction.action == "STRAFE")
+                {
+                    my_spaceship->commandCombatManeuverStrafe(axisAction.value);
+                    return true;
+                }
+                if (axisAction.action == "BOOST")
+                {
+                    my_spaceship->commandCombatManeuverBoost(axisAction.value);
+                    return true;
+                }
             }
         }
     }

--- a/src/screens/crew6/helmsScreen.h
+++ b/src/screens/crew6/helmsScreen.h
@@ -2,11 +2,12 @@
 #define HELMS_SCREEN_H
 
 #include "gui/gui2_overlay.h"
-#include "screenComponents/combatManeuver.h"
 #include "gui/joystickConfig.h"
 
 class GuiKeyValueDisplay;
 class GuiLabel;
+class GuiDockingButton;
+class GuiCombatManeuver;
 
 class HelmsScreen : public GuiOverlay
 {
@@ -21,6 +22,7 @@ private:
     GuiElement* jump_controls;
     GuiLabel* heading_hint;
     GuiCombatManeuver* combat_maneuver;
+    GuiDockingButton* docking_button;
 public:
     HelmsScreen(GuiContainer* owner);
     

--- a/src/screens/crew6/relayScreen.cpp
+++ b/src/screens/crew6/relayScreen.cpp
@@ -119,7 +119,7 @@ RelayScreen::RelayScreen(GuiContainer* owner, bool allow_comms)
         else
             my_spaceship->commandSetScienceLink(-1);
     });
-    link_to_science_button->setSize(GuiElement::GuiSizeMax, 50);
+    link_to_science_button->setSize(GuiElement::GuiSizeMax, 50)->setVisible(my_spaceship && my_spaceship->getCanLaunchProbe());
 
     // Manage waypoints.
     (new GuiButton(option_buttons, "WAYPOINT_PLACE_BUTTON", tr("Place Waypoint"), [this]() {
@@ -140,7 +140,7 @@ RelayScreen::RelayScreen(GuiContainer* owner, bool allow_comms)
         mode = LaunchProbe;
         option_buttons->hide();
     });
-    launch_probe_button->setSize(GuiElement::GuiSizeMax, 50);
+    launch_probe_button->setSize(GuiElement::GuiSizeMax, 50)->setVisible(my_spaceship && my_spaceship->getCanLaunchProbe());
 
     // Reputation display.
     info_reputation = new GuiKeyValueDisplay(option_buttons, "INFO_REPUTATION", 0.7, tr("Reputation:"), "");
@@ -274,6 +274,11 @@ void RelayScreen::onDraw(sf::RenderTarget& window)
     }
     if (my_spaceship)
     {
+        // Toggle ship capabilities.
+        launch_probe_button->setVisible(my_spaceship->getCanLaunchProbe());
+        link_to_science_button->setVisible(my_spaceship->getCanLaunchProbe());
+        hack_target_button->setVisible(my_spaceship->getCanHack());
+
         info_reputation->setValue(string(my_spaceship->getReputationPoints(), 0));
         launch_probe_button->setText(tr("Launch Probe") + " (" + string(my_spaceship->scan_probe_stock) + ")");
     }

--- a/src/screens/crew6/scienceScreen.cpp
+++ b/src/screens/crew6/scienceScreen.cpp
@@ -241,9 +241,6 @@ void ScienceScreen::onDraw(sf::RenderTarget& window)
     if (!my_spaceship)
         return;
 
-    // Toggle ship capabilities.
-    scan_button->setVisible(my_spaceship->getCanScan());
-
     if (game_server)
         probe = game_server->getObjectById(my_spaceship->linked_science_probe_id);
     else

--- a/src/screens/crew6/scienceScreen.cpp
+++ b/src/screens/crew6/scienceScreen.cpp
@@ -88,7 +88,7 @@ ScienceScreen::ScienceScreen(GuiContainer* owner, ECrewPosition crew_position)
 
     // Scan button.
     scan_button = new GuiScanTargetButton(info_sidebar, "SCAN_BUTTON", &targets);
-    scan_button->setSize(GuiElement::GuiSizeMax, 50);
+    scan_button->setSize(GuiElement::GuiSizeMax, 50)->setVisible(my_spaceship && my_spaceship->getCanScan());
 
     // Simple scan data.
     info_callsign = new GuiKeyValueDisplay(info_sidebar, "SCIENCE_CALLSIGN", 0.4, tr("Callsign"), "");
@@ -240,6 +240,9 @@ void ScienceScreen::onDraw(sf::RenderTarget& window)
 
     if (!my_spaceship)
         return;
+
+    // Toggle ship capabilities.
+    scan_button->setVisible(my_spaceship->getCanScan());
 
     if (game_server)
         probe = game_server->getObjectById(my_spaceship->linked_science_probe_id);

--- a/src/screens/crew6/scienceScreen.cpp
+++ b/src/screens/crew6/scienceScreen.cpp
@@ -453,6 +453,7 @@ void ScienceScreen::onHotkey(const HotkeyResult& key)
     {
         // Initiate a scan on scannable objects.
         if (key.hotkey == "SCAN_OBJECT" &&
+            my_spaceship->getCanScan() &&
             my_spaceship->scanning_delay == 0.0)
         {
             P<SpaceObject> obj = targets.get();

--- a/src/screens/gm/tweak.cpp
+++ b/src/screens/gm/tweak.cpp
@@ -691,6 +691,41 @@ GuiShipTweakPlayer2::GuiShipTweakPlayer2(GuiContainer* owner)
     long_range_radar_slider->addOverlay()->setSize(GuiElement::GuiSizeMax, 40);
 
     // Right column
+    // Can scan bool
+    can_scan = new GuiToggleButton(right_col, "", "Can scan", [this](bool value) {
+        target->setCanScan(value);
+    });
+    can_scan->setSize(GuiElement::GuiSizeMax, 40);
+
+    // Can hack bool
+    can_hack = new GuiToggleButton(right_col, "", "Can hack", [this](bool value) {
+        target->setCanHack(value);
+    });
+    can_hack->setSize(GuiElement::GuiSizeMax, 40);
+
+    // Can dock bool
+    can_dock = new GuiToggleButton(right_col, "", "Can dock", [this](bool value) {
+        target->setCanDock(value);
+    });
+    can_dock->setSize(GuiElement::GuiSizeMax, 40);
+
+    // Can combat maneuver bool
+    can_combat_maneuver = new GuiToggleButton(right_col, "", "Can combat maneuver", [this](bool value) {
+        target->setCanCombatManeuver(value);
+    });
+    can_combat_maneuver->setSize(GuiElement::GuiSizeMax, 40);
+
+    // Can self destruct bool
+    can_self_destruct = new GuiToggleButton(right_col, "", "Can self destruct", [this](bool value) {
+        target->setCanSelfDestruct(value);
+    });
+    can_self_destruct->setSize(GuiElement::GuiSizeMax, 40);
+
+    // Can launch probe bool
+    can_launch_probe = new GuiToggleButton(right_col, "", "Can launch probes", [this](bool value) {
+        target->setCanLaunchProbe(value);
+    });
+    can_launch_probe->setSize(GuiElement::GuiSizeMax, 40);
 }
 
 void GuiShipTweakPlayer2::onDraw(sf::RenderTarget& window)
@@ -698,6 +733,12 @@ void GuiShipTweakPlayer2::onDraw(sf::RenderTarget& window)
     coolant_slider->setValue(target->max_coolant);
     short_range_radar_slider->setValue(target->getShortRangeRadarRange());
     long_range_radar_slider->setValue(target->getLongRangeRadarRange());
+    can_scan->setValue(target->getCanScan());
+    can_hack->setValue(target->getCanHack());
+    can_dock->setValue(target->getCanDock());
+    can_combat_maneuver->setValue(target->getCanCombatManeuver());
+    can_self_destruct->setValue(target->getCanSelfDestruct());
+    can_launch_probe->setValue(target->getCanLaunchProbe());
 }
 
 void GuiShipTweakPlayer2::open(P<SpaceObject> target)

--- a/src/screens/gm/tweak.h
+++ b/src/screens/gm/tweak.h
@@ -185,6 +185,12 @@ private:
     GuiSlider* coolant_slider;
     GuiSlider* short_range_radar_slider;
     GuiSlider* long_range_radar_slider;
+    GuiToggleButton* can_scan;
+    GuiToggleButton* can_hack;
+    GuiToggleButton* can_dock;
+    GuiToggleButton* can_combat_maneuver;
+    GuiToggleButton* can_self_destruct;
+    GuiToggleButton* can_launch_probe;
 public:
     GuiShipTweakPlayer2(GuiContainer* owner);
 

--- a/src/shipTemplate.cpp
+++ b/src/shipTemplate.cpp
@@ -76,7 +76,6 @@ REGISTER_SCRIPT_CLASS(ShipTemplate)
     REGISTER_SCRIPT_CLASS_FUNCTION(ShipTemplate, setLongRangeRadarRange);
     REGISTER_SCRIPT_CLASS_FUNCTION(ShipTemplate, setShortRangeRadarRange);
     REGISTER_SCRIPT_CLASS_FUNCTION(ShipTemplate, canScan);
-    REGISTER_SCRIPT_CLASS_FUNCTION(ShipTemplate, canFullScan);
     REGISTER_SCRIPT_CLASS_FUNCTION(ShipTemplate, canHack);
     REGISTER_SCRIPT_CLASS_FUNCTION(ShipTemplate, canDock);
     REGISTER_SCRIPT_CLASS_FUNCTION(ShipTemplate, canCombatManeuver);
@@ -481,7 +480,6 @@ P<ShipTemplate> ShipTemplate::copy(string new_name)
     result->repair_crew_count = repair_crew_count;
 
     result->can_scan = can_scan;
-    result->can_full_scan = can_full_scan;
     result->can_hack = can_hack;
     result->can_dock = can_dock;
     result->can_combat_maneuver = can_combat_maneuver;

--- a/src/shipTemplate.cpp
+++ b/src/shipTemplate.cpp
@@ -75,12 +75,12 @@ REGISTER_SCRIPT_CLASS(ShipTemplate)
     REGISTER_SCRIPT_CLASS_FUNCTION(ShipTemplate, setRadarTrace);
     REGISTER_SCRIPT_CLASS_FUNCTION(ShipTemplate, setLongRangeRadarRange);
     REGISTER_SCRIPT_CLASS_FUNCTION(ShipTemplate, setShortRangeRadarRange);
-    REGISTER_SCRIPT_CLASS_FUNCTION(ShipTemplate, canScan);
-    REGISTER_SCRIPT_CLASS_FUNCTION(ShipTemplate, canHack);
-    REGISTER_SCRIPT_CLASS_FUNCTION(ShipTemplate, canDock);
-    REGISTER_SCRIPT_CLASS_FUNCTION(ShipTemplate, canCombatManeuver);
-    REGISTER_SCRIPT_CLASS_FUNCTION(ShipTemplate, canSelfDestruct);
-    REGISTER_SCRIPT_CLASS_FUNCTION(ShipTemplate, canLaunchProbe);
+    REGISTER_SCRIPT_CLASS_FUNCTION(ShipTemplate, setCanScan);
+    REGISTER_SCRIPT_CLASS_FUNCTION(ShipTemplate, setCanHack);
+    REGISTER_SCRIPT_CLASS_FUNCTION(ShipTemplate, setCanDock);
+    REGISTER_SCRIPT_CLASS_FUNCTION(ShipTemplate, setCanCombatManeuver);
+    REGISTER_SCRIPT_CLASS_FUNCTION(ShipTemplate, setCanSelfDestruct);
+    REGISTER_SCRIPT_CLASS_FUNCTION(ShipTemplate, setCanLaunchProbe);
     /// Return a new template with the given name, which is an exact copy of this template.
     /// Used to make easy variations of templates.
     REGISTER_SCRIPT_CLASS_FUNCTION(ShipTemplate, copy);

--- a/src/shipTemplate.cpp
+++ b/src/shipTemplate.cpp
@@ -75,6 +75,13 @@ REGISTER_SCRIPT_CLASS(ShipTemplate)
     REGISTER_SCRIPT_CLASS_FUNCTION(ShipTemplate, setRadarTrace);
     REGISTER_SCRIPT_CLASS_FUNCTION(ShipTemplate, setLongRangeRadarRange);
     REGISTER_SCRIPT_CLASS_FUNCTION(ShipTemplate, setShortRangeRadarRange);
+    REGISTER_SCRIPT_CLASS_FUNCTION(ShipTemplate, canScan);
+    REGISTER_SCRIPT_CLASS_FUNCTION(ShipTemplate, canFullScan);
+    REGISTER_SCRIPT_CLASS_FUNCTION(ShipTemplate, canHack);
+    REGISTER_SCRIPT_CLASS_FUNCTION(ShipTemplate, canDock);
+    REGISTER_SCRIPT_CLASS_FUNCTION(ShipTemplate, canCombatManeuver);
+    REGISTER_SCRIPT_CLASS_FUNCTION(ShipTemplate, canSelfDestruct);
+    REGISTER_SCRIPT_CLASS_FUNCTION(ShipTemplate, canLaunchProbe);
     /// Return a new template with the given name, which is an exact copy of this template.
     /// Used to make easy variations of templates.
     REGISTER_SCRIPT_CLASS_FUNCTION(ShipTemplate, copy);
@@ -472,6 +479,15 @@ P<ShipTemplate> ShipTemplate::copy(string new_name)
     result->can_be_docked_by_class = can_be_docked_by_class;
     result->energy_storage_amount = energy_storage_amount;
     result->repair_crew_count = repair_crew_count;
+
+    result->can_scan = can_scan;
+    result->can_full_scan = can_full_scan;
+    result->can_hack = can_hack;
+    result->can_dock = can_dock;
+    result->can_combat_maneuver = can_combat_maneuver;
+    result->can_self_destruct = can_self_destruct;
+    result->can_launch_probe = can_launch_probe;
+
     result->default_ai_name = default_ai_name;
     for(int n=0; n<max_beam_weapons; n++)
         result->beams[n] = beams[n];

--- a/src/shipTemplate.h
+++ b/src/shipTemplate.h
@@ -136,12 +136,12 @@ public:
     void setSharesEnergyWithDocked(bool enabled);
     void setRepairDocked(bool enabled);
     void setRestocksScanProbes(bool enabled);
-    void canScan(bool enabled) { can_scan = enabled; }
-    void canHack(bool enabled) { can_hack = enabled; }
-    void canDock(bool enabled) { can_dock = enabled; }
-    void canCombatManeuver(bool enabled) { can_combat_maneuver = enabled; }
-    void canSelfDestruct(bool enabled) { can_self_destruct = enabled; }
-    void canLaunchProbe(bool enabled) { can_launch_probe = enabled; }
+    void setCanScan(bool enabled) { can_scan = enabled; }
+    void setCanHack(bool enabled) { can_hack = enabled; }
+    void setCanDock(bool enabled) { can_dock = enabled; }
+    void setCanCombatManeuver(bool enabled) { can_combat_maneuver = enabled; }
+    void setCanSelfDestruct(bool enabled) { can_self_destruct = enabled; }
+    void setCanLaunchProbe(bool enabled) { can_launch_probe = enabled; }
     void setMesh(string model, string color_texture, string specular_texture, string illumination_texture);
     void setEnergyStorage(float energy_amount);
     void setRepairCrewCount(int amount);

--- a/src/shipTemplate.h
+++ b/src/shipTemplate.h
@@ -92,6 +92,13 @@ public:
     bool shares_energy_with_docked;
     bool repair_docked;
     bool restocks_scan_probes;
+    bool can_scan = true;
+    bool can_full_scan = true;
+    bool can_hack = true;
+    bool can_dock = true;
+    bool can_combat_maneuver = true;
+    bool can_self_destruct = true;
+    bool can_launch_probe = true;
     
     float energy_storage_amount;
     int repair_crew_count;
@@ -130,6 +137,13 @@ public:
     void setSharesEnergyWithDocked(bool enabled);
     void setRepairDocked(bool enabled);
     void setRestocksScanProbes(bool enabled);
+    void canScan(bool enabled) { can_scan = enabled; }
+    void canFullScan(bool enabled) { can_scan = true; can_full_scan = enabled; }
+    void canHack(bool enabled) { can_hack = enabled; }
+    void canDock(bool enabled) { can_dock = enabled; }
+    void canCombatManeuver(bool enabled) { can_combat_maneuver = enabled; }
+    void canSelfDestruct(bool enabled) { can_self_destruct = enabled; }
+    void canLaunchProbe(bool enabled) { can_launch_probe = enabled; }
     void setMesh(string model, string color_texture, string specular_texture, string illumination_texture);
     void setEnergyStorage(float energy_amount);
     void setRepairCrewCount(int amount);

--- a/src/shipTemplate.h
+++ b/src/shipTemplate.h
@@ -93,7 +93,6 @@ public:
     bool repair_docked;
     bool restocks_scan_probes;
     bool can_scan = true;
-    bool can_full_scan = true;
     bool can_hack = true;
     bool can_dock = true;
     bool can_combat_maneuver = true;
@@ -138,7 +137,6 @@ public:
     void setRepairDocked(bool enabled);
     void setRestocksScanProbes(bool enabled);
     void canScan(bool enabled) { can_scan = enabled; }
-    void canFullScan(bool enabled) { can_scan = true; can_full_scan = enabled; }
     void canHack(bool enabled) { can_hack = enabled; }
     void canDock(bool enabled) { can_dock = enabled; }
     void canCombatManeuver(bool enabled) { can_combat_maneuver = enabled; }

--- a/src/spaceObjects/playerSpaceship.cpp
+++ b/src/spaceObjects/playerSpaceship.cpp
@@ -298,7 +298,6 @@ PlayerSpaceship::PlayerSpaceship()
 
     updateMemberReplicationUpdateDelay(&target_rotation, 0.1);
     registerMemberReplication(&can_scan);
-    registerMemberReplication(&can_full_scan);
     registerMemberReplication(&can_hack);
     registerMemberReplication(&can_dock);
     registerMemberReplication(&can_combat_maneuver);
@@ -707,7 +706,6 @@ void PlayerSpaceship::applyTemplateValues()
 
     // Set the ship's capabilities.
     can_scan = ship_template->can_scan;
-    can_full_scan = ship_template->can_full_scan;
     can_hack = ship_template->can_hack;
     can_dock = ship_template->can_dock;
     can_combat_maneuver = ship_template->can_combat_maneuver;

--- a/src/spaceObjects/playerSpaceship.cpp
+++ b/src/spaceObjects/playerSpaceship.cpp
@@ -183,6 +183,22 @@ REGISTER_SCRIPT_SUBCLASS(PlayerSpaceship, SpaceShip)
     /// Returns a Boolean value.
     /// Example: ship:getCanLaunchProbe()
     REGISTER_SCRIPT_CLASS_FUNCTION(PlayerSpaceship, getCanLaunchProbe);
+    /// Set the amount of damage done by self destruction.
+    /// Requires a float; the value used is randomized +/- 33%.
+    /// Example: ship:setSelfDestructDamage(150)
+    REGISTER_SCRIPT_CLASS_FUNCTION(PlayerSpaceship, setSelfDestructDamage);
+    /// Get the amount of damage done by self destruction.
+    /// Returns a float.
+    /// Example: ship:getSelfDestructDamage()
+    REGISTER_SCRIPT_CLASS_FUNCTION(PlayerSpaceship, getSelfDestructDamage);
+    /// Set the size of the explosion created by self destruction.
+    /// Requires a float.
+    /// Example: ship:setSelfDestructSize(1500)
+    REGISTER_SCRIPT_CLASS_FUNCTION(PlayerSpaceship, setSelfDestructSize);
+    /// Get the size of the explosion created by self destruction.
+    /// Returns a float.
+    /// Example: ship:getSelfDestructSize()
+    REGISTER_SCRIPT_CLASS_FUNCTION(PlayerSpaceship, getSelfDestructSize);
 }
 
 float PlayerSpaceship::system_power_user_factor[] = {
@@ -623,20 +639,20 @@ void PlayerSpaceship::update(float delta)
                 // If the countdown has started, tick the clock.
                 self_destruct_countdown -= delta;
 
-                // When time runs out, blow up the ship and damage a 1.5U
-                // radius.
+                // When time runs out, blow up the ship and damage a
+                // configurable radius.
                 if (self_destruct_countdown <= 0.0)
                 {
                     for(int n = 0; n < 5; n++)
                     {
                         ExplosionEffect* e = new ExplosionEffect();
-                        e->setSize(1000.0f);
-                        e->setPosition(getPosition() + sf::rotateVector(sf::Vector2f(0, random(0, 500)), random(0, 360)));
+                        e->setSize(self_destruct_size * 0.67f);
+                        e->setPosition(getPosition() + sf::rotateVector(sf::Vector2f(0, random(0, self_destruct_size * 0.33f)), random(0, 360)));
                         e->setRadarSignatureInfo(0.0, 0.6, 0.6);
                     }
 
                     DamageInfo info(this, DT_Kinetic, getPosition());
-                    SpaceObject::damageArea(getPosition(), 1500, 100, 200, info, 0.0);
+                    SpaceObject::damageArea(getPosition(), self_destruct_size, self_destruct_damage - (self_destruct_damage / 3.0f), self_destruct_damage + (self_destruct_damage / 3.0f), info, 0.0);
 
                     destroy();
                     return;

--- a/src/spaceObjects/playerSpaceship.cpp
+++ b/src/spaceObjects/playerSpaceship.cpp
@@ -135,6 +135,54 @@ REGISTER_SCRIPT_SUBCLASS(PlayerSpaceship, SpaceShip)
     REGISTER_SCRIPT_CLASS_FUNCTION(PlayerSpaceship, getShortRangeRadarRange);
     REGISTER_SCRIPT_CLASS_FUNCTION(PlayerSpaceship, setLongRangeRadarRange);
     REGISTER_SCRIPT_CLASS_FUNCTION(PlayerSpaceship, setShortRangeRadarRange);
+    /// Set whether the object can scan other objects.
+    /// Requires a Boolean value.
+    /// Example: ship:setCanScan(true)
+    REGISTER_SCRIPT_CLASS_FUNCTION(PlayerSpaceship, setCanScan);
+    /// Get whether the object can scan other objects.
+    /// Returns a Boolean value.
+    /// Example: ship:getCanScan()
+    REGISTER_SCRIPT_CLASS_FUNCTION(PlayerSpaceship, getCanScan);
+    /// Set whether the object can hack other objects.
+    /// Requires a Boolean value.
+    /// Example: ship:setCanHack(true)
+    REGISTER_SCRIPT_CLASS_FUNCTION(PlayerSpaceship, setCanHack);
+    /// Get whether the object can hack other objects.
+    /// Returns a Boolean value.
+    /// Example: ship:getCanHack()
+    REGISTER_SCRIPT_CLASS_FUNCTION(PlayerSpaceship, getCanHack);
+    /// Set whether the object can dock with other objects.
+    /// Requires a Boolean value.
+    /// Example: ship:setCanDock(true)
+    REGISTER_SCRIPT_CLASS_FUNCTION(PlayerSpaceship, setCanDock);
+    /// Get whether the object can dock with other objects.
+    /// Returns a Boolean value.
+    /// Example: ship:getCanDock()
+    REGISTER_SCRIPT_CLASS_FUNCTION(PlayerSpaceship, getCanDock);
+    /// Set whether the object can perform combat maneuvers.
+    /// Requires a Boolean value.
+    /// Example: ship:setCanCombatManeuver(true)
+    REGISTER_SCRIPT_CLASS_FUNCTION(PlayerSpaceship, setCanCombatManeuver);
+    /// Get whether the object can perform combat maneuvers.
+    /// Returns a Boolean value.
+    /// Example: ship:getCanCombatManeuver()
+    REGISTER_SCRIPT_CLASS_FUNCTION(PlayerSpaceship, getCanCombatManeuver);
+    /// Set whether the object can self destruct.
+    /// Requires a Boolean value.
+    /// Example: ship:setCanSelfDestruct(true)
+    REGISTER_SCRIPT_CLASS_FUNCTION(PlayerSpaceship, setCanSelfDestruct);
+    /// Get whether the object self destruct.
+    /// Returns a Boolean value.
+    /// Example: ship:getCanSelfDestruct()
+    REGISTER_SCRIPT_CLASS_FUNCTION(PlayerSpaceship, getCanSelfDestruct);
+    /// Set whether the object can launch probes.
+    /// Requires a Boolean value.
+    /// Example: ship:setCanLaunchProbe(true)
+    REGISTER_SCRIPT_CLASS_FUNCTION(PlayerSpaceship, setCanLaunchProbe);
+    /// Get whether the object can launch probes.
+    /// Returns a Boolean value.
+    /// Example: ship:getCanLaunchProbe()
+    REGISTER_SCRIPT_CLASS_FUNCTION(PlayerSpaceship, getCanLaunchProbe);
 }
 
 float PlayerSpaceship::system_power_user_factor[] = {
@@ -237,14 +285,7 @@ PlayerSpaceship::PlayerSpaceship()
     auto_repair_enabled = false;
     auto_coolant_enabled = false;
     max_coolant = max_coolant_per_system;
-    activate_self_destruct = false;
-    self_destruct_countdown = 0.0;
-    scanning_delay = 0.0;
-    scanning_complexity = 0;
-    scanning_depth = 0;
-    max_scan_probes = 8;
     scan_probe_stock = max_scan_probes;
-    scan_probe_recharge = 0.0;
     alert_level = AL_Normal;
     shields_active = false;
     control_code = "";
@@ -256,6 +297,13 @@ PlayerSpaceship::PlayerSpaceship()
         setScannedStateForFaction(faction_id, SS_FullScan);
 
     updateMemberReplicationUpdateDelay(&target_rotation, 0.1);
+    registerMemberReplication(&can_scan);
+    registerMemberReplication(&can_full_scan);
+    registerMemberReplication(&can_hack);
+    registerMemberReplication(&can_dock);
+    registerMemberReplication(&can_combat_maneuver);
+    registerMemberReplication(&can_self_destruct);
+    registerMemberReplication(&can_launch_probe);
     registerMemberReplication(&hull_damage_indicator, 0.5);
     registerMemberReplication(&jump_indicator, 0.5);
     registerMemberReplication(&energy_level, 0.1);
@@ -653,8 +701,18 @@ void PlayerSpaceship::applyTemplateValues()
     // template.
     setRepairCrewCount(ship_template->repair_crew_count);
 
+    // Set the ship's radar ranges.
     long_range_radar_range = ship_template->long_range_radar_range;
     short_range_radar_range = ship_template->short_range_radar_range;
+
+    // Set the ship's capabilities.
+    can_scan = ship_template->can_scan;
+    can_full_scan = ship_template->can_full_scan;
+    can_hack = ship_template->can_hack;
+    can_dock = ship_template->can_dock;
+    can_combat_maneuver = ship_template->can_combat_maneuver;
+    can_self_destruct = ship_template->can_self_destruct;
+    can_launch_probe = ship_template->can_launch_probe;
 }
 
 void PlayerSpaceship::executeJump(float distance)

--- a/src/spaceObjects/playerSpaceship.cpp
+++ b/src/spaceObjects/playerSpaceship.cpp
@@ -171,7 +171,9 @@ REGISTER_SCRIPT_SUBCLASS(PlayerSpaceship, SpaceShip)
     /// Requires a Boolean value.
     /// Example: ship:setCanSelfDestruct(true)
     REGISTER_SCRIPT_CLASS_FUNCTION(PlayerSpaceship, setCanSelfDestruct);
-    /// Get whether the object self destruct.
+    /// Get whether the object can self destruct.
+    /// This returns false if self destruct size and damage are both 0, even if
+    /// you set setCanSelfDestruct(true).
     /// Returns a Boolean value.
     /// Example: ship:getCanSelfDestruct()
     REGISTER_SCRIPT_CLASS_FUNCTION(PlayerSpaceship, getCanSelfDestruct);

--- a/src/spaceObjects/playerSpaceship.cpp
+++ b/src/spaceObjects/playerSpaceship.cpp
@@ -2019,6 +2019,18 @@ string PlayerSpaceship::getExportLine()
         result += ":setShortRangeRadarRange(" + string(short_range_radar_range, 0) + ")";
     if (long_range_radar_range != ship_template->long_range_radar_range)
         result += ":setLongRangeRadarRange(" + string(long_range_radar_range, 0) + ")";
+    if (can_scan != ship_template->can_scan)
+        result += ":setCanScan(" + string(can_scan, true) + ")";
+    if (can_hack != ship_template->can_hack)
+        result += ":setCanHack(" + string(can_hack, true) + ")";
+    if (can_dock != ship_template->can_dock)
+        result += ":setCanDock(" + string(can_dock, true) + ")";
+    if (can_combat_maneuver != ship_template->can_combat_maneuver)
+        result += ":setCanCombatManeuver(" + string(can_combat_maneuver, true) + ")";
+    if (can_self_destruct != ship_template->can_self_destruct)
+        result += ":setCanSelfDestruct(" + string(can_self_destruct, true) + ")";
+    if (can_launch_probe != ship_template->can_launch_probe)
+        result += ":setCanLaunchProbe(" + string(can_launch_probe, true) + ")";
     return result;
 }
 

--- a/src/spaceObjects/playerSpaceship.h
+++ b/src/spaceObjects/playerSpaceship.h
@@ -126,7 +126,6 @@ public:
     // Ship functionality
     // Capable of scanning a target
     bool can_scan = true;
-    bool can_full_scan = true;
     // Target of a scan. Server-only value
     P<SpaceObject> scanning_target;
     // Time in seconds to scan an object if scanning_complexity is 0 (none)
@@ -205,8 +204,6 @@ public:
 
     void setCanScan(bool enabled) { can_scan = enabled; }
     bool getCanScan() { return can_scan; }
-    void setCanFullScan(bool enabled) { can_scan = true; can_full_scan = enabled; }
-    bool getCanFullScan(bool enabled) { return can_full_scan; }
     void setCanHack(bool enabled) { can_hack = enabled; }
     bool getCanHack() { return can_hack; }
     void setCanDock(bool enabled) { can_dock = enabled; }

--- a/src/spaceObjects/playerSpaceship.h
+++ b/src/spaceObjects/playerSpaceship.h
@@ -151,6 +151,8 @@ public:
     ECrewPosition self_destruct_code_entry_position[max_self_destruct_codes];
     ECrewPosition self_destruct_code_show_position[max_self_destruct_codes];
     float self_destruct_countdown = 0.0;
+    float self_destruct_damage = 150.0;
+    float self_destruct_size = 1500.0;
 
     // Capable of probe launches
     bool can_launch_probe = true;
@@ -211,9 +213,14 @@ public:
     void setCanCombatManeuver(bool enabled) { can_combat_maneuver = enabled; }
     bool getCanCombatManeuver() { return can_combat_maneuver; }
     void setCanSelfDestruct(bool enabled) { can_self_destruct = enabled; }
-    bool getCanSelfDestruct() { return can_self_destruct; }
+    bool getCanSelfDestruct() { return can_self_destruct && self_destruct_size > 0 && self_destruct_damage > 0; }
     void setCanLaunchProbe(bool enabled) { can_launch_probe = enabled; }
     bool getCanLaunchProbe() { return can_launch_probe; }
+
+    void setSelfDestructDamage(float amount) { self_destruct_damage = std::max(0.0f, amount); }
+    float getSelfDestructDamage() { return self_destruct_damage; }
+    void setSelfDestructSize(float size) { self_destruct_size = std::max(0.0f, size); }
+    float getSelfDestructSize() { return self_destruct_size; }
 
     void setScanProbeCount(int amount) { scan_probe_stock = std::max(0, std::min(amount, max_scan_probes)); }
     int getScanProbeCount() { return scan_probe_stock; }

--- a/src/spaceObjects/playerSpaceship.h
+++ b/src/spaceObjects/playerSpaceship.h
@@ -91,15 +91,6 @@ public:
     // Visual indicators of hull damage and in-progress jumps
     float hull_damage_indicator;
     float jump_indicator;
-    // Target of a scan. Server-only value
-    P<SpaceObject> scanning_target;
-    // Time in seconds to scan an object if scanning_complexity is 0 (none)
-    float scanning_delay;
-    // Number of sliders during a scan
-    int scanning_complexity;
-    // Number of times an object must be scanned to achieve a fully scanned
-    // state
-    int scanning_depth;
     // Time in seconds it takes to recalibrate shields
     float shield_calibration_delay;
     // Ship automation features, mostly for single-person ships like fighters
@@ -131,25 +122,48 @@ public:
     std::vector<CustomShipFunction> custom_functions;
 
     std::vector<sf::Vector2f> waypoints;
-    
-    // Scan probe capacity
-    int max_scan_probes;
-    int scan_probe_stock;
-    float scan_probe_recharge;
 
+    // Ship functionality
+    // Capable of scanning a target
+    bool can_scan = true;
+    bool can_full_scan = true;
+    // Target of a scan. Server-only value
+    P<SpaceObject> scanning_target;
+    // Time in seconds to scan an object if scanning_complexity is 0 (none)
+    float scanning_delay = 0.0;
+    // Number of sliders during a scan
+    int scanning_complexity = 0;
+    // Number of times an object must be scanned to achieve a fully scanned
+    // state
+    int scanning_depth = 0;
+
+    // Capable of hacking a target
+    bool can_hack = true;
+    // Capable of docking with a target
+    bool can_dock = true;
+    // Capable of combat maneuvers
+    bool can_combat_maneuver = true;
+
+    // Capable of self-destruction
+    bool can_self_destruct = true;
+    bool activate_self_destruct = false;
+    uint32_t self_destruct_code[max_self_destruct_codes];
+    bool self_destruct_code_confirmed[max_self_destruct_codes];
+    ECrewPosition self_destruct_code_entry_position[max_self_destruct_codes];
+    ECrewPosition self_destruct_code_show_position[max_self_destruct_codes];
+    float self_destruct_countdown = 0.0;
+
+    // Capable of probe launches
+    bool can_launch_probe = true;
+    int max_scan_probes = 8;
+    int scan_probe_stock;
+    float scan_probe_recharge = 0.0;
     ScriptSimpleCallback on_probe_launch;
 
     // Main screen content
     EMainScreenSetting main_screen_setting;
     // Content overlaid on the main screen, such as comms
     EMainScreenOverlay main_screen_overlay;
-
-    bool activate_self_destruct;
-    uint32_t self_destruct_code[max_self_destruct_codes];
-    bool self_destruct_code_confirmed[max_self_destruct_codes];
-    ECrewPosition self_destruct_code_entry_position[max_self_destruct_codes];
-    ECrewPosition self_destruct_code_show_position[max_self_destruct_codes];
-    float self_destruct_countdown;
 
     EAlertLevel alert_level;
 
@@ -188,7 +202,22 @@ public:
     void setEnergyLevelMax(float amount) { max_energy_level = std::max(0.0f, amount); energy_level = std::min(energy_level, max_energy_level); }
     float getEnergyLevel() { return energy_level; }
     float getEnergyLevelMax() { return max_energy_level; }
-    
+
+    void setCanScan(bool enabled) { can_scan = enabled; }
+    bool getCanScan() { return can_scan; }
+    void setCanFullScan(bool enabled) { can_scan = true; can_full_scan = enabled; }
+    bool getCanFullScan(bool enabled) { return can_full_scan; }
+    void setCanHack(bool enabled) { can_hack = enabled; }
+    bool getCanHack() { return can_hack; }
+    void setCanDock(bool enabled) { can_dock = enabled; }
+    bool getCanDock() { return can_dock; }
+    void setCanCombatManeuver(bool enabled) { can_combat_maneuver = enabled; }
+    bool getCanCombatManeuver() { return can_combat_maneuver; }
+    void setCanSelfDestruct(bool enabled) { can_self_destruct = enabled; }
+    bool getCanSelfDestruct() { return can_self_destruct; }
+    void setCanLaunchProbe(bool enabled) { can_launch_probe = enabled; }
+    bool getCanLaunchProbe() { return can_launch_probe; }
+
     void setScanProbeCount(int amount) { scan_probe_stock = std::max(0, std::min(amount, max_scan_probes)); }
     int getScanProbeCount() { return scan_probe_stock; }
     void setMaxScanProbeCount(int amount) { max_scan_probes = std::max(0, amount); scan_probe_stock = std::min(scan_probe_stock, max_scan_probes); }

--- a/src/spaceObjects/shipTemplateBasedObject.cpp
+++ b/src/spaceObjects/shipTemplateBasedObject.cpp
@@ -18,13 +18,26 @@ REGISTER_SCRIPT_SUBCLASS_NO_CREATE(ShipTemplateBasedObject, SpaceObject)
     REGISTER_SCRIPT_CLASS_FUNCTION(ShipTemplateBasedObject, setHull);
     /// Set the maximum amount of hull for this station. Stations never repair hull damage, so this only effects the percentage displays
     REGISTER_SCRIPT_CLASS_FUNCTION(ShipTemplateBasedObject, setHullMax);
-    /// Set if the object can be destroyed or not. true or false
+    /// Set whether the object can be destroyed.
+    /// Requires a Boolean value.
+    /// Example: ship:setCanBeDestroyed(true)
     REGISTER_SCRIPT_CLASS_FUNCTION(ShipTemplateBasedObject, setCanBeDestroyed);
-    /// Get if the object can be destroyed or not. true or false
+    /// Get whether the object can be destroyed.
+    /// Returns a Boolean value.
+    /// Example: ship:getCanBeDestroyed()
     REGISTER_SCRIPT_CLASS_FUNCTION(ShipTemplateBasedObject, getCanBeDestroyed);
-    /// Get the current shield level, stations only have a single shield, unlike ships that have a front&back shield
+    /// Get the specified shield's current level.
+    /// Requires an integer index value.
+    /// Returns a float value.
+    /// Example to get shield level on front shields of a ship with two shields:
+    ///     ship:getShieldLevel(0)
+    /// Rear shields: ship:getShieldLevel(1)
     REGISTER_SCRIPT_CLASS_FUNCTION(ShipTemplateBasedObject, getShieldLevel);
-    /// Get the amount of shields fit on this object.
+    /// Get the number of shields on this object.
+    /// For example, a ship with 1 shield count has a single shield covering
+    /// all angles, a ship with 2 covers front and back, etc.
+    /// Returns an integer count.
+    /// Example: ship:getShieldCount()
     REGISTER_SCRIPT_CLASS_FUNCTION(ShipTemplateBasedObject, getShieldCount);
     /// Get the maxium shield level.
     REGISTER_SCRIPT_CLASS_FUNCTION(ShipTemplateBasedObject, getShieldMax);


### PR DESCRIPTION
Allow player ship capabilities to be toggled. Disabled capabilities don't appear on ship screens.

Adds toggles to ship templates, the GM tweaks menu (Player 2 tab), and scripting.

Toggleable capabilities are:

- Combat maneuvers `setCanCombatManeuver(bool)`
- Docking `setCanDock(bool)`
- Scanning `setCanScan(bool)`
- Self destruct sequence `setCanSelfDestruct(bool)`
- Probe launching `setCanLaunchProbe(bool)`
- Hacking `setCanHack(bool)`

Example:

<img width="717" alt="Screen Shot 2020-04-01 at 8 50 40 PM" src="https://user-images.githubusercontent.com/19192104/78209581-4b751900-745c-11ea-95f4-873227d1502b.png">

<img width="707" alt="Screen Shot 2020-04-01 at 8 50 49 PM" src="https://user-images.githubusercontent.com/19192104/78209579-487a2880-745c-11ea-97fe-e3ae30c3d82a.png">