### PR TITLE
allow to show database entries on the main screen

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -148,6 +148,7 @@ set(SOURCES
 	src/screenComponents/viewportMainScreen.cpp
 	src/screenComponents/selfDestructEntry.cpp
 	src/screenComponents/dockingButton.cpp
+	src/screenComponents/linkScienceButton.cpp
 	src/screenComponents/shieldsEnableButton.cpp
 	src/screenComponents/selfDestructButton.cpp
 	src/screenComponents/shieldFreqencySelect.cpp

--- a/src/scienceDatabase.cpp
+++ b/src/scienceDatabase.cpp
@@ -210,6 +210,11 @@ P<ScienceDatabase> ScienceDatabase::queryScienceDatabase(string name, int32_t pa
     return nullptr;
 }
 
+bool ScienceDatabase::hasContent()
+{
+    return long_description != "" || model_data_name != "" || image != "" || keyValuePairs.size() > 0;
+}
+
 static int queryScienceDatabase(lua_State* L)
 {
     P<ScienceDatabase> entry = nullptr;

--- a/src/scienceDatabase.h
+++ b/src/scienceDatabase.h
@@ -100,6 +100,8 @@ public:
     bool hasEntries();
     PVector<ScienceDatabase> getEntries();
     static P<ScienceDatabase> queryScienceDatabase(string name, int32_t parent_id);
+
+    bool hasContent();
 private:
     string normalized_name; // used for sorting and querying
     string directionLabel(float direction);

--- a/src/screenComponents/databaseView.cpp
+++ b/src/screenComponents/databaseView.cpp
@@ -10,9 +10,11 @@
 
 #include "screenComponents/rotatingModelView.h"
 
-DatabaseViewComponent::DatabaseViewComponent(GuiContainer* owner)
+DatabaseViewComponent::DatabaseViewComponent(GuiContainer* owner, int add_nav_margin_bottom = 0, bool show_navigation = true)
 : GuiElement(owner, "DATABASE_VIEW")
 {
+    this->add_nav_margin_bottom = add_nav_margin_bottom;
+    this->show_navigation = show_navigation;
     database_entry = nullptr;
     selected_entry = nullptr;
 
@@ -23,7 +25,9 @@ DatabaseViewComponent::DatabaseViewComponent(GuiContainer* owner)
         selected_entry = findEntryById(id);
         display();
     });
-    item_list->setPosition(0, 0, ATopLeft)->setMargins(20, 20, 20, 130)->setSize(navigation_width, GuiElement::GuiSizeMax);
+    item_list->setPosition(0, 0, ATopLeft)->setMargins(20, 20, 20, 20 + add_nav_margin_bottom)->setSize(navigation_width, GuiElement::GuiSizeMax);
+    if (!show_navigation)
+        item_list->hide();
     display();
 }
 
@@ -78,6 +82,9 @@ P<ScienceDatabase> DatabaseViewComponent::getSelectedEntry()
 
 void DatabaseViewComponent::fillListBox()
 {
+    if (!show_navigation)
+        return;
+
     item_list->setOptions({});
     item_list->setSelectionIndex(-1);
 
@@ -153,7 +160,12 @@ void DatabaseViewComponent::display()
     database_entry = new GuiElement(this, "DATABASE_ENTRY");
     database_entry->setPosition(navigation_width, 0, ATopLeft)->setMargins(20)->setSize(GuiElement::GuiSizeMax, GuiElement::GuiSizeMax);
 
-    fillListBox();
+    if (show_navigation)
+    {
+        fillListBox();
+    } else {
+        database_entry->setPosition(0, 0, ATopLeft)->setMargins(navigation_width / 2 + 20, 20);
+    }
 
     if (!selected_entry)
         return;

--- a/src/screenComponents/databaseView.cpp
+++ b/src/screenComponents/databaseView.cpp
@@ -59,6 +59,18 @@ bool DatabaseViewComponent::findAndDisplayEntry(string name)
     return false;
 }
 
+bool DatabaseViewComponent::findAndDisplayEntry(int32_t id)
+{
+    P<ScienceDatabase> entry = findEntryById(id);
+    if (entry)
+    {
+        selected_entry = entry;
+        display();
+        return true;
+    }
+    return false;
+}
+
 P<ScienceDatabase> DatabaseViewComponent::getSelectedEntry()
 {
     return selected_entry;

--- a/src/screenComponents/databaseView.cpp
+++ b/src/screenComponents/databaseView.cpp
@@ -59,6 +59,11 @@ bool DatabaseViewComponent::findAndDisplayEntry(string name)
     return false;
 }
 
+P<ScienceDatabase> DatabaseViewComponent::getSelectedEntry()
+{
+    return selected_entry;
+}
+
 void DatabaseViewComponent::fillListBox()
 {
     item_list->setOptions({});

--- a/src/screenComponents/databaseView.h
+++ b/src/screenComponents/databaseView.h
@@ -2,8 +2,8 @@
 #define DATABASE_VIEW_H
 
 #include "gui/gui2_element.h"
+#include "scienceDatabase.h"
 
-class ScienceDatabase;
 class GuiListbox;
 
 class DatabaseViewComponent : public GuiElement
@@ -12,6 +12,7 @@ public:
     DatabaseViewComponent(GuiContainer* owner);
 
     bool findAndDisplayEntry(string name);
+    P<ScienceDatabase> getSelectedEntry();
 
 private:
     P<ScienceDatabase> findEntryById(int32_t id);

--- a/src/screenComponents/databaseView.h
+++ b/src/screenComponents/databaseView.h
@@ -9,7 +9,7 @@ class GuiListbox;
 class DatabaseViewComponent : public GuiElement
 {
 public:
-    DatabaseViewComponent(GuiContainer* owner);
+    DatabaseViewComponent(GuiContainer* owner, int navigation_height, bool show_navigation);
 
     bool findAndDisplayEntry(string name);
     bool findAndDisplayEntry(int32_t id);
@@ -26,7 +26,9 @@ private:
     GuiListbox* item_list;
     GuiElement* database_entry;
 
-    static constexpr int navigation_width = 400;
+    bool show_navigation;
+    int add_nav_margin_bottom;
+    int navigation_width = 400;
 };
 
 #endif//DATABASE_VIEW_H

--- a/src/screenComponents/databaseView.h
+++ b/src/screenComponents/databaseView.h
@@ -12,6 +12,7 @@ public:
     DatabaseViewComponent(GuiContainer* owner);
 
     bool findAndDisplayEntry(string name);
+    bool findAndDisplayEntry(int32_t id);
     P<ScienceDatabase> getSelectedEntry();
 
 private:

--- a/src/screenComponents/linkScienceButton.cpp
+++ b/src/screenComponents/linkScienceButton.cpp
@@ -1,0 +1,44 @@
+#include <i18n.h>
+#include "linkScienceButton.h"
+#include "playerInfo.h"
+#include "scienceDatabase.h"
+#include "spaceObjects/playerSpaceship.h"
+
+GuiLinkScienceButton::GuiLinkScienceButton(GuiContainer* owner, string id, string text, DatabaseViewComponent* database_view)
+: GuiToggleButton(owner, id, text, [this](bool active) { click(active); })
+{
+    this->database_view = database_view;
+}
+
+void GuiLinkScienceButton::click(bool active)
+{
+    if (!my_spaceship)
+        return;
+    P<ScienceDatabase> entry = database_view->getSelectedEntry();
+
+    if (!entry)
+        return;
+
+    int32_t entry_id = entry->getMultiplayerId();
+    if (entry_id == my_spaceship->shared_science_database_id)
+    {
+        // this entry is already selected. So unlink it.
+        entry_id = -1;
+    }
+
+    my_spaceship->commandSetDatabaseLink(entry_id);
+}
+
+
+void GuiLinkScienceButton::onUpdate()
+{
+    if (!my_spaceship)
+            return;
+
+    if (!database_view)
+        return;
+
+    P<ScienceDatabase> entry = database_view->getSelectedEntry();
+    setVisible(database_view->isVisible() && entry && entry->hasContent());
+    setValue(entry && entry->getMultiplayerId() == my_spaceship->shared_science_database_id);
+}

--- a/src/screenComponents/linkScienceButton.cpp
+++ b/src/screenComponents/linkScienceButton.cpp
@@ -39,6 +39,7 @@ void GuiLinkScienceButton::onUpdate()
         return;
 
     P<ScienceDatabase> entry = database_view->getSelectedEntry();
-    setVisible(database_view->isVisible() && entry && entry->hasContent());
+    setVisible(database_view->isVisible());
+    setEnable(entry && entry->hasContent());
     setValue(entry && entry->getMultiplayerId() == my_spaceship->shared_science_database_id);
 }

--- a/src/screenComponents/linkScienceButton.h
+++ b/src/screenComponents/linkScienceButton.h
@@ -1,0 +1,18 @@
+#ifndef LINK_SCIENCE_BUTTON_H
+#define LINK_SCIENCE_BUTTON_H
+
+#include "gui/gui2_togglebutton.h"
+#include "databaseView.h"
+
+class GuiLinkScienceButton : public GuiToggleButton
+{
+public:
+    GuiLinkScienceButton(GuiContainer* owner, string id, string text, DatabaseViewComponent* science_database);
+
+    DatabaseViewComponent* database_view;
+
+    virtual void onUpdate() override;
+    void click(bool active);
+};
+
+#endif//LINK_SCIENCE_BUTTON_H

--- a/src/screenComponents/mainScreenControls.cpp
+++ b/src/screenComponents/mainScreenControls.cpp
@@ -98,6 +98,20 @@ GuiMainScreenControls::GuiMainScreenControls(GuiContainer* owner)
     }));
     long_range_button = buttons.back();
 
+     // If the player has control over database, enable the database view option in the main screen controls.
+    if (my_player_info->crew_position[scienceOfficer] || my_player_info->crew_position[operationsOfficer] || my_player_info->crew_position[singlePilot] || my_player_info->crew_position[databaseView])
+    {
+        buttons.push_back(new GuiButton(this, "MAIN_SCREEN_DATABASE_BUTTON", "Database", [this]()
+        {
+            if (my_spaceship)
+            {
+                my_spaceship->commandMainScreenSetting(MSS_Database);
+            }
+            closePopup();
+        }));
+        database_button = buttons.back();
+    }
+
     // If the player has control over comms, they can toggle the comms overlay
     // on the main screen.
     if (my_player_info->crew_position[relayOfficer] || my_player_info->crew_position[operationsOfficer] || my_player_info->crew_position[singlePilot])

--- a/src/screenComponents/mainScreenControls.h
+++ b/src/screenComponents/mainScreenControls.h
@@ -14,6 +14,7 @@ private:
     GuiButton* target_lock_button = nullptr;
     GuiButton* tactical_button = nullptr;
     GuiButton* long_range_button = nullptr;
+    GuiButton* database_button = nullptr;
     GuiButton* show_comms_button = nullptr;
     GuiButton* hide_comms_button = nullptr;
     bool onscreen_comms_active = false;

--- a/src/screens/crew6/scienceScreen.cpp
+++ b/src/screens/crew6/scienceScreen.cpp
@@ -169,7 +169,7 @@ ScienceScreen::ScienceScreen(GuiContainer* owner, ECrewPosition crew_position)
     info_description->setTextSize(28)->setMargins(20, 20, 0, 0)->setSize(GuiElement::GuiSizeMax, 400)->hide();
 
     // Prep and hide the database view.
-    database_view = new DatabaseViewComponent(this);
+    database_view = new DatabaseViewComponent(this, 150, true);
     database_view->hide()->setSize(GuiElement::GuiSizeMax, GuiElement::GuiSizeMax);
 
     // Probe view button
@@ -214,8 +214,8 @@ ScienceScreen::ScienceScreen(GuiContainer* owner, ECrewPosition crew_position)
     });
     view_mode_selection->setOptions({tr("button", "Radar"), tr("button", "Database")})->setSelectionIndex(0)->setPosition(20, -20, ABottomLeft)->setSize(200, 100);
 
-    link_to_main = new GuiLinkScienceButton(this, "LINK_TO_MAIN", tr("button", "Link to Main Screen"), database_view);
-    link_to_main->setTextSize(28)->setPosition(240, -20, ABottomLeft)->setSize(200, 50);
+    link_to_main = new GuiLinkScienceButton(this, "LINK_TO_MAIN", tr("button", "Link to Main"), database_view);
+    link_to_main->setPosition(20, -120, ABottomLeft)->setSize(200, 50)->disable();
 
     // Scanning dialog.
     new GuiScanningDialog(this, "SCANNING_DIALOG");

--- a/src/screens/crew6/scienceScreen.cpp
+++ b/src/screens/crew6/scienceScreen.cpp
@@ -214,6 +214,9 @@ ScienceScreen::ScienceScreen(GuiContainer* owner, ECrewPosition crew_position)
     });
     view_mode_selection->setOptions({tr("button", "Radar"), tr("button", "Database")})->setSelectionIndex(0)->setPosition(20, -20, ABottomLeft)->setSize(200, 100);
 
+    link_to_main = new GuiLinkScienceButton(this, "LINK_TO_MAIN", tr("button", "Link to Main Screen"), database_view);
+    link_to_main->setTextSize(28)->setPosition(240, -20, ABottomLeft)->setSize(200, 50);
+
     // Scanning dialog.
     new GuiScanningDialog(this, "SCANNING_DIALOG");
 }

--- a/src/screens/crew6/scienceScreen.h
+++ b/src/screens/crew6/scienceScreen.h
@@ -5,6 +5,7 @@
 #include "gui/gui2_overlay.h"
 #include "spaceObjects/scanProbe.h"
 #include "playerInfo.h"
+#include "screenComponents/linkScienceButton.h"
 
 class GuiListbox;
 class GuiRadarView;
@@ -59,6 +60,7 @@ public:
     GuiToggleButton* probe_view_button;
     P<ScanProbe> observation_point;
     GuiListbox* view_mode_selection;
+    GuiLinkScienceButton* link_to_main;
 public:
     ScienceScreen(GuiContainer* owner, ECrewPosition crew_position=scienceOfficer);
 

--- a/src/screens/extra/databaseScreen.cpp
+++ b/src/screens/extra/databaseScreen.cpp
@@ -1,3 +1,4 @@
+#include <i18n.h>
 #include "databaseScreen.h"
 #include "scienceDatabase.h"
 
@@ -7,7 +8,11 @@
 DatabaseScreen::DatabaseScreen(GuiContainer* owner)
 : GuiOverlay(owner, "DATABASE_SCREEN", colorConfig.background)
 {
-    (new DatabaseViewComponent(this))->setPosition(0, 0, ATopLeft)->setSize(GuiElement::GuiSizeMax, GuiElement::GuiSizeMax);
+    database_view = new DatabaseViewComponent(this, 50, true);
+    database_view->setPosition(0, 0, ATopLeft)->setSize(GuiElement::GuiSizeMax, GuiElement::GuiSizeMax);
+
+    link_to_main = new GuiLinkScienceButton(this, "LINK_TO_MAIN", tr("button", "Link to Main"), database_view);
+    link_to_main->setPosition(20, -20, ABottomLeft)->setSize(200, 50)->disable();
 
     (new GuiCustomShipFunctions(this, databaseView, ""))->setPosition(-20, 120, ATopRight)->setSize(250, GuiElement::GuiSizeMax);
 }

--- a/src/screens/extra/databaseScreen.h
+++ b/src/screens/extra/databaseScreen.h
@@ -3,10 +3,13 @@
 
 #include "gui/gui2_overlay.h"
 #include "shipTemplate.h"
+#include "screenComponents/linkScienceButton.h"
 
 class DatabaseScreen : public GuiOverlay
 {
 private:
+    DatabaseViewComponent* database_view;
+    GuiLinkScienceButton* link_to_main;
 public:
     DatabaseScreen(GuiContainer* owner);
 };

--- a/src/screens/mainScreen.cpp
+++ b/src/screens/mainScreen.cpp
@@ -35,7 +35,7 @@ ScreenMainScreen::ScreenMainScreen()
     long_range_radar->setPosition(0, 0, ATopLeft)->setSize(GuiElement::GuiSizeMax, GuiElement::GuiSizeMax);
     long_range_radar->setRangeIndicatorStepSize(5000.0f)->longRange()->enableCallsigns()->hide();
     long_range_radar->setFogOfWarStyle(GuiRadarView::NebulaFogOfWar);
-    database_view = new DatabaseViewComponent(this);
+    database_view = new DatabaseViewComponent(this, 0, false);
     database_view->hide()->setSize(GuiElement::GuiSizeMax, GuiElement::GuiSizeMax);
     database_no_entry_text = new GuiLabel(this, "DATABASE_NO_ENTRY_TEXT", tr("main_screen", "No database entry linked"), 48);
     database_no_entry_text->setPosition(0, -100, ACenter)->setSize(400, 200);

--- a/src/screens/mainScreen.cpp
+++ b/src/screens/mainScreen.cpp
@@ -1,3 +1,4 @@
+#include <i18n.h>
 #include "playerInfo.h"
 #include "gameGlobalInfo.h"
 #include "mainScreen.h"
@@ -34,6 +35,12 @@ ScreenMainScreen::ScreenMainScreen()
     long_range_radar->setPosition(0, 0, ATopLeft)->setSize(GuiElement::GuiSizeMax, GuiElement::GuiSizeMax);
     long_range_radar->setRangeIndicatorStepSize(5000.0f)->longRange()->enableCallsigns()->hide();
     long_range_radar->setFogOfWarStyle(GuiRadarView::NebulaFogOfWar);
+    database_view = new DatabaseViewComponent(this);
+    database_view->hide()->setSize(GuiElement::GuiSizeMax, GuiElement::GuiSizeMax);
+    database_no_entry_text = new GuiLabel(this, "DATABASE_NO_ENTRY_TEXT", tr("main_screen", "No database entry linked"), 48);
+    database_no_entry_text->setPosition(0, -100, ACenter)->setSize(400, 200);
+    database_no_entry_text->hide();
+
     onscreen_comms = new GuiCommsOverlay(this);
     onscreen_comms->setSize(GuiElement::GuiSizeMax, GuiElement::GuiSizeMax)->setVisible(false);
 
@@ -91,17 +98,36 @@ void ScreenMainScreen::update(float delta)
             viewport->show();
             tactical_radar->hide();
             long_range_radar->hide();
+            database_view->hide();
+            database_no_entry_text->hide();
             break;
         case MSS_Tactical:
             viewport->hide();
             tactical_radar->show();
             long_range_radar->hide();
+            database_view->hide();
+            database_no_entry_text->hide();
             break;
         case MSS_LongRange:
             viewport->hide();
             tactical_radar->hide();
             long_range_radar->show();
+            database_view->hide();
+            database_no_entry_text->hide();
             break;
+        case MSS_Database:
+            viewport->hide();
+            tactical_radar->hide();
+            long_range_radar->hide();
+
+            if (database_view->findAndDisplayEntry(my_spaceship->shared_science_database_id))
+            {
+                database_view->show();
+                database_no_entry_text->hide();
+            } else {
+                database_view->hide();
+                database_no_entry_text->show();
+            }
         }
 
         switch(my_spaceship->main_screen_overlay)
@@ -161,14 +187,23 @@ void ScreenMainScreen::onClick(sf::Vector2f mouse_position)
                 my_spaceship->commandMainScreenSetting(MSS_Tactical);
             else if (gameGlobalInfo->allow_main_screen_long_range_radar)
                 my_spaceship->commandMainScreenSetting(MSS_LongRange);
+            else
+                my_spaceship->commandMainScreenSetting(MSS_Database);
             break;
         case MSS_Tactical:
             if (gameGlobalInfo->allow_main_screen_long_range_radar)
                 my_spaceship->commandMainScreenSetting(MSS_LongRange);
+            else
+                my_spaceship->commandMainScreenSetting(MSS_Database);
             break;
         case MSS_LongRange:
+            my_spaceship->commandMainScreenSetting(MSS_Database);
+            break;
+        case MSS_Database:
             if (gameGlobalInfo->allow_main_screen_tactical_radar)
                 my_spaceship->commandMainScreenSetting(MSS_Tactical);
+            else if (gameGlobalInfo->allow_main_screen_long_range_radar)
+                my_spaceship->commandMainScreenSetting(MSS_LongRange);
             break;
         }
     }
@@ -192,6 +227,8 @@ void ScreenMainScreen::onHotkey(const HotkeyResult& key)
             my_spaceship->commandMainScreenSetting(MSS_Tactical);
         else if (key.hotkey == "LONG_RANGE_RADAR")
             my_spaceship->commandMainScreenSetting(MSS_LongRange);
+        else if (key.hotkey == "VIEW_DATABASE")
+            my_spaceship->commandMainScreenSetting(MSS_Database);
         else if (key.hotkey == "FIRST_PERSON")
             viewport->first_person = !viewport->first_person;
     }

--- a/src/screens/mainScreen.h
+++ b/src/screens/mainScreen.h
@@ -5,7 +5,9 @@
 #include "engine.h"
 #include "screenComponents/helpOverlay.h"
 #include "gui/gui2_canvas.h"
+#include "gui/gui2_label.h"
 #include "threatLevelEstimate.h"
+#include "screenComponents/databaseView.h"
 
 class GuiViewportMainScreen;
 class GuiRadarView;
@@ -22,6 +24,8 @@ private:
     string keyboard_general = "";
     GuiRadarView* tactical_radar;
     GuiRadarView* long_range_radar;
+    DatabaseViewComponent* database_view;
+    GuiLabel* database_no_entry_text;
     GuiCommsOverlay* onscreen_comms;
     std::unique_ptr<ImpulseSound> impulse_sound;
 public:

--- a/src/spaceObjects/playerSpaceship.cpp
+++ b/src/spaceObjects/playerSpaceship.cpp
@@ -113,6 +113,7 @@ REGISTER_SCRIPT_SUBCLASS(PlayerSpaceship, SpaceShip)
     REGISTER_SCRIPT_CLASS_FUNCTION(PlayerSpaceship, commandConfirmDestructCode);
     REGISTER_SCRIPT_CLASS_FUNCTION(PlayerSpaceship, commandCombatManeuverBoost);
     REGISTER_SCRIPT_CLASS_FUNCTION(PlayerSpaceship, commandSetScienceLink);
+    REGISTER_SCRIPT_CLASS_FUNCTION(PlayerSpaceship, commandSetDatabaseLink);
     REGISTER_SCRIPT_CLASS_FUNCTION(PlayerSpaceship, commandSetAlertLevel);
 
     /// Return the number of Engineering repair crews on the ship.
@@ -258,6 +259,7 @@ static const int16_t CMD_SET_MAIN_SCREEN_OVERLAY = 0x0027;
 static const int16_t CMD_HACKING_FINISHED = 0x0028;
 static const int16_t CMD_CUSTOM_FUNCTION = 0x0029;
 static const int16_t CMD_TURN_SPEED = 0x002A;
+static const int16_t CMD_SET_DATABASE_LINK = 0x002B;
 
 string alertLevelToString(EAlertLevel level)
 {
@@ -349,6 +351,7 @@ PlayerSpaceship::PlayerSpaceship()
     registerMemberReplication(&self_destruct_countdown, 0.2);
     registerMemberReplication(&alert_level);
     registerMemberReplication(&linked_science_probe_id);
+    registerMemberReplication(&shared_science_database_id);
     registerMemberReplication(&control_code);
     registerMemberReplication(&long_range_radar_range);
     registerMemberReplication(&short_range_radar_range);
@@ -1626,6 +1629,11 @@ void PlayerSpaceship::onReceiveClientCommand(int32_t client_id, sf::Packet& pack
             packet >> linked_science_probe_id;
         }
         break;
+    case CMD_SET_DATABASE_LINK:
+        {
+            packet >> shared_science_database_id;
+        }
+        break;
     case CMD_HACKING_FINISHED:
         {
             uint32_t id;
@@ -1979,6 +1987,12 @@ void PlayerSpaceship::commandCustomFunction(string name)
 void PlayerSpaceship::commandSetScienceLink(int32_t id){
     sf::Packet packet;
     packet << CMD_SET_SCIENCE_LINK << id;
+    sendClientCommand(packet);
+}
+
+void PlayerSpaceship::commandSetDatabaseLink(int32_t id){
+    sf::Packet packet;
+    packet << CMD_SET_DATABASE_LINK << id;
     sendClientCommand(packet);
 }
 

--- a/src/spaceObjects/playerSpaceship.h
+++ b/src/spaceObjects/playerSpaceship.h
@@ -168,6 +168,7 @@ public:
     EAlertLevel alert_level;
 
     int32_t linked_science_probe_id = -1;
+    int32_t shared_science_database_id = -1;
 
     PlayerSpaceship();
     virtual ~PlayerSpaceship();
@@ -246,6 +247,7 @@ public:
     void commandJump(float distance);
     void commandSetTarget(P<SpaceObject> target);
     void commandSetScienceLink(int32_t id);
+    void commandSetDatabaseLink(int32_t id);
     void commandLoadTube(int8_t tubeNumber, EMissileWeapons missileType);
     void commandUnloadTube(int8_t tubeNumber);
     void commandFireTube(int8_t tubeNumber, float missile_target_angle);

--- a/src/spaceObjects/spaceship.h
+++ b/src/spaceObjects/spaceship.h
@@ -15,7 +15,8 @@ enum EMainScreenSetting
     MSS_Right,
     MSS_Target,
     MSS_Tactical,
-    MSS_LongRange
+    MSS_LongRange,
+    MSS_Database,
 };
 template<> void convert<EMainScreenSetting>::param(lua_State* L, int& idx, EMainScreenSetting& mss);
 


### PR DESCRIPTION
This allows science and the database view to link a database entry to the main screen. The database entry can be displayed by clicking the middle mouse button on the main screen or via the main screen controls.



![EmptyEpsilon_048](https://user-images.githubusercontent.com/264799/96247411-61869900-0faa-11eb-849d-b4f0d405223a.png)

![EmptyEpsilon_049](https://user-images.githubusercontent.com/264799/96247391-5b90b800-0faa-11eb-9fc0-fa33abcbe47e.png)
