### PR TITLE
Expose gameGlobalInfo.elapsed_time to Lua as getMissionTime

### DIFF
--- a/src/gameGlobalInfo.cpp
+++ b/src/gameGlobalInfo.cpp
@@ -264,6 +264,15 @@ static int setBanner(lua_State* L)
 /// Show a scrolling banner containing this text on the cinematic and top down views.
 REGISTER_SCRIPT_FUNCTION(setBanner);
 
+static int getMissionTime(lua_State* L)
+{
+    lua_pushnumber(L, gameGlobalInfo->elapsed_time);
+    return 1;
+}
+/// getMissionTime()
+/// Return the elapsed time of the mission.
+REGISTER_SCRIPT_FUNCTION(getMissionTime);
+
 static int getPlayerShip(lua_State* L)
 {
     int index = luaL_checkinteger(L, 1);


### PR DESCRIPTION
Elapsed Time seemed to me that it could be misleading.  Mission Time makes it more clear that when the game is paused it does not increase.

Implementation for #903.