### PR TITLE
Fix two UBs

### DIFF
--- a/src/screenComponents/impulseSound.cpp
+++ b/src/screenComponents/impulseSound.cpp
@@ -22,7 +22,9 @@ ImpulseSound::ImpulseSound(bool enabled)
 
 ImpulseSound::~ImpulseSound()
 {
-    soundManager->stopSound(impulse_sound_id);
+    if (soundManager) {
+        soundManager->stopSound(impulse_sound_id);
+    }
 }
 
 void ImpulseSound::play(string sound_file)

--- a/src/spaceObjects/playerSpaceship.cpp
+++ b/src/spaceObjects/playerSpaceship.cpp
@@ -1977,7 +1977,7 @@ void PlayerSpaceship::onReceiveServerCommand(sf::Packet& packet)
             ECrewPosition position;
             string sound_name;
             packet >> position >> sound_name;
-            if ((position == max_crew_positions && my_player_info->main_screen) || my_player_info->crew_position[position])
+            if ((position == max_crew_positions && my_player_info->main_screen) || (position < sizeof(my_player_info->crew_position) && my_player_info->crew_position[position]))
             {
                 soundManager->playSound(sound_name);
             }


### PR DESCRIPTION
Honestly, I don't get why SeriousProton `Engine` destructor is sometimes called before `ImpulseSound` destructor, in any case this avoids a potential issue when the game shuts down.

I encountered the issue in `playerSpaceship.cpp` playing the tutorial.