### PR TITLE
missileTubeControles: deactivate fire_button in warp

### DIFF
--- a/src/screenComponents/missileTubeControls.cpp
+++ b/src/screenComponents/missileTubeControls.cpp
@@ -141,6 +141,11 @@ void GuiMissileTubeControls::onDraw(sf::RenderTarget& window){
             rows[n].fire_button->setText(tr("missile","Firing"));
             rows[n].loading_bar->hide();
         }
+
+        if (my_spaceship->current_warp > 0.0)
+        {
+            rows[n].fire_button->disable();
+        }
     }
     for(int n=my_spaceship->weapon_tube_count; n<max_weapon_tubes; n++)
         rows[n].layout->hide();


### PR DESCRIPTION
This replaces pull request #947 and solves issue #943.

Please test.