### PR TITLE
Round up hull strength before showing on science

### DIFF
--- a/src/screens/crew6/scienceScreen.cpp
+++ b/src/screens/crew6/scienceScreen.cpp
@@ -338,7 +338,7 @@ void ScienceScreen::onDraw(sf::RenderTarget& window)
                 info_type->setValue(ship->getTypeName());
                 info_type_button->show();
                 info_shields->setValue(ship->getShieldDataString());
-                info_hull->setValue(int(ship->getHull()));
+                info_hull->setValue(int(ceil(ship->getHull())));
             }
 
             // On a full scan, show tactical and systems data (if any), and its
@@ -417,7 +417,7 @@ void ScienceScreen::onDraw(sf::RenderTarget& window)
             {
                 info_type->setValue(station->template_name);
                 info_shields->setValue(station->getShieldDataString());
-                info_hull->setValue(int(station->getHull()));
+                info_hull->setValue(int(ceil(station->getHull())));
             }
         }
     }


### PR DESCRIPTION
It sometimes confuses new players to see ships with 0 hull, as they
think the ship should be destroyed. Round up rather than max as
suggested in issue 1009 in case scripts want 0 hull for wrecks.
Fixes:1009