### PR TITLE
hide call signs of unscanned ships

### DIFF
--- a/src/screenComponents/radarView.cpp
+++ b/src/screenComponents/radarView.cpp
@@ -644,8 +644,16 @@ void GuiRadarView::drawObjects(sf::RenderTarget& window_normal, sf::RenderTarget
             if (!obj->canHideInNebula())
                 window = &window_alpha;
             obj->drawOnRadar(*window, object_position_on_screen, scale, view_rotation, long_range);
+
             if (show_callsigns && obj->getCallSign() != "")
-                drawText(*window, sf::FloatRect(object_position_on_screen.x, object_position_on_screen.y - 15, 0, 0), obj->getCallSign(), ACenter, 15, bold_font);
+            {
+                P<SpaceShip> ship = P<SpaceObject>(obj);
+                if (!my_spaceship || !ship || ship->getScannedStateFor(my_spaceship) >= SS_SimpleScan)
+                {
+                    // only show callsign of scanned space ships
+                    drawText(*window, sf::FloatRect(object_position_on_screen.x, object_position_on_screen.y - 15, 0, 0), obj->getCallSign(), ACenter, 15, bold_font);
+                }
+            }
         }
     }
     if (my_spaceship)

--- a/src/screens/crew6/relayScreen.cpp
+++ b/src/screens/crew6/relayScreen.cpp
@@ -243,15 +243,15 @@ void RelayScreen::onDraw(sf::RenderTarget& window)
         P<SpaceStation> station = obj;
         P<ScanProbe> probe = obj;
 
-        info_callsign->setValue(obj->getCallSign());
-
         if (ship)
         {
             if (ship->getScannedStateFor(my_spaceship) >= SS_SimpleScan)
             {
+                info_callsign->setValue(obj->getCallSign());
                 info_faction->setValue(factionInfo[obj->getFactionId()]->getLocaleName());
             }
         }else{
+            info_callsign->setValue(obj->getCallSign());
             info_faction->setValue(factionInfo[obj->getFactionId()]->getLocaleName());
         }
 

--- a/src/screens/crew6/scienceScreen.cpp
+++ b/src/screens/crew6/scienceScreen.cpp
@@ -307,7 +307,6 @@ void ScienceScreen::onDraw(sf::RenderTarget& window)
         if (fabs(rel_velocity) < 0.01)
             rel_velocity = 0.0;
 
-        info_callsign->setValue(obj->getCallSign());
         info_distance->setValue(string(distance / 1000.0f, 1) + DISTANCE_UNIT_1K);
         info_heading->setValue(string(int(heading)));
         info_relspeed->setValue(string(rel_velocity / 1000.0f * 60.0f, 1) + DISTANCE_UNIT_1K + "/min");
@@ -337,6 +336,7 @@ void ScienceScreen::onDraw(sf::RenderTarget& window)
             // hull integrity, and database reference button.
             if (ship->getScannedStateFor(my_spaceship) >= SS_SimpleScan)
             {
+                info_callsign->setValue(obj->getCallSign());
                 info_faction->setValue(factionInfo[obj->getFactionId()]->getLocaleName());
                 info_type->setValue(ship->getTypeName());
                 info_type_button->show();
@@ -413,6 +413,7 @@ void ScienceScreen::onDraw(sf::RenderTarget& window)
         else
         {
             sidebar_pager->hide();
+            info_callsign->setValue(obj->getCallSign());
             info_faction->setValue(factionInfo[obj->getFactionId()]->getLocaleName());
 
             // If the target is a station, show basic tactical info.


### PR DESCRIPTION
This pull request is up for discussion. 

I always thought that it was better to not show the call signs of ships that have not been scanned, because the name can give a lot away: The "USF Michigan" is probably not just a small fighter and "Crimson Raider" and "Skullcrusher" flying at you are probably not up to any good.

It also gives one more incentive for Science to scan a ship, because the other stations can not communicate efficiently about it if they do not know a ships name.