### PR TITLE
Gm create menu

### DIFF
--- a/src/missileWeaponData.cpp
+++ b/src/missileWeaponData.cpp
@@ -22,6 +22,21 @@ const MissileWeaponData& MissileWeaponData::getDataFor(EMissileWeapons type)
     return missile_data[type];
 }
 
+string getMissileSizeString(EMissileSizes size)
+{
+    switch (size)
+    {
+        case MS_Small:
+            return "small";
+        case MS_Medium:
+            return "medium";
+        case MS_Large:
+            return "large";
+        default:
+            return "unknown size:" + size;
+    }
+}
+
 #ifndef _MSC_VER
 // MFC: GCC does proper external template instantiation, VC++ doesn't.
 #include "missileWeaponData.hpp"

--- a/src/missileWeaponData.h
+++ b/src/missileWeaponData.h
@@ -21,6 +21,7 @@ enum EMissileSizes
     MS_Large = 2,
 };
 REGISTER_MULTIPLAYER_ENUM(EMissileSizes);
+string getMissileSizeString(EMissileSizes size);
 
 /* Define script conversion function for the EMissileWeapons enum. */
 template<> void convert<EMissileWeapons>::param(lua_State* L, int& idx, EMissileWeapons& es);

--- a/src/screens/gm/objectCreationView.cpp
+++ b/src/screens/gm/objectCreationView.cpp
@@ -4,6 +4,7 @@
 #include "shipTemplate.h"
 #include "gui/gui2_panel.h"
 #include "gui/gui2_selector.h"
+#include "gameGlobalInfo.h"
 
 
 GuiObjectCreationView::GuiObjectCreationView(GuiContainer* owner, func_t enterCreateMode)
@@ -119,6 +120,18 @@ GuiObjectCreationView::GuiObjectCreationView(GuiContainer* owner, func_t enterCr
         create_script = "";
         this->hide();
     }))->setPosition(20, -20, ABottomLeft)->setSize(300, 50);
+}
+
+void GuiObjectCreationView::onDraw(sf::RenderTarget& target)
+{
+    if (gameGlobalInfo->allow_new_player_ships)
+    {
+        player_cpu_selector->show();
+    } else {
+        player_cpu_selector->hide();
+        cpu_ship_listbox->show();
+        player_ship_listbox->hide();
+    }
 }
 
 bool GuiObjectCreationView::onMouseDown(sf::Vector2f position)

--- a/src/screens/gm/objectCreationView.cpp
+++ b/src/screens/gm/objectCreationView.cpp
@@ -47,6 +47,10 @@ GuiObjectCreationView::GuiObjectCreationView(GuiContainer* owner, func_t enterCr
         setCreateScript("Asteroid()");
     }))->setTextSize(20)->setPosition(-350, y, ATopRight)->setSize(300, 30);
     y += 30;
+    (new GuiButton(box, "CREATE_VISUAL_ASTEROID", "Visual Asteroid", [this]() {
+        setCreateScript("VisualAsteroid()");
+    }))->setTextSize(20)->setPosition(-350, y, ATopRight)->setSize(300, 30);
+    y += 30;
     (new GuiButton(box, "CREATE_BLACKHOLE", "BlackHole", [this]() {
         setCreateScript("BlackHole()");
     }))->setTextSize(20)->setPosition(-350, y, ATopRight)->setSize(300, 30);

--- a/src/screens/gm/objectCreationView.cpp
+++ b/src/screens/gm/objectCreationView.cpp
@@ -30,6 +30,10 @@ GuiObjectCreationView::GuiObjectCreationView(GuiContainer* owner, func_t enterCr
         y += 30;
     }
     
+    (new GuiButton(box, "CREATE_ARTIFACT", "Artifact", [this]() {
+        setCreateScript("Artifact()");
+    }))->setTextSize(20)->setPosition(-350, y, ATopRight)->setSize(300, 30);
+    y += 30;
     (new GuiButton(box, "CREATE_WARP_JAMMER", "Warp Jammer", [this]() {
         setCreateScript("WarpJammer():setRotation(random(0, 360)):setFactionId(" + string(faction_selector->getSelectionIndex()) + ")");
     }))->setTextSize(20)->setPosition(-350, y, ATopRight)->setSize(300, 30);

--- a/src/screens/gm/objectCreationView.cpp
+++ b/src/screens/gm/objectCreationView.cpp
@@ -103,7 +103,7 @@ GuiObjectCreationView::GuiObjectCreationView(GuiContainer* owner, func_t enterCr
     }
 
     auto player_template_names = ShipTemplate::getTemplateNameList(ShipTemplate::PlayerShip);
-    std::sort(template_names.begin(), template_names.end());
+    std::sort(player_template_names.begin(), player_template_names.end());
     player_ship_listbox = new GuiListbox(box, "CREATE_PLAYER_SHIPS", [this](int index, string value)
     {
         setCreateScript("PlayerSpaceship():setFactionId(" + string(faction_selector->getSelectionIndex()) + "):setTemplate(\"" + value + "\")");

--- a/src/screens/gm/objectCreationView.cpp
+++ b/src/screens/gm/objectCreationView.cpp
@@ -51,6 +51,10 @@ GuiObjectCreationView::GuiObjectCreationView(GuiContainer* owner, func_t enterCr
         setCreateScript("VisualAsteroid()");
     }))->setTextSize(20)->setPosition(-350, y, ATopRight)->setSize(300, 30);
     y += 30;
+    (new GuiButton(box, "CREATE_PLANET", "Planet", [this]() {
+        setCreateScript("Planet()");
+    }))->setTextSize(20)->setPosition(-350, y, ATopRight)->setSize(300, 30);
+    y += 30;
     (new GuiButton(box, "CREATE_BLACKHOLE", "BlackHole", [this]() {
         setCreateScript("BlackHole()");
     }))->setTextSize(20)->setPosition(-350, y, ATopRight)->setSize(300, 30);

--- a/src/screens/gm/objectCreationView.cpp
+++ b/src/screens/gm/objectCreationView.cpp
@@ -4,7 +4,6 @@
 #include "shipTemplate.h"
 #include "gui/gui2_panel.h"
 #include "gui/gui2_selector.h"
-#include "gui/gui2_listbox.h"
 
 
 GuiObjectCreationView::GuiObjectCreationView(GuiContainer* owner, func_t enterCreateMode)
@@ -18,7 +17,25 @@ GuiObjectCreationView::GuiObjectCreationView(GuiContainer* owner, func_t enterCr
         faction_selector->addEntry(info->getLocaleName(), info->getName());
     faction_selector->setSelectionIndex(0);
     faction_selector->setPosition(20, 20, ATopLeft)->setSize(300, 50);
-    
+
+    player_cpu_selector = new GuiSelector(box, "NPC_PC_SELECTOR", [this](int index, string)
+    {
+        if (index==1)
+        {
+            cpu_ship_listbox->hide();
+            player_ship_listbox->show();
+        }
+        else
+        {
+            cpu_ship_listbox->show();
+            player_ship_listbox->hide();
+        }
+    });
+    player_cpu_selector->addEntry("cpu ship","cpu ship");
+    player_cpu_selector->addEntry("player ship","player ship");
+    player_cpu_selector->setSelectionIndex(0);
+    player_cpu_selector->setPosition(20, 70, ATopLeft)->setSize(300, 50);
+
     float y = 20;
     std::vector<string> template_names = ShipTemplate::getTemplateNameList(ShipTemplate::Station);
     std::sort(template_names.begin(), template_names.end());
@@ -72,17 +89,31 @@ GuiObjectCreationView::GuiObjectCreationView(GuiContainer* owner, func_t enterCr
     }))->setTextSize(20)->setPosition(-350, y, ATopRight)->setSize(300, 30);
     y += 30;
     y = 20;
+
     template_names = ShipTemplate::getTemplateNameList(ShipTemplate::Ship);
     std::sort(template_names.begin(), template_names.end());
-    GuiListbox* listbox = new GuiListbox(box, "CREATE_SHIPS", [this](int index, string value)
+    cpu_ship_listbox = new GuiListbox(box, "CREATE_SHIPS", [this](int index, string value)
     {
         setCreateScript("CpuShip():setRotation(random(0, 360)):setFactionId(" + string(faction_selector->getSelectionIndex()) + "):setTemplate(\"" + value + "\"):orderRoaming()");
     });
-    listbox->setTextSize(20)->setButtonHeight(30)->setPosition(-20, 20, ATopRight)->setSize(300, 460);
+    cpu_ship_listbox->setTextSize(20)->setButtonHeight(30)->setPosition(-20, 20, ATopRight)->setSize(300, 460);
     for(string template_name : template_names)
     {
-        listbox->addEntry(template_name, template_name);
+        cpu_ship_listbox->addEntry(template_name, template_name);
     }
+
+    auto player_template_names = ShipTemplate::getTemplateNameList(ShipTemplate::PlayerShip);
+    std::sort(template_names.begin(), template_names.end());
+    player_ship_listbox = new GuiListbox(box, "CREATE_PLAYER_SHIPS", [this](int index, string value)
+    {
+        setCreateScript("PlayerSpaceship():setFactionId(" + string(faction_selector->getSelectionIndex()) + "):setTemplate(\"" + value + "\")");
+    });
+    player_ship_listbox->setTextSize(20)->setButtonHeight(30)->setPosition(-20, 20, ATopRight)->setSize(300, 460);
+    for (const auto template_name : player_template_names)
+    {
+        player_ship_listbox->addEntry(template_name, template_name);
+    }
+    player_ship_listbox->hide();
     
     (new GuiButton(box, "CLOSE_BUTTON", "Cancel", [this]() {
         create_script = "";

--- a/src/screens/gm/objectCreationView.h
+++ b/src/screens/gm/objectCreationView.h
@@ -2,6 +2,7 @@
 #define OBJECT_CREATION_VIEW_H
 
 #include "gui/gui2_overlay.h"
+#include "gui/gui2_listbox.h"
 
 class GuiSelector;
 class GuiContainer;
@@ -12,8 +13,11 @@ class GuiObjectCreationView : public GuiOverlay
 private:
     string create_script;
     GuiSelector* faction_selector;
+    GuiSelector* player_cpu_selector;
     func_t enterCreateMode;
 public:
+    GuiListbox* cpu_ship_listbox;
+    GuiListbox* player_ship_listbox;
     GuiObjectCreationView(GuiContainer* owner, func_t enterCreateMode);
     
     virtual bool onMouseDown(sf::Vector2f position);

--- a/src/screens/gm/objectCreationView.h
+++ b/src/screens/gm/objectCreationView.h
@@ -19,7 +19,9 @@ public:
     GuiListbox* cpu_ship_listbox;
     GuiListbox* player_ship_listbox;
     GuiObjectCreationView(GuiContainer* owner, func_t enterCreateMode);
-    
+
+    virtual void onDraw(sf::RenderTarget& window) override;
+
     virtual bool onMouseDown(sf::Vector2f position);
     
     void setCreateScript(string script);

--- a/src/screens/gm/tweak.cpp
+++ b/src/screens/gm/tweak.cpp
@@ -743,6 +743,11 @@ GuiShipTweakPlayer2::GuiShipTweakPlayer2(GuiContainer* owner)
         target->setAutoCoolant(value);
     });
     auto_coolant_enabled->setSize(GuiElement::GuiSizeMax, 40);
+
+    auto_repair_enabled = new GuiToggleButton(right_col, "", "Auto repair", [this](bool value) {
+        target->commandSetAutoRepair(value);
+    });
+    auto_repair_enabled->setSize(GuiElement::GuiSizeMax, 40);
 }
 
 void GuiShipTweakPlayer2::onDraw(sf::RenderTarget& window)
@@ -757,6 +762,7 @@ void GuiShipTweakPlayer2::onDraw(sf::RenderTarget& window)
     can_self_destruct->setValue(target->getCanSelfDestruct());
     can_launch_probe->setValue(target->getCanLaunchProbe());
     auto_coolant_enabled->setValue(target->auto_coolant_enabled);
+    auto_repair_enabled->setValue(target->auto_repair_enabled);
 }
 
 void GuiShipTweakPlayer2::open(P<SpaceObject> target)

--- a/src/screens/gm/tweak.cpp
+++ b/src/screens/gm/tweak.cpp
@@ -738,6 +738,11 @@ GuiShipTweakPlayer2::GuiShipTweakPlayer2(GuiContainer* owner)
         target->setCanLaunchProbe(value);
     });
     can_launch_probe->setSize(GuiElement::GuiSizeMax, 40);
+
+    auto_coolant_enabled = new GuiToggleButton(right_col, "", "Auto coolant", [this](bool value) {
+        target->setAutoCoolant(value);
+    });
+    auto_coolant_enabled->setSize(GuiElement::GuiSizeMax, 40);
 }
 
 void GuiShipTweakPlayer2::onDraw(sf::RenderTarget& window)
@@ -751,6 +756,7 @@ void GuiShipTweakPlayer2::onDraw(sf::RenderTarget& window)
     can_combat_maneuver->setValue(target->getCanCombatManeuver());
     can_self_destruct->setValue(target->getCanSelfDestruct());
     can_launch_probe->setValue(target->getCanLaunchProbe());
+    auto_coolant_enabled->setValue(target->auto_coolant_enabled);
 }
 
 void GuiShipTweakPlayer2::open(P<SpaceObject> target)

--- a/src/screens/gm/tweak.h
+++ b/src/screens/gm/tweak.h
@@ -192,6 +192,7 @@ private:
     GuiToggleButton* can_combat_maneuver;
     GuiToggleButton* can_self_destruct;
     GuiToggleButton* can_launch_probe;
+    GuiToggleButton* auto_coolant_enabled;
 public:
     GuiShipTweakPlayer2(GuiContainer* owner);
 

--- a/src/screens/gm/tweak.h
+++ b/src/screens/gm/tweak.h
@@ -193,6 +193,7 @@ private:
     GuiToggleButton* can_self_destruct;
     GuiToggleButton* can_launch_probe;
     GuiToggleButton* auto_coolant_enabled;
+    GuiToggleButton* auto_repair_enabled;
 public:
     GuiShipTweakPlayer2(GuiContainer* owner);
 

--- a/src/spaceObjects/playerSpaceship.cpp
+++ b/src/spaceObjects/playerSpaceship.cpp
@@ -2060,6 +2060,8 @@ string PlayerSpaceship::getExportLine()
         result += ":setCanLaunchProbe(" + string(can_launch_probe, true) + ")";
     if (auto_coolant_enabled)
         result += ":setAutoCoolant(true)";
+    if (auto_repair_enabled)
+        result += ":commandSetAutoRepair(true)";
     return result;
 }
 

--- a/src/spaceObjects/playerSpaceship.cpp
+++ b/src/spaceObjects/playerSpaceship.cpp
@@ -2058,6 +2058,8 @@ string PlayerSpaceship::getExportLine()
         result += ":setCanSelfDestruct(" + string(can_self_destruct, true) + ")";
     if (can_launch_probe != ship_template->can_launch_probe)
         result += ":setCanLaunchProbe(" + string(can_launch_probe, true) + ")";
+    if (auto_coolant_enabled)
+        result += ":setAutoCoolant(true)";
     return result;
 }
 

--- a/src/spaceObjects/spaceship.cpp
+++ b/src/spaceObjects/spaceship.cpp
@@ -1387,10 +1387,17 @@ string SpaceShip::getScriptExportModificationsOnTemplate()
     for(int n=0; n<weapon_tube_count; n++)
     {
         WeaponTube& tube = weapon_tube[n];
-        if (tube.getDirection() != ship_template->weapon_tube[n].direction)
+        auto& template_tube = ship_template->weapon_tube[n];
+        if (tube.getDirection() != template_tube.direction)
+        {
             ret += ":setWeaponTubeDirection(" + string(n) + ", " + string(tube.getDirection(), 0) + ")";
+        }
         //TODO: Weapon tube "type_allowed_mask"
         //TODO: Weapon tube "load_time"
+        if (tube.getSize() != template_tube.size)
+        {
+            ret += ":setTubeSize(" + string(n) + ",\"" + getMissileSizeString(tube.getSize()) + "\")";
+        }
     }
     for(int n=0; n<MW_Count; n++)
     {


### PR DESCRIPTION
I intended to create 2 topic branches but messed up on my end - I suspect this isnt a issue though

when spawning >32 player ships they stop spawning with a P object assertion in debug mode, in release mode it runs fine

create menu defualts to CPU ships, as such if the new selector isnt changed or new buttons arent pressed nothing has changed, screenshot below

extra tweak menu items below as well
![image](https://user-images.githubusercontent.com/37894123/81829963-6646ad00-9533-11ea-8069-3e27565ce768.png)
![image](https://user-images.githubusercontent.com/37894123/81830024-73fc3280-9533-11ea-91a0-8a6c1f9617c1.png)