### PR TITLE
Tweak and scripting 2

### DIFF
--- a/src/screens/gm/tweak.cpp
+++ b/src/screens/gm/tweak.cpp
@@ -807,23 +807,42 @@ GuiObjectTweakBase::GuiObjectTweakBase(GuiContainer* owner)
     // Edit object's description.
     // TODO: Fix long strings in GuiTextEntry, or make a new GUI element for
     // editing long strings.
-    (new GuiLabel(left_col, "", "Description:", 30))->setSize(GuiElement::GuiSizeMax, 50);
-
-    // Set object's description.
-    description = new GuiTextEntry(left_col, "", "");
-    description->setSize(GuiElement::GuiSizeMax, 50);
-    description->callback([this](string text) {
-        target->setDescription(text);
+    (new GuiLabel(left_col, "", "Unscanned description:", 30))->setSize(GuiElement::GuiSizeMax, 50);
+    unscanned_description = new GuiTextEntry(left_col, "", "");
+    unscanned_description->setSize(GuiElement::GuiSizeMax, 50);
+    unscanned_description->callback([this](string text) {
+        target->setDescriptionForScanState(SS_NotScanned,text);
     });
 
+    (new GuiLabel(left_col, "", "Friend or Description:", 30))->setSize(GuiElement::GuiSizeMax, 50);
+    friend_or_foe_description = new GuiTextEntry(left_col, "", "");
+    friend_or_foe_description->setSize(GuiElement::GuiSizeMax, 50);
+    friend_or_foe_description->callback([this](string text) {
+        target->setDescriptionForScanState(SS_FriendOrFoeIdentified,text);
+    });
+
+    (new GuiLabel(left_col, "", "Simple Scan Description:", 30))->setSize(GuiElement::GuiSizeMax, 50);
+    simple_scan_description = new GuiTextEntry(left_col, "", "");
+    simple_scan_description->setSize(GuiElement::GuiSizeMax, 50);
+    simple_scan_description->callback([this](string text) {
+        target->setDescriptionForScanState(SS_SimpleScan,text);
+    });
+
+    (new GuiLabel(left_col, "", "Full Scan Description:", 30))->setSize(GuiElement::GuiSizeMax, 50);
+    full_scan_description = new GuiTextEntry(left_col, "", "");
+    full_scan_description->setSize(GuiElement::GuiSizeMax, 50);
+    full_scan_description->callback([this](string text) {
+        target->setDescriptionForScanState(SS_FullScan,text);
+    });
+
+    // Right column
+
     // Set object's heading.
-    (new GuiLabel(left_col, "", "Heading:", 30))->setSize(GuiElement::GuiSizeMax, 50);
-    heading_slider = new GuiSlider(left_col, "", 0.0, 359.9, 0.0, [this](float value) {
+    (new GuiLabel(right_col, "", "Heading:", 30))->setSize(GuiElement::GuiSizeMax, 50);
+    heading_slider = new GuiSlider(right_col, "", 0.0, 359.9, 0.0, [this](float value) {
         target->setHeading(value);
     });
     heading_slider->addOverlay()->setSize(GuiElement::GuiSizeMax, 40);
-
-    // Right column
 }
 
 void GuiObjectTweakBase::onDraw(sf::RenderTarget& window)
@@ -838,5 +857,8 @@ void GuiObjectTweakBase::open(P<SpaceObject> target)
     callsign->setText(target->callsign);
     // TODO: Fix long strings in GuiTextEntry, or make a new GUI element for
     // editing long strings.
-    description->setText(target->getDescription(SS_NotScanned));
+    unscanned_description->setText(target->getDescription(SS_NotScanned));
+    friend_or_foe_description->setText(target->getDescription(SS_FriendOrFoeIdentified));
+    simple_scan_description->setText(target->getDescription(SS_SimpleScan));
+    full_scan_description->setText(target->getDescription(SS_FullScan));
 }

--- a/src/screens/gm/tweak.cpp
+++ b/src/screens/gm/tweak.cpp
@@ -28,16 +28,13 @@ GuiObjectTweak::GuiObjectTweak(GuiContainer* owner, ETweakType tweak_type)
     list->setSize(300, GuiElement::GuiSizeMax);
     list->setPosition(25, 25, ATopLeft);
 
-    if (tweak_type == TW_Object || tweak_type == TW_Station || tweak_type==TW_Jammer)
-    {
-        pages.push_back(new GuiObjectTweakBase(this));
-        list->addEntry("Base", "");
-    }
+    pages.push_back(new GuiObjectTweakBase(this));
+    list->addEntry("Base", "");
 
     if (tweak_type == TW_Ship || tweak_type == TW_Player)
     {
-        pages.push_back(new GuiShipTweakBase(this));
-        list->addEntry("Base", "");
+        pages.push_back(new GuiTweakShip(this));
+        list->addEntry("Ship", "");
     }
 
     if (tweak_type == TW_Jammer)
@@ -103,7 +100,7 @@ void GuiObjectTweak::onDraw(sf::RenderTarget& window)
         hide();
 }
 
-GuiShipTweakBase::GuiShipTweakBase(GuiContainer* owner)
+GuiTweakShip::GuiTweakShip(GuiContainer* owner)
 : GuiTweakPage(owner)
 {
     GuiAutoLayout* left_col = new GuiAutoLayout(this, "LEFT_LAYOUT", GuiAutoLayout::LayoutVerticalTopToBottom);
@@ -113,25 +110,6 @@ GuiShipTweakBase::GuiShipTweakBase(GuiContainer* owner)
     right_col->setPosition(-25, 25, ATopRight)->setSize(300, GuiElement::GuiSizeMax);
 
     // Left column
-    (new GuiLabel(left_col, "", "Callsign:", 30))->setSize(GuiElement::GuiSizeMax, 50);
-
-    callsign = new GuiTextEntry(left_col, "", "");
-    callsign->setSize(GuiElement::GuiSizeMax, 50);
-    callsign->callback([this](string text) {
-        target->callsign = text;
-    });
-
-    // Edit object's description.
-    // TODO: Fix long strings in GuiTextEntry, or make a new GUI element for
-    // editing long strings.
-    (new GuiLabel(left_col, "", "Description:", 30))->setSize(GuiElement::GuiSizeMax, 50);
-
-    description = new GuiTextEntry(left_col, "", "");
-    description->setSize(GuiElement::GuiSizeMax, 50);
-    description->callback([this](string text) {
-        target->setDescription(text);
-    });
-
     (new GuiLabel(left_col, "", "Impulse speed:", 30))->setSize(GuiElement::GuiSizeMax, 50);
     impulse_speed_slider = new GuiSlider(left_col, "", 0.0, 250, 0.0, [this](float value) {
         target->impulse_max_speed = value;
@@ -143,17 +121,6 @@ GuiShipTweakBase::GuiShipTweakBase(GuiContainer* owner)
         target->turn_speed = value;
     });
     turn_speed_slider->addOverlay()->setSize(GuiElement::GuiSizeMax, 40);
-
-    (new GuiLabel(left_col, "", "Heading:", 30))->setSize(GuiElement::GuiSizeMax, 50);
-    heading_slider = new GuiSlider(left_col, "", 0.0, 359.9, 0.0, [this](float value) {
-        target->setHeading(value);
-
-        // If the target is a player, also set its target rotation.
-        P<PlayerSpaceship> player = target;
-        if (player)
-            player->commandTargetRotation(value - 90.0f);
-    });
-    heading_slider->addOverlay()->setSize(GuiElement::GuiSizeMax, 40);
 
     // Right column
     // Set type name. Does not change ship type.
@@ -198,20 +165,17 @@ GuiShipTweakBase::GuiShipTweakBase(GuiContainer* owner)
     jump_toggle->setSize(GuiElement::GuiSizeMax, 40);
 }
 
-void GuiShipTweakBase::onDraw(sf::RenderTarget& window)
+void GuiTweakShip::onDraw(sf::RenderTarget& window)
 {
-    heading_slider->setValue(target->getHeading());
     hull_slider->setValue(target->hull_strength);
 }
 
-void GuiShipTweakBase::open(P<SpaceObject> target)
+void GuiTweakShip::open(P<SpaceObject> target)
 {
     P<SpaceShip> ship = target;
     this->target = ship;
     
     type_name->setText(ship->getTypeName());
-    callsign->setText(ship->callsign);
-    description->setText(ship->getDescription(SS_NotScanned));
     warp_toggle->setValue(ship->has_warp_drive);
     jump_toggle->setValue(ship->hasJumpDrive());
     impulse_speed_slider->setValue(ship->impulse_max_speed);

--- a/src/screens/gm/tweak.cpp
+++ b/src/screens/gm/tweak.cpp
@@ -843,11 +843,28 @@ GuiObjectTweakBase::GuiObjectTweakBase(GuiContainer* owner)
         target->setHeading(value);
     });
     heading_slider->addOverlay()->setSize(GuiElement::GuiSizeMax, 40);
+
+    (new GuiLabel(right_col, "", "Scanning Complexity:", 30))->setSize(GuiElement::GuiSizeMax, 50);
+    scanning_complexity_slider = new GuiSlider(right_col, "", 0, 4, 0, [this](float value) {
+        target->setScanningParameters(value,target->scanningChannelDepth(target));
+    });
+    scanning_complexity_slider->addOverlay()->setSize(GuiElement::GuiSizeMax, 40);
+
+    (new GuiLabel(right_col, "", "Scanning Depth:", 30))->setSize(GuiElement::GuiSizeMax, 50);
+    scanning_depth_slider = new GuiSlider(right_col, "", 1, 5, 0, [this](float value) {
+        target->setScanningParameters(target->scanningComplexity(target),value);
+    });
+    scanning_depth_slider->addOverlay()->setSize(GuiElement::GuiSizeMax, 40);
 }
 
 void GuiObjectTweakBase::onDraw(sf::RenderTarget& window)
 {
     heading_slider->setValue(target->getHeading());
+
+    // we probably dont need to set these each onDraw
+    // but doing it forces the slider to round to a integer
+    scanning_complexity_slider->setValue(target->scanningComplexity(target));
+    scanning_depth_slider->setValue(target->scanningChannelDepth(target));
 }
 
 void GuiObjectTweakBase::open(P<SpaceObject> target)

--- a/src/screens/gm/tweak.cpp
+++ b/src/screens/gm/tweak.cpp
@@ -122,6 +122,12 @@ GuiTweakShip::GuiTweakShip(GuiContainer* owner)
     });
     turn_speed_slider->addOverlay()->setSize(GuiElement::GuiSizeMax, 40);
 
+    (new GuiLabel(left_col, "", "Jump charge:", 30))->setSize(GuiElement::GuiSizeMax, 50);
+    jump_charge_slider = new GuiSlider(left_col, "", 0.0, 100000, 0.0, [this](float value) {
+        target->setJumpDriveCharge(value);
+    });
+    jump_charge_slider->addOverlay()->setSize(GuiElement::GuiSizeMax, 40);
+
     // Right column
     // Set type name. Does not change ship type.
     (new GuiLabel(right_col, "", "Type name:", 30))->setSize(GuiElement::GuiSizeMax, 50);
@@ -168,6 +174,7 @@ GuiTweakShip::GuiTweakShip(GuiContainer* owner)
 void GuiTweakShip::onDraw(sf::RenderTarget& window)
 {
     hull_slider->setValue(target->hull_strength);
+    jump_charge_slider->setValue(target->getJumpDriveCharge());
 }
 
 void GuiTweakShip::open(P<SpaceObject> target)

--- a/src/screens/gm/tweak.h
+++ b/src/screens/gm/tweak.h
@@ -225,6 +225,8 @@ private:
     GuiTextEntry* simple_scan_description;
     GuiTextEntry* full_scan_description;
     GuiSlider* heading_slider;
+    GuiSlider* scanning_complexity_slider;
+    GuiSlider* scanning_depth_slider;
 public:
     GuiObjectTweakBase(GuiContainer* owner);
 

--- a/src/screens/gm/tweak.h
+++ b/src/screens/gm/tweak.h
@@ -220,7 +220,10 @@ private:
     P<SpaceObject> target;
 
     GuiTextEntry* callsign;
-    GuiTextEntry* description;
+    GuiTextEntry* unscanned_description;
+    GuiTextEntry* friend_or_foe_description;
+    GuiTextEntry* simple_scan_description;
+    GuiTextEntry* full_scan_description;
     GuiSlider* heading_slider;
 public:
     GuiObjectTweakBase(GuiContainer* owner);

--- a/src/screens/gm/tweak.h
+++ b/src/screens/gm/tweak.h
@@ -46,24 +46,21 @@ private:
     std::vector<GuiTweakPage*> pages;
 };
 
-class GuiShipTweakBase : public GuiTweakPage
+class GuiTweakShip : public GuiTweakPage
 {
 private:
     P<SpaceShip> target;
 
     GuiTextEntry* type_name;
-    GuiTextEntry* callsign;
-    GuiTextEntry* description;
     GuiToggleButton* warp_toggle;
     GuiToggleButton* jump_toggle;
     GuiSlider* impulse_speed_slider;
     GuiSlider* turn_speed_slider;
-    GuiSlider* heading_slider;
     GuiSlider* hull_max_slider;
     GuiSlider* hull_slider;
     GuiToggleButton* can_be_destroyed_toggle;
 public:
-    GuiShipTweakBase(GuiContainer* owner);
+    GuiTweakShip(GuiContainer* owner);
 
     virtual void onDraw(sf::RenderTarget& window) override;
     

--- a/src/screens/gm/tweak.h
+++ b/src/screens/gm/tweak.h
@@ -58,6 +58,7 @@ private:
     GuiSlider* turn_speed_slider;
     GuiSlider* hull_max_slider;
     GuiSlider* hull_slider;
+    GuiSlider* jump_charge_slider;
     GuiToggleButton* can_be_destroyed_toggle;
 public:
     GuiTweakShip(GuiContainer* owner);

--- a/src/spaceObjects/spaceship.cpp
+++ b/src/spaceObjects/spaceship.cpp
@@ -52,6 +52,13 @@ REGISTER_SCRIPT_SUBCLASS_NO_CREATE(SpaceShip, ShipTemplateBasedObject)
     REGISTER_SCRIPT_CLASS_FUNCTION(SpaceShip, hasJumpDrive);
     REGISTER_SCRIPT_CLASS_FUNCTION(SpaceShip, setJumpDrive);
     REGISTER_SCRIPT_CLASS_FUNCTION(SpaceShip, setJumpDriveRange);
+    /// sets the current jump range charged.
+    /// ships will be able to jump when this is equal to their max jump drive range. 
+    /// Example ship:setJumpCharge(50000)
+    REGISTER_SCRIPT_CLASS_FUNCTION(SpaceShip, setJumpDriveCharge);
+    /// returns the current amount of jump charged. 
+    /// Example ship:getJumpCharge()
+    REGISTER_SCRIPT_CLASS_FUNCTION(SpaceShip, getJumpDriveCharge);
     REGISTER_SCRIPT_CLASS_FUNCTION(SpaceShip, hasWarpDrive);
     REGISTER_SCRIPT_CLASS_FUNCTION(SpaceShip, setWarpDrive);
     /// Set the warp speed for this ship's warp level 1.

--- a/src/spaceObjects/spaceship.h
+++ b/src/spaceObjects/spaceship.h
@@ -351,6 +351,8 @@ public:
             return 0.0f;
         }
      }
+    float getJumpDriveCharge() { return jump_drive_charge; }
+    void setJumpDriveCharge(float charge) { jump_drive_charge = charge; }
 
     float getBeamWeaponArc(int index) { if (index < 0 || index >= max_beam_weapons) return 0.0; return beam_weapons[index].getArc(); }
     float getBeamWeaponDirection(int index) { if (index < 0 || index >= max_beam_weapons) return 0.0; return beam_weapons[index].getDirection(); }


### PR DESCRIPTION
base menu
![image](https://user-images.githubusercontent.com/37894123/82763337-d6401780-9dfe-11ea-9aa7-02a8843225fb.png)

ship menu (which started with everything not on the base menu)

![image](https://user-images.githubusercontent.com/37894123/82763355-f374e600-9dfe-11ea-93f0-13f0388bf8d9.png)

both the base menu and ship menu show, rather than having 2 base menus which switch depending on type
jump charge is exposed to scripting as well as being in the gm menu