### PR TITLE
Scenario descriptions with provided ships

### DIFF
--- a/scripts/scenario_00_basic.lua
+++ b/scripts/scenario_00_basic.lua
@@ -1,5 +1,8 @@
 -- Name: Basic
 -- Description: Basic scenario. A few random stations, with random stuff around them, are under attack by enemies. Kill all enemies to win.
+---
+--- The scenario provides a single Atlantis (which is sufficient to win even on "Extreme").
+--- Other player ships can be spawned, but the strength of the enemy is independent of their number and type.
 -- Type: Basic
 -- Variation[Empty]: Places no enemies. Recommended for GM-controlled scenarios and rookie crew orientation. The scenario continues until the GM declares victory or all Human Navy craft are destroyed.
 -- Variation[Easy]: Places fewer enemies. Recommended for inexperienced crews.

--- a/scripts/scenario_01_waves.lua
+++ b/scripts/scenario_01_waves.lua
@@ -1,6 +1,8 @@
 -- Name: Waves
 -- Description: Waves of increasingly difficult enemies.
 --- There is no victory. How many waves can you destroy?
+---
+--- Spawn the player ship(s) you want. The strength of the enemy is independent of their number and type.
 -- Type: Basic
 -- Variation[Hard]: Difficulty starts at wave 5 and increases by 1.5 after the players defeat each wave. (Players are more quickly overwhelmed, leading to shorter games.)
 -- Variation[Easy]: Makes each wave easier by decreasing the number of ships in each wave. (Takes longer for the players to be overwhelmed; good for new players.)

--- a/scripts/scenario_02_beacon.lua
+++ b/scripts/scenario_02_beacon.lua
@@ -1,6 +1,8 @@
 -- Name: Beacon of light series
 -- Description: The beacon of light scenario, build from the series at EmptyEpsilon.org.
---- Near the far outpost of Orion-5, Kraylor attacks are increasing. A diplomat went missing, and your mission will start with recovering him. (Must use Epsilon as ship)
+--- Near the far outpost of Orion-5, Kraylor attacks are increasing. A diplomat went missing, and your mission will start with recovering him.
+---
+--- This scenario is played with exactly one player ship: the Atlantis Epsilon.
 -- Type: Mission
 
 -- Init is run when the scenario is started. Create your initial world

--- a/scripts/scenario_03_edgeofspace.lua
+++ b/scripts/scenario_03_edgeofspace.lua
@@ -2,6 +2,8 @@
 -- Description: You command the Technician Cruiser Apollo, a repair ship on the border of dangerous space.
 --- The Apollo is outfitted with minimal weapons as there is a cease-fire between the Human Navy and the neighboring Kraylor.
 ---- You are tasked with discovering the cause of damage on one of your deep space telescopes.
+---
+--- This scenario is played with exactly one player ship: the Atlantis Apollo.
 -- Type: Mission
 -- Author: Visjammer
 

--- a/scripts/scenario_04_gftp.lua
+++ b/scripts/scenario_04_gftp.lua
@@ -2,6 +2,8 @@
 -- Description: Far from any frontline or civilization, patrolling the Stakhanov Mining Complex can be dull,
 --- consisting mainly of seizing contraband and stopping drunken brawls. It is indeed a lonely ward brightened only by R&R at the Marco Polo station.
 --- However, when an inbound FTL-capable Ktlitan Swarm is announced, you must scramble to save the Sector ! [Requires beam/shield frequenies] [Hard]
+---
+--- This scenario is played with exactly one player ship: the Atlantis Epsilon.
 -- Type: Mission
 -- Author: Fouindor
 

--- a/scripts/scenario_05_surrounded.lua
+++ b/scripts/scenario_05_surrounded.lua
@@ -1,5 +1,8 @@
 -- Name: Surrounded
 -- Description: You are surrounded by astroids, enemies and mines.
+---
+--- Spawn the player ship(s) you want. The strength of the enemy is independent of their number and type.
+--- (The scenario can be won with a single Atlantis.)
 -- Type: Basic
 
 function setCirclePos(obj, angle, distance)

--- a/scripts/scenario_07_quick_basic.lua
+++ b/scripts/scenario_07_quick_basic.lua
@@ -1,6 +1,8 @@
 -- Name: Quick Basic
 -- Description: Different version of the basic scenario. Which intended to play out quicker. There is only a single small station to defend.
 --- This scenario is designed to be ran on conventions. As you can run a 4 player crew in 20 minutes trough a game with minimal experience.
+---
+--- This scenario is designed for the provided player ship of type Phobos (or Atlantis on Advanced).
 -- Type: Convention
 -- Variation[Advanced]: Give the players a stronger Atlantis instead of the Phobos. Which is more difficult to control, but has more firepower and defense. Increases enemy strengh as well.
 -- Variation[GM Start]: The scenario is not started until the GM gives the start sign. This gives some time for a new crew to get a feeling for the controls before the actual scenario starts.
@@ -155,6 +157,7 @@ function init()
     player:setPosition(random(-2000, 2000), random(-2000, 2000)):setCallSign(ship_names[math.random(1,#ship_names)])
     player:setJumpDrive(true)
     player:setWarpDrive(false)
+
     allowNewPlayerShips(false)
 
     -- Put a single small station here, which needs to be defended.

--- a/scripts/scenario_08_atlantis.lua
+++ b/scripts/scenario_08_atlantis.lua
@@ -1,6 +1,8 @@
 -- Name: Birth of the Atlantis
 -- Description: You are the first crew of a new and improved version of the Atlantis space explorer.
 --- You must check out ship systems and complete an initial mission.
+---
+--- This scenario is played with exactly one player ship: the Atlantis Atlantis-1.
 -- Type: Mission
 
 --[[Problems


### PR DESCRIPTION
Mention the provided player ships in the scenario descriptions (0 to 8) or the effect of spawning them.

For _Quick Basic_, recommend the default, but allow more ships. Why prevent playing it with a support ship or 4 starfighters instead of a phobos?

If you have suggestions to improve the text, leave a comment.

Apart from the line in Quick Basic, this is a text-only commit and easy to merge.