### PR TITLE
Feature: CpuShips restock missiles

### DIFF
--- a/src/ai/ai.h
+++ b/src/ai/ai.h
@@ -77,6 +77,7 @@ protected:
      * Used for missiles, as they require some intelligence to fire.
      */
     float calculateFiringSolution(P<SpaceObject> target, int tube_index);
+    P<SpaceObject> findBestMissileRestockTarget(sf::Vector2f position, float radius);
 };
 
 #endif//AI_H

--- a/src/shipTemplate.cpp
+++ b/src/shipTemplate.cpp
@@ -63,6 +63,8 @@ REGISTER_SCRIPT_CLASS(ShipTemplate)
     REGISTER_SCRIPT_CLASS_FUNCTION(ShipTemplate, setSharesEnergyWithDocked);
     /// Set if this ship restocks scan probes on docked ships. Example: template:setRestocksScanProbes(false)
     REGISTER_SCRIPT_CLASS_FUNCTION(ShipTemplate, setRestocksScanProbes);
+    /// Set if this ship restores missiles on docked cpuships. Example template:setRestocksMissilesDocked(false)
+    REGISTER_SCRIPT_CLASS_FUNCTION(ShipTemplate, setRestocksMissilesDocked);
     /// Set if this ship has a jump drive. Example: template:setJumpDrive(true)
     REGISTER_SCRIPT_CLASS_FUNCTION(ShipTemplate, setJumpDrive);
     /// Set this ship's minimum and maximum jump drive distances.
@@ -100,6 +102,7 @@ ShipTemplate::ShipTemplate()
     shares_energy_with_docked = true;
     repair_docked = false;
     restocks_scan_probes = false;
+    restocks_missiles_docked = false;
     energy_storage_amount = 1000;
     repair_crew_count = 3;
     weapon_tube_count = 0;
@@ -415,6 +418,11 @@ void ShipTemplate::setRestocksScanProbes(bool enabled)
     restocks_scan_probes = enabled;
 }
 
+void ShipTemplate::setRestocksMissilesDocked(bool enabled)
+{
+    restocks_missiles_docked = enabled;
+}
+
 void ShipTemplate::setJumpDrive(bool enabled)
 {
     has_jump_drive = enabled;
@@ -513,6 +521,7 @@ P<ShipTemplate> ShipTemplate::copy(string new_name)
     result->shares_energy_with_docked = shares_energy_with_docked;
     result->repair_docked = repair_docked;
     result->restocks_scan_probes = restocks_scan_probes;
+    result->restocks_missiles_docked = restocks_missiles_docked;
     result->has_jump_drive = has_jump_drive;
     result->has_cloaking = has_cloaking;
     for(int n=0; n<MW_Count; n++)

--- a/src/shipTemplate.h
+++ b/src/shipTemplate.h
@@ -92,6 +92,7 @@ public:
     bool shares_energy_with_docked;
     bool repair_docked;
     bool restocks_scan_probes;
+    bool restocks_missiles_docked;
     bool can_scan = true;
     bool can_hack = true;
     bool can_dock = true;
@@ -137,6 +138,7 @@ public:
     void setSharesEnergyWithDocked(bool enabled);
     void setRepairDocked(bool enabled);
     void setRestocksScanProbes(bool enabled);
+    void setRestocksMissilesDocked(bool enabled);
     void setCanScan(bool enabled) { can_scan = enabled; }
     void setCanHack(bool enabled) { can_hack = enabled; }
     void setCanDock(bool enabled) { can_dock = enabled; }

--- a/src/spaceObjects/cpuShip.cpp
+++ b/src/spaceObjects/cpuShip.cpp
@@ -160,6 +160,20 @@ void CpuShip::orderRoamingAt(sf::Vector2f position)
     this->addBroadcast(FVF_Friendly, "Searching for hostiles around " + string(position.x) + "," + string(position.y) + ".");
 }
 
+void CpuShip::orderRetreat(P<SpaceObject> object)
+{
+    orders = AI_Retreat;
+    if (!object)
+    {
+        order_target = NULL;
+        this->addBroadcast(FVF_Friendly, "Searching for supplies.");
+    }else{
+        order_target = object;
+        this->addBroadcast(FVF_Friendly, "Docking to " + object->getCallSign() + ".");
+    }
+    order_target_location = sf::Vector2f();
+}
+
 void CpuShip::orderStandGround()
 {
     target_rotation = getRotation();
@@ -254,6 +268,7 @@ string CpuShip::getExportLine()
     {
     case AI_Idle: break;
     case AI_Roaming: ret += ":orderRoaming()"; break;
+    case AI_Retreat: ret += ":orderRetreat(?)"; break;
     case AI_StandGround: ret += ":orderStandGround()"; break;
     case AI_DefendLocation: ret += ":orderDefendLocation(" + string(order_target_location.x, 0) + ", " + string(order_target_location.y, 0) + ")"; break;
     case AI_DefendTarget: ret += ":orderDefendTarget(?)"; break;
@@ -272,6 +287,7 @@ string getAIOrderString(EAIOrder order)
     {
     case AI_Idle: return "Idle";
     case AI_Roaming: return "Roaming";
+    case AI_Retreat: return "Retreat";
     case AI_StandGround: return "Stand Ground";
     case AI_DefendLocation: return "Defend Location";
     case AI_DefendTarget: return "Defend Target";

--- a/src/spaceObjects/cpuShip.cpp
+++ b/src/spaceObjects/cpuShip.cpp
@@ -56,6 +56,7 @@ CpuShip::CpuShip()
     setRotation(random(0, 360));
     target_rotation = getRotation();
 
+    restocks_missiles_docked = true;
     comms_script_name = "comms_ship.lua";
 
     missile_resupply = 0.0;
@@ -91,13 +92,13 @@ void CpuShip::update(float delta)
     }
     ai->run(delta);
 
-    //recharge missiles of CPU ships docked to station. uses the same trick as player ships. VERY hackish.
+    //recharge missiles of CPU ships docked to station. Can be disabled setting the restocks_missiles_docked flag to false.
     if (docking_state == DS_Docked)
     {
         P<ShipTemplateBasedObject> docked_with_template_based = docking_target;
         P<SpaceShip> docked_with_ship = docking_target;
 
-        if (docked_with_template_based && !docked_with_ship)
+        if (docked_with_template_based && docked_with_template_based->restocks_missiles_docked)
         {
             bool needs_missile = 0;
 

--- a/src/spaceObjects/cpuShip.h
+++ b/src/spaceObjects/cpuShip.h
@@ -8,6 +8,7 @@ enum EAIOrder
 {
     AI_Idle,            //Don't do anything, don't even attack.
     AI_Roaming,         //Fly around and engage at will, without a clear target
+    AI_Retreat,         //Dock on [order_target] that can restore our weapons. Find one if neccessary. Continue roaming after our missiles are restocked, or no target is found.
     AI_StandGround,     //Keep current position, do not fly away, but attack nearby targets.
     AI_DefendLocation,  //Defend against enemies getting close to [order_target_location]
     AI_DefendTarget,    //Defend against enemies getting close to [order_target] (falls back to AI_Roaming if the target is destroyed)
@@ -42,6 +43,7 @@ public:
     void orderIdle();
     void orderRoaming();
     void orderRoamingAt(sf::Vector2f position);
+    void orderRetreat(P<SpaceObject> object);
     void orderStandGround();
     void orderDefendLocation(sf::Vector2f position);
     void orderDefendTarget(P<SpaceObject> object);

--- a/src/spaceObjects/shipTemplateBasedObject.cpp
+++ b/src/spaceObjects/shipTemplateBasedObject.cpp
@@ -62,6 +62,8 @@ REGISTER_SCRIPT_SUBCLASS_NO_CREATE(ShipTemplateBasedObject, SpaceObject)
     REGISTER_SCRIPT_CLASS_FUNCTION(ShipTemplateBasedObject, setRepairDocked);
     REGISTER_SCRIPT_CLASS_FUNCTION(ShipTemplateBasedObject, getRestocksScanProbes);
     REGISTER_SCRIPT_CLASS_FUNCTION(ShipTemplateBasedObject, setRestocksScanProbes);
+    REGISTER_SCRIPT_CLASS_FUNCTION(ShipTemplateBasedObject, getRestocksMissilesDocked);
+    REGISTER_SCRIPT_CLASS_FUNCTION(ShipTemplateBasedObject, setRestocksMissilesDocked);
 
     /// [Depricated]
     REGISTER_SCRIPT_CLASS_FUNCTION(ShipTemplateBasedObject, getFrontShield);

--- a/src/spaceObjects/shipTemplateBasedObject.h
+++ b/src/spaceObjects/shipTemplateBasedObject.h
@@ -45,6 +45,7 @@ public:
     virtual void update(float delta) override;
 
     virtual std::unordered_map<string, string> getGMInfo() override;
+    virtual bool canRestockMissiles() override { return restocks_missiles_docked; }
     virtual bool canBeTargetedBy(P<SpaceObject> other) override { return true; }
     virtual bool hasShield() override;
     virtual string getCallSign() override { return callsign; }

--- a/src/spaceObjects/shipTemplateBasedObject.h
+++ b/src/spaceObjects/shipTemplateBasedObject.h
@@ -31,6 +31,7 @@ public:
     bool shares_energy_with_docked;       //[config]
     bool repair_docked;                   //[config]
     bool restocks_scan_probes;
+    bool restocks_missiles_docked;        //only restocks cpuships; playerships should use comms
 
     ScriptSimpleCallback on_destruction;
     ScriptSimpleCallback on_taking_damage;
@@ -98,6 +99,8 @@ public:
     void setRepairDocked(bool enabled) { repair_docked = enabled; }
     bool getRestocksScanProbes() { return restocks_scan_probes; }
     void setRestocksScanProbes(bool enabled) { restocks_scan_probes = enabled; }
+    bool getRestocksMissilesDocked() { return restocks_missiles_docked; }
+    void setRestocksMissilesDocked(bool enabled) { restocks_missiles_docked = enabled; }
 
     void onTakingDamage(ScriptSimpleCallback callback);
     void onDestruction(ScriptSimpleCallback callback);

--- a/src/spaceObjects/spaceObject.h
+++ b/src/spaceObjects/spaceObject.h
@@ -176,6 +176,7 @@ public:
     virtual void setCallSign(string new_callsign) { callsign = new_callsign; }
     virtual string getCallSign() { return callsign; }
     virtual bool canBeDockedBy(P<SpaceObject> obj) { return false; }
+    virtual bool canRestockMissiles() { return false; }
     virtual bool hasShield() { return false; }
     virtual bool canHideInNebula() { return true; }
     virtual bool canBeTargetedBy(P<SpaceObject> other);

--- a/src/spaceObjects/spaceStation.cpp
+++ b/src/spaceObjects/spaceStation.cpp
@@ -19,6 +19,7 @@ SpaceStation::SpaceStation()
 : ShipTemplateBasedObject(300, "SpaceStation")
 {
     restocks_scan_probes = true;
+    restocks_missiles_docked = true;
     comms_script_name = "comms_station.lua";
     setRadarSignatureInfo(0.2, 0.5, 0.5);
 


### PR DESCRIPTION
* CpuShips can also restock their missiles docking on ships with the restockMissilesDocked flag. (Not only on stations)
* Missile Cruiser AI searches for missile resupply when out of ammo.