### PR TITLE
Change key from RESET_POWER to SET_POWER_100

### DIFF
--- a/src/gui/hotkeyConfig.cpp
+++ b/src/gui/hotkeyConfig.cpp
@@ -94,7 +94,7 @@ HotkeyConfig::HotkeyConfig()
     newKey("SELECT_JUMP_DRIVE", std::make_tuple("Select jump drive system", "Num7"));
     newKey("SELECT_FRONT_SHIELDS", std::make_tuple("Select front shields system", "Num8"));
     newKey("SELECT_REAR_SHIELDS", std::make_tuple("Select rear shields system", "Num9"));
-    newKey("RESET_POWER", std::make_tuple("Reset system power to 100%", "Space"));
+    newKey("SET_POWER_100", std::make_tuple("Set system power to 100%", "Space"));
     newKey("INCREASE_POWER", std::make_tuple("Increase system power", "Up"));
     newKey("DECREASE_POWER", std::make_tuple("Decrease system power", "Down"));
     newKey("INCREASE_COOLANT", std::make_tuple("Increase system coolant", "Right"));

--- a/src/screens/crew6/engineeringScreen.cpp
+++ b/src/screens/crew6/engineeringScreen.cpp
@@ -363,7 +363,7 @@ void EngineeringScreen::onHotkey(const HotkeyResult& key)
         
         if (selected_system != SYS_None)
         {
-            if (key.hotkey == "RESET_POWER")
+            if (key.hotkey == "SET_POWER_100")
             {
                 power_slider->setValue(1.0f);
                 my_spaceship->commandSetSystemPowerRequest(selected_system, power_slider->getValue());

--- a/src/screens/extra/powerManagement.cpp
+++ b/src/screens/extra/powerManagement.cpp
@@ -136,7 +136,7 @@ void PowerManagementScreen::onHotkey(const HotkeyResult& key)
         {
             GuiSlider* power_slider = systems[selected_system].power_slider;
 
-            if (key.hotkey == "RESET_POWER")
+            if (key.hotkey == "SET_POWER_100")
             {
                 power_slider->setValue(1.0f);
                 my_spaceship->commandSetSystemPowerRequest(selected_system, power_slider->getValue());


### PR DESCRIPTION
Change key from `RESET_POWER` to `SET_POWER_100`.
This allows analogous keys for other values.

This is an improvement of #951.

If in the same release, there are no incompatibilities.