### PR TITLE
fix ship selection screen when player ships are destroyed

### DIFF
--- a/src/menus/shipSelectionScreen.cpp
+++ b/src/menus/shipSelectionScreen.cpp
@@ -355,10 +355,12 @@ void ShipSelectionScreen::update(float delta)
         if (ship)
         {
             string ship_name = ship->getFaction() + " " + ship->getTypeName() + " " + ship->getCallSign();
+
+            int index = player_ship_list->indexByValue(string(n));
             // If a player ship isn't in already in the list, add it.
-            if (player_ship_list->indexByValue(string(n)) == -1)
+            if (index == -1)
             {
-                int index = player_ship_list->addEntry(ship_name, string(n));
+                index = player_ship_list->addEntry(ship_name, string(n));
                 if (my_spaceship == ship)
                     player_ship_list->setSelectionIndex(index);
             }
@@ -370,7 +372,7 @@ void ShipSelectionScreen::update(float delta)
                 if (ship->hasPlayerAtPosition(ECrewPosition(n)))
                     ship_position_count += 1;
             }
-            player_ship_list->setEntryName(n, ship_name + " (" + string(ship_position_count) + ")");
+            player_ship_list->setEntryName(index, ship_name + " (" + string(ship_position_count) + ")");
         }else{
             if (player_ship_list->indexByValue(string(n)) != -1)
                 player_ship_list->removeEntry(player_ship_list->indexByValue(string(n)));


### PR DESCRIPTION
**How To reproduce**

* create three player ships
* destroy the first one
* go back to the mission selection screen

**What happens**

The name of the second player ship is displayed twice and the name of the third one is not visible.

![ship-selection](https://user-images.githubusercontent.com/264799/78662917-8bf7eb00-78d1-11ea-894d-c86f9ce2b4de.png)
