### PR TITLE
Health max

### DIFF
--- a/src/gameStateLogger.cpp
+++ b/src/gameStateLogger.cpp
@@ -1,3 +1,4 @@
+#include <memory>
 #include <time.h>
 
 //We need a really fast float to string conversion. dtoa from milo does this very well.

--- a/src/gui/gui2_progressbar.cpp
+++ b/src/gui/gui2_progressbar.cpp
@@ -16,6 +16,8 @@ void GuiProgressbar::onDraw(sf::RenderTarget& window)
     if (rect.width >= rect.height)
     {
         fill_rect.width *= f;
+        if (max_value < min_value)
+            fill_rect.left = rect.left + rect.width - fill_rect.width;
         drawStretchedH(window, fill_rect, "gui/ProgressbarFill", color);
     }
     else

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1,3 +1,4 @@
+#include <memory>
 #include <string.h>
 #include <i18n.h>
 #include <multiplayer_proxy.h>

--- a/src/repairCrew.cpp
+++ b/src/repairCrew.cpp
@@ -179,13 +179,11 @@ void RepairCrew::update(float delta)
             position = sf::Vector2f(pos);
 
             ESystem system = ship->ship_template->getSystemAtRoom(pos);
-            if (system != SYS_None && ship->systems[system].health < ship->systems[system].health_max)
+            if (system != SYS_None)
             {
                 ship->systems[system].health += repair_per_second * delta;
                 if (ship->systems[system].health > 1.0)
                     ship->systems[system].health = 1.0;
-                if (ship->systems[system].health > ship->systems[system].health_max)
-                    ship->systems[system].health = ship->systems[system].health_max;
                 ship->systems[system].hacked_level -= repair_per_second * delta;
                 if (ship->systems[system].hacked_level < 0.0)
                     ship->systems[system].hacked_level = 0.0;

--- a/src/repairCrew.cpp
+++ b/src/repairCrew.cpp
@@ -179,11 +179,13 @@ void RepairCrew::update(float delta)
             position = sf::Vector2f(pos);
 
             ESystem system = ship->ship_template->getSystemAtRoom(pos);
-            if (system != SYS_None)
+            if (system != SYS_None && ship->systems[system].health < ship->systems[system].health_max)
             {
                 ship->systems[system].health += repair_per_second * delta;
                 if (ship->systems[system].health > 1.0)
                     ship->systems[system].health = 1.0;
+                if (ship->systems[system].health > ship->systems[system].health_max)
+                    ship->systems[system].health = ship->systems[system].health_max;
                 ship->systems[system].hacked_level -= repair_per_second * delta;
                 if (ship->systems[system].hacked_level < 0.0)
                     ship->systems[system].hacked_level = 0.0;

--- a/src/screens/crew6/engineeringScreen.cpp
+++ b/src/screens/crew6/engineeringScreen.cpp
@@ -59,6 +59,8 @@ EngineeringScreen::EngineeringScreen(GuiContainer* owner, ECrewPosition crew_pos
         info.button->setSize(300, GuiElement::GuiSizeMax);
         info.damage_bar = new GuiProgressbar(info.layout, id + "_DAMAGE", 0.0, 1.0, 0.0);
         info.damage_bar->setSize(150, GuiElement::GuiSizeMax);
+        info.health_max_bar = new GuiProgressbar(info.damage_bar, id + "_MAX", 1.0, 0.0, 0.0);
+        info.health_max_bar->setSize(GuiElement::GuiSizeMax, GuiElement::GuiSizeMax);
         info.damage_label = new GuiLabel(info.damage_bar, id + "_DAMAGE_LABEL", "...", 20);
         info.damage_label->setSize(GuiElement::GuiSizeMax, GuiElement::GuiSizeMax);
         info.heat_bar = new GuiProgressbar(info.layout, id + "_HEAT", 0.0, 1.0, 0.0);
@@ -79,6 +81,7 @@ EngineeringScreen::EngineeringScreen(GuiContainer* owner, ECrewPosition crew_pos
         info.coolant_bar->setColor(sf::Color(32, 128, 128, 128))->setSize(100, GuiElement::GuiSizeMax);
         if (!gameGlobalInfo->use_system_damage){
             info.damage_bar->hide();
+            info.health_max_bar->hide();
             info.heat_bar->setSize(150, GuiElement::GuiSizeMax);
             info.power_bar->setSize(150, GuiElement::GuiSizeMax);
             info.coolant_bar->setSize(150, GuiElement::GuiSizeMax);
@@ -195,6 +198,9 @@ void EngineeringScreen::onDraw(sf::RenderTarget& window)
                 info.damage_bar->setValue(health)->setColor(sf::Color(64, 128 * health, 64 * health, 192));
             info.damage_label->setText(string(int(health * 100)) + "%");
 
+            float health_max = my_spaceship->systems[n].health_max;
+            info.health_max_bar->setValue(health_max)->setColor(sf::Color(0, 0, 0, 192));
+
             float heat = my_spaceship->systems[n].heat_level;
             info.heat_bar->setValue(heat)->setColor(sf::Color(128, 32 + 96 * (1.0 - heat), 32, 192));
             float heating_diff = my_spaceship->systems[n].getHeatingDelta();
@@ -224,6 +230,9 @@ void EngineeringScreen::onDraw(sf::RenderTarget& window)
 
             system_effects_index = 0;
             float effectiveness = my_spaceship->getSystemEffectiveness(selected_system);
+            float health_max = my_spaceship->getSystemHealthMax(selected_system);
+            if (health_max < 1.0)
+                addSystemEffect("Maximal health", string(int(health_max * 100)) + "%");
             switch(selected_system)
             {
             case SYS_Reactor:

--- a/src/screens/crew6/engineeringScreen.cpp
+++ b/src/screens/crew6/engineeringScreen.cpp
@@ -59,8 +59,8 @@ EngineeringScreen::EngineeringScreen(GuiContainer* owner, ECrewPosition crew_pos
         info.button->setSize(300, GuiElement::GuiSizeMax);
         info.damage_bar = new GuiProgressbar(info.layout, id + "_DAMAGE", 0.0, 1.0, 0.0);
         info.damage_bar->setSize(150, GuiElement::GuiSizeMax);
-        info.health_max_bar = new GuiProgressbar(info.damage_bar, id + "_MAX", 1.0, 0.0, 0.0);
-        info.health_max_bar->setSize(GuiElement::GuiSizeMax, GuiElement::GuiSizeMax);
+        info.damage_icon = new GuiImage(info.damage_bar, "", "gui/icons/system_health");
+        info.damage_icon->setColor(colorConfig.overlay_damaged)->setPosition(0, 0, ACenterRight)->setSize(GuiElement::GuiSizeMatchHeight, GuiElement::GuiSizeMax);
         info.damage_label = new GuiLabel(info.damage_bar, id + "_DAMAGE_LABEL", "...", 20);
         info.damage_label->setSize(GuiElement::GuiSizeMax, GuiElement::GuiSizeMax);
         info.heat_bar = new GuiProgressbar(info.layout, id + "_HEAT", 0.0, 1.0, 0.0);
@@ -68,7 +68,7 @@ EngineeringScreen::EngineeringScreen(GuiContainer* owner, ECrewPosition crew_pos
         info.heat_arrow = new GuiArrow(info.heat_bar, id + "_HEAT_ARROW", 0);
         info.heat_arrow->setSize(GuiElement::GuiSizeMax, GuiElement::GuiSizeMax);
         info.heat_icon = new GuiImage(info.heat_bar, "", "gui/icons/status_overheat");
-        info.heat_icon->setColor(colorConfig.overlay_overheating)->setPosition(0, 0, ACenter)->setSize(GuiElement::GuiSizeMatchHeight, GuiElement::GuiSizeMax);
+        info.heat_icon->setColor(colorConfig.overlay_overheating)->setPosition(0, 0, ACenter)->setSize(GuiElement::GuiSizeMatchHeight, GuiElement::GuiSizeMax);        
         info.power_bar = new GuiProgressSlider(info.layout, id + "_POWER", 0.0, 3.0, 0.0, [this,n](float value){
             if (my_spaceship)
                 my_spaceship->commandSetSystemPowerRequest(ESystem(n), value);
@@ -197,9 +197,11 @@ void EngineeringScreen::onDraw(sf::RenderTarget& window)
             else
                 info.damage_bar->setValue(health)->setColor(sf::Color(64, 128 * health, 64 * health, 192));
             info.damage_label->setText(string(int(health * 100)) + "%");
-
             float health_max = my_spaceship->systems[n].health_max;
-            info.health_max_bar->setValue(health_max)->setColor(sf::Color(0, 0, 0, 192));
+            if (health_max < 1.0)
+                info.damage_icon->show();
+            else
+                info.damage_icon->hide();
 
             float heat = my_spaceship->systems[n].heat_level;
             info.heat_bar->setValue(heat)->setColor(sf::Color(128, 32 + 96 * (1.0 - heat), 32, 192));

--- a/src/screens/crew6/engineeringScreen.h
+++ b/src/screens/crew6/engineeringScreen.h
@@ -38,6 +38,7 @@ private:
         GuiAutoLayout* layout;
         GuiToggleButton* button;
         GuiProgressbar* damage_bar;
+        GuiProgressbar* health_max_bar;
         GuiLabel* damage_label;
         GuiProgressbar* heat_bar;
         GuiArrow* heat_arrow;

--- a/src/screens/crew6/engineeringScreen.h
+++ b/src/screens/crew6/engineeringScreen.h
@@ -38,6 +38,7 @@ private:
         GuiAutoLayout* layout;
         GuiToggleButton* button;
         GuiProgressbar* damage_bar;
+        GuiImage* damage_icon;
         GuiProgressbar* health_max_bar;
         GuiLabel* damage_label;
         GuiProgressbar* heat_bar;

--- a/src/screens/crewStationScreen.h
+++ b/src/screens/crewStationScreen.h
@@ -1,6 +1,7 @@
 #ifndef CREW_STATION_SCREEN_H
 #define CREW_STATION_SCREEN_H
 
+#include <memory>
 #include "engine.h"
 #include "threatLevelEstimate.h"
 #include "playerInfo.h"

--- a/src/screens/extra/damcon.cpp
+++ b/src/screens/extra/damcon.cpp
@@ -47,6 +47,8 @@ void DamageControlScreen::onDraw(sf::RenderTarget& window)
             system_health[n]->setValue(string(int(my_spaceship->systems[n].health * 100)) + "%");
             if (my_spaceship->systems[n].health < 0)
                 system_health[n]->setColor(sf::Color::Red);
+            else if (my_spaceship->systems[n].health_max < 1.0)
+                system_health[n]->setColor(sf::Color::Yellow);
             else
                 system_health[n]->setColor(sf::Color::White);
         }

--- a/src/screens/gm/tweak.cpp
+++ b/src/screens/gm/tweak.cpp
@@ -524,15 +524,13 @@ GuiShipTweakSystems::GuiShipTweakSystems(GuiContainer* owner)
         system_damage[n]->addSnapValue( 1.0, 0.01);
 
         (new GuiLabel(center_col, "", tr("{system} health max").format({{"system", getLocaleSystemName(system)}}), 20))->setSize(GuiElement::GuiSizeMax, 30);
-        system_health_max[n] = new GuiSlider(center_col, "", 0.0, 1.0, 1.0, [this, n](float value) {
+        system_health_max[n] = new GuiSlider(center_col, "", -1.0, 1.0, 1.0, [this, n](float value) {
             target->systems[n].health_max = value;
             target->systems[n].health = std::min(value,target->systems[n].health);
         });
         system_health_max[n]->setSize(GuiElement::GuiSizeMax, 30);
+        system_health_max[n]->addSnapValue(-1.0, 0.01);
         system_health_max[n]->addSnapValue( 0.0, 0.01);
-        system_health_max[n]->addSnapValue( 0.25, 0.01);
-        system_health_max[n]->addSnapValue( 0.5, 0.01);
-        system_health_max[n]->addSnapValue( 0.75, 0.01);
         system_health_max[n]->addSnapValue( 1.0, 0.01);
 
         (new GuiLabel(right_col, "", tr("{system} heat").format({{"system", getLocaleSystemName(system)}}), 20))->setSize(GuiElement::GuiSizeMax, 30);

--- a/src/screens/gm/tweak.cpp
+++ b/src/screens/gm/tweak.cpp
@@ -505,21 +505,35 @@ GuiShipTweakSystems::GuiShipTweakSystems(GuiContainer* owner)
 : GuiTweakPage(owner)
 {
     GuiAutoLayout* left_col = new GuiAutoLayout(this, "LEFT_LAYOUT", GuiAutoLayout::LayoutVerticalTopToBottom);
-    left_col->setPosition(50, 25, ATopLeft)->setSize(300, GuiElement::GuiSizeMax);
+    left_col->setPosition(50, 25, ATopLeft)->setSize(200, GuiElement::GuiSizeMax);
+    GuiAutoLayout* center_col = new GuiAutoLayout(this, "CENTER_LAYOUT", GuiAutoLayout::LayoutVerticalTopToBottom);
+    center_col->setPosition(10, 25, ATopCenter)->setSize(200, GuiElement::GuiSizeMax);
     GuiAutoLayout* right_col = new GuiAutoLayout(this, "RIGHT_LAYOUT", GuiAutoLayout::LayoutVerticalTopToBottom);
-    right_col->setPosition(-25, 25, ATopRight)->setSize(300, GuiElement::GuiSizeMax);
+    right_col->setPosition(-25, 25, ATopRight)->setSize(200, GuiElement::GuiSizeMax);
     
     for(int n=0; n<SYS_COUNT; n++)
     {
         ESystem system = ESystem(n);
         (new GuiLabel(left_col, "", tr("{system} health").format({{"system", getLocaleSystemName(system)}}), 20))->setSize(GuiElement::GuiSizeMax, 30);
         system_damage[n] = new GuiSlider(left_col, "", -1.0, 1.0, 0.0, [this, n](float value) {
-            target->systems[n].health = value;
+            target->systems[n].health = std::min(value,target->systems[n].health_max);
         });
         system_damage[n]->setSize(GuiElement::GuiSizeMax, 30);
         system_damage[n]->addSnapValue(-1.0, 0.01);
         system_damage[n]->addSnapValue( 0.0, 0.01);
         system_damage[n]->addSnapValue( 1.0, 0.01);
+
+        (new GuiLabel(center_col, "", tr("{system} health max").format({{"system", getLocaleSystemName(system)}}), 20))->setSize(GuiElement::GuiSizeMax, 30);
+        system_health_max[n] = new GuiSlider(center_col, "", 0.0, 1.0, 1.0, [this, n](float value) {
+            target->systems[n].health_max = value;
+            target->systems[n].health = std::min(value,target->systems[n].health);
+        });
+        system_health_max[n]->setSize(GuiElement::GuiSizeMax, 30);
+        system_health_max[n]->addSnapValue( 0.0, 0.01);
+        system_health_max[n]->addSnapValue( 0.25, 0.01);
+        system_health_max[n]->addSnapValue( 0.5, 0.01);
+        system_health_max[n]->addSnapValue( 0.75, 0.01);
+        system_health_max[n]->addSnapValue( 1.0, 0.01);
 
         (new GuiLabel(right_col, "", tr("{system} heat").format({{"system", getLocaleSystemName(system)}}), 20))->setSize(GuiElement::GuiSizeMax, 30);
         system_heat[n] = new GuiSlider(right_col, "", 0.0, 1.0, 0.0, [this, n](float value) {
@@ -536,6 +550,7 @@ void GuiShipTweakSystems::onDraw(sf::RenderTarget& window)
     for(int n=0; n<SYS_COUNT; n++)
     {
         system_damage[n]->setValue(target->systems[n].health);
+        system_health_max[n]->setValue(target->systems[n].health_max);
         system_heat[n]->setValue(target->systems[n].heat_level);
     }
 }

--- a/src/screens/gm/tweak.h
+++ b/src/screens/gm/tweak.h
@@ -147,6 +147,7 @@ private:
     P<SpaceShip> target;
 
     GuiSlider* system_damage[SYS_COUNT];
+    GuiSlider* system_health_max[SYS_COUNT];
     GuiSlider* system_heat[SYS_COUNT];
 
 public:

--- a/src/screens/mainScreen.h
+++ b/src/screens/mainScreen.h
@@ -1,3 +1,4 @@
+#include <memory>
 #ifndef MAIN_SCREEN_H
 #define MAIN_SCREEN_H
 

--- a/src/spaceObjects/spaceship.cpp
+++ b/src/spaceObjects/spaceship.cpp
@@ -769,6 +769,7 @@ void SpaceShip::update(float delta)
     for(int n=0; n<SYS_COUNT; n++)
     {
         systems[n].hacked_level = std::max(0.0f, systems[n].hacked_level - delta / unhack_time);
+        systems[n].health = std::min(systems[n].health,systems[n].health_max);
     }
 
     model_info.engine_scale = std::min(1.0f, (float) std::max(fabs(getAngularVelocity() / turn_speed), fabs(current_impulse)));

--- a/src/spaceObjects/spaceship.cpp
+++ b/src/spaceObjects/spaceship.cpp
@@ -36,6 +36,8 @@ REGISTER_SCRIPT_SUBCLASS_NO_CREATE(SpaceShip, ShipTemplateBasedObject)
     REGISTER_SCRIPT_CLASS_FUNCTION(SpaceShip, setEnergy);
     REGISTER_SCRIPT_CLASS_FUNCTION(SpaceShip, getSystemHealth);
     REGISTER_SCRIPT_CLASS_FUNCTION(SpaceShip, setSystemHealth);
+    REGISTER_SCRIPT_CLASS_FUNCTION(SpaceShip, getSystemHealthMax);
+    REGISTER_SCRIPT_CLASS_FUNCTION(SpaceShip, setSystemHealthMax);
     REGISTER_SCRIPT_CLASS_FUNCTION(SpaceShip, getSystemHeat);
     REGISTER_SCRIPT_CLASS_FUNCTION(SpaceShip, setSystemHeat);
     REGISTER_SCRIPT_CLASS_FUNCTION(SpaceShip, getSystemPower);
@@ -177,6 +179,7 @@ SpaceShip::SpaceShip(string multiplayerClassName, float multiplayer_significant_
     for(int n=0; n<SYS_COUNT; n++)
     {
         systems[n].health = 1.0;
+        systems[n].health_max = 1.0;
         systems[n].power_level = 1.0;
         systems[n].power_request = 1.0;
         systems[n].coolant_level = 0.0;
@@ -185,6 +188,7 @@ SpaceShip::SpaceShip(string multiplayerClassName, float multiplayer_significant_
         systems[n].hacked_level = 0.0;
 
         registerMemberReplication(&systems[n].health, 0.1);
+        registerMemberReplication(&systems[n].health_max, 0.1);
         registerMemberReplication(&systems[n].hacked_level, 0.1);
     }
 

--- a/src/spaceObjects/spaceship.h
+++ b/src/spaceObjects/spaceship.h
@@ -37,6 +37,7 @@ class ShipSystem
 {
 public:
     float health; //1.0-0.0, where 0.0 is fully broken.
+    float health_max; //1.0-0.0, where 0.0 is fully broken.
     float power_level; //0.0-3.0, default 1.0
     float power_request;
     float heat_level; //0.0-1.0, system will damage at 1.0
@@ -312,6 +313,8 @@ public:
     void setEnergy(float amount) { if ( (amount > 0.0) && (amount <= max_energy_level)) { energy_level = amount; } }
     float getSystemHealth(ESystem system) { if (system >= SYS_COUNT) return 0.0; if (system <= SYS_None) return 0.0; return systems[system].health; }
     void setSystemHealth(ESystem system, float health) { if (system >= SYS_COUNT) return; if (system <= SYS_None) return; systems[system].health = std::min(1.0f, std::max(-1.0f, health)); }
+    float getSystemHealthMax(ESystem system) { if (system >= SYS_COUNT) return 0.0; if (system <= SYS_None) return 0.0; return systems[system].health_max; }
+    void setSystemHealthMax(ESystem system, float health_max) { if (system >= SYS_COUNT) return; if (system <= SYS_None) return; systems[system].health_max = std::min(1.0f, std::max(0.0f, health_max)); }
     float getSystemHeat(ESystem system) { if (system >= SYS_COUNT) return 0.0; if (system <= SYS_None) return 0.0; return systems[system].heat_level; }
     void setSystemHeat(ESystem system, float heat) { if (system >= SYS_COUNT) return; if (system <= SYS_None) return; systems[system].heat_level = std::min(1.0f, std::max(0.0f, heat)); }
     float getSystemPower(ESystem system) { if (system >= SYS_COUNT) return 0.0; if (system <= SYS_None) return 0.0; return systems[system].power_level; }

--- a/src/spaceObjects/spaceship.h
+++ b/src/spaceObjects/spaceship.h
@@ -314,7 +314,7 @@ public:
     float getSystemHealth(ESystem system) { if (system >= SYS_COUNT) return 0.0; if (system <= SYS_None) return 0.0; return systems[system].health; }
     void setSystemHealth(ESystem system, float health) { if (system >= SYS_COUNT) return; if (system <= SYS_None) return; systems[system].health = std::min(1.0f, std::max(-1.0f, health)); }
     float getSystemHealthMax(ESystem system) { if (system >= SYS_COUNT) return 0.0; if (system <= SYS_None) return 0.0; return systems[system].health_max; }
-    void setSystemHealthMax(ESystem system, float health_max) { if (system >= SYS_COUNT) return; if (system <= SYS_None) return; systems[system].health_max = std::min(1.0f, std::max(0.0f, health_max)); }
+    void setSystemHealthMax(ESystem system, float health_max) { if (system >= SYS_COUNT) return; if (system <= SYS_None) return; systems[system].health_max = std::min(1.0f, std::max(-1.0f, health_max)); }
     float getSystemHeat(ESystem system) { if (system >= SYS_COUNT) return 0.0; if (system <= SYS_None) return 0.0; return systems[system].heat_level; }
     void setSystemHeat(ESystem system, float heat) { if (system >= SYS_COUNT) return; if (system <= SYS_None) return; systems[system].heat_level = std::min(1.0f, std::max(0.0f, heat)); }
     float getSystemPower(ESystem system) { if (system >= SYS_COUNT) return 0.0; if (system <= SYS_None) return 0.0; return systems[system].power_level; }


### PR DESCRIPTION
It allows the GM to limit the maximal health of each system to simulate major failure. Automatic or damcom repair cannot repair it, only GM can fix it with tweak. Engineer can see the maximal health with a black progress bar for the broken system. 

Useful for scenario with GM and LARP.

Change in the actual game : There is no change until GM want to use this feature.

![Capture d'écran de 2020-05-14 02-50-59](https://user-images.githubusercontent.com/13868149/81880463-de41c100-958d-11ea-8cb3-c722c66999be.png)
![Capture d'écran de 2020-05-14 02-51-08](https://user-images.githubusercontent.com/13868149/81880500-f87b9f00-958d-11ea-9fa9-7da20d2abaf9.png)
