### PR TITLE
Add hotkey to reset system power to 100%

### DIFF
--- a/src/gui/hotkeyConfig.cpp
+++ b/src/gui/hotkeyConfig.cpp
@@ -94,6 +94,7 @@ HotkeyConfig::HotkeyConfig()
     newKey("SELECT_JUMP_DRIVE", std::make_tuple("Select jump drive system", "Num7"));
     newKey("SELECT_FRONT_SHIELDS", std::make_tuple("Select front shields system", "Num8"));
     newKey("SELECT_REAR_SHIELDS", std::make_tuple("Select rear shields system", "Num9"));
+    newKey("RESET_POWER", std::make_tuple("Reset system power to 100%", "Space"));
     newKey("INCREASE_POWER", std::make_tuple("Increase system power", "Up"));
     newKey("DECREASE_POWER", std::make_tuple("Decrease system power", "Down"));
     newKey("INCREASE_COOLANT", std::make_tuple("Increase system coolant", "Right"));

--- a/src/screens/crew6/engineeringScreen.cpp
+++ b/src/screens/crew6/engineeringScreen.cpp
@@ -363,6 +363,11 @@ void EngineeringScreen::onHotkey(const HotkeyResult& key)
         
         if (selected_system != SYS_None)
         {
+            if (key.hotkey == "RESET_POWER")
+            {
+                power_slider->setValue(1.0f);
+                my_spaceship->commandSetSystemPowerRequest(selected_system, power_slider->getValue());
+            }
             if (key.hotkey == "INCREASE_POWER")
             {
                 power_slider->setValue(my_spaceship->systems[selected_system].power_request + 0.1f);

--- a/src/screens/extra/powerManagement.cpp
+++ b/src/screens/extra/powerManagement.cpp
@@ -136,6 +136,11 @@ void PowerManagementScreen::onHotkey(const HotkeyResult& key)
         {
             GuiSlider* power_slider = systems[selected_system].power_slider;
 
+            if (key.hotkey == "RESET_POWER")
+            {
+                power_slider->setValue(1.0f);
+                my_spaceship->commandSetSystemPowerRequest(selected_system, power_slider->getValue());
+            }
             if (key.hotkey == "INCREASE_POWER")
             {
                 power_slider->setValue(my_spaceship->systems[selected_system].power_request + 0.1f);


### PR DESCRIPTION
I always wanted to have this key, there it is.

The default key `Space` is a suggestion. It is kind of similar to Space for Helms.