### PR TITLE
Missile size tweak

### DIFF
--- a/src/screens/gm/tweak.cpp
+++ b/src/screens/gm/tweak.cpp
@@ -311,6 +311,17 @@ GuiShipTweakMissileTubes::GuiShipTweakMissileTubes(GuiContainer* owner)
     });
     load_time_slider->addOverlay()->setSize(GuiElement::GuiSizeMax, 40);
 
+    (new GuiLabel(right_col, "", "Size:", 20))->setSize(GuiElement::GuiSizeMax, 30);
+    size_selector=new GuiSelector(right_col, "", [this](int index, string value)
+    {
+        target->weapon_tube[tube_index].setSize(EMissileSizes(index));
+    });
+    size_selector->addEntry("Small",MS_Small);
+    size_selector->addEntry("Medium",MS_Medium);
+    size_selector->addEntry("large",MS_Large);
+    size_selector->setSelectionIndex(MS_Medium);
+    size_selector->setSize(GuiElement::GuiSizeMax, 40);
+
     (new GuiLabel(right_col, "", "Allowed use:", 30))->setSize(GuiElement::GuiSizeMax, 50);
     for(int n=0; n<MW_Count; n++)
     {
@@ -332,6 +343,7 @@ void GuiShipTweakMissileTubes::onDraw(sf::RenderTarget& window)
     {
         allowed_use[n]->setValue(target->weapon_tube[tube_index].canLoad(EMissileWeapons(n)));
     }
+    size_selector->setSelectionIndex(target->weapon_tube[tube_index].getSize());
 }
 
 void GuiShipTweakMissileTubes::open(P<SpaceObject> target)

--- a/src/screens/gm/tweak.h
+++ b/src/screens/gm/tweak.h
@@ -93,6 +93,7 @@ private:
     GuiSelector* missile_tube_amount_selector;
     GuiSlider* direction_slider;
     GuiSlider* load_time_slider;
+    GuiSelector* size_selector;
     GuiToggleButton* allowed_use[MW_Count];
 public:
     GuiShipTweakMissileTubes(GuiContainer* owner);

--- a/src/spaceObjects/spaceship.cpp
+++ b/src/spaceObjects/spaceship.cpp
@@ -80,6 +80,13 @@ REGISTER_SCRIPT_SUBCLASS_NO_CREATE(SpaceShip, ShipTemplateBasedObject)
     REGISTER_SCRIPT_CLASS_FUNCTION(SpaceShip, weaponTubeDisallowMissle);
     REGISTER_SCRIPT_CLASS_FUNCTION(SpaceShip, setWeaponTubeExclusiveFor);
     REGISTER_SCRIPT_CLASS_FUNCTION(SpaceShip, setWeaponTubeDirection);
+    /// Set the tube size
+    /// Example: ship:setTubeSize(0,"small")
+    /// Valid Sizes: "small" "medium" "large"
+    REGISTER_SCRIPT_CLASS_FUNCTION(SpaceShip, setTubeSize);
+    /// Returns the size of the tube
+    /// Example: local size = ship:getTubeSize(0)
+    REGISTER_SCRIPT_CLASS_FUNCTION(SpaceShip, getTubeSize);
     /// Set the icon to be used for this ship on the radar.
     /// For example, ship:setRadarTrace("RadarBlip.png") will show a dot instead of an arrow for this ship.
     /// Note: Icon is only shown after scanning, before the ship is scanned it is always shown as an arrow.
@@ -1231,6 +1238,20 @@ void SpaceShip::setWeaponTubeDirection(int index, float direction)
     if (index < 0 || index >= weapon_tube_count)
         return;
     weapon_tube[index].setDirection(direction);
+}
+
+void SpaceShip::setTubeSize(int index, EMissileSizes size)
+{
+    if (index < 0 || index >= max_weapon_tubes)
+        return;
+    weapon_tube[index].setSize(size);
+}
+
+EMissileSizes SpaceShip::getTubeSize(int index)
+{
+    if (index < 0 || index >= max_weapon_tubes)
+        return MS_Medium;
+    return weapon_tube[index].getSize();
 }
 
 void SpaceShip::addBroadcast(int threshold, string message)

--- a/src/spaceObjects/spaceship.h
+++ b/src/spaceObjects/spaceship.h
@@ -424,6 +424,8 @@ public:
     void setWeaponTubeExclusiveFor(int index, EMissileWeapons type);
     void setWeaponTubeDirection(int index, float direction);
     void setWeaponTubeSize(int index, EMissileSizes size);
+    void setTubeSize(int index, EMissileSizes size);
+    EMissileSizes getTubeSize(int index);
 
     void setRadarTrace(string trace) { radar_trace = trace; }
 


### PR DESCRIPTION
Add missile size to scripting and the tweak menu

I have tested and it seems to work, I still have not looked at the network code, I dont know if anything would need to change now that tube size can be changed during a spaceships lifetime

![image](https://user-images.githubusercontent.com/37894123/81611546-2799e100-93d3-11ea-8184-05062de0acd4.png)
