### PR TITLE
Docstrings

### DIFF
--- a/src/spaceObjects/nebula.cpp
+++ b/src/spaceObjects/nebula.cpp
@@ -6,7 +6,7 @@
 
 #include "scriptInterface.h"
 
-// Nebulae block long-range radar in a 5U range.
+/// Nebulae block long-range radar in a 5U range.
 REGISTER_SCRIPT_SUBCLASS(Nebula, SpaceObject)
 {
 }

--- a/src/spaceObjects/playerSpaceship.cpp
+++ b/src/spaceObjects/playerSpaceship.cpp
@@ -87,6 +87,7 @@ REGISTER_SCRIPT_SUBCLASS(PlayerSpaceship, SpaceShip)
     REGISTER_SCRIPT_CLASS_FUNCTION(PlayerSpaceship, commandMainScreenSetting);
     REGISTER_SCRIPT_CLASS_FUNCTION(PlayerSpaceship, commandMainScreenOverlay);
     REGISTER_SCRIPT_CLASS_FUNCTION(PlayerSpaceship, commandScan);
+    /// Set power of the system to e.g. 1.5 ("150 percent")
     REGISTER_SCRIPT_CLASS_FUNCTION(PlayerSpaceship, commandSetSystemPowerRequest);
     REGISTER_SCRIPT_CLASS_FUNCTION(PlayerSpaceship, commandSetSystemCoolantRequest);
     REGISTER_SCRIPT_CLASS_FUNCTION(PlayerSpaceship, commandDock);

--- a/src/spaceObjects/playerSpaceship.cpp
+++ b/src/spaceObjects/playerSpaceship.cpp
@@ -12,28 +12,28 @@
 // PlayerSpaceship are ships controlled by a player crew.
 REGISTER_SCRIPT_SUBCLASS(PlayerSpaceship, SpaceShip)
 {
-    // Returns the sf::Vector2f of a specific waypoint set by this ship.
-    // Takes the index of the waypoint as its parameter.
+    /// Returns the sf::Vector2f of a specific waypoint set by this ship.
+    /// Takes the index of the waypoint as its parameter.
     REGISTER_SCRIPT_CLASS_FUNCTION(PlayerSpaceship, getWaypoint);
-    // Returns the total number of this ship's active waypoints.
+    /// Returns the total number of this ship's active waypoints.
     REGISTER_SCRIPT_CLASS_FUNCTION(PlayerSpaceship, getWaypointCount);
-    // Returns the ship's EAlertLevel.
+    /// Returns the ship's EAlertLevel.
     REGISTER_SCRIPT_CLASS_FUNCTION(PlayerSpaceship, getAlertLevel);
-    // Sets whether this ship's shields are raised or lowered.
-    // Takes a Boolean value.
+    /// Sets whether this ship's shields are raised or lowered.
+    /// Takes a Boolean value.
     REGISTER_SCRIPT_CLASS_FUNCTION(PlayerSpaceship, setShieldsActive);
-    // Adds a message to the ship's log. Takes a string as the message and a
-    // sf::Color.
+    /// Adds a message to the ship's log. Takes a string as the message and a
+    /// sf::Color.
     REGISTER_SCRIPT_CLASS_FUNCTION(PlayerSpaceship, addToShipLog);
-    // Move all players connected to this ship to the same stations on a
-    // different PlayerSpaceship. If the target isn't a PlayerSpaceship, this
-    // function does nothing.
-    // This can be used in scenarios to change the crew's ship.
+    /// Move all players connected to this ship to the same stations on a
+    /// different PlayerSpaceship. If the target isn't a PlayerSpaceship, this
+    /// function does nothing.
+    /// This can be used in scenarios to change the crew's ship.
     REGISTER_SCRIPT_CLASS_FUNCTION(PlayerSpaceship, transferPlayersToShip);
-    // Transfers only the crew members who fill a specific station to another
-    // PlayerSpaceship.
+    /// Transfers only the crew members who fill a specific station to another
+    /// PlayerSpaceship.
     REGISTER_SCRIPT_CLASS_FUNCTION(PlayerSpaceship, transferPlayersAtPositionToShip);
-    // Returns true if a station is occupied by a player, and false if not.
+    /// Returns true if a station is occupied by a player, and false if not.
     REGISTER_SCRIPT_CLASS_FUNCTION(PlayerSpaceship, hasPlayerAtPosition);
 
     // Comms functions return Boolean values if true.
@@ -97,9 +97,9 @@ REGISTER_SCRIPT_SUBCLASS(PlayerSpaceship, SpaceShip)
     REGISTER_SCRIPT_CLASS_FUNCTION(PlayerSpaceship, commandAnswerCommHail);
     REGISTER_SCRIPT_CLASS_FUNCTION(PlayerSpaceship, commandSendComm);
     REGISTER_SCRIPT_CLASS_FUNCTION(PlayerSpaceship, commandSendCommPlayer);
-    // Command repair crews to automatically move to damaged subsystems.
-    // is command on ships to require less player interaction, especially
-    // when combined with setAutoCoolant/auto_coolant_enabled.
+    /// Command repair crews to automatically move to damaged subsystems.
+    /// is command on ships to require less player interaction, especially
+    /// when combined with setAutoCoolant/auto_coolant_enabled.
     REGISTER_SCRIPT_CLASS_FUNCTION(PlayerSpaceship, commandSetAutoRepair);
     REGISTER_SCRIPT_CLASS_FUNCTION(PlayerSpaceship, commandSetBeamFrequency);
     REGISTER_SCRIPT_CLASS_FUNCTION(PlayerSpaceship, commandSetBeamSystemTarget);
@@ -114,22 +114,22 @@ REGISTER_SCRIPT_SUBCLASS(PlayerSpaceship, SpaceShip)
     REGISTER_SCRIPT_CLASS_FUNCTION(PlayerSpaceship, commandSetScienceLink);
     REGISTER_SCRIPT_CLASS_FUNCTION(PlayerSpaceship, commandSetAlertLevel);
 
-    // Return the number of Engineering repair crews on the ship.
+    /// Return the number of Engineering repair crews on the ship.
     REGISTER_SCRIPT_CLASS_FUNCTION(PlayerSpaceship, getRepairCrewCount);
-    // Set the total number of Engineering repair crews. If this value is less
-    // than the number of repair crews, this function removes repair crews.
-    // If the value is greater, it adds new repair crews at random locations.
+    /// Set the total number of Engineering repair crews. If this value is less
+    /// than the number of repair crews, this function removes repair crews.
+    /// If the value is greater, it adds new repair crews at random locations.
     REGISTER_SCRIPT_CLASS_FUNCTION(PlayerSpaceship, setRepairCrewCount);
-    // Sets whether automatic coolant distribution is enabled. This sets the
-    // amount of coolant proportionally to the amount of heat in that system.
-    // Use this command on ships to require less player interaction, especially
-    // when combined with commandSetAutoRepair/auto_repair_enabled.
+    /// Sets whether automatic coolant distribution is enabled. This sets the
+    /// amount of coolant proportionally to the amount of heat in that system.
+    /// Use this command on ships to require less player interaction, especially
+    /// when combined with commandSetAutoRepair/auto_repair_enabled.
     REGISTER_SCRIPT_CLASS_FUNCTION(PlayerSpaceship, setAutoCoolant);
-    // Set a password to join the ship.
+    /// Set a password to join the ship.
     REGISTER_SCRIPT_CLASS_FUNCTION(PlayerSpaceship, setControlCode);
-    // Callback when this ship launches a probe.
-    // Returns the launching PlayerSpaceship and launched ScanProbe.
-    // Example: player:onProbeLaunch(trackProbe)
+    /// Callback when this ship launches a probe.
+    /// Returns the launching PlayerSpaceship and launched ScanProbe.
+    /// Example: player:onProbeLaunch(trackProbe)
     REGISTER_SCRIPT_CLASS_FUNCTION(PlayerSpaceship, onProbeLaunch);
     REGISTER_SCRIPT_CLASS_FUNCTION(PlayerSpaceship, getLongRangeRadarRange);
     REGISTER_SCRIPT_CLASS_FUNCTION(PlayerSpaceship, getShortRangeRadarRange);

--- a/src/spaceObjects/scanProbe.cpp
+++ b/src/spaceObjects/scanProbe.cpp
@@ -4,6 +4,8 @@
 #include "main.h"
 
 #include "scriptInterface.h"
+
+/// A scan probe.
 REGISTER_SCRIPT_SUBCLASS_NO_CREATE(ScanProbe, SpaceObject)
 {
     // Callback when the probe's lifetime expires.

--- a/src/spaceObjects/spaceship.cpp
+++ b/src/spaceObjects/spaceship.cpp
@@ -13,9 +13,9 @@
 #include "scriptInterface.h"
 REGISTER_SCRIPT_SUBCLASS_NO_CREATE(SpaceShip, ShipTemplateBasedObject)
 {
-    //[DEPRECATED]
+    /// [DEPRECATED]
     REGISTER_SCRIPT_CLASS_FUNCTION(SpaceShip, isFriendOrFoeIdentified);
-    //[DEPRECATED]
+    /// [DEPRECATED]
     REGISTER_SCRIPT_CLASS_FUNCTION(SpaceShip, isFullyScanned);
     REGISTER_SCRIPT_CLASS_FUNCTION(SpaceShip, isFriendOrFoeIdentifiedBy);
     REGISTER_SCRIPT_CLASS_FUNCTION(SpaceShip, isFullyScannedBy);

--- a/src/spaceObjects/supplyDrop.cpp
+++ b/src/spaceObjects/supplyDrop.cpp
@@ -5,6 +5,8 @@
 #include "main.h"
 
 #include "scriptInterface.h"
+
+/// A supply drop.
 REGISTER_SCRIPT_SUBCLASS(SupplyDrop, SpaceObject)
 {
     REGISTER_SCRIPT_CLASS_FUNCTION(SupplyDrop, setEnergy);

--- a/src/spaceObjects/warpJammer.cpp
+++ b/src/spaceObjects/warpJammer.cpp
@@ -5,6 +5,8 @@
 #include "main.h"
 
 #include "scriptInterface.h"
+
+/// A warp jammer.
 REGISTER_SCRIPT_SUBCLASS(WarpJammer, SpaceObject)
 {
     REGISTER_SCRIPT_CLASS_FUNCTION(WarpJammer, setRange);

--- a/src/spaceObjects/wormHole.cpp
+++ b/src/spaceObjects/wormHole.cpp
@@ -12,8 +12,8 @@
 #define AVOIDANCE_MULTIPLIER      1.2
 #define TARGET_SPREAD             500
 
-// A wormhole object that drags objects toward it like a black hole, and then
-// teleports them to another point when they reach its center.
+/// A wormhole object that drags objects toward it like a black hole, and then
+/// teleports them to another point when they reach its center.
 REGISTER_SCRIPT_SUBCLASS(WormHole, SpaceObject)
 {
     /// Set the target of this wormhole


### PR DESCRIPTION
Replace several `//` by `///` to let the "docstrings" of Lua functions be included in `script_reference.html`.

Add a few strings.