### PR TITLE
Strip IP entries in serverBrowseMenu.

### DIFF
--- a/src/menus/serverBrowseMenu.cpp
+++ b/src/menus/serverBrowseMenu.cpp
@@ -43,7 +43,7 @@ ServerBrowserMenu::ServerBrowserMenu(SearchSource source)
     manual_ip = new GuiTextEntry(this, "IP", "");
     manual_ip->setPosition(-50, -120, ABottomRight)->setSize(300, 50);
     manual_ip->enterCallback([this](string text) {
-        new JoinServerScreen(lan_internet_selector->getSelectionIndex() == 0 ? Local : Internet, sf::IpAddress(text));
+        new JoinServerScreen(lan_internet_selector->getSelectionIndex() == 0 ? Local : Internet, sf::IpAddress(text.strip()));
         destroy();
     });
     server_list = new GuiListbox(this, "SERVERS", [this](int index, string value) {


### PR DESCRIPTION
Fix for:

If the IP address starts with a space (like ` 127.0.0.1` rather than `127.0.0.1`) it will fail to connect.
- Starry

This appears to be platform dependent.  But this patch will work on any platform.

I have not tested this patch on Window but it works (without changing the behavior) on Linux (NixOS).