### PR TITLE
Rename getMissionTime to getScenarioTime

### DIFF
--- a/src/gameGlobalInfo.cpp
+++ b/src/gameGlobalInfo.cpp
@@ -276,14 +276,14 @@ static int setBanner(lua_State* L)
 /// Show a scrolling banner containing this text on the cinematic and top down views.
 REGISTER_SCRIPT_FUNCTION(setBanner);
 
-static int getMissionTime(lua_State* L)
+static int getScenarioTime(lua_State* L)
 {
     lua_pushnumber(L, gameGlobalInfo->elapsed_time);
     return 1;
 }
-/// getMissionTime()
-/// Return the elapsed time of the mission.
-REGISTER_SCRIPT_FUNCTION(getMissionTime);
+/// getScenarioTime()
+/// Return the elapsed time of the scenario.
+REGISTER_SCRIPT_FUNCTION(getScenarioTime);
 
 static int getPlayerShip(lua_State* L)
 {


### PR DESCRIPTION
A lot of scenarios contain several missions (some with "mission timers"). Therefore the time of the scenario should be called "_scenario_ time" and `getScenarioTime` is the better name for the function.

The function getMissionTime was not yet released, so this improvement is no problem.

(By the way, the Relay and GM consoles call it "mission clock", this could be changed as well. Would clock be better name? But then "scenario clock"!?)