### PR TITLE
fix parsing of the author of a scenario

### DIFF
--- a/src/scenarioInfo.cpp
+++ b/src/scenarioInfo.cpp
@@ -52,7 +52,7 @@ void ScenarioInfo::addKeyValue(string key, string value)
     }
     else if (key.lower() == "author")
     {
-        type = value;
+        author = value;
     }
     else if (key.lower() == "type")
     {


### PR DESCRIPTION
The author is not used anywhere, but still it was obviously wrong.