### PR TITLE
Address compiler warnings

### DIFF
--- a/src/factionInfo.h
+++ b/src/factionInfo.h
@@ -16,7 +16,6 @@ enum EFactionVsFactionState
 class FactionInfo : public PObject
 {
 private:
-    int callsign_counter;
 public:
     FactionInfo();
 

--- a/src/gui/gui2_canvas.h
+++ b/src/gui/gui2_canvas.h
@@ -15,8 +15,8 @@ public:
     GuiCanvas();
     virtual ~GuiCanvas();
 
-    virtual void render(sf::RenderTarget& window);
-    virtual void handleKeyPress(sf::Event::KeyEvent key, int unicode);
+    virtual void render(sf::RenderTarget& window) override;
+    virtual void handleKeyPress(sf::Event::KeyEvent key, int unicode) override;
     virtual void handleJoystickAxis(unsigned int joystickId, sf::Joystick::Axis axis, float position) override;
     virtual void handleJoystickButton(unsigned int joystickId, unsigned int button, bool state) override;
 

--- a/src/math/triangulate.h
+++ b/src/math/triangulate.h
@@ -33,7 +33,7 @@ public:
             if (count-- < 0)
             {
                 //** Triangulate: ERROR - probable bad polygon!
-                delete indexes;
+                delete[] indexes;
                 return false;
             }
 
@@ -65,7 +65,7 @@ public:
             }
         }
 
-        delete indexes;
+        delete[] indexes;
         return true;
     }
 

--- a/src/screenComponents/helpOverlay.cpp
+++ b/src/screenComponents/helpOverlay.cpp
@@ -7,7 +7,7 @@
 #include "gui/gui2_scrolltext.h"
 
 GuiHelpOverlay::GuiHelpOverlay(GuiCanvas* owner, string title, string contents)
-: GuiElement(owner, "HELP_OVERLAY"), owner(owner)
+: GuiElement(owner, "HELP_OVERLAY")
 {
     setSize(GuiElement::GuiSizeMax, GuiElement::GuiSizeMax);
     

--- a/src/screenComponents/helpOverlay.h
+++ b/src/screenComponents/helpOverlay.h
@@ -10,7 +10,6 @@ class GuiScrollText;
 class GuiHelpOverlay : public GuiElement
 {
 private:
-    GuiCanvas* owner;
     GuiScrollText* text;
 
     string help_text = "";

--- a/src/screenComponents/indicatorOverlays.cpp
+++ b/src/screenComponents/indicatorOverlays.cpp
@@ -42,7 +42,7 @@ GuiIndicatorOverlays::~GuiIndicatorOverlays()
 
 static float glow(float min, float max, float time)
 {
-    return min + (max - min) * fabsf(fmodf(engine->getElapsedTime() / time, 2.0) - 1.0);
+    return min + (max - min) * std::abs(fmodf(engine->getElapsedTime() / time, 2.0) - 1.0);
 }
 
 void GuiIndicatorOverlays::onDraw(sf::RenderTarget& window)

--- a/src/screenComponents/radarView.cpp
+++ b/src/screenComponents/radarView.cpp
@@ -10,24 +10,58 @@
 #include "targetsContainer.h"
 
 GuiRadarView::GuiRadarView(GuiContainer* owner, string id, TargetsContainer* targets)
-: GuiElement(owner, id), next_ghost_dot_update(0.0), targets(targets), missile_tube_controls(nullptr), distance(5000.0f), long_range(false), show_ghost_dots(false)
-, show_waypoints(false), show_target_projection(false), show_missile_tubes(false), show_callsigns(false), show_heading_indicators(false), show_game_master_data(false)
-, view_position(sf::Vector2f(0.0f,0.0f)), view_rotation(0)
-, range_indicator_step_size(0.0f), style(Circular), fog_style(NoFogOfWar), mouse_down_func(nullptr), mouse_drag_func(nullptr), mouse_up_func(nullptr)
+: GuiElement(owner, id),
+    next_ghost_dot_update(0.0),
+    targets(targets),
+    missile_tube_controls(nullptr),
+    view_position(sf::Vector2f(0.0f,0.0f)),
+    view_rotation(0),
+    auto_center_on_my_ship(true),
+    auto_rotate_on_my_ship(false),
+    auto_distance(true),
+    distance(5000.0f),
+    long_range(false),
+    show_ghost_dots(false),
+    show_waypoints(false),
+    show_target_projection(false),
+    show_missile_tubes(false),
+    show_callsigns(false),
+    show_heading_indicators(false),
+    show_game_master_data(false),
+    range_indicator_step_size(0.0f),
+    style(Circular),
+    fog_style(NoFogOfWar),
+    mouse_down_func(nullptr),
+    mouse_drag_func(nullptr),
+    mouse_up_func(nullptr)
 {
-    auto_center_on_my_ship = true;
-    auto_rotate_on_my_ship = false;
-    auto_distance = true;
 }
 
 GuiRadarView::GuiRadarView(GuiContainer* owner, string id, float distance, TargetsContainer* targets)
-: GuiElement(owner, id), next_ghost_dot_update(0.0), targets(targets), missile_tube_controls(nullptr), distance(distance), long_range(false), show_ghost_dots(false)
-, show_waypoints(false), show_target_projection(false), show_missile_tubes(false), show_callsigns(false), show_heading_indicators(false), show_game_master_data(false)
-, view_position(sf::Vector2f(0.0f,0.0f)), view_rotation(0)
-, range_indicator_step_size(0.0f), style(Circular), fog_style(NoFogOfWar), mouse_down_func(nullptr), mouse_drag_func(nullptr), mouse_up_func(nullptr)
+: GuiElement(owner, id),
+    next_ghost_dot_update(0.0),
+    targets(targets),
+    missile_tube_controls(nullptr),
+    view_position(sf::Vector2f(0.0f,0.0f)),
+    view_rotation(0),
+    auto_center_on_my_ship(true),
+    auto_rotate_on_my_ship(false),
+    distance(distance),
+    long_range(false),
+    show_ghost_dots(false),
+    show_waypoints(false),
+    show_target_projection(false),
+    show_missile_tubes(false),
+    show_callsigns(false),
+    show_heading_indicators(false),
+    show_game_master_data(false),
+    range_indicator_step_size(0.0f),
+    style(Circular),
+    fog_style(NoFogOfWar),
+    mouse_down_func(nullptr),
+    mouse_drag_func(nullptr),
+    mouse_up_func(nullptr)
 {
-    auto_center_on_my_ship = true;
-    auto_rotate_on_my_ship = false;
 }
 
 void GuiRadarView::onDraw(sf::RenderTarget& window)

--- a/src/screenComponents/radarView.h
+++ b/src/screenComponents/radarView.h
@@ -45,10 +45,12 @@ private:
     TargetsContainer* targets;
     GuiMissileTubeControls* missile_tube_controls;
 
-    bool auto_distance = false;
-    float distance;
     sf::Vector2f view_position;
     float view_rotation;
+    bool auto_center_on_my_ship;
+    bool auto_rotate_on_my_ship;
+    bool auto_distance = false;
+    float distance;
     bool long_range;
     bool show_ghost_dots;
     bool show_waypoints;
@@ -57,8 +59,6 @@ private:
     bool show_callsigns;
     bool show_heading_indicators;
     bool show_game_master_data;
-    bool auto_center_on_my_ship;
-    bool auto_rotate_on_my_ship;
     float range_indicator_step_size;
     ERadarStyle style;
     EFogOfWarStyle fog_style;

--- a/src/screenComponents/scanTargetButton.h
+++ b/src/screenComponents/scanTargetButton.h
@@ -17,7 +17,7 @@ public:
     GuiScanTargetButton(GuiContainer* owner, string id, TargetsContainer* targets);
     
     virtual void onUpdate() override;
-    virtual void onDraw(sf::RenderTarget& window);
+    virtual void onDraw(sf::RenderTarget& window) override;
 };
 
 #endif//SCAN_TARGET_BUTTON_H

--- a/src/screenComponents/scanningDialog.h
+++ b/src/screenComponents/scanningDialog.h
@@ -30,7 +30,7 @@ private:
 public:
     GuiScanningDialog(GuiContainer* owner, string id);
 
-    virtual void onDraw(sf::RenderTarget& window);
+    virtual void onDraw(sf::RenderTarget& window) override;
     virtual bool onJoystickAxis(const AxisAction& axisAction) override;
     
     void setupParameters();

--- a/src/screenComponents/shipDestroyedPopup.h
+++ b/src/screenComponents/shipDestroyedPopup.h
@@ -11,7 +11,6 @@ class GuiShipDestroyedPopup : public GuiElement
 {
 private:
     GuiOverlay* ship_destroyed_overlay;
-    GuiPanel* frame;
     GuiCanvas* owner;
     sf::Clock show_timeout;
     

--- a/src/screens/cinematicViewScreen.h
+++ b/src/screens/cinematicViewScreen.h
@@ -36,7 +36,6 @@ private:
     // camera_position is a Vector3, so no need to declare one here.
     sf::Vector2f camera_position_2D;
     float target_rotation;
-    float target_velocity;
 
     P<SpaceObject> target_of_target;
 

--- a/src/screens/crew4/operationsScreen.h
+++ b/src/screens/crew4/operationsScreen.h
@@ -20,7 +20,6 @@ private:
     EMode mode;
     int drag_waypoint_index;
 
-    GuiKeyValueDisplay* info_reputation;
     GuiButton* place_waypoint_button;
     GuiButton* delete_waypoint_button;
 

--- a/src/screens/crew6/engineeringScreen.h
+++ b/src/screens/crew6/engineeringScreen.h
@@ -19,7 +19,6 @@ class GuiProgressSlider;
 class EngineeringScreen : public GuiOverlay
 {
 private:
-    GuiOverlay* background_gradient;
     GuiOverlay* background_crosses;
 
     GuiKeyValueDisplay* energy_display;

--- a/src/spaceObjects/artifact.h
+++ b/src/spaceObjects/artifact.h
@@ -16,7 +16,7 @@ public:
 
     virtual void update(float delta) override;
 
-    virtual void draw3D();
+    virtual void draw3D() override;
 
     virtual void drawOnRadar(sf::RenderTarget& window, sf::Vector2f position, float scale, float rotation, bool long_range) override;
 

--- a/src/spaceObjects/asteroid.h
+++ b/src/spaceObjects/asteroid.h
@@ -13,7 +13,7 @@ public:
 
     Asteroid();
     
-    virtual void draw3D();
+    virtual void draw3D() override;
 
     virtual void drawOnRadar(sf::RenderTarget& window, sf::Vector2f position, float scale, float rotation, bool long_range) override;
 
@@ -34,7 +34,7 @@ public:
 
     VisualAsteroid();
 
-    virtual void draw3D();
+    virtual void draw3D() override;
     
     void setSize(float size);
 

--- a/src/spaceObjects/mine.h
+++ b/src/spaceObjects/mine.h
@@ -22,8 +22,8 @@ public:
 
     Mine();
 
-    virtual void draw3D();
-    virtual void draw3DTransparent();
+    virtual void draw3D() override;
+    virtual void draw3DTransparent() override;
     virtual void drawOnRadar(sf::RenderTarget& window, sf::Vector2f position, float scale, float rotation, bool long_range);
     virtual void drawOnGMRadar(sf::RenderTarget& window, sf::Vector2f position, float scale, float rotation, bool long_range);
     virtual void update(float delta);

--- a/src/spaceObjects/playerSpaceship.h
+++ b/src/spaceObjects/playerSpaceship.h
@@ -102,8 +102,6 @@ public:
     string control_code;
 
 private:
-    // soundManager index of the shield object
-    int shield_sound;
     // Comms variables
     ECommsState comms_state;
     float comms_open_delay;

--- a/src/spaceObjects/spaceObject.cpp
+++ b/src/spaceObjects/spaceObject.cpp
@@ -287,12 +287,12 @@ SpaceObject::~SpaceObject()
 {
 }
 
-#if FEATURE_3D_RENDERING
 void SpaceObject::draw3D()
 {
+#if FEATURE_3D_RENDERING
     model_info.render(getPosition(), getRotation());
-}
 #endif//FEATURE_3D_RENDERING
+}
 
 void SpaceObject::drawOnRadar(sf::RenderTarget& window, sf::Vector2f position, float scale, float rotation, bool longRange)
 {

--- a/src/spaceObjects/spaceObject.h
+++ b/src/spaceObjects/spaceObject.h
@@ -167,10 +167,8 @@ public:
         on_destroyed = callback;
     }
 
-#if FEATURE_3D_RENDERING
     virtual void draw3D();
     virtual void draw3DTransparent() {}
-#endif//FEATURE_3D_RENDERING
     virtual void drawOnRadar(sf::RenderTarget& window, sf::Vector2f position, float scale, float rotation, bool longRange);
     virtual void drawOnGMRadar(sf::RenderTarget& window, sf::Vector2f position, float scale, float rotation, bool longRange);
     virtual void destroy();


### PR DESCRIPTION
Before:

   1 [-Wabsolute-value]
 237 [-Winconsistent-missing-override]
   4 [-Wmismatched-new-delete]
   1 [-Wparentheses-equality]
   2 [-Wreorder]
  10 [-Wunused-private-field]
   2 [-Wunused-variable]

After:

   2 [-Wformat]
   1 [-Wparentheses-equality]
   3 [-Wunused-private-field]

and none in EmptyEpsilon (all in SeriousProton)