### PR TITLE
Convert Single Pilot to glass cockpit

### DIFF
--- a/src/gui/hotkeyConfig.cpp
+++ b/src/gui/hotkeyConfig.cpp
@@ -107,6 +107,9 @@ HotkeyConfig::HotkeyConfig()
     newKey("SELF_DESTRUCT_CONFIRM", std::make_tuple("Confirm self-destruct", ""));
     newKey("SELF_DESTRUCT_CANCEL", std::make_tuple("Cancel self-destruct", ""));
 
+    newCategory("SINGLE_PILOT", "Single Pilot");
+    newKey("TOGGLE_RADAR_SIZE", std::make_tuple("Toggle radar size", "G"));
+    newKey("TOGGLE_VIEWPORT", std::make_tuple("Toggle viewport", "V"));
 }
 
 static std::vector<std::pair<string, sf::Keyboard::Key> > sfml_key_names = {

--- a/src/screenComponents/radarView.h
+++ b/src/screenComponents/radarView.h
@@ -49,6 +49,7 @@ private:
     float distance;
     sf::Vector2f view_position;
     float view_rotation;
+    float view_transparency;
     bool long_range;
     bool show_ghost_dots;
     bool show_waypoints;
@@ -76,6 +77,7 @@ public:
     GuiRadarView* setRangeIndicatorStepSize(float step) { range_indicator_step_size = step; return this; }
     GuiRadarView* longRange() { long_range = true; return this; }
     GuiRadarView* shortRange() { long_range = false; return this; }
+    GuiRadarView* setBackgroundTransparency(float transparency) { view_transparency = std::max(0.0f, std::min(255.0f, transparency)); return this; }
     GuiRadarView* enableGhostDots() { show_ghost_dots = true; return this; }
     GuiRadarView* disableGhostDots() { show_ghost_dots = false; return this; }
     GuiRadarView* enableWaypoints() { show_waypoints = true; return this; }

--- a/src/screens/crew1/singlePilotScreen.cpp
+++ b/src/screens/crew1/singlePilotScreen.cpp
@@ -8,7 +8,6 @@
 
 #include "screenComponents/alertOverlay.h"
 #include "screenComponents/combatManeuver.h"
-#include "screenComponents/radarView.h"
 #include "screenComponents/impulseControls.h"
 #include "screenComponents/warpControls.h"
 #include "screenComponents/jumpControls.h"
@@ -31,30 +30,48 @@
 SinglePilotScreen::SinglePilotScreen(GuiContainer* owner)
 : GuiOverlay(owner, "SINGLEPILOT_SCREEN", colorConfig.background)
 {
-    // Create a 3D viewport behind everything, to serve as the right-side panel
-    viewport = new GuiViewport3D(this, "3D_VIEW");
-    viewport->setPosition(1000, 0, ATopLeft)->setSize(GuiElement::GuiSizeMax, GuiElement::GuiSizeMax);
-
-    first_person = PreferencesManager::get("first_person") == "1";
-
-    // Create left panel for controls.
-    left_panel = new GuiElement(this, "LEFT_PANEL");
-    left_panel->setPosition(0, 0, ATopLeft)->setSize(1000, GuiElement::GuiSizeMax);
-
     // Render the radar shadow and background decorations.
-    background_gradient = new GuiOverlay(left_panel, "BACKGROUND_GRADIENT", sf::Color::White);
+    background_gradient = new GuiOverlay(this, "BACKGROUND_GRADIENT", sf::Color::White);
     background_gradient->setTextureCenter("gui/BackgroundGradientSingle");
 
-    background_crosses = new GuiOverlay(left_panel, "BACKGROUND_CROSSES", sf::Color::White);
+    background_crosses = new GuiOverlay(this, "BACKGROUND_CROSSES", sf::Color::White);
     background_crosses->setTextureTiled("gui/BackgroundCrosses");
+
+    EGuiAlign radar_alignment = ACenter;
+    float radar_size = RADAR_SIZE_LARGE;
+    float radar_transparency = 255;
+    float radar_position_y = 0;
+    float aim_position_y = 0;
+
+#ifdef FEATURE_3D_RENDERING
+    // Hide the background and show the 3D viewport by default.
+    background_gradient->hide();
+    background_crosses->hide();
+
+    viewport = new GuiViewport3D(this, "3D_VIEW");
+    viewport->setPosition(0, 0, ACenter)->setSize(GuiElement::GuiSizeMax, GuiElement::GuiSizeMax);
+    viewport->show();
+
+    // Configure default first-person view from preferences file.
+    first_person = PreferencesManager::get("first_person") == "1";
+
+    // Set starting radar size and position defaults.
+    radar_alignment = ABottomCenter;
+    radar_size = RADAR_SIZE_SMALL;
+    radar_transparency = 192;
+    radar_position_y = -20;
+    aim_position_y = radar_position_y + (radar_size / 26);
+#endif
 
     // Render the alert level color overlay.
     (new AlertLevelOverlay(this));
 
     // 5U tactical radar with piloting features.
-    radar = new GuiRadarView(left_panel, "TACTICAL_RADAR", &targets);
-    radar->setPosition(0, 0, ACenter)->setSize(GuiElement::GuiSizeMatchHeight, 650);
+    radar = new GuiRadarView(this, "TACTICAL_RADAR", &targets);
+    radar->setPosition(0, radar_position_y, radar_alignment)->setSize(GuiElement::GuiSizeMatchHeight, radar_size);
     radar->setRangeIndicatorStepSize(1000.0)->shortRange()->enableGhostDots()->enableWaypoints()->enableCallsigns()->enableHeadingIndicators()->setStyle(GuiRadarView::Circular);
+    radar->setAutoRotating(PreferencesManager::get("weapons_radar_lock", "0") == "1");
+    radar->setBackgroundTransparency(radar_transparency);
     radar->setCallbacks(
         [this](sf::Vector2f position) {
             targets.setToClosestTo(position, 250, TargetsContainer::Targetable);
@@ -74,43 +91,43 @@ SinglePilotScreen::SinglePilotScreen(GuiContainer* owner)
     );
 
     // Ship stats and combat maneuver at bottom right corner of left panel.
-    (new GuiCombatManeuver(left_panel, "COMBAT_MANEUVER"))->setPosition(-20, -180, ABottomRight)->setSize(200, 150);
+    (new GuiCombatManeuver(this, "COMBAT_MANEUVER"))->setPosition(-20, -180, ABottomRight)->setSize(200, 150);
 
-    energy_display = new GuiKeyValueDisplay(left_panel, "ENERGY_DISPLAY", 0.45, "Energy", "");
+    energy_display = new GuiKeyValueDisplay(this, "ENERGY_DISPLAY", 0.45, "Energy", "");
     energy_display->setIcon("gui/icons/energy")->setTextSize(20)->setPosition(-20, -140, ABottomRight)->setSize(240, 40);
-    heading_display = new GuiKeyValueDisplay(left_panel, "HEADING_DISPLAY", 0.45, "Heading", "");
+    heading_display = new GuiKeyValueDisplay(this, "HEADING_DISPLAY", 0.45, "Heading", "");
     heading_display->setIcon("gui/icons/heading")->setTextSize(20)->setPosition(-20, -100, ABottomRight)->setSize(240, 40);
-    velocity_display = new GuiKeyValueDisplay(left_panel, "VELOCITY_DISPLAY", 0.45, "Speed", "");
+    velocity_display = new GuiKeyValueDisplay(this, "VELOCITY_DISPLAY", 0.45, "Speed", "");
     velocity_display->setIcon("gui/icons/speed")->setTextSize(20)->setPosition(-20, -60, ABottomRight)->setSize(240, 40);
-    shields_display = new GuiKeyValueDisplay(left_panel, "SHIELDS_DISPLAY", 0.45, "Shields", "");
+    shields_display = new GuiKeyValueDisplay(this, "SHIELDS_DISPLAY", 0.45, "Shields", "");
     shields_display->setIcon("gui/icons/shields")->setTextSize(20)->setPosition(-20, -20, ABottomRight)->setSize(240, 40);
 
     // Unlocked missile aim dial and lock controls.
-    missile_aim = new GuiRotationDial(left_panel, "MISSILE_AIM", -90, 360 - 90, 0, [this](float value){
+    missile_aim = new AimLock(this, "MISSILE_AIM", radar, -90, 360 - 90, 0, [this](float value){
         tube_controls->setMissileTargetAngle(value);
     });
-    missile_aim->setPosition(0, 0, ACenter)->setSize(GuiElement::GuiSizeMatchHeight, 700);
+    missile_aim->setPosition(0, aim_position_y, radar_alignment)->setSize(GuiElement::GuiSizeMatchHeight, radar_size + (radar_size / 13));
 
     // Weapon tube controls.
-    tube_controls = new GuiMissileTubeControls(left_panel, "MISSILE_TUBES");
+    tube_controls = new GuiMissileTubeControls(this, "MISSILE_TUBES");
     tube_controls->setPosition(20, -20, ABottomLeft);
     radar->enableTargetProjections(tube_controls);
 
     // Engine layout in top left corner of left panel.
-    GuiAutoLayout* engine_layout = new GuiAutoLayout(left_panel, "ENGINE_LAYOUT", GuiAutoLayout::LayoutHorizontalLeftToRight);
+    GuiAutoLayout* engine_layout = new GuiAutoLayout(this, "ENGINE_LAYOUT", GuiAutoLayout::LayoutHorizontalLeftToRight);
     engine_layout->setPosition(20, 80, ATopLeft)->setSize(GuiElement::GuiSizeMax, 250);
     (new GuiImpulseControls(engine_layout, "IMPULSE"))->setSize(100, GuiElement::GuiSizeMax);
     warp_controls = (new GuiWarpControls(engine_layout, "WARP"))->setSize(100, GuiElement::GuiSizeMax);
     jump_controls = (new GuiJumpControls(engine_layout, "JUMP"))->setSize(100, GuiElement::GuiSizeMax);
 
     // Docking, comms, and shields buttons across top.
-    (new GuiDockingButton(left_panel, "DOCKING"))->setPosition(20, 20, ATopLeft)->setSize(250, 50);
-    (new GuiOpenCommsButton(left_panel, "OPEN_COMMS_BUTTON", "Open Comms", &targets))->setPosition(270, 20, ATopLeft)->setSize(250, 50);
+    (new GuiDockingButton(this, "DOCKING"))->setPosition(20, 20, ATopLeft)->setSize(250, 50);
+    (new GuiOpenCommsButton(this, "OPEN_COMMS_BUTTON", "Open Comms", &targets))->setPosition(270, 20, ATopLeft)->setSize(250, 50);
     (new GuiCommsOverlay(this))->setSize(GuiElement::GuiSizeMax, GuiElement::GuiSizeMax);
-    (new GuiShieldsEnableButton(left_panel, "SHIELDS_ENABLE"))->setPosition(520, 20, ATopLeft)->setSize(250, 50);
+    (new GuiShieldsEnableButton(this, "SHIELDS_ENABLE"))->setPosition(520, 20, ATopLeft)->setSize(250, 50);
 
     // Missile lock button near top right of left panel.
-    lock_aim = new AimLockButton(left_panel, "LOCK_AIM", tube_controls, missile_aim);
+    lock_aim = new AimLockButton(this, "LOCK_AIM", tube_controls, missile_aim);
     lock_aim->setPosition(250, 70, ATopCenter)->setSize(130, 50);
     
     (new GuiCustomShipFunctions(this, singlePilot, ""))->setPosition(-20, 120, ATopRight)->setSize(250, GuiElement::GuiSizeMax);
@@ -135,16 +152,6 @@ void SinglePilotScreen::onDraw(sf::RenderTarget& window)
         targets.set(my_spaceship->getTarget());
     }
     GuiOverlay::onDraw(window);
-
-    // Responsively show/hide the 3D viewport.
-    if (viewport->getRect().width < viewport->getRect().height / 3.0f)
-    {
-        viewport->hide();
-        left_panel->setSize(GuiElement::GuiSizeMax, GuiElement::GuiSizeMax);
-    } else {
-        viewport->show();
-        left_panel->setSize(1000, GuiElement::GuiSizeMax);
-    }
 
     if (my_spaceship)
     {
@@ -215,6 +222,7 @@ void SinglePilotScreen::onHotkey(const HotkeyResult& key)
         else if (key.hotkey == "TURN_RIGHT")
             my_spaceship->commandTargetRotation(my_spaceship->getRotation() + 5.0f);
     }
+
     if (key.category == "WEAPONS" && my_spaceship)
     {
         if (key.hotkey == "NEXT_ENEMY_TARGET")
@@ -289,5 +297,68 @@ void SinglePilotScreen::onHotkey(const HotkeyResult& key)
             missile_aim->setValue(missile_aim->getValue() + 5.0f);
             tube_controls->setMissileTargetAngle(missile_aim->getValue());
         }
+    }
+
+    if (key.category == "MAIN_SCREEN" && my_spaceship)
+    {
+        if (key.hotkey == "FIRST_PERSON")
+            first_person = !first_person;
+    }
+
+    if (key.category == "SINGLE_PILOT" && my_spaceship)
+    {
+        if (key.hotkey == "TOGGLE_RADAR_SIZE" && viewport->isVisible())
+            toggleRadarSize(radar->getSize().y);
+        if (key.hotkey == "TOGGLE_VIEWPORT")
+            toggleViewport(viewport->isVisible());
+    }
+}
+
+void SinglePilotScreen::toggleRadarSize(float size)
+{
+    float new_radar_size, new_aim_size, new_radar_position_y, new_aim_position_y;
+    EGuiAlign new_alignment;
+
+    if (size == RADAR_SIZE_SMALL)
+    {
+        // If the current radar size is small, enlarge and center it.
+        new_radar_size = RADAR_SIZE_LARGE;
+        new_alignment = ACenter;
+        new_radar_position_y = 0;
+        new_aim_position_y = 0;
+    } else {
+        // Otherwise, shrink and move it to the bottom.
+        new_radar_size = RADAR_SIZE_SMALL;
+        new_alignment = ABottomCenter;
+        new_radar_position_y = -20;
+        new_aim_position_y = -20 + (new_radar_size / 26);
+    }
+
+    // Manual aim rotation ring is a little larger than the radar itself.
+    new_aim_size = new_radar_size + (new_radar_size / 13);
+
+    radar->setSize(GuiElement::GuiSizeMatchHeight, new_radar_size);
+    radar->setPosition(0, new_radar_position_y, new_alignment);
+    missile_aim->setSize(GuiElement::GuiSizeMatchHeight, new_aim_size);
+    missile_aim->setPosition(0, new_aim_position_y, new_alignment);
+}
+
+void SinglePilotScreen::toggleViewport(bool is_visible)
+{
+    if (is_visible)
+    {
+        // Hide 3D viewport, show background, and resize radar.
+        background_gradient->show();
+        background_crosses->show();
+        viewport->hide();
+        radar->setBackgroundTransparency(255);
+        toggleRadarSize(RADAR_SIZE_SMALL);
+    } else {
+        // Show 3D viewport, hide background, and resize radar..
+        background_gradient->hide();
+        background_crosses->hide();
+        viewport->show();
+        radar->setBackgroundTransparency(192);
+        toggleRadarSize(RADAR_SIZE_LARGE);
     }
 }

--- a/src/screens/crew1/singlePilotScreen.cpp
+++ b/src/screens/crew1/singlePilotScreen.cpp
@@ -307,10 +307,12 @@ void SinglePilotScreen::onHotkey(const HotkeyResult& key)
 
     if (key.category == "SINGLE_PILOT" && my_spaceship)
     {
+#ifdef FEATURE_3D_RENDERING
         if (key.hotkey == "TOGGLE_RADAR_SIZE" && viewport->isVisible())
             toggleRadarSize(radar->getSize().y);
         if (key.hotkey == "TOGGLE_VIEWPORT")
             toggleViewport(viewport->isVisible());
+#endif
     }
 }
 
@@ -345,6 +347,7 @@ void SinglePilotScreen::toggleRadarSize(float size)
 
 void SinglePilotScreen::toggleViewport(bool is_visible)
 {
+#ifdef FEATURE_3D_RENDERING
     if (is_visible)
     {
         // Hide 3D viewport, show background, and resize radar.
@@ -361,4 +364,5 @@ void SinglePilotScreen::toggleViewport(bool is_visible)
         radar->setBackgroundTransparency(192);
         toggleRadarSize(RADAR_SIZE_LARGE);
     }
+#endif
 }

--- a/src/screens/crew1/singlePilotScreen.cpp
+++ b/src/screens/crew1/singlePilotScreen.cpp
@@ -43,7 +43,7 @@ SinglePilotScreen::SinglePilotScreen(GuiContainer* owner)
     float radar_position_y = 0;
     float aim_position_y = 0;
 
-#ifdef FEATURE_3D_RENDERING
+#ifndef __ANDROID__
     // Hide the background and show the 3D viewport by default.
     background_gradient->hide();
     background_crosses->hide();
@@ -307,7 +307,7 @@ void SinglePilotScreen::onHotkey(const HotkeyResult& key)
 
     if (key.category == "SINGLE_PILOT" && my_spaceship)
     {
-#ifdef FEATURE_3D_RENDERING
+#ifndef __ANDROID__
         if (key.hotkey == "TOGGLE_RADAR_SIZE" && viewport->isVisible())
             toggleRadarSize(radar->getSize().y);
         if (key.hotkey == "TOGGLE_VIEWPORT")
@@ -347,7 +347,7 @@ void SinglePilotScreen::toggleRadarSize(float size)
 
 void SinglePilotScreen::toggleViewport(bool is_visible)
 {
-#ifdef FEATURE_3D_RENDERING
+#ifndef __ANDROID__
     if (is_visible)
     {
         // Hide 3D viewport, show background, and resize radar.

--- a/src/screens/crew1/singlePilotScreen.h
+++ b/src/screens/crew1/singlePilotScreen.h
@@ -2,6 +2,7 @@
 #define SINGLE_PILOT_SCREEN_H
 
 #include "gui/gui2_overlay.h"
+#include "screenComponents/radarView.h"
 #include "screenComponents/targetsContainer.h"
 #include "gui/joystickConfig.h"
 
@@ -11,30 +12,33 @@ class GuiRadarView;
 class GuiKeyValueDisplay;
 class GuiToggleButton;
 class GuiRotationDial;
+class GuiViewport3D;
 
 class SinglePilotScreen : public GuiOverlay
 {
 private:
-    bool first_person;
+    const float RADAR_SIZE_LARGE = 650.0f;
+    const float RADAR_SIZE_SMALL = 300.0f;
+    bool first_person = false;
 
     GuiOverlay* background_gradient;
     GuiOverlay* background_crosses;
-
     GuiViewport3D* viewport;
-    GuiElement* left_panel;
 
+    TargetsContainer targets;
     GuiKeyValueDisplay* energy_display;
     GuiKeyValueDisplay* heading_display;
     GuiKeyValueDisplay* velocity_display;
     GuiKeyValueDisplay* shields_display;
+    GuiRadarView* radar;
+    GuiMissileTubeControls* tube_controls;
+    GuiRotationDial* missile_aim;
+    GuiToggleButton* lock_aim;
     GuiElement* warp_controls;
     GuiElement* jump_controls;
-    
-    TargetsContainer targets;
-    GuiRadarView* radar;
-    GuiRotationDial* missile_aim;
-    GuiMissileTubeControls* tube_controls;
-    GuiToggleButton* lock_aim;
+
+    void toggleRadarSize(float size);
+    void toggleViewport(bool is_visible);
 public:
     SinglePilotScreen(GuiContainer* owner);
     


### PR DESCRIPTION
On 3D-capable devices, allow and default to replacing the static
background with a 3D viewport, of either a forward chase camera view
or a first-person view (using the MAIN_SCREEN FIRST_PERSON keybind
and respecting the first_person preferences file option). The radar
is semi-transparent and can be resized.

Allow toggling the 3D viewport to a normal opaque background.

Add hotkey bindings to toggle radar size (SINGLE_PILOT category,
TOGGLE_RADAR_SIZE, G default) and 3D viewport visibility (TOGGLE_VIEWPORT,
V default).

On devices not capable of rendering the 3D viewport, default to the
normal view with a static background.

Examples:

<img width="1181" alt="Screen Shot 2020-04-01 at 9 28 19 PM" src="https://user-images.githubusercontent.com/19192104/78210772-0eab2100-7460-11ea-9654-5f98f7f7e472.png">
<img width="1185" alt="Screen Shot 2020-04-01 at 9 29 18 PM" src="https://user-images.githubusercontent.com/19192104/78210773-0f43b780-7460-11ea-983b-f47bdff6a92f.png">
<img width="1188" alt="Screen Shot 2020-04-01 at 9 29 24 PM" src="https://user-images.githubusercontent.com/19192104/78210775-1074e480-7460-11ea-9ac1-d7bb2e1f8e81.png">
<img width="1183" alt="Screen Shot 2020-04-01 at 9 29 27 PM" src="https://user-images.githubusercontent.com/19192104/78210778-1074e480-7460-11ea-91fc-964615300429.png">
