### PR TITLE
Add orbital movement to spaceObject

### DIFF
--- a/src/spaceObjects/planet.h
+++ b/src/spaceObjects/planet.h
@@ -31,7 +31,6 @@ public:
     void setPlanetCloudRadius(float size);
     void setDistanceFromMovementPlane(float distance_from_movement_plane);
     void setAxialRotationTime(float time);
-    void setOrbit(P<SpaceObject> target, float orbit_time);
     
     virtual string getExportLine() override { return "Planet():setPosition(" + string(getPosition().x, 0) + ", " + string(getPosition().y, 0) + ", setPlanetRadius(" + string(getPlanetRadius(), 0) + ")"; }
 
@@ -47,9 +46,6 @@ private:
     float distance_from_movement_plane;
     
     float axial_rotation_time;
-    int32_t orbit_target_id;
-    float orbit_time;
-    float orbit_distance;
     
     float collision_size;
 

--- a/src/spaceObjects/shipTemplateBasedObject.cpp
+++ b/src/spaceObjects/shipTemplateBasedObject.cpp
@@ -231,6 +231,9 @@ void ShipTemplateBasedObject::update(float delta)
             shield_hit_effect[n] -= delta;
         }
     }
+
+    if (orbit_target_id > -1)
+        applyOrbit(delta);
 }
 
 std::unordered_map<string, string> ShipTemplateBasedObject::getGMInfo()

--- a/src/spaceObjects/spaceObject.h
+++ b/src/spaceObjects/spaceObject.h
@@ -106,6 +106,11 @@ public:
     int scanning_depth_value;
     string callsign;
 
+    P<SpaceObject> orbit_target;
+    int32_t orbit_target_id;
+    float orbit_time;
+    float orbit_distance;
+
     SpaceObject(float collisionRange, string multiplayerName, float multiplayer_significant_range=-1);
     virtual ~SpaceObject();
 
@@ -222,6 +227,10 @@ public:
     string getSectorName();
     bool openCommsTo(P<PlayerSpaceship> target);
     bool sendCommsMessage(P<PlayerSpaceship> target, string message);
+
+    virtual void unsetOrbit();
+    virtual void setOrbit(P<SpaceObject> target, float orbit_time);
+    virtual void applyOrbit(float delta);
 
     ScriptSimpleCallback on_destroyed;
 


### PR DESCRIPTION
Move the Planet orbit mechanics to SpaceObject as
SpaceObject::setOrbit(target, time) and SpaceObject::unsetOrbit()
functions. Also expose these functions to scripting.

Add applyOrbit(delta) function, to be added to the update(delta)
functions of objects. Adds it to ShipTemplateBasedObject,
could be added to other SpaceObjects.

These aren't orbital physics — objects in an orbit are dragged
around by setPosition. Ships locked into an orbit can rotate
but can't move.