### PR TITLE
Refactor Waves Scenario: Unglue Enemies

### DIFF
--- a/scripts/scenario_01_waves.lua
+++ b/scripts/scenario_01_waves.lua
@@ -279,6 +279,20 @@ function update(delta)
 		globalMessage("Wave cleared!");
 	end
 	if friendly_count == 0 then
+		globalMessage(string.format("Stopped on Wave %d", waveNumber));
 		victory("Ghosts");	--Victory for the Ghosts (== defeat for the players)
+	end
+	for pidx=1,32 do
+		local p = getPlayerShip(pidx)
+		if p ~= nil and p:isValid() then
+			if p:hasPlayerAtPosition("Relay") then
+				p.wave_info = "wave_info"
+				p:addCustomInfo("Relay",p.wave_info,string.format(_("Wave %d"), waveNumber))
+			end
+			if p:hasPlayerAtPosition("Operations") then
+				p.wave_info_ops = "wave_info_ops"
+				p:addCustomInfo("Operations",p.wave_info_ops,string.format(_("Wave %d"), waveNumber))
+			end
+		end
 	end
 end

--- a/scripts/scenario_01_waves.lua
+++ b/scripts/scenario_01_waves.lua
@@ -199,34 +199,7 @@ function update(delta)
 		if enemy:isValid() then
 			enemy_count = enemy_count + 1
 			order = enemy:getOrder()
-			if order == "Defend Target" or order == "Attack" then
-				order_target = enemy:getOrderTarget()
-				if order_target ~= nil then
-					if not order_target:isValid() then
-						if random(1,100) < 50 then
-							enemy:orderRoaming()
-						else
-							victim_station = nil
-							repeat
-								victim_station = friendlyList[math.random(1,#friendlyList)]
-							until(victim_station ~= nil and victim_station:isValid())
-							local vx, vy = victim_station:getPosition()
-							enemy:orderFlyTowards(vx,vy)
-						end
-					end
-				else
-					if random(1,100) < 50 then
-						enemy:orderRoaming()
-					else
-						victim_station = nil
-						repeat
-							victim_station = friendlyList[math.random(1,#friendlyList)]
-						until(victim_station ~= nil and victim_station:isValid())
-						local vx, vy = victim_station:getPosition()
-						enemy:orderFlyTowards(vx,vy)
-					end
-				end
-			elseif order == "Idle" then
+			if order == "Idle" then
 				if random(1,100) < 50 then
 					enemy:orderRoaming()
 				else

--- a/scripts/scenario_01_waves.lua
+++ b/scripts/scenario_01_waves.lua
@@ -194,6 +194,7 @@ function update(delta)
 	local order = nil
 	local order_target = nil
 	local ship_type = nil
+	local victim_station = nil
 	for _, enemy in ipairs(enemyList) do
 		if enemy:isValid() then
 			enemy_count = enemy_count + 1
@@ -205,21 +206,36 @@ function update(delta)
 						if random(1,100) < 50 then
 							enemy:orderRoaming()
 						else
-							enemy:orderAttack(getPlayerShip(-1))
+							victim_station = nil
+							repeat
+								victim_station = friendlyList[math.random(1,#friendlyList)]
+							until(victim_station ~= nil and victim_station:isValid())
+							local vx, vy = victim_station:getPosition()
+							enemy:orderFlyTowards(vx,vy)
 						end
 					end
 				else
 					if random(1,100) < 50 then
 						enemy:orderRoaming()
 					else
-						endmy:orderAttack(getPlayerShip(-1))
+						victim_station = nil
+						repeat
+							victim_station = friendlyList[math.random(1,#friendlyList)]
+						until(victim_station ~= nil and victim_station:isValid())
+						local vx, vy = victim_station:getPosition()
+						enemy:orderFlyTowards(vx,vy)
 					end
 				end
 			elseif order == "Idle" then
 				if random(1,100) < 50 then
 					enemy:orderRoaming()
 				else
-					enemy:orderAttack(getPlayerShip(-1))
+					victim_station = nil
+					repeat
+						victim_station = friendlyList[math.random(1,#friendlyList)]
+					until(victim_station ~= nil and victim_station:isValid())
+					local vx, vy = victim_station:getPosition()
+					enemy:orderFlyTowards(vx,vy)
 				end
 			end
 			ship_type = enemy:getTypeName()

--- a/scripts/scenario_01_waves.lua
+++ b/scripts/scenario_01_waves.lua
@@ -191,9 +191,66 @@ function update(delta)
 	end
 	enemy_count = 0
 	friendly_count = 0
+	local order = nil
+	local order_target = nil
+	local ship_type = nil
 	for _, enemy in ipairs(enemyList) do
 		if enemy:isValid() then
 			enemy_count = enemy_count + 1
+			order = enemy:getOrder()
+			if order == "Defend Target" or order == "Attack" then
+				order_target = enemy:getOrderTarget()
+				if order_target ~= nil then
+					if not order_target:isValid() then
+						if random(1,100) < 50 then
+							enemy:orderRoaming()
+						else
+							enemy:orderAttack(getPlayerShip(-1))
+						end
+					end
+				else
+					if random(1,100) < 50 then
+						enemy:orderRoaming()
+					else
+						endmy:orderAttack(getPlayerShip(-1))
+					end
+				end
+			elseif order == "Idle" then
+				if random(1,100) < 50 then
+					enemy:orderRoaming()
+				else
+					enemy:orderAttack(getPlayerShip(-1))
+				end
+			end
+			ship_type = enemy:getTypeName()
+			if ship_type == "WX-Lindworm" or ship_type == "Piranha F12" then
+				if enemy.regenerate_timer == nil then
+					if enemy:getWeaponStorage("HVLI") < 1 and enemy:getWeaponStorage("Homing") < 1 then
+						enemy.regenerate_timer = delta + 60
+					end
+				else
+					enemy.regenerate_timer = enemy.regenerate_timer - delta
+					if enemy.regenerate_timer < 0 then
+						enemy.regenerate_timer = nil
+						enemy:setWeaponStorage("Homing",enemy:getWeaponStorageMax("Homing"))
+						enemy:setWeaponStorage("HVLI",enemy:getWeaponStorageMax("HVLI"))
+					end
+				end
+			end
+			if ship_type == "Ranus U" then
+				if enemy.regenerate_timer == nil then
+					if enemy:getWeaponStorage("Nuke") < 1 and enemy:getWeaponStorage("Homing") < 1 then
+						enemy.regenerate_timer = delta + 60
+					end
+				else
+					enemy.regenerate_timer = enemy.regenerate_timer - delta
+					if enemy.regenerate_timer < 0 then
+						enemy.regenerate_timer = nil
+						enemy:setWeaponStorage("Homing",enemy:getWeaponStorageMax("Homing"))
+						enemy:setWeaponStorage("Nuke",enemy:getWeaponStorageMax("Nuke"))
+					end
+				end
+			end
 		end
 	end
 	for _, friendly in ipairs(friendlyList) do


### PR DESCRIPTION
I noticed that when playing Waves, the enemy ships often seem to get stuck out far away from the action and just sit there. I've added code to handle some of these situations:

- Attack and Defend Orders
  - If the target of the attack or defend order is invalid, change the order to roaming or to attack the current player
- Idle Orders
  - If the enemy ship is idle, change the order to roaming or to attack the current player
- Missile Ships Out of Missiles
  - If the enemy ship has no beam weapons and is out of missiles, wait a minute, then replenish the missile stocks