### PR TITLE
Add more optional hotkeys for system power

### DIFF
--- a/src/gui/hotkeyConfig.cpp
+++ b/src/gui/hotkeyConfig.cpp
@@ -96,6 +96,7 @@ HotkeyConfig::HotkeyConfig()
     newKey("SELECT_REAR_SHIELDS", std::make_tuple("Select rear shields system", "Num9"));
     newKey("SET_POWER_000", std::make_tuple("Set system power to 0%", ""));
     newKey("SET_POWER_030", std::make_tuple("Set system power to 30%", ""));
+    newKey("SET_POWER_050", std::make_tuple("Set system power to 50%", ""));
     newKey("SET_POWER_100", std::make_tuple("Set system power to 100%", "Space"));
     newKey("SET_POWER_150", std::make_tuple("Set system power to 150%", ""));
     newKey("SET_POWER_200", std::make_tuple("Set system power to 200%", ""));

--- a/src/gui/hotkeyConfig.cpp
+++ b/src/gui/hotkeyConfig.cpp
@@ -94,7 +94,13 @@ HotkeyConfig::HotkeyConfig()
     newKey("SELECT_JUMP_DRIVE", std::make_tuple("Select jump drive system", "Num7"));
     newKey("SELECT_FRONT_SHIELDS", std::make_tuple("Select front shields system", "Num8"));
     newKey("SELECT_REAR_SHIELDS", std::make_tuple("Select rear shields system", "Num9"));
+    newKey("SET_POWER_000", std::make_tuple("Set system power to 0%", ""));
+    newKey("SET_POWER_030", std::make_tuple("Set system power to 30%", ""));
     newKey("SET_POWER_100", std::make_tuple("Set system power to 100%", "Space"));
+    newKey("SET_POWER_150", std::make_tuple("Set system power to 150%", ""));
+    newKey("SET_POWER_200", std::make_tuple("Set system power to 200%", ""));
+    newKey("SET_POWER_250", std::make_tuple("Set system power to 250%", ""));
+    newKey("SET_POWER_300", std::make_tuple("Set system power to 300%", ""));
     newKey("INCREASE_POWER", std::make_tuple("Increase system power", "Up"));
     newKey("DECREASE_POWER", std::make_tuple("Decrease system power", "Down"));
     newKey("INCREASE_COOLANT", std::make_tuple("Increase system coolant", "Right"));

--- a/src/screens/crew6/engineeringScreen.cpp
+++ b/src/screens/crew6/engineeringScreen.cpp
@@ -363,9 +363,39 @@ void EngineeringScreen::onHotkey(const HotkeyResult& key)
         
         if (selected_system != SYS_None)
         {
+            if (key.hotkey == "SET_POWER_000")
+            {
+                power_slider->setValue(0.0f);
+                my_spaceship->commandSetSystemPowerRequest(selected_system, power_slider->getValue());
+            }
+            if (key.hotkey == "SET_POWER_030")
+            {
+                power_slider->setValue(0.3f);
+                my_spaceship->commandSetSystemPowerRequest(selected_system, power_slider->getValue());
+            }
             if (key.hotkey == "SET_POWER_100")
             {
                 power_slider->setValue(1.0f);
+                my_spaceship->commandSetSystemPowerRequest(selected_system, power_slider->getValue());
+            }
+            if (key.hotkey == "SET_POWER_150")
+            {
+                power_slider->setValue(1.5f);
+                my_spaceship->commandSetSystemPowerRequest(selected_system, power_slider->getValue());
+            }
+            if (key.hotkey == "SET_POWER_200")
+            {
+                power_slider->setValue(2.0f);
+                my_spaceship->commandSetSystemPowerRequest(selected_system, power_slider->getValue());
+            }
+            if (key.hotkey == "SET_POWER_250")
+            {
+                power_slider->setValue(2.5f);
+                my_spaceship->commandSetSystemPowerRequest(selected_system, power_slider->getValue());
+            }
+            if (key.hotkey == "SET_POWER_300")
+            {
+                power_slider->setValue(3.0f);
                 my_spaceship->commandSetSystemPowerRequest(selected_system, power_slider->getValue());
             }
             if (key.hotkey == "INCREASE_POWER")

--- a/src/screens/crew6/engineeringScreen.cpp
+++ b/src/screens/crew6/engineeringScreen.cpp
@@ -363,6 +363,7 @@ void EngineeringScreen::onHotkey(const HotkeyResult& key)
         
         if (selected_system != SYS_None)
         {
+            // Note the code duplication with extra/powerManagement
             if (key.hotkey == "SET_POWER_000")
             {
                 power_slider->setValue(0.0f);
@@ -371,6 +372,11 @@ void EngineeringScreen::onHotkey(const HotkeyResult& key)
             if (key.hotkey == "SET_POWER_030")
             {
                 power_slider->setValue(0.3f);
+                my_spaceship->commandSetSystemPowerRequest(selected_system, power_slider->getValue());
+            }
+            if (key.hotkey == "SET_POWER_050")
+            {
+                power_slider->setValue(0.5f);
                 my_spaceship->commandSetSystemPowerRequest(selected_system, power_slider->getValue());
             }
             if (key.hotkey == "SET_POWER_100")

--- a/src/screens/extra/powerManagement.cpp
+++ b/src/screens/extra/powerManagement.cpp
@@ -136,9 +136,39 @@ void PowerManagementScreen::onHotkey(const HotkeyResult& key)
         {
             GuiSlider* power_slider = systems[selected_system].power_slider;
 
+            if (key.hotkey == "SET_POWER_000")
+            {
+                power_slider->setValue(0.0f);
+                my_spaceship->commandSetSystemPowerRequest(selected_system, power_slider->getValue());
+            }
+            if (key.hotkey == "SET_POWER_030")
+            {
+                power_slider->setValue(0.3f);
+                my_spaceship->commandSetSystemPowerRequest(selected_system, power_slider->getValue());
+            }
             if (key.hotkey == "SET_POWER_100")
             {
                 power_slider->setValue(1.0f);
+                my_spaceship->commandSetSystemPowerRequest(selected_system, power_slider->getValue());
+            }
+            if (key.hotkey == "SET_POWER_150")
+            {
+                power_slider->setValue(1.5f);
+                my_spaceship->commandSetSystemPowerRequest(selected_system, power_slider->getValue());
+            }
+            if (key.hotkey == "SET_POWER_200")
+            {
+                power_slider->setValue(2.0f);
+                my_spaceship->commandSetSystemPowerRequest(selected_system, power_slider->getValue());
+            }
+            if (key.hotkey == "SET_POWER_250")
+            {
+                power_slider->setValue(2.5f);
+                my_spaceship->commandSetSystemPowerRequest(selected_system, power_slider->getValue());
+            }
+            if (key.hotkey == "SET_POWER_300")
+            {
+                power_slider->setValue(3.0f);
                 my_spaceship->commandSetSystemPowerRequest(selected_system, power_slider->getValue());
             }
             if (key.hotkey == "INCREASE_POWER")

--- a/src/screens/extra/powerManagement.cpp
+++ b/src/screens/extra/powerManagement.cpp
@@ -136,6 +136,7 @@ void PowerManagementScreen::onHotkey(const HotkeyResult& key)
         {
             GuiSlider* power_slider = systems[selected_system].power_slider;
 
+            // Note the code duplication with crew6/engineeringScreen
             if (key.hotkey == "SET_POWER_000")
             {
                 power_slider->setValue(0.0f);
@@ -144,6 +145,11 @@ void PowerManagementScreen::onHotkey(const HotkeyResult& key)
             if (key.hotkey == "SET_POWER_030")
             {
                 power_slider->setValue(0.3f);
+                my_spaceship->commandSetSystemPowerRequest(selected_system, power_slider->getValue());
+            }
+            if (key.hotkey == "SET_POWER_050")
+            {
+                power_slider->setValue(0.5f);
                 my_spaceship->commandSetSystemPowerRequest(selected_system, power_slider->getValue());
             }
             if (key.hotkey == "SET_POWER_100")


### PR DESCRIPTION
Continuation of #951 and #955.

Engineers _can_ now have hotkeys to set the power of the currently selected system to 0, 30, 100, 150, 200 or 300 percent. (No default keys apart from Space for 100.)