### PR TITLE
ImpulseSound methods should not be virtual

### DIFF
--- a/src/screenComponents/impulseSound.h
+++ b/src/screenComponents/impulseSound.h
@@ -16,9 +16,9 @@ public:
 
     int getImpulseSoundID() { return impulse_sound_id; }
 
-    virtual void play(string sound_file);
-    virtual void stop();
-    virtual void update(float delta);
+    void play(string sound_file);
+    void stop();
+    void update(float delta);
 };
 
 #endif//IMPULSE_SOUND_H


### PR DESCRIPTION
I noticed that `ImpulseSound` has virtual methods, but not a virtual destructor. Because no other class uses `ImpulseSound` as a base class, the member functions don't need to be virtual.