### PR TITLE
Rename mission to scenario clock (on screens)

### DIFF
--- a/src/screens/crew6/relayScreen.cpp
+++ b/src/screens/crew6/relayScreen.cpp
@@ -147,8 +147,8 @@ RelayScreen::RelayScreen(GuiContainer* owner, bool allow_comms)
     info_reputation = new GuiKeyValueDisplay(option_buttons, "INFO_REPUTATION", 0.7, tr("Reputation:"), "");
     info_reputation->setSize(GuiElement::GuiSizeMax, 40);
 
-    // Mission clock display.
-    info_clock = new GuiKeyValueDisplay(option_buttons, "INFO_CLOCK", 0.7, tr("Mission Clock") + ":", "");
+    // Scenario clock display.
+    info_clock = new GuiKeyValueDisplay(option_buttons, "INFO_CLOCK", 0.7, tr("Scenario Clock") + ":", "");
     info_clock->setSize(GuiElement::GuiSizeMax, 40);
 
     // Bottom layout.

--- a/src/screens/gm/gameMasterScreen.cpp
+++ b/src/screens/gm/gameMasterScreen.cpp
@@ -137,7 +137,7 @@ GameMasterScreen::GameMasterScreen()
     info_layout = new GuiAutoLayout(this, "INFO_LAYOUT", GuiAutoLayout::LayoutVerticalTopToBottom);
     info_layout->setPosition(-20, 20, ATopRight)->setSize(300, GuiElement::GuiSizeMax);
 
-    info_clock = new GuiKeyValueDisplay(info_layout, "INFO_CLOCK", 0.5, tr("Mission Clock"), "");
+    info_clock = new GuiKeyValueDisplay(info_layout, "INFO_CLOCK", 0.5, tr("Scenario Clock"), "");
     info_clock->setSize(GuiElement::GuiSizeMax, 30);
 
     gm_script_options = new GuiListbox(this, "GM_SCRIPT_OPTIONS", [this](int index, string value)


### PR DESCRIPTION
Also rename "mission" to "scenario" clock on Relay and GM screen.