### PR TITLE
Black Holes destroy objects by causing damage

### DIFF
--- a/src/spaceObjects/blackHole.cpp
+++ b/src/spaceObjects/blackHole.cpp
@@ -68,13 +68,19 @@ void BlackHole::collide(Collisionable* target, float collision_force)
     sf::Vector2f diff = getPosition() - target->getPosition();
     float distance = sf::length(diff);
     float force = (getRadius() * getRadius() * 50.0f) / (distance * distance);
+    DamageInfo info(NULL, DT_Kinetic, getPosition());
     if (force > 10000.0)
     {
         force = 10000.0;
         if (isServer())
-            target->destroy();
+        {
+            P<SpaceObject> obj = P<Collisionable>(target);
+            if (obj)
+                obj->takeDamage(100000.0, info); //try to destroy the object by inflicting a huge amount of damage
+            if (target)
+                target->destroy();
+        }
     }
-    DamageInfo info(NULL, DT_Kinetic, getPosition());
     if (force > 100.0 && isServer())
     {
         P<SpaceObject> obj = P<Collisionable>(target);


### PR DESCRIPTION
Before deleting a ship at the singularity, the game now tries to destroy it by dealing a huge amount of damage first. That way onDestruction() will be called when a sturdy ship gets swallowed by a black hole.