### PR TITLE
Paginate options menu

### DIFF
--- a/src/menus/optionsMenu.h
+++ b/src/menus/optionsMenu.h
@@ -3,12 +3,20 @@
 
 #include "gui/gui2_canvas.h"
 
+class GuiAutoLayout;
+class GuiSelector;
 class GuiSlider;
 class GuiLabel;
 
 class OptionsMenu : public GuiCanvas
 {
 private:
+    GuiAutoLayout* left_container;
+    GuiAutoLayout* right_container;
+    GuiSelector* options_pager;
+    GuiAutoLayout* graphics_page;
+    GuiAutoLayout* audio_page;
+    GuiAutoLayout* interface_page;
     GuiSlider* sound_volume_slider;
     GuiSlider* music_volume_slider;
     GuiSlider* impulse_volume_slider;


### PR DESCRIPTION
With the addition of radar lock, impulse engine, and save controls on the Options menu, the buttons are starting to overlap, especially if custom music is added.

<img width="1312" alt="Screen Shot 2020-04-04 at 1 18 13 AM" src="https://user-images.githubusercontent.com/19192104/78422193-743f0f00-7612-11ea-99c7-dfc0f3271167.png">

Paginate the options menu to give more space. Use AutoLayouts to make future additions easier to lay out, and sort the music by ambient/combat type.

<img width="1312" alt="Screen Shot 2020-04-04 at 1 18 53 AM" src="https://user-images.githubusercontent.com/19192104/78422213-920c7400-7612-11ea-9ed3-925ba11afbe5.png">
<img width="1312" alt="Screen Shot 2020-04-04 at 1 18 51 AM" src="https://user-images.githubusercontent.com/19192104/78422216-959ffb00-7612-11ea-972d-5823642064bf.png">
<img width="1312" alt="Screen Shot 2020-04-04 at 1 18 42 AM" src="https://user-images.githubusercontent.com/19192104/78422217-96d12800-7612-11ea-82e1-6ce23d82dfc3.png">
