### PR TITLE
Fix for building under newer mingw with lto on

### DIFF
--- a/src/spaceObjects/warpJammer.cpp
+++ b/src/spaceObjects/warpJammer.cpp
@@ -36,6 +36,11 @@ WarpJammer::WarpJammer()
     model_info.setData("shield_generator");
 }
 
+// Due to a suspected compiler bug this desconstructor needs to be explicity defined
+WarpJammer::~WarpJammer()
+{
+}
+
 void WarpJammer::drawOnRadar(sf::RenderTarget& window, sf::Vector2f position, float scale, float rotation, bool long_range)
 {
     sf::Sprite object_sprite;

--- a/src/spaceObjects/warpJammer.h
+++ b/src/spaceObjects/warpJammer.h
@@ -14,6 +14,7 @@ class WarpJammer : public SpaceObject
     ScriptSimpleCallback on_taking_damage;
 public:
     WarpJammer();
+    ~WarpJammer();
     
     void setRange(float range) { this->range = range; }
     float getRange() { return range; }


### PR DESCRIPTION
Same mingw release build lto issue has cropped up again

still no clue as to why

I didnt isolate which patch caused the build to break, probably related to the warp jammer additions for the gm screen