### PR TITLE
Set minimum macOS version compat to 10.10

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -54,6 +54,11 @@ elseif(UNIX)
     add_definitions(-DRESOURCE_BASE_DIR="${CMAKE_INSTALL_PREFIX}/share/emptyepsilon/")
 endif()
 
+# Set minimum target macOS version
+if(APPLE)
+	set(MACOSX_DEPLOYMENT_TARGET "10.10")
+endif()
+
 if(CONFIG_DIR)
     add_definitions(-DCONFIG_DIR="${CONFIG_DIR}")
 elseif(UNIX)


### PR DESCRIPTION
Specify the minimum version of macOS on which the target binaries are to be deployed. (When not specified, it defaults to XCode's highest supported SDK version, or the running version of macOS.) This should have no effect on running EE on newer versions of macOS, but should help when running it against older versions.

See https://cmake.org/cmake/help/latest/envvar/MACOSX_DEPLOYMENT_TARGET.html and https://developer.apple.com/library/archive/documentation/DeveloperTools/Conceptual/cross_development/Configuring/configuring.html.

Note that if a macOS user is also compiling SFML, they should likely compile it by passing the same flag and value manually at build time, since SFML (logically, as library maintainers) removed the flag from their build in SFML/SFML#1436 in favor of setting the SDK path on compile time. Since we're distributing an app bundle, and aren't necessarily distributing SFML with it, those concerns don't have to apply here.

While builds setting this to 10.6 (the earliest accepted version) compile without error on XCode 9.2, setting it to 10.10 (Yosemite) covers the span of EE's commit history and is less likely to fail on recent/future XCode versions.

Compiling has been tested against XCode 9.2 and 11.4, and the resulting builds run on macOS 10.14 and 10.15 without issue, but have not been tested on older versions of macOS yet.