### PR TITLE
Work around how flaky GitHub Actions are

### DIFF
--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -10,6 +10,8 @@ jobs:
     name: Build and test
     runs-on: ubuntu-latest
     steps:
+    - name: Update apt index
+      run: sudo apt-get update -qq
     - name: Instal SFML
       run: sudo apt-get install libsfml-dev
     - name: Checkout EmptyEpsilon


### PR DESCRIPTION
See https://github.com/actions/virtual-environments/issues/675

If this doesn't work, the next step is to nuke the azure mirror because it's not reliable. See https://github.com/zmeadows/lldbg/commit/9f348de35910db24f7f4442caae357490bfb856f