### PR TITLE
fix that sometimes the currently not selected item is not shown by default

### DIFF
--- a/src/gui/gui2_listbox.cpp
+++ b/src/gui/gui2_listbox.cpp
@@ -24,6 +24,12 @@ GuiListbox* GuiListbox::setButtonHeight(float height)
     return this;
 }
 
+GuiListbox* GuiListbox::scrollTo(int index)
+{
+    scroll->setValue(index);
+    return this;
+}
+
 void GuiListbox::onDraw(sf::RenderTarget& window)
 {
     if (last_rect != rect)

--- a/src/gui/gui2_listbox.h
+++ b/src/gui/gui2_listbox.h
@@ -23,6 +23,8 @@ public:
     GuiListbox* setTextSize(float size);
     GuiListbox* setButtonHeight(float height);
 
+    GuiListbox* scrollTo(int index);
+
     virtual void onDraw(sf::RenderTarget& window);
     virtual bool onMouseDown(sf::Vector2f position);
     virtual void onMouseUp(sf::Vector2f position);

--- a/src/gui/gui2_scrollbar.cpp
+++ b/src/gui/gui2_scrollbar.cpp
@@ -2,7 +2,7 @@
 #include "gui2_arrowbutton.h"
 
 GuiScrollbar::GuiScrollbar(GuiContainer* owner, string id, int min_value, int max_value, int start_value, func_t func)
-: GuiElement(owner, id), min_value(min_value), max_value(max_value), value(start_value), value_size(1), func(func)
+: GuiElement(owner, id), min_value(min_value), max_value(max_value), desired_value(start_value), value_size(1), func(func)
 {
     (new GuiArrowButton(this, id + "_UP_ARROW", 90, [this]() {
         setValue(getValue() - 1);
@@ -22,7 +22,7 @@ void GuiScrollbar::onDraw(sf::RenderTarget& window)
     float bar_size = move_height * value_size / range;
     if (bar_size > move_height)
         bar_size = move_height;
-    drawStretched(window, sf::FloatRect(rect.left, rect.top + arrow_size + move_height * value / range, rect.width, bar_size), "gui/ScrollbarSelection", sf::Color::White);
+    drawStretched(window, sf::FloatRect(rect.left, rect.top + arrow_size + move_height * getValue() / range, rect.width, bar_size), "gui/ScrollbarSelection", sf::Color::White);
 }
 
 bool GuiScrollbar::onMouseDown(sf::Vector2f position)
@@ -33,7 +33,7 @@ bool GuiScrollbar::onMouseDown(sf::Vector2f position)
     float bar_size = move_height * value_size / range;
     if (bar_size > move_height)
         bar_size = move_height;
-    float bar_y = rect.top + arrow_size + move_height * value / range;
+    float bar_y = rect.top + arrow_size + move_height * getValue() / range;
     if (position.y >= bar_y && position.y <= bar_y + bar_size)
     {
         drag_scrollbar = true;
@@ -88,31 +88,31 @@ void GuiScrollbar::setRange(int min_value, int max_value)
 {
     this->min_value = min_value;
     this->max_value = max_value;
-    setValue(value);
 }
 
 void GuiScrollbar::setValueSize(int size)
 {
     value_size = size;
-    setValue(value);
 }
 
 void GuiScrollbar::setValue(int value)
 {
-    if (value > max_value - value_size)
-        value = max_value - value_size;
-    if (value < min_value)
-        value = min_value;
-    if (this->value == value)
+    if (this->desired_value == value)
         return;
 
-    this->value = value;
+    this->desired_value = value;
+
     if (func)
-        func(value);
+        func(getValue());
 }
 
 int GuiScrollbar::getValue() const
 {
+    auto value = desired_value;
+    if (value > max_value - value_size)
+        value = max_value - value_size;
+    if (value < min_value)
+        value = min_value;
     return value;
 }
 

--- a/src/gui/gui2_scrollbar.h
+++ b/src/gui/gui2_scrollbar.h
@@ -9,7 +9,8 @@ class GuiScrollbar : public GuiElement
 protected:
     int min_value;
     int max_value;
-    int value;
+    // WARNING: this value could be out of bounds. Use getValue() to ensure a value between min_value and max_value.
+    int desired_value;
     int value_size;
     func_t func;
 

--- a/src/menus/serverCreationScreen.cpp
+++ b/src/menus/serverCreationScreen.cpp
@@ -215,6 +215,7 @@ ServerCreationScreen::ServerCreationScreen()
     }
 
     scenario_list->setSelectionIndex(mission_selected);
+    scenario_list->scrollTo(mission_selected);
     selectScenario(scenario_list->getSelectionValue());
 
     gameGlobalInfo->reset();


### PR DESCRIPTION
affected the scenario selection when you jumped back from a running scenario (#1018) and the science database where selecting an entry made the navigation jump to the top.

Fixes #1018