### PR TITLE
expose EE version in lua

### DIFF
--- a/src/gameGlobalInfo.cpp
+++ b/src/gameGlobalInfo.cpp
@@ -439,3 +439,11 @@ static int allowNewPlayerShips(lua_State* L)
 /// Set if the server is allowed to create new player ships from the ship creation screen.
 /// allowNewPlayerShip(false) -- disallow new player ships to be created
 REGISTER_SCRIPT_FUNCTION(allowNewPlayerShips);
+
+static int getEEVersion(lua_State* L)
+{
+    lua_pushinteger(L, VERSION_NUMBER);
+    return 1;
+}
+/// Get a string with the current version number, like "20191231"
+REGISTER_SCRIPT_FUNCTION(getEEVersion);


### PR DESCRIPTION
This is how it could look like to prevent a scenario from loading in a too old version of EE. It is better than showing an arbitrary "this function does not exist" error somewhere during a running scenario.

````lua
local version = getEEVersion()
local requiredVersion = 20200409
if version ~= 0 and version < requiredVersion then
    error(string.format("This scenario requires EmptyEpsilon %d or higher, but you got %d.", requiredVersion, version))
end
````
