### PR TITLE
Add mission clock to Relay

### DIFF
--- a/src/screens/crew6/relayScreen.cpp
+++ b/src/screens/crew6/relayScreen.cpp
@@ -146,6 +146,10 @@ RelayScreen::RelayScreen(GuiContainer* owner, bool allow_comms)
     info_reputation = new GuiKeyValueDisplay(option_buttons, "INFO_REPUTATION", 0.7, tr("Reputation:"), "");
     info_reputation->setSize(GuiElement::GuiSizeMax, 40);
 
+    // Mission clock display.
+    info_clock = new GuiKeyValueDisplay(option_buttons, "INFO_CLOCK", 0.7, tr("Mission Clock:"), "");
+    info_clock->setSize(GuiElement::GuiSizeMax, 40);
+
     // Bottom layout.
     GuiAutoLayout* layout = new GuiAutoLayout(this, "", GuiAutoLayout::LayoutVerticalBottomToTop);
     layout->setPosition(-20, -70, ABottomRight)->setSize(300, GuiElement::GuiSizeMax);
@@ -280,6 +284,7 @@ void RelayScreen::onDraw(sf::RenderTarget& window)
         hack_target_button->setVisible(my_spaceship->getCanHack());
 
         info_reputation->setValue(string(my_spaceship->getReputationPoints(), 0));
+        info_clock->setValue(string(engine->getElapsedTime(), 0));
         launch_probe_button->setText(tr("Launch Probe") + " (" + string(my_spaceship->scan_probe_stock) + ")");
     }
 

--- a/src/screens/crew6/relayScreen.h
+++ b/src/screens/crew6/relayScreen.h
@@ -33,6 +33,7 @@ private:
     GuiKeyValueDisplay* info_faction;
 
     GuiKeyValueDisplay* info_reputation;
+    GuiKeyValueDisplay* info_clock;
     GuiAutoLayout* option_buttons;
     GuiButton* hack_target_button;
     GuiToggleButton* link_to_science_button;


### PR DESCRIPTION
Clock counts up in seconds, same as ship's log entries.

<img width="281" alt="Screen Shot 2020-04-04 at 1 14 42 PM" src="https://user-images.githubusercontent.com/19192104/78460522-560afa80-7676-11ea-9eed-43acfe42f755.png">
