### PR TITLE
Station defense fleet

### DIFF
--- a/scripts/comms_defend.lua
+++ b/scripts/comms_defend.lua
@@ -1,0 +1,97 @@
+--	Communications for a ship that is part of a defensive fleet
+function mainMenu()
+    if comms_target.comms_data == nil then
+        comms_target.comms_data = {friendlyness = random(0.0, 100.0)}
+    end
+    -- comms_data is used globally
+    comms_data = comms_target.comms_data
+
+    if player:isFriendly(comms_target) then
+        return friendlyComms(comms_data)
+    end
+    if player:isEnemy(comms_target) and comms_target:isFriendOrFoeIdentifiedBy(player) then
+        return enemyComms(comms_data)
+    end
+    return neutralComms(comms_data)
+end
+function friendlyComms(comms_data)
+    if comms_data.friendlyness < 20 then
+        setCommsMessage("What do you want?");
+    else
+        setCommsMessage("Sir, how can we assist?");
+    end
+    addCommsReply("Report status", function()
+        local msg = "Hull: " .. math.floor(comms_target:getHull() / comms_target:getHullMax() * 100) .. "%\n"
+        local shields = comms_target:getShieldCount()
+        if shields == 1 then
+            msg = msg .. "Shield: " .. math.floor(comms_target:getShieldLevel(0) / comms_target:getShieldMax(0) * 100) .. "%\n"
+        elseif shields == 2 then
+            msg = msg .. "Front Shield: " .. math.floor(comms_target:getShieldLevel(0) / comms_target:getShieldMax(0) * 100) .. "%\n"
+            msg = msg .. "Rear Shield: " .. math.floor(comms_target:getShieldLevel(1) / comms_target:getShieldMax(1) * 100) .. "%\n"
+        else
+            for n=0,shields-1 do
+                msg = msg .. "Shield " .. n .. ": " .. math.floor(comms_target:getShieldLevel(n) / comms_target:getShieldMax(n) * 100) .. "%\n"
+            end
+        end
+
+        -- TODO this should use a global
+        local missile_types = {'Homing', 'Nuke', 'Mine', 'EMP', 'HVLI'}
+        for i, missile_type in ipairs(missile_types) do
+            if comms_target:getWeaponStorageMax(missile_type) > 0 then
+                    msg = msg .. missile_type .. " Missiles: " .. math.floor(comms_target:getWeaponStorage(missile_type)) .. "/" .. math.floor(comms_target:getWeaponStorageMax(missile_type)) .. "\n"
+            end
+        end
+
+        setCommsMessage(msg);
+        addCommsReply("Back", mainMenu)
+    end)
+    return true
+end
+function enemyComms(comms_data)
+    if comms_data.friendlyness > 50 then
+        local faction = comms_target:getFaction()
+        local taunt_option = "We will see to your destruction!"
+        local taunt_success_reply = "Your bloodline will end here!"
+        local taunt_failed_reply = "Your feeble threats are meaningless."
+        if faction == "Kraylor" then
+            setCommsMessage("Ktzzzsss.\nYou will DIEEee weaklingsss!");
+        elseif faction == "Arlenians" then
+            setCommsMessage("We wish you no harm, but will harm you if we must.\nEnd of transmission.");
+        elseif faction == "Exuari" then
+            setCommsMessage("Stay out of our way, or your death will amuse us extremely!");
+        elseif faction == "Ghosts" then
+            setCommsMessage("One zero one.\nNo binary communication detected.\nSwitching to universal speech.\nGenerating appropriate response for target from human language archives.\n:Do not cross us:\nCommunication halted.");
+            taunt_option = "EXECUTE: SELFDESTRUCT"
+            taunt_success_reply = "Rogue command received. Targeting source."
+            taunt_failed_reply = "External command ignored."
+        elseif faction == "Ktlitans" then
+            setCommsMessage("The hive suffers no threats. Opposition to any of us is opposition to us all.\nStand down or prepare to donate your corpses toward our nutrition.");
+            taunt_option = "<Transmit 'The Itsy-Bitsy Spider' on all wavelengths>"
+            taunt_success_reply = "We do not need permission to pluck apart such an insignificant threat."
+            taunt_failed_reply = "The hive has greater priorities than exterminating pests."
+        else
+            setCommsMessage("Mind your own business!");
+        end
+        comms_data.friendlyness = comms_data.friendlyness - random(0, 10)
+        addCommsReply(taunt_option, function()
+            if random(0, 100) < 30 then
+                comms_target:orderAttack(player)
+                setCommsMessage(taunt_success_reply);
+            else
+                setCommsMessage(taunt_failed_reply);
+            end
+        end)
+        return true
+    end
+    return false
+end
+function neutralComms(comms_data)
+    if comms_data.friendlyness > 50 then
+        setCommsMessage("Sorry, we have no time to chat with you.\nWe are on an important mission.");
+    else
+        setCommsMessage("We have nothing for you.\nGood day.");
+    end
+    return true
+end
+
+mainMenu()

--- a/scripts/comms_station.lua
+++ b/scripts/comms_station.lua
@@ -23,10 +23,12 @@ function mainMenu()
         services = {
             supplydrop = "friend",
             reinforcements = "friend",
+            activatedefensefleet = "neutral",
         },
         service_cost = {
             supplydrop = 100,
             reinforcements = 150,
+            activatedefensefleet = 20,
         },
         reputation_cost_multipliers = {
             friend = 1.0,
@@ -89,6 +91,37 @@ function handleDockedState()
         addCommsReply("Please re-stock our EMP missiles. ("..getWeaponCost("EMP").."rep each)", function()
             handleWeaponRestock("EMP")
         end)
+    end
+    if comms_target.comms_data.idle_defense_fleet ~= nil then
+    	local defense_fleet_count = 0
+    	for name, template in pairs(comms_target.comms_data.idle_defense_fleet) do
+    		defense_fleet_count = defense_fleet_count + 1
+    	end
+    	if defense_fleet_count > 0 then
+    		addCommsReply("Activate station defense fleet (" .. getServiceCost("activatedefensefleet") .. " rep)",function()
+    			if player:takeReputationPoints(getServiceCost("activatedefensefleet")) then
+    				local out = string.format("%s defense fleet\n",comms_target:getCallSign())
+    				for name, template in pairs(comms_target.comms_data.idle_defense_fleet) do
+    					local script = Script()
+						local position_x, position_y = comms_target:getPosition()
+						local station_name = comms_target:getCallSign()
+						script:setVariable("position_x", position_x):setVariable("position_y", position_y)
+						script:setVariable("station_name",station_name)
+    					script:setVariable("name",name)
+    					script:setVariable("template",template)
+    					script:setVariable("faction_id",comms_target:getFactionId())
+    					script:run("defend_station.lua")
+    					out = out .. " " .. name
+    					comms_target.comms_data.idle_defense_fleet[name] = nil
+    				end
+    				out = out .. "\nactivated"
+    				setCommsMessage(out)
+    			else
+    				setCommsMessage("Insufficient reputation")
+    			end
+				addCommsReply("Back", mainMenu)
+    		end)
+		end
     end
 end
 
@@ -177,6 +210,38 @@ function handleUndockedState()
             end
             addCommsReply("Back", mainMenu)
         end)
+    end
+    if isAllowedTo(comms_target.comms_data.services.activatedefensefleet) and 
+    	comms_target.comms_data.idle_defense_fleet ~= nil then
+    	local defense_fleet_count = 0
+    	for name, template in pairs(comms_target.comms_data.idle_defense_fleet) do
+    		defense_fleet_count = defense_fleet_count + 1
+    	end
+    	if defense_fleet_count > 0 then
+    		addCommsReply("Activate station defense fleet (" .. getServiceCost("activatedefensefleet") .. " rep)",function()
+    			if player:takeReputationPoints(getServiceCost("activatedefensefleet")) then
+    				local out = string.format("%s defense fleet\n",comms_target:getCallSign())
+    				for name, template in pairs(comms_target.comms_data.idle_defense_fleet) do
+    					local script = Script()
+						local position_x, position_y = comms_target:getPosition()
+						local station_name = comms_target:getCallSign()
+						script:setVariable("position_x", position_x):setVariable("position_y", position_y)
+						script:setVariable("station_name",station_name)
+    					script:setVariable("name",name)
+    					script:setVariable("template",template)
+    					script:setVariable("faction_id",comms_target:getFactionId())
+    					script:run("defend_station.lua")
+    					out = out .. " " .. name
+    					comms_target.comms_data.idle_defense_fleet[name] = nil
+    				end
+    				out = out .. "\nactivated"
+    				setCommsMessage(out)
+    			else
+    				setCommsMessage("Insufficient reputation")
+    			end
+				addCommsReply("Back", mainMenu)
+    		end)
+		end
     end
 end
 

--- a/scripts/defend_station.lua
+++ b/scripts/defend_station.lua
@@ -1,0 +1,119 @@
+--	Supporting script for a station's defensive fleet.
+--	In the main script, the station will need a defensive fleet attached/defined.
+--	For example:
+--	station_1 = SpaceStation():setTemplate("Medium Station"):setFaction("Human Navy")
+--	station_1.comms_data = {
+--		idle_defense_fleet = {
+--			DF1 = "MT52 Hornet",
+--			DF2 = "MT52 Hornet",
+--			DF3 = "Adder MK5",
+--			DF4 = "Adder MK5",
+--			DF5 = "Phobos T3",
+--		}
+--	}
+require("utils.lua")
+function init()
+	check_interval = random(4,6)
+	check_timer = check_interval
+	inactivity_count = 0
+	inactivity_max = 300
+	local objects = getObjectsInRadius(position_x, position_y, 100)	--position_[x|y] set by calling script
+	for _, object in ipairs(objects) do
+		if object.typeName == "SpaceStation" then
+			if object:getCallSign() == station_name then	--station_name set by calling script
+				my_station = object
+				break
+			end
+		end
+	end
+	if my_station == nil then
+		destroyScript()
+		return
+	end
+	--name, faction _id and template set by calling script
+	my_ship = CpuShip():setCallSign(string.format("%s %s",station_name,name)):setCommsScript("comms_defend.lua"):setFactionId(faction_id):setPosition(position_x, position_y):setTemplate(template):setScanned(true):orderDefendTarget(my_station)
+end
+function shipHealthy()
+	if my_ship:getHull() < my_ship:getHullMax() then return false end
+	if my_ship:getSystemHealth("reactor") <  my_ship:getSystemHealthMax("reactor") then return false end
+	if my_ship:getSystemHealth("impulse") <  my_ship:getSystemHealthMax("impulse") then return false end
+	if my_ship:getSystemHealth("maneuver") <  my_ship:getSystemHealthMax("maneuver") then return false end
+	if my_ship:getBeamWeaponRange(0) > 0 then
+		if my_ship:getSystemHealth("beamweapons") <  my_ship:getSystemHealthMax("beamweapons") then return false end
+	end
+	if my_ship:getWeaponTubeCount() > 0 then
+		if my_ship:getSystemHealth("missilesystem") <  my_ship:getSystemHealthMax("missilesystem") then return false end
+	end
+	if my_ship:hasWarpDrive() then
+		if my_ship:getSystemHealth("warp") <  my_ship:getSystemHealthMax("warp") then return false end
+	end
+	if my_ship:hasJumpDrive() then
+		if my_ship:getSystemHealth("jumpdrive") <  my_ship:getSystemHealthMax("jumpdrive") then return false end
+	end
+	if my_ship:getShieldCount() > 0 then
+		if my_ship:getSystemHealth("frontshield") <  my_ship:getSystemHealthMax("frontshield") then return false end
+	end
+	if my_ship:getShieldCount() > 1 then
+		if my_ship:getSystemHealth("rearshield") <  my_ship:getSystemHealthMax("rearshield") then return false end
+	end
+	return true
+end
+function shipFull()
+	if my_ship:getWeaponTubeCount() > 0 then
+		if my_ship:getWeaponStorage("Homing") < my_ship:getWeaponStorageMax("Homing") then return false end
+		if my_ship:getWeaponStorage("HVLI") < my_ship:getWeaponStorageMax("HVLI") then return false end
+		if my_ship:getWeaponStorage("EMP") < my_ship:getWeaponStorageMax("EMP") then return false end
+		if my_ship:getWeaponStorage("Nuke") < my_ship:getWeaponStorageMax("Nuke") then return false end
+	end
+	return true
+end
+function update(delta)
+	if not my_ship:isValid() then
+		destroyScript()
+		return
+	end
+	if my_station ~= nil and my_station:isValid() then
+		check_timer = check_timer - delta
+		if check_timer < 0 then
+			local ship_healthy = shipHealthy()
+			local ship_full = shipFull()
+			if my_ship:isDocked(my_station) then
+				if my_station:areEnemiesInRange(10000) then
+					my_ship:orderDefendTarget(my_station)
+				else
+					if ship_healthy and ship_full then
+						my_ship:orderDefendTarget(my_station)
+					end
+				end
+			else
+				if my_station:areEnemiesInRange(10000) then
+					my_ship:orderDefendTarget(my_station)
+				else
+					if not ship_healthy then
+						my_ship:orderDock(my_station)
+					else
+						if not ship_full then
+							if not my_station:areEnemiesInRange(15000) then
+								my_ship:orderDock(my_station)
+							end
+						end
+					end
+				end
+			end
+			if ship_healthy and ship_full then
+				inactivity_count = inactivity_count + check_interval
+			else
+				inactivity_count = 0
+			end
+			if inactivity_count > inactivity_max then
+				my_station.comms_data.idle_defense_fleet[name] = my_ship:getTypeName()
+				my_ship:destroy()
+				destroyScript()
+			end
+			check_timer = check_interval
+		end
+	else
+		my_ship:setCommsScript("comms_ship.lua")
+		destroyScript()
+	end
+end


### PR DESCRIPTION
Allows for a friendly or neutral station to have a defense fleet. The player can activate the defense fleet through Relay or Operations. If the defense fleet doesn't do anything for 5 minutes, the surviving members of the fleet return to the station and can be activated again.

- Changed: comms_station.lua
  - Included defense fleet activation as default service with default cost of 125 reputation.
  - Added button to activate fleet if present. 
  - Changes will not have any effect on existing scripts until they are updated with stations that have defense fleets (see example code below).
- Added: defend_station.lua
  - External script called to instantiate the ship that's a member of the defense fleet.
  - Script runs until the ship is destroyed or the station is destroyed.
  - Script assigns comms_defend.lua as the ship communication script (see below).
  - If station is destroyed, script switches defense ship over to standard ship comms before destroying itself.
  - Script will have defense ship dock with station when appropriate to repair and replenish.
- Added: comms_defend.lua
  - Used for defense ship communications.
  - Will report status to friendly players. Other friendly functions like defend waypoint or assist me removed.

Example of changes needed to take advantage of defense fleet:
```
station_1 = SpaceStation():setTemplate("Medium Station"):setFaction("Human Navy")
station_1.comms_data = {
    idle_defense_fleet = {
        DF1 = "MT52 Hornet",
        DF2 = "MT52 Hornet",
        DF3 = "Adder MK5",
        DF4 = "Adder MK5",
        DF5 = "Phobos T3",
    }
}
```