### PR TITLE
Resolve minor compiler warnings

### DIFF
--- a/src/missileWeaponData.cpp
+++ b/src/missileWeaponData.cpp
@@ -2,12 +2,12 @@
 
 MissileWeaponData missile_data[MW_Count] =
 {
-    //                speed, turnrate, lifetime, color, homing_range
-    MissileWeaponData(200.0f, 10.f, 27.0f, sf::Color(255, 200, 0), 1200.0, "sfx/rlaunch.wav"),/*MW_Homing*/
-    MissileWeaponData(200.0f, 10.f, 27.0f, sf::Color(255, 100, 32), 500.0, "sfx/rlaunch.wav"),/*MW_Nuke*/
-    MissileWeaponData(100.0f,  0.f, 10.0f, sf::Color(255, 255, 255), 0.0, "missile_launch.wav"),/*MW_Mine, lifetime is used at time which the mine is ejecting from the ship*/
-    MissileWeaponData(200.0f, 10.f, 27.0f, sf::Color(100, 32, 255), 500.0, "sfx/rlaunch.wav"),/*MW_EMP*/
-    MissileWeaponData(500.0f,  0.f, 13.5f, sf::Color(200, 200, 200), 0.0, "sfx/hvli_fire.wav"),/*MW_HVLI*/
+    //                 speed, turnrate, lifetime,                    color, homing_range, soundfx
+    MissileWeaponData(200.0f,     10.f,    27.0f,   sf::Color(255, 200, 0),       1200.0, "sfx/rlaunch.wav"),    // MW_Homing
+    MissileWeaponData(200.0f,     10.f,    27.0f,  sf::Color(255, 100, 32),        500.0, "sfx/rlaunch.wav"),    // MW_Nuke
+    MissileWeaponData(100.0f,      0.f,    10.0f, sf::Color(255, 255, 255),          0.0, "missile_launch.wav"), // MW_Mine, lifetime is used at time which the mine is ejecting from the ship
+    MissileWeaponData(200.0f,     10.f,    27.0f,  sf::Color(100, 32, 255),        500.0, "sfx/rlaunch.wav"),    // MW_EMP
+    MissileWeaponData(500.0f,      0.f,    13.5f, sf::Color(200, 200, 200),          0.0, "sfx/hvli_fire.wav"),  // MW_HVLI
 };
 
 MissileWeaponData::MissileWeaponData(float speed, float turnrate, float lifetime, sf::Color color, float homing_range, string fire_sound)
@@ -33,7 +33,7 @@ string getMissileSizeString(EMissileSizes size)
         case MS_Large:
             return "large";
         default:
-            return "unknown size:" + size;
+            return "unknown size";
     }
 }
 

--- a/src/screens/gm/objectCreationView.h
+++ b/src/screens/gm/objectCreationView.h
@@ -19,7 +19,7 @@ public:
 
     virtual void onDraw(sf::RenderTarget& window) override;
 
-    virtual bool onMouseDown(sf::Vector2f position);
+    virtual bool onMouseDown(sf::Vector2f position) override;
 
     void setCreateScript(const string create, const string configure = "");
 };


### PR DESCRIPTION
- EMissileSizes can't be appended to strings
- specify onMouseDown override in objectCreationView