### PR TITLE
Fix scenarios 50, 56, 60: hasWarp() to hasWarpDrive()

### DIFF
--- a/scripts/scenario_50_gaps.lua
+++ b/scripts/scenario_50_gaps.lua
@@ -3769,7 +3769,7 @@ function setPlayers()
 						pobj.healthyMissile = 1.0
 						pobj.prevMissile = 1.0
 					end
-					if pobj:hasWarp() then
+					if pobj:hasWarpDrive() then
 						pobj.healthyWarp = 1.0
 						pobj.prevWarp = 1.0
 					end

--- a/scripts/scenario_56_carrierTurret.lua
+++ b/scripts/scenario_56_carrierTurret.lua
@@ -5656,7 +5656,7 @@ function setPlayers()
 						pobj.healthyMissile = 1.0
 						pobj.prevMissile = 1.0
 					end
-					if pobj:hasWarp() then
+					if pobj:hasWarpDrive() then
 						pobj.healthyWarp = 1.0
 						pobj.prevWarp = 1.0
 					end

--- a/scripts/scenario_60_captureFlag.lua
+++ b/scripts/scenario_60_captureFlag.lua
@@ -3357,7 +3357,7 @@ function setPlayer(pobj)
 		pobj.healthyMissile = 1.0
 		pobj.prevMissile = 1.0
 	end
-	if pobj:hasWarp() then
+	if pobj:hasWarpDrive() then
 		pobj.healthyWarp = 1.0
 		pobj.prevWarp = 1.0
 	end


### PR DESCRIPTION
Fix scenarios 50, 56, 60: `hasWarp()` to `hasWarpDrive()`