### PR TITLE
Introduce indicator for weapons blocked by warp

### DIFF
--- a/resources/gui/colors.ini
+++ b/resources/gui/colors.ini
@@ -43,6 +43,7 @@ label = #FFFFFF
 
 overlay_damaged = #FF0000
 overlay_jammed = #FF0000
+overlay_blocked_by_warp = #0000FF
 overlay_no_power = #FF0000
 overlay_low_energy = #FF8000
 overlay_low_power = #FF8000

--- a/src/gui/colorConfig.cpp
+++ b/src/gui/colorConfig.cpp
@@ -51,6 +51,7 @@ void ColorConfig::load()
     DEF_WIDGETCOLORSET(textbox);
     DEF_COLOR(overlay_damaged);
     DEF_COLOR(overlay_jammed);
+    DEF_COLOR(overlay_blocked_by_warp);
     DEF_COLOR(overlay_hacked);
     DEF_COLOR(overlay_no_power);
     DEF_COLOR(overlay_low_energy);

--- a/src/gui/colorConfig.h
+++ b/src/gui/colorConfig.h
@@ -42,6 +42,7 @@ public:
 
     sf::Color overlay_damaged;
     sf::Color overlay_jammed;
+    sf::Color overlay_blocked_by_warp;
     sf::Color overlay_hacked;
     sf::Color overlay_no_power;
     sf::Color overlay_low_energy;

--- a/src/screenComponents/powerDamageIndicator.cpp
+++ b/src/screenComponents/powerDamageIndicator.cpp
@@ -35,6 +35,10 @@ void GuiPowerDamageIndicator::onDraw(sf::RenderTarget& window)
     {
         color = colorConfig.overlay_jammed;
         display_text = "JAMMED";
+    }else if ((system == SYS_BeamWeapons || system == SYS_MissileSystem) && my_spaceship->current_warp > 0.0)
+    {
+        color = colorConfig.overlay_blocked_by_warp;
+        display_text = "BLOCKED BY WARP";
     }else if (power == 0.0)
     {
         color = colorConfig.overlay_no_power;
@@ -114,6 +118,7 @@ void GuiPowerDamageIndicator::onDraw(sf::RenderTarget& window)
     {
         drawIcon(window, "gui/icons/status_jammed", colorConfig.overlay_jammed);
     }
+    // TODO consider icon for blocked by warp
     if (power == 0.0)
     {
         drawIcon(window, "gui/icons/status_no_power", colorConfig.overlay_no_power);


### PR DESCRIPTION
Add indicator for weapons (beams/missiles) blocked by warp to the weapons consoles.

This is a small and useful improvement for the weapons officer. So far it can be strange (in particluar in slow warp) why clicking on missiles etc. does have no effect. Additionally this is consistent with other indicators for blocked systems.

This will solve issue #943.

There are some open questions.

1. Is the code correct, in particular the comparison with current_warp?
2. Does it work for all three weapons consoles?
3. (Are weapons blocked during jumps? Do we need a similar indicator?)
4. Is the order (health, BLOCKED, energy, ...) the best?
5. Better or shorter text instead of "BLOCKED BY WARP"?
6. Which color? (It could be a more neutral yellow or blue, not orange or red.)
7. How do we get an icon?

Please test or comment.

Feel free to add modifications.