### PR TITLE
arrange elements in database view

### DIFF
--- a/src/gui/gui2_scrolltext.cpp
+++ b/src/gui/gui2_scrolltext.cpp
@@ -62,5 +62,14 @@ void GuiScrollText::onDraw(sf::RenderTarget& window)
             scrollbar->setValue(scrollbar->getValue() + diff);
     }
 
+    if (max_lines >= wrap.line_count)
+    {
+        scrollbar->hide();
+    }
+    else
+    {
+        scrollbar->show();
+    }
+
     drawText(window, sf::FloatRect(rect.left, rect.top, rect.width - scrollbar->getSize().x, rect.height), wrap.text, ATopLeft, text_size, main_font, selectColor(colorConfig.textbox.forground));
 }

--- a/src/screenComponents/databaseView.cpp
+++ b/src/screenComponents/databaseView.cpp
@@ -33,7 +33,7 @@ DatabaseViewComponent::DatabaseViewComponent(GuiContainer* owner)
         }
         display(entry);
     });
-    item_list->setPosition(0, 0, ATopLeft)->setMargins(20, 20, 20, 20)->setSize(navigation_width, GuiElement::GuiSizeMax);
+    item_list->setPosition(0, 0, ATopLeft)->setMargins(20, 20, 20, 130)->setSize(navigation_width, GuiElement::GuiSizeMax);
     fillListBox();
 }
 

--- a/src/screenComponents/databaseView.h
+++ b/src/screenComponents/databaseView.h
@@ -22,6 +22,8 @@ private:
     P<ScienceDatabase> selected_entry;
     GuiListbox* item_list;
     GuiElement* database_entry;
+
+    int navigation_width = 400;
 };
 
 #endif//DATABASE_VIEW_H

--- a/src/screenComponents/databaseView.h
+++ b/src/screenComponents/databaseView.h
@@ -23,7 +23,7 @@ private:
     GuiListbox* item_list;
     GuiElement* database_entry;
 
-    int navigation_width = 400;
+    static constexpr int navigation_width = 400;
 };
 
 #endif//DATABASE_VIEW_H


### PR DESCRIPTION
I rearranged text, KeyValuePairs, model and image on the database view so it looks nicer and uses the available space.

![EmptyEpsilon_013](https://user-images.githubusercontent.com/264799/79274082-4e342d00-7ea4-11ea-8ec2-f2348ff8f773.png)
![EmptyEpsilon_015](https://user-images.githubusercontent.com/264799/79274090-53917780-7ea4-11ea-8630-2becbf201473.png)
![EmptyEpsilon_016](https://user-images.githubusercontent.com/264799/79274101-57bd9500-7ea4-11ea-9f76-b81227271a16.png)
![EmptyEpsilon_018](https://user-images.githubusercontent.com/264799/79274116-5db37600-7ea4-11ea-89fa-855869f5fc8d.png)
![EmptyEpsilon_019](https://user-images.githubusercontent.com/264799/79274127-62782a00-7ea4-11ea-9c29-49d0005fe74b.png)
![EmptyEpsilon_020](https://user-images.githubusercontent.com/264799/79274157-6c9a2880-7ea4-11ea-96cf-1f673986e367.png)
![EmptyEpsilon_021](https://user-images.githubusercontent.com/264799/79274165-6e63ec00-7ea4-11ea-8fa2-2ecb6493e8b9.png)
