### PR TITLE
Wormhole fixes

### DIFF
--- a/src/spaceObjects/wormHole.cpp
+++ b/src/spaceObjects/wormHole.cpp
@@ -128,6 +128,10 @@ void WormHole::collide(Collisionable* target, float collision_force)
     
     P<SpaceObject> obj = P<Collisionable>(target);
     P<SpaceShip> spaceship = P<Collisionable>(target);
+
+    // Warp postprocessor-alpha is calculated using alpha = (1 - (delay/10))
+    if (spaceship)
+        spaceship->wormhole_alpha = ((distance / getRadius()) * ALPHA_MULTIPLIER);
     
     if (force > FORCE_MAX)
     {
@@ -145,10 +149,6 @@ void WormHole::collide(Collisionable* target, float collision_force)
             spaceship->wormhole_alpha = 0.0;
         }
     }
-    
-    // Warp postprocessor-alpha is calculated using alpha = (1 - (delay/10))
-    if (spaceship)
-        spaceship->wormhole_alpha = ((distance / getRadius()) * ALPHA_MULTIPLIER);
     
     // TODO: Escaping is impossible. Change setPosition to something Newtonianish.
     target->setPosition(target->getPosition() + diff / distance * update_delta * force);

--- a/src/spaceObjects/wormHole.cpp
+++ b/src/spaceObjects/wormHole.cpp
@@ -126,7 +126,8 @@ void WormHole::collide(Collisionable* target, float collision_force)
     float distance = sf::length(diff);
     float force = (getRadius() * getRadius() * FORCE_MULTIPLIER) / (distance * distance);
     
-    P<SpaceShip> obj = P<Collisionable>(target);
+    P<SpaceObject> obj = P<Collisionable>(target);
+    P<SpaceShip> spaceship = P<Collisionable>(target);
     
     if (force > FORCE_MAX)
     {
@@ -135,19 +136,19 @@ void WormHole::collide(Collisionable* target, float collision_force)
             target->setPosition( (target_position + 
                                   sf::Vector2f(random(-TARGET_SPREAD, TARGET_SPREAD), 
                                                random(-TARGET_SPREAD, TARGET_SPREAD))));
-        if (obj)
+        if (on_teleportation.isSet())
         {
-            obj->wormhole_alpha = 0.0;
-            if (on_teleportation.isSet())
-            {
-                on_teleportation.call(P<WormHole>(this), obj);
-            }
+            on_teleportation.call(P<WormHole>(this), obj);
+        }
+        if (spaceship)
+        {
+            spaceship->wormhole_alpha = 0.0;
         }
     }
     
     // Warp postprocessor-alpha is calculated using alpha = (1 - (delay/10))
-    if (obj)
-        obj->wormhole_alpha = ((distance / getRadius()) * ALPHA_MULTIPLIER);
+    if (spaceship)
+        spaceship->wormhole_alpha = ((distance / getRadius()) * ALPHA_MULTIPLIER);
     
     // TODO: Escaping is impossible. Change setPosition to something Newtonianish.
     target->setPosition(target->getPosition() + diff / distance * update_delta * force);


### PR DESCRIPTION
techincally the onTeleportation change could break scripts if they depend on objects going through the wormhole being spaceships.

The documentation says its called for any spaceobject, and it is logical for it to be called with any spaceobject