### PR TITLE
Fallback to old width for Single Pilot

### DIFF
--- a/src/screens/crewStationScreen.cpp
+++ b/src/screens/crewStationScreen.cpp
@@ -89,7 +89,7 @@ GuiContainer* CrewStationScreen::getTabContainer()
 void CrewStationScreen::addStationTab(GuiElement* element, ECrewPosition position, string name, string icon)
 {
     CrewTabInfo info;
-
+    tileViewport();
     element->setSize(GuiElement::GuiSizeMax, GuiElement::GuiSizeMax);
     info.position = position;
     info.element = element;
@@ -162,7 +162,7 @@ void CrewStationScreen::update(float delta)
         main_panel->setSize(GuiElement::GuiSizeMax, GuiElement::GuiSizeMax);
     } else {
         viewport->show();
-        main_panel->setSize(1200, GuiElement::GuiSizeMax);
+        tileViewport();
     }
 
     if (my_spaceship)
@@ -334,6 +334,18 @@ string CrewStationScreen::listHotkeysLimited(string station)
 	}
 
     return ret;
+}
+
+void CrewStationScreen::tileViewport()
+{
+    if (current_position == singlePilot)
+    {
+        main_panel->setSize(1000, GuiElement::GuiSizeMax);
+        viewport->setPosition(1000, 0, ATopLeft);
+    } else {
+        main_panel->setSize(1200, GuiElement::GuiSizeMax);
+        viewport->setPosition(1200, 0, ATopLeft);
+    }
 }
 
 std::vector<std::pair<string, string>> CrewStationScreen::listControlsByCategory(string category){

--- a/src/screens/crewStationScreen.h
+++ b/src/screens/crewStationScreen.h
@@ -59,6 +59,7 @@ private:
     GuiElement* findTab(string name);
     
     string listHotkeysLimited(string station);
+    void tileViewport();
     std::vector<std::pair<string, string>> listControlsByCategory(string category);
 };
 


### PR DESCRIPTION
This falls back to the old viewport tiling when at the single Pilot Station. So the viewport for that station will be as wide as it was prior to a2ed0b2ea36a1993624b1f197bc270eb79272238