### PR TITLE
Remote Science Database

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,24 @@
 # Change Log
 
+## [...]
+
+### Added
+
+- Science database can be filled and edited from within scenarios. Additional methods have been added to the Lua API
+  - `destroy()` can be used to remove selective entries or the whole pre-filled database from within scenarios
+  - `getScienceDatabases()` returns a table of all databases at the root level.
+  - sub entries can be traversed with `getEntries()` and `getEntryByName()`
+  - key value pairs can be inquired and manipulated through `setKeyValue()`, `getKeyValue()`, `getKeyValues()` and `removeKey`.
+  - `queryScienceDatabase()` allows to easily query for deeply nested entries
+- Science database entries allow to display an image `ScienceDatabase:setImage()`
+  - The image files have to be available on all clients in order to be displayed.
+
+### Changed
+
+- Science database entries are sorted alphabetically.
+
+### Fixed
+
 ## [2020-04-09]
 
 ### Added

--- a/src/gameGlobalInfo.cpp
+++ b/src/gameGlobalInfo.cpp
@@ -1,6 +1,7 @@
 #include <i18n.h>
 #include "gameGlobalInfo.h"
 #include "preferenceManager.h"
+#include "scienceDatabase.h"
 
 P<GameGlobalInfo> gameGlobalInfo;
 
@@ -179,6 +180,14 @@ void GameGlobalInfo::startScenario(string filename)
     i18n::reset();
     i18n::load("locale/" + PreferencesManager::get("language", "en") + ".po");
     i18n::load("locale/" + filename.replace(".lua", "." + PreferencesManager::get("language", "en") + ".po"));
+
+    flushDatabaseData();
+    fillDefaultDatabaseData();
+
+    P<ScriptObject> scienceInfoScript = new ScriptObject("science_db.lua");
+    if (scienceInfoScript->getError() != "") exit(1);
+    scienceInfoScript->destroy();
+
     P<ScriptObject> script = new ScriptObject();
     script->run(filename);
     engine->registerObject("scenario", script);

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -19,7 +19,6 @@
 #include "gameGlobalInfo.h"
 #include "spaceObjects/spaceObject.h"
 #include "packResourceProvider.h"
-#include "scienceDatabase.h"
 #include "main.h"
 #include "epsilonServer.h"
 #include "httpScriptAccess.h"
@@ -280,12 +279,6 @@ int main(int argc, char** argv)
         P<ScriptObject> factionInfoScript = new ScriptObject("factionInfo.lua");
         if (factionInfoScript->getError() != "") exit(1);
         factionInfoScript->destroy();
-
-        fillDefaultDatabaseData();
-
-        P<ScriptObject> scienceInfoScript = new ScriptObject("science_db.lua");
-        if (scienceInfoScript->getError() != "") exit(1);
-        scienceInfoScript->destroy();
 
         //Find out which model data isn't used by ship templates and output that to log.
         std::set<string> used_model_data;

--- a/src/scienceDatabase.cpp
+++ b/src/scienceDatabase.cpp
@@ -35,6 +35,29 @@ ScienceDatabase::~ScienceDatabase()
 {
 }
 
+void ScienceDatabase::destroy()
+{
+    // if this code is used in the client, the server could try to destroy an object that has already been destroyed
+    if(this->isDestroyed()) return;
+
+    auto my_id = this->getId();
+    ScienceDatabase::science_databases.remove(this);
+    MultiplayerObject::destroy();
+
+    PVector<ScienceDatabase>::iterator it = ScienceDatabase::science_databases.begin();
+
+    while(it != ScienceDatabase::science_databases.end()) {
+        if (!(*it)->isDestroyed() && (*it)->getParentId() == my_id)
+        {
+            (*it)->destroy();
+        }
+        else
+        {
+            ++it;
+        }
+    }
+}
+
 P<ScienceDatabase> ScienceDatabase::addEntry(string name)
 {
     P<ScienceDatabase> e = new ScienceDatabase();
@@ -97,9 +120,17 @@ static string directionLabel(float direction)
 
 void flushDatabaseData()
 {
-    for (unsigned i=0; i<ScienceDatabase::science_databases.size(); i++)
-    {
-        ScienceDatabase::science_databases[i]->destroy();
+    PVector<ScienceDatabase>::iterator it = ScienceDatabase::science_databases.begin();
+
+    while(it != ScienceDatabase::science_databases.end()) {
+        if (!(*it)->isDestroyed())
+        {
+            (*it)->destroy();
+        }
+        else
+        {
+            ++it;
+        }
     }
     ScienceDatabase::science_databases.resize(0);
 }

--- a/src/scienceDatabase.cpp
+++ b/src/scienceDatabase.cpp
@@ -14,16 +14,12 @@ REGISTER_SCRIPT_CLASS(ScienceDatabase)
     REGISTER_SCRIPT_CLASS_FUNCTION(ScienceDatabase, setImage);
 }
 
-unsigned int ScienceDatabase::next_id = 1;
 PVector<ScienceDatabase> ScienceDatabase::science_databases;
 
 REGISTER_MULTIPLAYER_CLASS(ScienceDatabase, "ScienceDatabase");
 ScienceDatabase::ScienceDatabase()
 : MultiplayerObject("ScienceDatabase")
 {
-    id = ScienceDatabase::next_id++;
-
-    registerMemberReplication(&id);
     registerMemberReplication(&parent_id);
     registerMemberReplication(&name);
     registerMemberReplication(&model_data_name);
@@ -42,7 +38,7 @@ ScienceDatabase::~ScienceDatabase()
 P<ScienceDatabase> ScienceDatabase::addEntry(string name)
 {
     P<ScienceDatabase> e = new ScienceDatabase();
-    e->parent_id = this->id;
+    e->parent_id = this->getId();
     e->setName(name);
     return e;
 }
@@ -99,7 +95,8 @@ static string directionLabel(float direction)
     return name;
 }
 
-void flushDatabaseData() {
+void flushDatabaseData()
+{
     for (unsigned i=0; i<ScienceDatabase::science_databases.size(); i++)
     {
         ScienceDatabase::science_databases[i]->destroy();

--- a/src/scienceDatabase.cpp
+++ b/src/scienceDatabase.cpp
@@ -8,10 +8,28 @@
 REGISTER_SCRIPT_CLASS(ScienceDatabase)
 {
     REGISTER_SCRIPT_CLASS_FUNCTION(ScienceDatabase, setName);
+    REGISTER_SCRIPT_CLASS_FUNCTION(ScienceDatabase, getName);
     REGISTER_SCRIPT_CLASS_FUNCTION(ScienceDatabase, addEntry);
+    /// returns a child entry by its case-insensitive name
+    REGISTER_SCRIPT_CLASS_FUNCTION(ScienceDatabase, getEntryByName);
+    /// returns a table of all child entries in arbitrary order
+    REGISTER_SCRIPT_CLASS_FUNCTION(ScienceDatabase, getEntries);
+    /// returns true if this entry has child entries
+    REGISTER_SCRIPT_CLASS_FUNCTION(ScienceDatabase, hasEntries);
+    /// add a new key-value pair in the center column of the database
     REGISTER_SCRIPT_CLASS_FUNCTION(ScienceDatabase, addKeyValue);
+    /// if an entry with this key exists already, its value will be changed. If not, the pair is created.
+    REGISTER_SCRIPT_CLASS_FUNCTION(ScienceDatabase, setKeyValue);
+    /// get the value of the key value-pair with the given key. returns empty string when key does not exist.
+    REGISTER_SCRIPT_CLASS_FUNCTION(ScienceDatabase, getKeyValue);
+    /// get all the key value pairs as a table. Warning: if there are duplicate keys only appear once with the last value.
+    REGISTER_SCRIPT_CLASS_FUNCTION(ScienceDatabase, getKeyValues);
+    /// remove all key value pairs with the case-insensitive key value name
+    REGISTER_SCRIPT_CLASS_FUNCTION(ScienceDatabase, removeKey);
     REGISTER_SCRIPT_CLASS_FUNCTION(ScienceDatabase, setLongDescription);
+    REGISTER_SCRIPT_CLASS_FUNCTION(ScienceDatabase, getLongDescription);
     REGISTER_SCRIPT_CLASS_FUNCTION(ScienceDatabase, setImage);
+    REGISTER_SCRIPT_CLASS_FUNCTION(ScienceDatabase, getImage);
 }
 
 PVector<ScienceDatabase> ScienceDatabase::science_databases;
@@ -23,7 +41,7 @@ ScienceDatabase::ScienceDatabase()
     registerMemberReplication(&parent_id);
     registerMemberReplication(&name);
     registerMemberReplication(&model_data_name);
-    registerMemberReplication(&longDescription);
+    registerMemberReplication(&long_description);
     registerMemberReplication(&image);
     registerMemberReplication(&keyValuePairs);
 
@@ -68,12 +86,59 @@ P<ScienceDatabase> ScienceDatabase::addEntry(string name)
 
 void ScienceDatabase::addKeyValue(string key, string value)
 {
-    keyValuePairs.push_back(ScienceDatabaseKeyValue(key, value));
+    keyValuePairs.push_back(KeyValue(key, value));
+}
+
+string ScienceDatabase::getKeyValue(string key)
+{
+    auto normalized_key = normalizeName(key);
+
+    for (auto kv : keyValuePairs)
+    {
+        if (kv.getNormalizedKey() == normalized_key)
+        {
+            return kv.getValue();
+        }
+    }
+    return "";
+}
+
+void ScienceDatabase::setKeyValue(string key, string value)
+{
+    bool is_set = false;
+    auto normalized_key = normalizeName(key);
+
+    for (auto& kv : keyValuePairs)
+    {
+        if (kv.getNormalizedKey() == normalized_key)
+        {
+            kv.setValue(value);
+            is_set = true;
+        }
+    }
+    if (!is_set) { addKeyValue(key, value); }
+}
+
+void ScienceDatabase::removeKey(string key)
+{
+    auto normalized_key = normalizeName(key);
+    keyValuePairs.erase(std::remove_if(keyValuePairs.begin(), keyValuePairs.end(), [normalized_key](KeyValue& kv) { return kv.getNormalizedKey() == normalized_key; }), keyValuePairs.end());
+}
+
+std::map<string, string> ScienceDatabase::getKeyValues()
+{
+    std::map<string, string> map;
+    for (auto kv : keyValuePairs)
+    {
+        map.insert(std::make_pair(kv.getKey(), kv.getValue()));
+    }
+
+    return map;
 }
 
 void ScienceDatabase::setLongDescription(string text)
 {
-    longDescription = text;
+    long_description = text;
 }
 
 
@@ -103,6 +168,94 @@ P<ModelData> ScienceDatabase::getModelData()
         return nullptr;
     }
 }
+
+P<ScienceDatabase> ScienceDatabase::getEntryByName(string name)
+{
+    return queryScienceDatabase(name, this->getId());
+}
+
+bool ScienceDatabase::hasEntries()
+{
+    for(auto sd : ScienceDatabase::science_databases)
+    {
+        if (sd->getParentId() == this->getId())
+        {
+            return true;
+        }
+    }
+
+    return false;
+}
+
+PVector<ScienceDatabase> ScienceDatabase::getEntries()
+{
+    PVector<ScienceDatabase> entries;
+    for(auto sd : ScienceDatabase::science_databases)
+    {
+        if (sd->getParentId() == this->getId())
+        {
+            entries.push_back(sd);
+        }
+    }
+
+    return entries;
+}
+
+P<ScienceDatabase> ScienceDatabase::queryScienceDatabase(string name, int32_t parent_id = 0)
+{
+    name = normalizeName(name);
+
+    for(auto sd : ScienceDatabase::science_databases)
+    {
+        if (sd->getParentId() == parent_id && sd->getNormalizedName() == name)
+        {
+            return sd;
+        }
+    }
+
+    return nullptr;
+}
+
+static int queryScienceDatabase(lua_State* L)
+{
+    P<ScienceDatabase> entry = nullptr;
+
+    for(int i=1; i<=lua_gettop(L); i++)
+    {
+        string segment = string(luaL_checkstring(L, i));
+        entry = ScienceDatabase::queryScienceDatabase(segment, entry ? entry->getId() : 0);
+
+        if (!entry)
+        {
+            // no entry at that path
+            return 0;
+        }
+    }
+
+    return convert<P<ScienceDatabase> >::returnType(L, entry);
+}
+
+/// finds a ScienceDatabase entry by its case-insensitive name. You have to give the full path to the entry by using multiple arguments.
+/// Returns nil if no entry is found.
+/// e.g. local mine_db = queryScienceDatabase("Natural", "Mine")
+REGISTER_SCRIPT_FUNCTION(queryScienceDatabase);
+
+static int getScienceDatabases(lua_State* L)
+{
+    PVector<ScienceDatabase> entries;
+    for(auto sd : ScienceDatabase::science_databases)
+    {
+        if (sd->getParentId() == 0)
+        {
+            entries.push_back(sd);
+        }
+    }
+
+    return convert<PVector<ScienceDatabase>>::returnType(L, entries);;
+}
+
+/// get all ScienceDatabases that do not have a parent. Use getEntries() or getEntryByName() to navigate.
+REGISTER_SCRIPT_FUNCTION(getScienceDatabases);
 
 static string directionLabel(float direction)
 {

--- a/src/scienceDatabase.h
+++ b/src/scienceDatabase.h
@@ -27,8 +27,7 @@ static inline sf::Packet& operator >> (sf::Packet& packet, ScienceDatabaseKeyVal
 class ScienceDatabase : public MultiplayerObject
 {
 public:
-    unsigned int id;
-    unsigned int parent_id = 0;
+    int32_t parent_id = 0;
 
     string name;
     std::vector<ScienceDatabaseKeyValue> keyValuePairs;
@@ -37,7 +36,6 @@ public:
     string image;
 
     ScienceDatabase();
-    ScienceDatabase(P<ScienceDatabase> parent, string name);
     virtual ~ScienceDatabase();
 
     void addKeyValue(string key, string value);
@@ -48,8 +46,8 @@ public:
         image = path;
     }
     P<ScienceDatabase> addEntry(string name);
-    unsigned int getId() { return this->id; }
-    unsigned int getParentId() { return this->parent_id; }
+    int32_t getId() { return this->getMultiplayerId(); }
+    int32_t getParentId() { return this->parent_id; }
     void setModelData(P<ModelData> model_data);
     void setModelDataName(string model_data_name);
     bool hasModelData();
@@ -57,7 +55,6 @@ public:
     string getName() {return this->name;}
 private:
     string directionLabel(float direction);
-    static unsigned int next_id;
 
 public: /* static members */
     static PVector<ScienceDatabase> science_databases;

--- a/src/scienceDatabase.h
+++ b/src/scienceDatabase.h
@@ -10,23 +10,30 @@ class ScienceDatabaseKeyValue
 {
 public:
     string key, value;
+    ScienceDatabaseKeyValue() {}
     ScienceDatabaseKeyValue(string key, string value) : key(key), value(value) {}
+
+    bool operator!=(const ScienceDatabaseKeyValue& kv) { return key != kv.key || value != kv.value; }
 };
+
+static inline sf::Packet& operator << (sf::Packet& packet, const ScienceDatabaseKeyValue& kv) { return packet << kv.key << kv.value; }
+static inline sf::Packet& operator >> (sf::Packet& packet, ScienceDatabaseKeyValue& kv) { return packet >> kv.key >> kv.value; }
+
 /*!
  * \brief An entry for the science database that is formed by a number of key value pairs.
  *  The database is build up in a tree structure, where every node can have key/value pairs and a long description.
  *  As well as a 3D model assigned to it.
  */
-class ScienceDatabase : public virtual PObject
+class ScienceDatabase : public MultiplayerObject
 {
 public:
-    PVector<ScienceDatabase> items;
-    P<ScienceDatabase> parent;
+    unsigned int id;
+    unsigned int parent_id = 0;
 
     string name;
     std::vector<ScienceDatabaseKeyValue> keyValuePairs;
     string longDescription;
-    P<ModelData> model_data;
+    string model_data_name = "";
     string image;
 
     ScienceDatabase();
@@ -41,9 +48,16 @@ public:
         image = path;
     }
     P<ScienceDatabase> addEntry(string name);
+    unsigned int getId() { return this->id; }
+    unsigned int getParentId() { return this->parent_id; }
+    void setModelData(P<ModelData> model_data);
+    void setModelDataName(string model_data_name);
+    bool hasModelData();
+    P<ModelData> getModelData();
     string getName() {return this->name;}
 private:
     string directionLabel(float direction);
+    static unsigned int next_id;
 
 public: /* static members */
     static PVector<ScienceDatabase> science_databases;
@@ -51,5 +65,6 @@ public: /* static members */
 
 //Called during startup to fill the database with faction and ship data.
 void fillDefaultDatabaseData();
+void flushDatabaseData();
 
 #endif//SCIENCE_DATABASE_H

--- a/src/scienceDatabase.h
+++ b/src/scienceDatabase.h
@@ -62,6 +62,7 @@ public:
     bool hasModelData();
     P<ModelData> getModelData();
     string getName() {return this->name;}
+    virtual void destroy();
 private:
     string normalized_name; // used for sorting and querying
     string directionLabel(float direction);

--- a/src/scienceDatabase.h
+++ b/src/scienceDatabase.h
@@ -42,6 +42,15 @@ public:
     void setLongDescription(string text);
 
     void setName(string name) { this->name = name; }
+    string getNormalizedName() {
+        if(normalized_name == "")
+        {
+            normalized_name = name;
+            transform(normalized_name.begin(), normalized_name.end(), normalized_name.begin(), ::tolower);
+        }
+
+        return normalized_name;
+    }
     void setImage(string path) {
         image = path;
     }
@@ -54,6 +63,7 @@ public:
     P<ModelData> getModelData();
     string getName() {return this->name;}
 private:
+    string normalized_name; // used for sorting and querying
     string directionLabel(float direction);
 
 public: /* static members */
@@ -63,5 +73,9 @@ public: /* static members */
 //Called during startup to fill the database with faction and ship data.
 void fillDefaultDatabaseData();
 void flushDatabaseData();
+
+static inline bool operator < (P<ScienceDatabase> a, P<ScienceDatabase> b) {
+    return a->getNormalizedName() < b->getNormalizedName();
+}
 
 #endif//SCIENCE_DATABASE_H

--- a/src/scienceDatabase.h
+++ b/src/scienceDatabase.h
@@ -104,10 +104,7 @@ private:
     string normalized_name; // used for sorting and querying
     string directionLabel(float direction);
 
-    static string normalizeName(string name) {
-        transform(name.begin(), name.end(), name.begin(), ::tolower);
-        return name;
-    }
+    static string normalizeName(string name) { return name.lower(); }
 
 public: /* static members */
     static PVector<ScienceDatabase> science_databases;

--- a/src/scienceDatabase.h
+++ b/src/scienceDatabase.h
@@ -3,21 +3,6 @@
 
 #include "engine.h"
 #include "shipTemplate.h"
-/*!
- * \brief Simple key value pair for database.
- */
-class ScienceDatabaseKeyValue
-{
-public:
-    string key, value;
-    ScienceDatabaseKeyValue() {}
-    ScienceDatabaseKeyValue(string key, string value) : key(key), value(value) {}
-
-    bool operator!=(const ScienceDatabaseKeyValue& kv) { return key != kv.key || value != kv.value; }
-};
-
-static inline sf::Packet& operator << (sf::Packet& packet, const ScienceDatabaseKeyValue& kv) { return packet << kv.key << kv.value; }
-static inline sf::Packet& operator >> (sf::Packet& packet, ScienceDatabaseKeyValue& kv) { return packet >> kv.key >> kv.value; }
 
 /*!
  * \brief An entry for the science database that is formed by a number of key value pairs.
@@ -27,45 +12,102 @@ static inline sf::Packet& operator >> (sf::Packet& packet, ScienceDatabaseKeyVal
 class ScienceDatabase : public MultiplayerObject
 {
 public:
+    /*!
+     * \brief Simple key value pair for database.
+     */
+    class KeyValue
+    {
+    public:
+        string key, value;
+        KeyValue() {}
+        KeyValue(string key, string value) : key(key), value(value) {}
+        string getValue() { return this->value; }
+        void setValue(string value) { this->value = value; }
+        string getKey() { return this->key; }
+        void setKey(string key) {
+            this->key = key;
+            this->normalized_key = "";
+        }
+
+        string getNormalizedKey()
+        {
+            if(normalized_key == "") { normalized_key = normalizeName(key); }
+            return normalized_key;
+        }
+
+        bool operator!=(const KeyValue& kv) { return key != kv.key || value != kv.value; }
+    private:
+        string normalized_key;
+    };
+
     int32_t parent_id = 0;
 
     string name;
-    std::vector<ScienceDatabaseKeyValue> keyValuePairs;
-    string longDescription;
+    std::vector<KeyValue> keyValuePairs;
+    string long_description;
     string model_data_name = "";
     string image;
 
     ScienceDatabase();
     virtual ~ScienceDatabase();
 
-    void addKeyValue(string key, string value);
-    void setLongDescription(string text);
-
-    void setName(string name) { this->name = name; }
-    string getNormalizedName() {
-        if(normalized_name == "")
-        {
-            normalized_name = name;
-            transform(normalized_name.begin(), normalized_name.end(), normalized_name.begin(), ::tolower);
-        }
-
-        return normalized_name;
-    }
-    void setImage(string path) {
-        image = path;
-    }
-    P<ScienceDatabase> addEntry(string name);
     int32_t getId() { return this->getMultiplayerId(); }
     int32_t getParentId() { return this->parent_id; }
+
+    void setName(string name)
+    {
+        this->name = name;
+        this->normalized_name = "";
+    }
+    string getName() { return this->name; }
+    string getNormalizedName()
+    {
+        if(normalized_name == "") { normalized_name = normalizeName(name); }
+        return normalized_name;
+    }
+
+    void addKeyValue(string key, string value);
+    void setKeyValue(string key, string value);
+    string getKeyValue(string key);
+    void removeKey(string key);
+    std::map<string, string> getKeyValues();
+
+    void setLongDescription(string text);
+    string getLongDescription()
+    {
+        return long_description;
+    }
+
+    void setImage(string path)
+    {
+        image = path;
+    }
+    string getImage()
+    {
+        return image;
+    }
+
     void setModelData(P<ModelData> model_data);
     void setModelDataName(string model_data_name);
     bool hasModelData();
     P<ModelData> getModelData();
-    string getName() {return this->name;}
+
+    P<ScienceDatabase> addEntry(string name);
+
     virtual void destroy();
+
+    P<ScienceDatabase> getEntryByName(string name);
+    bool hasEntries();
+    PVector<ScienceDatabase> getEntries();
+    static P<ScienceDatabase> queryScienceDatabase(string name, int32_t parent_id);
 private:
     string normalized_name; // used for sorting and querying
     string directionLabel(float direction);
+
+    static string normalizeName(string name) {
+        transform(name.begin(), name.end(), name.begin(), ::tolower);
+        return name;
+    }
 
 public: /* static members */
     static PVector<ScienceDatabase> science_databases;
@@ -78,5 +120,8 @@ void flushDatabaseData();
 static inline bool operator < (P<ScienceDatabase> a, P<ScienceDatabase> b) {
     return a->getNormalizedName() < b->getNormalizedName();
 }
+
+static inline sf::Packet& operator << (sf::Packet& packet, const ScienceDatabase::KeyValue& kv) { return packet << kv.key << kv.value; }
+static inline sf::Packet& operator >> (sf::Packet& packet, ScienceDatabase::KeyValue& kv) { return packet >> kv.key >> kv.value; }
 
 #endif//SCIENCE_DATABASE_H

--- a/src/screenComponents/databaseView.cpp
+++ b/src/screenComponents/databaseView.cpp
@@ -142,8 +142,8 @@ void DatabaseViewComponent::display()
         return;
 
     bool has_key_values = selected_entry->keyValuePairs.size() > 0;
-    bool has_image_or_model = selected_entry->hasModelData() || selected_entry->image != "";
-    bool has_text = selected_entry->longDescription.length() > 0;
+    bool has_image_or_model = selected_entry->hasModelData() || selected_entry->getImage() != "";
+    bool has_text = selected_entry->getLongDescription().length() > 0;
 
     int left_column_width = 0;
     if (has_key_values)
@@ -161,7 +161,7 @@ void DatabaseViewComponent::display()
             (new GuiRotatingModelView(visual, "DATABASE_MODEL_VIEW", selected_entry->getModelData()))->setMargins(-100, -50)->setSize(GuiElement::GuiSizeMax, has_text ? GuiElement::GuiSizeMax : 450);
         }
 
-        if(selected_entry->image != "")
+        if(selected_entry->getImage() != "")
         {
             (new GuiImage(visual, "DATABASE_IMAGE", selected_entry->image))->setScaleUp(false)->setMargins(0)->setSize(GuiElement::GuiSizeMax, GuiElement::GuiSizeMax);
         }
@@ -178,7 +178,7 @@ void DatabaseViewComponent::display()
                 right->setMargins(0, 120, 0, 0);
             }
         }
-        (new GuiScrollText(right, "DATABASE_LONG_DESCRIPTION", selected_entry->longDescription))->setTextSize(24)->setSize(GuiElement::GuiSizeMax, GuiElement::GuiSizeMax);
+        (new GuiScrollText(right, "DATABASE_LONG_DESCRIPTION", selected_entry->getLongDescription()))->setTextSize(24)->setSize(GuiElement::GuiSizeMax, GuiElement::GuiSizeMax);
     }
 
     // we render the left column second so it overlays the rotating 3D model

--- a/src/screenComponents/databaseView.cpp
+++ b/src/screenComponents/databaseView.cpp
@@ -113,7 +113,9 @@ void DatabaseViewComponent::fillListBox()
     // the indices we actually want to display
     std::vector<unsigned> display_idx = children_idx.size() > 0 ? children_idx : siblings_idx;
 
-    // @TODO: sort entries
+    sort(display_idx.begin(), display_idx.end(), [](unsigned idxA, unsigned idxB) -> bool {
+        return ScienceDatabase::science_databases[idxA] < ScienceDatabase::science_databases[idxB];
+    });
 
     for (auto idx : display_idx)
     {

--- a/src/screenComponents/databaseView.cpp
+++ b/src/screenComponents/databaseView.cpp
@@ -14,53 +14,45 @@ DatabaseViewComponent::DatabaseViewComponent(GuiContainer* owner)
 : GuiElement(owner, "DATABASE_VIEW")
 {
     database_entry = nullptr;
+    selected_entry = nullptr;
 
     item_list = new GuiListbox(this, "DATABASE_ITEM_LIST", [this](int index, string value) {
         P<ScienceDatabase> entry;
-        if (selected_entry)
-        {
-            if (index == 0)
-            {
-                selected_entry = selected_entry->parent;
-                fillListBox();
-            }else{
-                entry = selected_entry->items[index - 1];
-            }
-        }
-        else
-        {
-            entry = ScienceDatabase::science_databases[index];
-        }
-        display(entry);
+
+        unsigned int id = std::stoul(value, nullptr, 10);
+        selected_entry = findEntryById(id);
+        display();
     });
     item_list->setPosition(0, 0, ATopLeft)->setMargins(20, 20, 20, 130)->setSize(navigation_width, GuiElement::GuiSizeMax);
-    fillListBox();
+    display();
+}
+
+P<ScienceDatabase> DatabaseViewComponent::findEntryById(unsigned int id)
+{
+    if (id == 0)
+    {
+        return nullptr;
+    }
+    foreach(ScienceDatabase, sd, ScienceDatabase::science_databases)
+    {
+        if (sd->getId() == id)
+        {
+            return sd;
+        }
+    }
+    return nullptr;
 }
 
 bool DatabaseViewComponent::findAndDisplayEntry(string name)
 {
     foreach(ScienceDatabase, sd, ScienceDatabase::science_databases)
     {
-        if (findAndDisplayEntry(name, sd))
-            return true;
-    }
-    return false;
-}
-
-bool DatabaseViewComponent::findAndDisplayEntry(string name, P<ScienceDatabase> parent)
-{
-    foreach(ScienceDatabase, sd, parent->items)
-    {
         if (sd->getName() == name)
         {
-            selected_entry = parent;
-            fillListBox();
-            display(sd);
-            item_list->setSelectionIndex(item_list->indexByValue(name));
+            selected_entry = sd;
+            display();
             return true;
         }
-        if (findAndDisplayEntry(name, sd))
-            return true;
     }
     return false;
 }
@@ -69,22 +61,75 @@ void DatabaseViewComponent::fillListBox()
 {
     item_list->setOptions({});
     item_list->setSelectionIndex(-1);
-    if (!selected_entry)
+
+    // indices of child or sibling pages in the science_databases vector
+    std::vector<unsigned> children_idx;
+    std::vector<unsigned> siblings_idx;
+    P<ScienceDatabase> parent_entry;
+
+    for (unsigned idx=0; idx<ScienceDatabase::science_databases.size(); idx++)
     {
-        foreach(ScienceDatabase, sd, ScienceDatabase::science_databases)
+        P<ScienceDatabase> sd = ScienceDatabase::science_databases[idx];
+        if (!sd) continue;
+
+        if(selected_entry)
         {
-            item_list->addEntry(sd->getName(), sd->getName());
+            if(sd->getId() == selected_entry->getParentId())
+            {
+                parent_entry = sd;
+            }
+            if(sd->getParentId() == selected_entry->getParentId())
+            {
+                siblings_idx.push_back(idx);
+            }
+            if(sd->getParentId() == selected_entry->getId())
+            {
+                children_idx.push_back(idx);
+            }
         }
-    }else{
-        item_list->addEntry(tr("Back"), "");
-        foreach(ScienceDatabase, sd, selected_entry->items)
+        else
         {
-            item_list->addEntry(sd->getName(), sd->getName());
+            if(sd->getParentId() == 0)
+            {
+                siblings_idx.push_back(idx);
+            }
+        }
+    }
+
+    if(selected_entry)
+    {
+        if (children_idx.size() != 0)
+        {
+            item_list->addEntry(tr("Back"), std::to_string(selected_entry->getParentId()));
+        }
+        else if(parent_entry)
+        {
+            item_list->addEntry(tr("Back"), std::to_string(parent_entry->getParentId()));
+        }
+    }
+    if(children_idx.size() > 0)
+    {
+        for (unsigned i=0; i<children_idx.size(); i++)
+        {
+            P<ScienceDatabase> sd = ScienceDatabase::science_databases[children_idx[i]];
+            item_list->addEntry(sd->getName(), std::to_string(sd->getId()));
+        }
+    }
+    else if(siblings_idx.size() > 0)
+    {
+        for (unsigned i=0; i<siblings_idx.size(); i++)
+        {
+            P<ScienceDatabase> sd = ScienceDatabase::science_databases[siblings_idx[i]];
+            int item_list_idx = item_list->addEntry(sd->getName(), std::to_string(sd->getId()));
+            if (selected_entry && selected_entry->getId() == sd->getId())
+            {
+                item_list->setSelectionIndex(item_list_idx);
+            }
         }
     }
 }
 
-void DatabaseViewComponent::display(P<ScienceDatabase> entry)
+void DatabaseViewComponent::display()
 {
     if (database_entry)
         database_entry->destroy();
@@ -92,12 +137,14 @@ void DatabaseViewComponent::display(P<ScienceDatabase> entry)
     database_entry = new GuiElement(this, "DATABASE_ENTRY");
     database_entry->setPosition(navigation_width, 0, ATopLeft)->setMargins(20)->setSize(GuiElement::GuiSizeMax, GuiElement::GuiSizeMax);
 
-    if (!entry)
+    fillListBox();
+
+    if (!selected_entry)
         return;
 
-    bool has_key_values = entry->keyValuePairs.size() > 0;
-    bool has_image_or_model = entry->model_data || entry->image != "";
-    bool has_text = entry->longDescription.length() > 0;
+    bool has_key_values = selected_entry->keyValuePairs.size() > 0;
+    bool has_image_or_model = selected_entry->hasModelData() || selected_entry->image != "";
+    bool has_text = selected_entry->longDescription.length() > 0;
 
     int left_column_width = 0;
     if (has_key_values)
@@ -110,14 +157,14 @@ void DatabaseViewComponent::display(P<ScienceDatabase> entry)
     {
         GuiElement* visual = (new GuiElement(right, "DATABASE_VISUAL_ELEMENT"))->setMargins(0, 0, 0, 40)->setSize(GuiElement::GuiSizeMax, GuiElement::GuiSizeMax);
 
-        if (entry->model_data)
+        if (selected_entry->hasModelData())
         {
-            (new GuiRotatingModelView(visual, "DATABASE_MODEL_VIEW", entry->model_data))->setMargins(-100, -50)->setSize(GuiElement::GuiSizeMax, has_text ? GuiElement::GuiSizeMax : 450);
+            (new GuiRotatingModelView(visual, "DATABASE_MODEL_VIEW", selected_entry->getModelData()))->setMargins(-100, -50)->setSize(GuiElement::GuiSizeMax, has_text ? GuiElement::GuiSizeMax : 450);
         }
 
-        if(entry->image != "")
+        if(selected_entry->image != "")
         {
-            (new GuiImage(visual, "DATABASE_IMAGE", entry->image))->setScaleUp(false)->setMargins(0)->setSize(GuiElement::GuiSizeMax, GuiElement::GuiSizeMax);
+            (new GuiImage(visual, "DATABASE_IMAGE", selected_entry->image))->setScaleUp(false)->setMargins(0)->setSize(GuiElement::GuiSizeMax, GuiElement::GuiSizeMax);
         }
     }
     if (has_text)
@@ -132,7 +179,7 @@ void DatabaseViewComponent::display(P<ScienceDatabase> entry)
                 right->setMargins(0, 120, 0, 0);
             }
         }
-        (new GuiScrollText(right, "DATABASE_LONG_DESCRIPTION", entry->longDescription))->setTextSize(24)->setSize(GuiElement::GuiSizeMax, GuiElement::GuiSizeMax);
+        (new GuiScrollText(right, "DATABASE_LONG_DESCRIPTION", selected_entry->longDescription))->setTextSize(24)->setSize(GuiElement::GuiSizeMax, GuiElement::GuiSizeMax);
     }
 
     // we render the left column second so it overlays the rotating 3D model
@@ -141,15 +188,9 @@ void DatabaseViewComponent::display(P<ScienceDatabase> entry)
         GuiAutoLayout* left = new GuiAutoLayout(database_entry, "DATABASE_ENTRY_LEFT", GuiAutoLayout::LayoutVerticalTopToBottom);
         left->setPosition(0, 0, ATopLeft)->setMargins(0, 0, 20, 0)->setSize(left_column_width, GuiElement::GuiSizeMax);
 
-        for(unsigned int n=0; n<entry->keyValuePairs.size(); n++)
+        for(unsigned int n=0; n<selected_entry->keyValuePairs.size(); n++)
         {
-            (new GuiKeyValueDisplay(left, "", 0.37, entry->keyValuePairs[n].key, entry->keyValuePairs[n].value))->setSize(GuiElement::GuiSizeMax, 40);
+            (new GuiKeyValueDisplay(left, "", 0.37, selected_entry->keyValuePairs[n].key, selected_entry->keyValuePairs[n].value))->setSize(GuiElement::GuiSizeMax, 40);
         }
-    }
-
-    if (entry->items.size() > 0)
-    {
-        selected_entry = entry;
-        fillListBox();
     }
 }

--- a/src/screenComponents/databaseView.h
+++ b/src/screenComponents/databaseView.h
@@ -14,10 +14,11 @@ public:
     bool findAndDisplayEntry(string name);
 
 private:
+    P<ScienceDatabase> findEntryById(unsigned int id);
     bool findAndDisplayEntry(string name, P<ScienceDatabase> parent);
     //Fill the selection listbox with options from the selected_entry, or the main database list if selected_entry is nullptr
     void fillListBox();
-    void display(P<ScienceDatabase> entry);
+    void display();
 
     P<ScienceDatabase> selected_entry;
     GuiListbox* item_list;

--- a/src/screenComponents/databaseView.h
+++ b/src/screenComponents/databaseView.h
@@ -14,7 +14,7 @@ public:
     bool findAndDisplayEntry(string name);
 
 private:
-    P<ScienceDatabase> findEntryById(unsigned int id);
+    P<ScienceDatabase> findEntryById(int32_t id);
     bool findAndDisplayEntry(string name, P<ScienceDatabase> parent);
     //Fill the selection listbox with options from the selected_entry, or the main database list if selected_entry is nullptr
     void fillListBox();


### PR DESCRIPTION
You might know that I have a big thing for dynamcial generated pseudo-random missions. So a Science Database that can be manipulated within mission scripts is very high on my wishlist. Few use cases, where it can enhance a scenario:

* Check the registrar of a ship. Is Baddy McEvil *really* the owner of that gold transport as he claims?
* What is known about the nebula we are about to fly into?
* What is Station DS1 selling? And in which sector is it?
* Who is Jane Doe? How could we convince her to help us?
* Is the atmosphere on Primus toxic?
* or this...

![EmptyEpsilon_022](https://user-images.githubusercontent.com/264799/79618814-635ec500-810b-11ea-8a82-e598c1af92e4.png)
(no kitten today, but a science joke)

I created a draft of this with my highly trained copy-and-paste C++ coding skills, so I am asking for someone - not saying @daid :smile: - to review the code and give a second opinion. Basically I changed the `ScienceDatabase` into a `MultiplayerObject`, let it replicate and recreate the tree structure via ids. But I have too little insight into the net code and possible performance bottle necks. And as always... I probably used strange types. :wink: 

## Things I'm planning before it gets merged

- [x] Sorting of the `Science Database` entries on the clients is random. ~~Should be trivial to sort them by their ascending id~~ Sorting is case-insensitive lexigraphic
- [x] Making sure there is no way where the navigation breaks and you can't navigate away from a page (for instance when a page is removed)
- [x] Extend the LUA Api to find/edit/delete database entries. tackles #398 at least partially and could allow to hide factions or ships in the database that the players should not know about yet.
- [x] Changelog entry