### PR TITLE
Revise game state logging options and default behavior

### DIFF
--- a/src/gameGlobalInfo.cpp
+++ b/src/gameGlobalInfo.cpp
@@ -204,9 +204,9 @@ void GameGlobalInfo::startScenario(string filename)
     }
 
     // Deprecate the game_logs setting.
-    if (PreferencesManager::get("game_logs", "0").toInt())
+    if (PreferencesManager::getOnly("game_logs") == "1")
     {
-        LOG(WARNING) << "The game_logs setting is deprecated. To record game state logs, set game_state_logs=1 or use the Options menu.";
+        LOG(WARNING) << "The game_logs setting is deprecated. To enable game state logging, set game_state_logs=1 or use the Options menu.";
     }
 }
 

--- a/src/gameGlobalInfo.cpp
+++ b/src/gameGlobalInfo.cpp
@@ -197,10 +197,16 @@ void GameGlobalInfo::startScenario(string filename)
     engine->registerObject("scenario", script);
 
     // If game state logging is enabled, start logging now.
-    if (PreferencesManager::get("game_logs", "0").toInt())
+    if (PreferencesManager::get("game_state_logs", "0").toInt())
     {
         state_logger = new GameStateLogger();
         state_logger->start();
+    }
+
+    // Deprecate the game_logs setting.
+    if (PreferencesManager::get("game_logs", "0").toInt())
+    {
+        LOG(WARNING) << "The game_logs setting is deprecated. To record game state logs, set game_state_logs=1 or use the Options menu.";
     }
 }
 

--- a/src/gameGlobalInfo.cpp
+++ b/src/gameGlobalInfo.cpp
@@ -196,7 +196,8 @@ void GameGlobalInfo::startScenario(string filename)
     script->run(filename);
     engine->registerObject("scenario", script);
 
-    if (PreferencesManager::get("game_logs", "1").toInt())
+    // If game state logging is enabled, start logging now.
+    if (PreferencesManager::get("game_logs", "0").toInt())
     {
         state_logger = new GameStateLogger();
         state_logger->start();

--- a/src/gameStateLogger.cpp
+++ b/src/gameStateLogger.cpp
@@ -133,8 +133,8 @@ void GameStateLogger::start()
     rawtime = time(nullptr);
 
     // If there's a home directory, put the logs in its .emptyepsilon directory
-    // instead of a relative logs path.
-    // Otherwise they wind up in weird places (like in the app bundle on macOS)
+    // instead of a relative path.
+    // Otherwise logs wind up in weird places, like in the app bundle on macOS
     if(getenv("HOME"))
     {
         log_dir = string(getenv("HOME")) + "/.emptyepsilon/";
@@ -142,10 +142,14 @@ void GameStateLogger::start()
 
     strftime(filename_buffer, sizeof(filename_buffer), string(log_dir + "game_log_%d-%m-%Y_%H.%M.%S.txt").c_str(), localtime(&rawtime));
     log_file = fopen(filename_buffer, "wt");
+
     if (log_file)
+    {
         LOG(INFO) << "Opened game state log: " << filename_buffer;
-    else
+    } else {
         LOG(WARNING) << "Failed to open game state log file: " << filename_buffer;
+    }
+
     start_time = engine->getElapsedTime();
 }
 

--- a/src/gameStateLogger.cpp
+++ b/src/gameStateLogger.cpp
@@ -116,10 +116,8 @@ private:
 };
 
 GameStateLogger::GameStateLogger()
+: log_dir("logs/"), log_file(nullptr), logging_interval(1.0), logging_delay(0.0)
 {
-    log_file = nullptr;
-    logging_interval = 1.0;
-    logging_delay = 0.0;
 }
 
 GameStateLogger::~GameStateLogger()
@@ -133,7 +131,16 @@ void GameStateLogger::start()
     char filename_buffer[128];
 
     rawtime = time(nullptr);
-    strftime(filename_buffer, sizeof(filename_buffer), "logs/game_log_%d-%m-%Y_%H.%M.%S.txt", localtime(&rawtime));
+
+    // If there's a home directory, put the logs in its .emptyepsilon directory
+    // instead of a relative logs path.
+    // Otherwise they wind up in weird places (like in the app bundle on macOS)
+    if(getenv("HOME"))
+    {
+        log_dir = string(getenv("HOME")) + "/.emptyepsilon/";
+    }
+
+    strftime(filename_buffer, sizeof(filename_buffer), string(log_dir + "game_log_%d-%m-%Y_%H.%M.%S.txt").c_str(), localtime(&rawtime));
     log_file = fopen(filename_buffer, "wt");
     if (log_file)
         LOG(INFO) << "Opened game state log: " << filename_buffer;

--- a/src/gameStateLogger.h
+++ b/src/gameStateLogger.h
@@ -29,6 +29,7 @@ public:
     virtual void update(float delta);
 
 private:
+    string log_dir;
     FILE* log_file;
     float logging_interval;
     float logging_delay;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -107,9 +107,17 @@ int main(int argc, char** argv)
     PreferencesManager::load(CONFIG_DIR "options.ini");
 #endif
     if (getenv("HOME"))
+    {
+        // Create .emptyepsilon in the homedir if it doesn't already exist.
+#ifdef __WIN32__
+        mkdir((string(getenv("HOME")) + "/.emptyepsilon").c_str());
+#else
+        mkdir((string(getenv("HOME")) + "/.emptyepsilon").c_str(), S_IRWXU | S_IRWXG | S_IROTH | S_IXOTH);
+#endif//__WIN32__
         PreferencesManager::load(string(getenv("HOME")) + "/.emptyepsilon/options.ini");
-    else
+    } else {
         PreferencesManager::load("options.ini");
+    }
 
     for(int n=1; n<argc; n++)
     {
@@ -342,14 +350,9 @@ int main(int argc, char** argv)
         // MFC TODO: Fix me -- save prefs to user prefs dir on Windows.
         if (getenv("HOME"))
         {
-#ifdef __WIN32__
-            mkdir((string(getenv("HOME")) + "/.emptyepsilon").c_str());
-#else
-            mkdir((string(getenv("HOME")) + "/.emptyepsilon").c_str(), S_IRWXU | S_IRWXG | S_IROTH | S_IXOTH);
-#endif
             PreferencesManager::save(string(getenv("HOME")) + "/.emptyepsilon/options.ini");
-        }else
-#endif
+        } else
+#endif//_MSC_VER
         {
             PreferencesManager::save("options.ini");
         }

--- a/src/menus/optionsMenu.cpp
+++ b/src/menus/optionsMenu.cpp
@@ -137,8 +137,12 @@ OptionsMenu::OptionsMenu()
     impulse_volume_overlay_label->setSize(GuiElement::GuiSizeMax, GuiElement::GuiSizeMax);
 
     // Interface options
+    // Radar rotation lock settings.
+    (new GuiLabel(interface_page, "ROTATION_LOCK_LABEL", tr("Radar Rotation"), 30)
+    )->addBackground()->setSize(GuiElement::GuiSizeMax, 50);
+
     // Helms rotation lock.
-    (new GuiToggleButton(interface_page, "HEMS_RADAR_LOCK", tr("Helms Radar Lock"), [](bool value)
+    (new GuiToggleButton(interface_page, "HELMS_RADAR_LOCK", tr("Helms Radar Lock"), [](bool value)
     {
         PreferencesManager::set("helms_radar_lock", value ? "1" : "");
         PreferencesManager::set("tactical_radar_lock", value ? "1" : "");
@@ -157,6 +161,16 @@ OptionsMenu::OptionsMenu()
         PreferencesManager::set("science_radar_lock", value ? "1" : "");
         PreferencesManager::set("operations_radar_lock", value ? "1" : "");
     }))->setValue(PreferencesManager::get("science_radar_lock", "0") == "1")->setSize(GuiElement::GuiSizeMax, 50);
+
+    // Logging settings.
+    (new GuiLabel(interface_page, "LOGGING_LABEL", tr("Logging"), 30)
+    )->addBackground()->setSize(GuiElement::GuiSizeMax, 50);
+
+    // Game state logging.
+    (new GuiToggleButton(interface_page, "GAME_STATE_LOGGING", tr("Game State Logging"), [](bool value)
+    {
+        PreferencesManager::set("game_logs", value ? "1" : "");
+    }))->setValue(PreferencesManager::get("game_logs", "0") == "1")->setSize(GuiElement::GuiSizeMax, 50);
 
     // Right column, auto layout. Draw first element 50px from top.
     // Music preview jukebox.

--- a/src/menus/optionsMenu.cpp
+++ b/src/menus/optionsMenu.cpp
@@ -167,6 +167,8 @@ OptionsMenu::OptionsMenu()
     )->addBackground()->setSize(GuiElement::GuiSizeMax, 50);
 
     // Game state logging.
+    // TODO: Move this to server settings/scenario selection, or move server
+    // settings to the options screen. This does nothing if set by a client.
     (new GuiToggleButton(interface_page, "GAME_STATE_LOGGING", tr("Game State Logging"), [](bool value)
     {
         PreferencesManager::set("game_state_logs", value ? "1" : "");

--- a/src/menus/optionsMenu.cpp
+++ b/src/menus/optionsMenu.cpp
@@ -169,8 +169,8 @@ OptionsMenu::OptionsMenu()
     // Game state logging.
     (new GuiToggleButton(interface_page, "GAME_STATE_LOGGING", tr("Game State Logging"), [](bool value)
     {
-        PreferencesManager::set("game_logs", value ? "1" : "");
-    }))->setValue(PreferencesManager::get("game_logs", "0") == "1")->setSize(GuiElement::GuiSizeMax, 50);
+        PreferencesManager::set("game_state_logs", value ? "1" : "");
+    }))->setValue(PreferencesManager::get("game_state_logs", "0") == "1")->setSize(GuiElement::GuiSizeMax, 50);
 
     // Right column, auto layout. Draw first element 50px from top.
     // Music preview jukebox.

--- a/src/preferenceManager.cpp
+++ b/src/preferenceManager.cpp
@@ -9,8 +9,27 @@ void PreferencesManager::set(string key, string value)
 
 string PreferencesManager::get(string key, string default_value)
 {
+    // Return the preference's value.
+    // If it doesn't have one, set the value to the given default.
+    // This getter is a setter too!
     if (preference.find(key) == preference.end())
+    {
         preference[key] = default_value;
+    }
+
+    return preference[key];
+}
+
+string PreferencesManager::getOnly(string key)
+{
+    // Return the preference's value.
+    // If it doesn't have one, return an empty string.
+    // This getter only gets! 
+    if (preference.find(key) == preference.end())
+    {
+        return "";
+    }
+
     return preference[key];
 }
 

--- a/src/preferenceManager.h
+++ b/src/preferenceManager.h
@@ -10,6 +10,7 @@ private:
 public:
     static void set(string key, string value);
     static string get(string key, string default_value="");
+    static string getOnly(string key);
 
     static void load(string filename);
     static void save(string filename);


### PR DESCRIPTION
- Game state logging is disabled by default. It's previously enabled by default, but doesn't write anything because the relatively-pathed `logs` directory is intentionally not created in the distribution zip (#1054).
- Add game state logging toggle to the interface options. (TODO: Seems like a better option to fit an in-game setting for this in the scenario selection/server settings screen, but that interface is crammed.)
- If a HOME environment variable is set (macOS, Linux, some Windows users), move the game state logging dir to `~/.emptyepsilon/`. This avoids an issue on macOS where the relative `logs` directory must be created inside the app bundle (`EmptyEpsilon.app/Contents/Resources/logs`) to capture game state logs. The behavior on most Windows systems (no HOME envvar) should not change.
- Create `~/.emptyepsilon` closer to game init, instead of waiting for the game to be closed. This allows game state logs to be captured during the first run of EE if logging is enabled, and also allows the Save button on the options screen to actually save `options.ini` on the first run of EE.
- Add a getter to PreferencesManager that doesn't set the preference value to an empty string value by default. This allows for key values to be checked in `options.ini` (`getOnly`) without adding the key to the file.
- Deprecate the `game_logs` preference in favor of `game_state_logs`, to avoid unexpectedly writing game state logs to the new HOME path.