### PR TITLE
Allow tweaking cpuship and station capabilities

### DIFF
--- a/src/screens/gm/gameMasterScreen.cpp
+++ b/src/screens/gm/gameMasterScreen.cpp
@@ -105,9 +105,6 @@ GameMasterScreen::GameMasterScreen()
             } else if (P<PlayerSpaceship>(obj)) {
                 player_tweak_dialog->open(obj);
                 break;
-            } else if (P<SpaceShip>(obj)) {
-                ship_tweak_dialog->open(obj);
-                break;
             } else {
                 object_tweak_dialog->open(obj);
                 break;
@@ -186,8 +183,6 @@ GameMasterScreen::GameMasterScreen()
     cpu_tweak_dialog->hide();
     player_tweak_dialog = new GuiObjectTweak(this, TW_Player);
     player_tweak_dialog->hide();
-    ship_tweak_dialog = new GuiObjectTweak(this, TW_Ship);
-    ship_tweak_dialog->hide();
     object_tweak_dialog = new GuiObjectTweak(this, TW_Object);
     object_tweak_dialog->hide();
 

--- a/src/screens/gm/gameMasterScreen.cpp
+++ b/src/screens/gm/gameMasterScreen.cpp
@@ -95,18 +95,20 @@ GameMasterScreen::GameMasterScreen()
     tweak_button = new GuiButton(this, "TWEAK_OBJECT", "Tweak", [this]() {
         for(P<SpaceObject> obj : targets.getTargets())
         {
-            if (P<PlayerSpaceship>(obj))
+            if (P<SpaceStation>(obj))
             {
+                station_tweak_dialog->open(obj);
+                break;
+            } else if (P<CpuShip>(obj)) {
+                cpu_tweak_dialog->open(obj);
+                break;
+            } else if (P<PlayerSpaceship>(obj)) {
                 player_tweak_dialog->open(obj);
                 break;
-            }
-            else if (P<SpaceShip>(obj))
-            {
+            } else if (P<SpaceShip>(obj)) {
                 ship_tweak_dialog->open(obj);
                 break;
-            }
-            else
-            {
+            } else {
                 object_tweak_dialog->open(obj);
                 break;
             }
@@ -178,6 +180,10 @@ GameMasterScreen::GameMasterScreen()
         chat_dialog_per_ship[n]->hide();
     }
 
+    station_tweak_dialog = new GuiObjectTweak(this, TW_Station);
+    station_tweak_dialog->hide();
+    cpu_tweak_dialog = new GuiObjectTweak(this, TW_CpuShip);
+    cpu_tweak_dialog->hide();
     player_tweak_dialog = new GuiObjectTweak(this, TW_Player);
     player_tweak_dialog->hide();
     ship_tweak_dialog = new GuiObjectTweak(this, TW_Ship);

--- a/src/screens/gm/gameMasterScreen.h
+++ b/src/screens/gm/gameMasterScreen.h
@@ -39,7 +39,6 @@ private:
     GuiObjectTweak* station_tweak_dialog;
     GuiObjectTweak* cpu_tweak_dialog;
     GuiObjectTweak* player_tweak_dialog;
-    GuiObjectTweak* ship_tweak_dialog;
     GuiObjectTweak* object_tweak_dialog;
     
     GuiAutoLayout* info_layout;

--- a/src/screens/gm/gameMasterScreen.h
+++ b/src/screens/gm/gameMasterScreen.h
@@ -36,6 +36,8 @@ private:
     std::vector<GameMasterChatDialog*> chat_dialog_per_ship;
     GuiGlobalMessageEntryView* global_message_entry;
     GuiObjectCreationView* object_creation_view;
+    GuiObjectTweak* station_tweak_dialog;
+    GuiObjectTweak* cpu_tweak_dialog;
     GuiObjectTweak* player_tweak_dialog;
     GuiObjectTweak* ship_tweak_dialog;
     GuiObjectTweak* object_tweak_dialog;

--- a/src/screens/gm/tweak.cpp
+++ b/src/screens/gm/tweak.cpp
@@ -766,6 +766,25 @@ GuiShipTweakPlayer2::GuiShipTweakPlayer2(GuiContainer* owner)
     restocks_scan_probes_toggle->setSize(GuiElement::GuiSizeMax, 40);
 }
 
+void GuiShipTweakPlayer2::onDraw(sf::RenderTarget& window)
+{
+    coolant_slider->setValue(target->max_coolant);
+    short_range_radar_slider->setValue(target->getShortRangeRadarRange());
+    long_range_radar_slider->setValue(target->getLongRangeRadarRange());
+    can_scan->setValue(target->getCanScan());
+    can_hack->setValue(target->getCanHack());
+    can_dock->setValue(target->getCanDock());
+    can_combat_maneuver->setValue(target->getCanCombatManeuver());
+    can_self_destruct->setValue(target->getCanSelfDestruct());
+    can_launch_probe->setValue(target->getCanLaunchProbe());
+}
+
+void GuiShipTweakPlayer2::open(P<SpaceObject> target)
+{
+    P<PlayerSpaceship> player = target;
+    this->target = player;
+}
+
 GuiShipTweakCpu::GuiShipTweakCpu(GuiContainer* owner)
 : GuiTweakPage(owner)
 {
@@ -784,6 +803,18 @@ GuiShipTweakCpu::GuiShipTweakCpu(GuiContainer* owner)
     repair_rate_slider->setSize(GuiElement::GuiSizeMax, 40);
     repair_rate_overlay_label = new GuiLabel(repair_rate_slider, "REPAIR_RATE_SLIDER_LABEL", "", 30);
     repair_rate_overlay_label->setSize(GuiElement::GuiSizeMax, GuiElement::GuiSizeMax);
+}
+
+void GuiShipTweakCpu::onDraw(sf::RenderTarget& window)
+{
+    // Update repair rate.
+    repair_rate_slider->setValue(target->getAutoRepairRate());
+    repair_rate_overlay_label->setText(string(target->getAutoRepairRate(), 4));
+}
+
+void GuiShipTweakCpu::open(P<SpaceObject> target)
+{
+    this->target = target;
 }
 
 GuiStationTweakBase::GuiStationTweakBase(GuiContainer* owner)
@@ -868,40 +899,9 @@ GuiStationTweakBase::GuiStationTweakBase(GuiContainer* owner)
     restocks_scan_probes_toggle->setSize(GuiElement::GuiSizeMax, 40);
 }
 
-void GuiShipTweakPlayer2::onDraw(sf::RenderTarget& window)
-{
-    coolant_slider->setValue(target->max_coolant);
-    short_range_radar_slider->setValue(target->getShortRangeRadarRange());
-    long_range_radar_slider->setValue(target->getLongRangeRadarRange());
-    can_scan->setValue(target->getCanScan());
-    can_hack->setValue(target->getCanHack());
-    can_dock->setValue(target->getCanDock());
-    can_combat_maneuver->setValue(target->getCanCombatManeuver());
-    can_self_destruct->setValue(target->getCanSelfDestruct());
-    can_launch_probe->setValue(target->getCanLaunchProbe());
-}
-
-void GuiShipTweakCpu::onDraw(sf::RenderTarget& window)
-{
-    // Update repair rate.
-    repair_rate_slider->setValue(target->getAutoRepairRate());
-    repair_rate_overlay_label->setText(string(target->getAutoRepairRate(), 4));
-}
-
 void GuiStationTweakBase::onDraw(sf::RenderTarget& window)
 {
     hull_slider->setValue(target->hull_strength);
-}
-
-void GuiShipTweakPlayer2::open(P<SpaceObject> target)
-{
-    P<PlayerSpaceship> player = target;
-    this->target = player;
-}
-
-void GuiShipTweakCpu::open(P<SpaceObject> target)
-{
-    this->target = target;
 }
 
 void GuiStationTweakBase::open(P<SpaceObject> target)
@@ -911,6 +911,9 @@ void GuiStationTweakBase::open(P<SpaceObject> target)
 
     if (station)
     {
+        callsign->setText(station->callsign);
+        description->setText(station->getDescription(SS_NotScanned));
+        heading_slider->setValue(station->getHeading());
         hull_max_slider->setValue(station->hull_max);
         hull_max_slider->clearSnapValues()->addSnapValue(station->ship_template->hull, 5.0f);
         can_be_destroyed_toggle->setValue(station->getCanBeDestroyed());

--- a/src/screens/gm/tweak.cpp
+++ b/src/screens/gm/tweak.cpp
@@ -656,6 +656,26 @@ void GuiShipTweakPlayer::onDraw(sf::RenderTarget& window)
     reputation_point_slider->setValue(target->getReputationPoints());
 }
 
+void GuiShipTweakPlayer::open(P<SpaceObject> target)
+{
+    P<PlayerSpaceship> player = target;
+    this->target = player;
+
+    if (player)
+    {
+        // Read ship's control code.
+        control_code->setText(player->control_code);
+
+        // Set and snap boost speed slider to current value
+        combat_maneuver_boost_speed_slider->setValue(player->combat_maneuver_boost_speed);
+        combat_maneuver_boost_speed_slider->clearSnapValues()->addSnapValue(player->combat_maneuver_boost_speed, 20.0f);
+
+        // Set and snap strafe speed slider to current value
+        combat_maneuver_strafe_speed_slider->setValue(player->combat_maneuver_strafe_speed);
+        combat_maneuver_strafe_speed_slider->clearSnapValues()->addSnapValue(player->combat_maneuver_strafe_speed, 20.0f);
+    }
+}
+
 GuiShipTweakPlayer2::GuiShipTweakPlayer2(GuiContainer* owner)
 : GuiTweakPage(owner)
 {
@@ -871,26 +891,6 @@ void GuiShipTweakCpu::onDraw(sf::RenderTarget& window)
 void GuiStationTweakBase::onDraw(sf::RenderTarget& window)
 {
     hull_slider->setValue(target->hull_strength);
-}
-
-void GuiShipTweakPlayer::open(P<SpaceObject> target)
-{
-    P<PlayerSpaceship> player = target;
-    this->target = player;
-
-    if (player)
-    {
-        // Read ship's control code.
-        control_code->setText(player->control_code);
-
-        // Set and snap boost speed slider to current value
-        combat_maneuver_boost_speed_slider->setValue(player->combat_maneuver_boost_speed);
-        combat_maneuver_boost_speed_slider->clearSnapValues()->addSnapValue(player->combat_maneuver_boost_speed, 20.0f);
-
-        // Set and snap strafe speed slider to current value
-        combat_maneuver_strafe_speed_slider->setValue(player->combat_maneuver_strafe_speed);
-        combat_maneuver_strafe_speed_slider->clearSnapValues()->addSnapValue(player->combat_maneuver_strafe_speed, 20.0f);
-    }
 }
 
 void GuiShipTweakPlayer2::open(P<SpaceObject> target)

--- a/src/screens/gm/tweak.cpp
+++ b/src/screens/gm/tweak.cpp
@@ -756,12 +756,14 @@ GuiShipTweakCpu::GuiShipTweakCpu(GuiContainer* owner)
     GuiAutoLayout* right_col = new GuiAutoLayout(this, "RIGHT_LAYOUT", GuiAutoLayout::LayoutVerticalTopToBottom);
     right_col->setPosition(-25, 25, ATopRight)->setSize(300, GuiElement::GuiSizeMax);
 
-    // System autorepair rate (CpuShip)
-    (new GuiLabel(left_col, "", "CpuShip repair rate:", 30))->setSize(GuiElement::GuiSizeMax, 50);
+    // System autorepair rate
+    (new GuiLabel(left_col, "", "System repair rate:", 30))->setSize(GuiElement::GuiSizeMax, 50);
     repair_rate_slider = new GuiSlider(left_col, "", 0.0, 0.1, 0.0, [this](float value) {
         target->setAutoRepairRate(value);
     });
-    repair_rate_slider->addOverlay()->setSize(GuiElement::GuiSizeMax, 40);
+    repair_rate_slider->setSize(GuiElement::GuiSizeMax, 40);
+    repair_rate_overlay_label = new GuiLabel(repair_rate_slider, "REPAIR_RATE_SLIDER_LABEL", "", 30);
+    repair_rate_overlay_label->setSize(GuiElement::GuiSizeMax, GuiElement::GuiSizeMax);
 }
 
 GuiStationTweakBase::GuiStationTweakBase(GuiContainer* owner)
@@ -863,6 +865,7 @@ void GuiShipTweakCpu::onDraw(sf::RenderTarget& window)
 {
     // Update repair rate.
     repair_rate_slider->setValue(target->getAutoRepairRate());
+    repair_rate_overlay_label->setText(string(target->getAutoRepairRate(), 4));
 }
 
 void GuiStationTweakBase::onDraw(sf::RenderTarget& window)

--- a/src/screens/gm/tweak.cpp
+++ b/src/screens/gm/tweak.cpp
@@ -638,13 +638,14 @@ GuiShipTweakPlayer2::GuiShipTweakPlayer2(GuiContainer* owner)
     right_col->setPosition(-25, 25, ATopRight)->setSize(300, GuiElement::GuiSizeMax);
 
     // Left column
-    (new GuiLabel(left_col, "", "Coolant:", 30))->setSize(GuiElement::GuiSizeMax, 50);
-
+    // Maximum coolant amount
+    (new GuiLabel(left_col, "", "Max coolant:", 30))->setSize(GuiElement::GuiSizeMax, 50);
     coolant_slider = new GuiSlider(left_col, "", 0.0, 50.0, 0.0, [this](float value) {
         target->setMaxCoolant(value);
     });
     coolant_slider->addOverlay()->setSize(GuiElement::GuiSizeMax, 40);
 
+    // Radar ranges
     (new GuiLabel(left_col, "", "Short range radar:", 30))->setSize(GuiElement::GuiSizeMax, 50);
     short_range_radar_slider = new GuiSlider(left_col, "", 100.0, 20000.0, 0.0, [this](float value) {
         target->setShortRangeRadarRange(value);
@@ -658,6 +659,9 @@ GuiShipTweakPlayer2::GuiShipTweakPlayer2(GuiContainer* owner)
     long_range_radar_slider->addOverlay()->setSize(GuiElement::GuiSizeMax, 40);
 
     // Right column
+    // Ship capabilities
+    (new GuiLabel(right_col, "", "Capabilities:", 30))->setSize(GuiElement::GuiSizeMax, 50);
+
     // Can scan bool
     can_scan = new GuiToggleButton(right_col, "", "Can scan", [this](bool value) {
         target->setCanScan(value);
@@ -693,6 +697,24 @@ GuiShipTweakPlayer2::GuiShipTweakPlayer2(GuiContainer* owner)
         target->setCanLaunchProbe(value);
     });
     can_launch_probe->setSize(GuiElement::GuiSizeMax, 40);
+
+    // Shares energy with docked bool
+    shares_energy_with_docked_toggle = new GuiToggleButton(right_col, "", "Shares energy w/docked", [this](bool value) {
+        target->shares_energy_with_docked = value;
+    });
+    shares_energy_with_docked_toggle->setSize(GuiElement::GuiSizeMax, 40);
+
+    // Repairs docked ships bool
+    repair_docked_toggle = new GuiToggleButton(right_col, "", "Repairs docked hulls", [this](bool value) {
+        target->repair_docked = value;
+    });
+    repair_docked_toggle->setSize(GuiElement::GuiSizeMax, 40);
+
+    // Restocks probes bool
+    restocks_scan_probes_toggle = new GuiToggleButton(right_col, "", "Restocks probes", [this](bool value) {
+        target->setRestocksScanProbes(value);
+    });
+    restocks_scan_probes_toggle->setSize(GuiElement::GuiSizeMax, 40);
 }
 
 GuiShipTweakCpu::GuiShipTweakCpu(GuiContainer* owner)
@@ -738,11 +760,33 @@ GuiStationTweakBase::GuiStationTweakBase(GuiContainer* owner)
     });
     hull_slider->addOverlay()->setSize(GuiElement::GuiSizeMax, 40);
 
-   // Can be destroyed bool
-   can_be_destroyed_toggle = new GuiToggleButton(left_col, "", "Could be destroyed", [this](bool value) {
+    // Can be destroyed bool
+    can_be_destroyed_toggle = new GuiToggleButton(left_col, "", "Could be destroyed", [this](bool value) {
        target->setCanBeDestroyed(value);
-   });
-   can_be_destroyed_toggle->setSize(GuiElement::GuiSizeMax, 40);
+    });
+    can_be_destroyed_toggle->setSize(GuiElement::GuiSizeMax, 40);
+
+    // Right column
+    // Station capabilities
+    (new GuiLabel(right_col, "", "Capabilities:", 30))->setSize(GuiElement::GuiSizeMax, 50);
+
+    // Shares energy with docked bool
+    shares_energy_with_docked_toggle = new GuiToggleButton(right_col, "", "Shares energy w/docked", [this](bool value) {
+        target->setSharesEnergyWithDocked(value);
+    });
+    shares_energy_with_docked_toggle->setSize(GuiElement::GuiSizeMax, 40);
+
+    // Repairs docked ships bool
+    repair_docked_toggle = new GuiToggleButton(right_col, "", "Repairs docked hulls", [this](bool value) {
+        target->setRepairDocked(value);
+    });
+    repair_docked_toggle->setSize(GuiElement::GuiSizeMax, 40);
+
+    // Restocks probes bool
+    restocks_scan_probes_toggle = new GuiToggleButton(right_col, "", "Restocks probes", [this](bool value) {
+        target->setRestocksScanProbes(value);
+    });
+    restocks_scan_probes_toggle->setSize(GuiElement::GuiSizeMax, 40);
 }
 
 void GuiShipTweakPlayer::onDraw(sf::RenderTarget& window)
@@ -823,7 +867,8 @@ void GuiShipTweakPlayer::open(P<SpaceObject> target)
 
 void GuiShipTweakPlayer2::open(P<SpaceObject> target)
 {
-    this->target = target;
+    P<PlayerSpaceship> player = target;
+    this->target = player;
 }
 
 void GuiShipTweakCpu::open(P<SpaceObject> target)
@@ -841,6 +886,9 @@ void GuiStationTweakBase::open(P<SpaceObject> target)
         hull_max_slider->setValue(station->hull_max);
         hull_max_slider->clearSnapValues()->addSnapValue(station->ship_template->hull, 5.0f);
         can_be_destroyed_toggle->setValue(station->getCanBeDestroyed());
+        restocks_scan_probes_toggle->setValue(station->getRestocksScanProbes());
+        shares_energy_with_docked_toggle->setValue(station->getSharesEnergyWithDocked());
+        repair_docked_toggle->setValue(station->getRepairDocked());
     }
 }
 

--- a/src/screens/gm/tweak.h
+++ b/src/screens/gm/tweak.h
@@ -194,6 +194,9 @@ private:
     GuiToggleButton* can_combat_maneuver;
     GuiToggleButton* can_self_destruct;
     GuiToggleButton* can_launch_probe;
+    GuiToggleButton* shares_energy_with_docked_toggle;
+    GuiToggleButton* repair_docked_toggle;
+    GuiToggleButton* restocks_scan_probes_toggle;
 public:
     GuiShipTweakPlayer2(GuiContainer* owner);
 
@@ -224,6 +227,9 @@ private:
     GuiSlider* hull_max_slider;
     GuiSlider* hull_slider;
     GuiToggleButton* can_be_destroyed_toggle;
+    GuiToggleButton* shares_energy_with_docked_toggle;
+    GuiToggleButton* repair_docked_toggle;
+    GuiToggleButton* restocks_scan_probes_toggle;
 public:
     GuiStationTweakBase(GuiContainer* owner);
 

--- a/src/screens/gm/tweak.h
+++ b/src/screens/gm/tweak.h
@@ -210,6 +210,7 @@ private:
     P<CpuShip> target;
 
     GuiSlider* repair_rate_slider;
+    GuiLabel* repair_rate_overlay_label;
 public:
     GuiShipTweakCpu(GuiContainer* owner);
 

--- a/src/screens/gm/tweak.h
+++ b/src/screens/gm/tweak.h
@@ -20,9 +20,8 @@ class GuiToggleButton;
 enum ETweakType
 {
     TW_Object,  // TODO: Space object
-    TW_Ship,    // Ships
     TW_CpuShip, // Ships
-    TW_Station, // TODO: Space stations
+    TW_Station, // Space stations
     TW_Player   // Player ships
 };
 
@@ -224,6 +223,9 @@ class GuiStationTweakBase : public GuiTweakPage
 private:
     P<SpaceStation> target;
 
+    GuiTextEntry* callsign;
+    GuiTextEntry* description;
+    GuiSlider* heading_slider;
     GuiSlider* hull_max_slider;
     GuiSlider* hull_slider;
     GuiToggleButton* can_be_destroyed_toggle;

--- a/src/screens/gm/tweak.h
+++ b/src/screens/gm/tweak.h
@@ -5,6 +5,8 @@
 #include "missileWeaponData.h"
 #include "shipTemplate.h"
 #include "playerInfo.h"
+#include "spaceObjects/cpuShip.h"
+#include "spaceObjects/spaceStation.h"
 #include "spaceObjects/playerSpaceship.h"
 
 class SpaceShip;
@@ -19,6 +21,7 @@ enum ETweakType
 {
     TW_Object,  // TODO: Space object
     TW_Ship,    // Ships
+    TW_CpuShip, // Ships
     TW_Station, // TODO: Space stations
     TW_Player   // Player ships
 };
@@ -197,6 +200,36 @@ public:
     virtual void open(P<SpaceObject> target) override;
 
     virtual void onDraw(sf::RenderTarget& window) override;
+};
+
+class GuiShipTweakCpu : public GuiTweakPage
+{
+private:
+    P<CpuShip> target;
+
+    GuiSlider* repair_rate_slider;
+public:
+    GuiShipTweakCpu(GuiContainer* owner);
+
+    virtual void open(P<SpaceObject> target) override;
+
+    virtual void onDraw(sf::RenderTarget& window) override;
+};
+
+class GuiStationTweakBase : public GuiTweakPage
+{
+private:
+    P<SpaceStation> target;
+
+    GuiSlider* hull_max_slider;
+    GuiSlider* hull_slider;
+    GuiToggleButton* can_be_destroyed_toggle;
+public:
+    GuiStationTweakBase(GuiContainer* owner);
+
+    virtual void onDraw(sf::RenderTarget& window) override;
+
+    virtual void open(P<SpaceObject> target) override;
 };
 
 class GuiObjectTweakBase : public GuiTweakPage

--- a/src/shipTemplate.cpp
+++ b/src/shipTemplate.cpp
@@ -371,6 +371,11 @@ void ShipTemplate::setModel(string model_name)
     this->model_data = ModelData::getModel(model_name);
 }
 
+void ShipTemplate::setAutoRepairRate(float repaired_per_second)
+{
+    this->auto_system_repair_per_second = repaired_per_second;
+}
+
 void ShipTemplate::setDefaultAI(string default_ai_name)
 {
     this->default_ai_name = default_ai_name;
@@ -492,6 +497,8 @@ P<ShipTemplate> ShipTemplate::copy(string new_name)
     result->can_combat_maneuver = can_combat_maneuver;
     result->can_self_destruct = can_self_destruct;
     result->can_launch_probe = can_launch_probe;
+
+    result->auto_system_repair_per_second = auto_system_repair_per_second;
 
     result->default_ai_name = default_ai_name;
     for(int n=0; n<max_beam_weapons; n++)

--- a/src/shipTemplate.h
+++ b/src/shipTemplate.h
@@ -101,6 +101,7 @@ public:
     
     float energy_storage_amount;
     int repair_crew_count;
+    float auto_system_repair_per_second = 0.005f;
     string default_ai_name;
     BeamTemplate beams[max_beam_weapons];
     int weapon_tube_count;
@@ -133,6 +134,7 @@ public:
     void setDescription(string description);
     void setModel(string model_name);
     void setDefaultAI(string default_ai_name);
+    void setAutoRepairRate(float repaired_per_second);
     void setDockClasses(std::vector<string> classes);
     void setSharesEnergyWithDocked(bool enabled);
     void setRepairDocked(bool enabled);

--- a/src/spaceObjects/cpuShip.h
+++ b/src/spaceObjects/cpuShip.h
@@ -18,17 +18,17 @@ enum EAIOrder
     AI_Attack,          //Attack [order_target] very specificly.
 };
 
-
 class ShipAI;
+
 class CpuShip : public SpaceShip
 {
-    static constexpr float auto_system_repair_per_second = 0.005f;
     static constexpr float missile_resupply_time = 10.0f;
 
     EAIOrder orders;                    //Server only
     sf::Vector2f order_target_location; //Server only
     P<SpaceObject> order_target;        //Server only
     ShipAI* ai;
+    float auto_system_repair_per_second = 0.005f;
 
     string new_ai_name;
 public:
@@ -54,6 +54,9 @@ public:
     EAIOrder getOrder() { return orders; }
     sf::Vector2f getOrderTargetLocation() { return order_target_location; }
     P<SpaceObject> getOrderTarget() { return order_target; }
+
+    void setAutoRepairRate(float repaired_per_second) { auto_system_repair_per_second = std::max(0.0f, repaired_per_second); }
+    float getAutoRepairRate() { return auto_system_repair_per_second; }
 
     virtual void drawOnGMRadar(sf::RenderTarget& window, sf::Vector2f position, float scale, float rotation, bool long_range) override;
     virtual std::unordered_map<string, string> getGMInfo() override;


### PR DESCRIPTION
Add CpuShip autorepair capability adjustment `setAutoRepairRate()`.
A rate of 0 effectively disabled CpuShip system autorepair.

Add Station tab and tweak state to the GM menu, and allow hull and
destructability tweaks similar to ships.