### PR TITLE
expose target selection to scripts when custom button is clicked

### DIFF
--- a/src/screenComponents/customShipFunctions.cpp
+++ b/src/screenComponents/customShipFunctions.cpp
@@ -1,5 +1,6 @@
 #include "customShipFunctions.h"
 #include "playerInfo.h"
+#include "radarView.h"
 #include "spaceObjects/playerSpaceship.h"
 #include "gui/gui2_button.h"
 #include "gui/gui2_label.h"
@@ -7,6 +8,13 @@
 GuiCustomShipFunctions::GuiCustomShipFunctions(GuiContainer* owner, ECrewPosition position, string id)
 : GuiAutoLayout(owner, id, GuiAutoLayout::LayoutVerticalTopToBottom), position(position)
 {
+    this->targets = nullptr;
+}
+
+GuiCustomShipFunctions::GuiCustomShipFunctions(GuiContainer* owner, ECrewPosition position, string id, TargetsContainer* targets)
+: GuiCustomShipFunctions::GuiCustomShipFunctions(owner, position, id)
+{
+    this->targets = targets;
 }
 
 void GuiCustomShipFunctions::onDraw(sf::RenderTarget& window)
@@ -80,10 +88,18 @@ void GuiCustomShipFunctions::createEntries()
             if (csf.type == PlayerSpaceship::CustomShipFunction::Type::Button)
             {
                 string name = e.name;
-                e.element = new GuiButton(this, "", csf.caption, [name]()
+
+                e.element = new GuiButton(this, "", csf.caption, [name, this]()
                 {
                     if (my_spaceship)
-                        my_spaceship->commandCustomFunction(name);
+                    {
+                        P<SpaceObject> target = nullptr;
+                        if (targets)
+                        {
+                            target = targets->get();
+                        }
+                        my_spaceship->commandCustomFunction(name, target);
+                    }
                 });
                 e.element->setSize(GuiElement::GuiSizeMax, 50);
             }

--- a/src/screenComponents/customShipFunctions.h
+++ b/src/screenComponents/customShipFunctions.h
@@ -3,11 +3,13 @@
 
 #include "playerInfo.h"
 #include "gui/gui2_autolayout.h"
+#include "screenComponents/radarView.h"
 
 class GuiCustomShipFunctions : public GuiAutoLayout
 {
 public:
     GuiCustomShipFunctions(GuiContainer* owner, ECrewPosition position, string id);
+    GuiCustomShipFunctions(GuiContainer* owner, ECrewPosition position, string id, TargetsContainer* targets);
 
     virtual void onDraw(sf::RenderTarget& window) override;
 
@@ -19,6 +21,8 @@ private:
         string name;
         GuiElement* element;
     };
+
+    TargetsContainer* targets;
 
     ECrewPosition position;
     std::vector<Entry> entries;

--- a/src/screens/crew1/singlePilotScreen.cpp
+++ b/src/screens/crew1/singlePilotScreen.cpp
@@ -105,7 +105,7 @@ SinglePilotScreen::SinglePilotScreen(GuiContainer* owner)
     lock_aim = new AimLockButton(this, "LOCK_AIM", tube_controls, missile_aim);
     lock_aim->setPosition(250, 70, ATopCenter)->setSize(130, 50);
 
-    (new GuiCustomShipFunctions(this, singlePilot, ""))->setPosition(-20, 120, ATopRight)->setSize(250, GuiElement::GuiSizeMax);
+    (new GuiCustomShipFunctions(this, singlePilot, "", &targets))->setPosition(-20, 120, ATopRight)->setSize(250, GuiElement::GuiSizeMax);
 }
 
 void SinglePilotScreen::onDraw(sf::RenderTarget& window)

--- a/src/screens/crew4/tacticalScreen.cpp
+++ b/src/screens/crew4/tacticalScreen.cpp
@@ -105,7 +105,7 @@ TacticalScreen::TacticalScreen(GuiContainer* owner)
     jump_controls = (new GuiJumpControls(engine_layout, "JUMP"))->setSize(100, GuiElement::GuiSizeMax);
     (new GuiDockingButton(this, "DOCKING"))->setPosition(-20, -20, ABottomRight)->setSize(280, 50);
 
-    (new GuiCustomShipFunctions(this, tacticalOfficer, ""))->setPosition(-20, 120, ATopRight)->setSize(250, GuiElement::GuiSizeMax);
+    (new GuiCustomShipFunctions(this, tacticalOfficer, "", &targets))->setPosition(-20, 120, ATopRight)->setSize(250, GuiElement::GuiSizeMax);
 }
 
 void TacticalScreen::onDraw(sf::RenderTarget& window)

--- a/src/screens/crew6/relayScreen.cpp
+++ b/src/screens/crew6/relayScreen.cpp
@@ -179,7 +179,7 @@ RelayScreen::RelayScreen(GuiContainer* owner, bool allow_comms)
         alert_level_buttons.push_back(alert_button);
     }
 
-    (new GuiCustomShipFunctions(this, relayOfficer, ""))->setPosition(-20, 240, ATopRight)->setSize(250, GuiElement::GuiSizeMax);
+    (new GuiCustomShipFunctions(this, relayOfficer, "", &targets))->setPosition(-20, 240, ATopRight)->setSize(250, GuiElement::GuiSizeMax);
 
     hacking_dialog = new GuiHackingDialog(this, "");
 

--- a/src/screens/crew6/scienceScreen.cpp
+++ b/src/screens/crew6/scienceScreen.cpp
@@ -83,7 +83,7 @@ ScienceScreen::ScienceScreen(GuiContainer* owner, ECrewPosition crew_position)
     info_sidebar = new GuiAutoLayout(radar_view, "SIDEBAR", GuiAutoLayout::LayoutVerticalTopToBottom);
     info_sidebar->setPosition(-20, 170, ATopRight)->setSize(250, GuiElement::GuiSizeMax);
 
-    custom_function_sidebar = new GuiCustomShipFunctions(radar_view, crew_position, "");
+    custom_function_sidebar = new GuiCustomShipFunctions(radar_view, crew_position, "", &targets);
     custom_function_sidebar->setPosition(-20, 170, ATopRight)->setSize(250, GuiElement::GuiSizeMax)->hide();
 
     // Scan button.

--- a/src/screens/crew6/weaponsScreen.cpp
+++ b/src/screens/crew6/weaponsScreen.cpp
@@ -88,7 +88,7 @@ WeaponsScreen::WeaponsScreen(GuiContainer* owner)
         (new GuiShieldsEnableButton(this, "SHIELDS_ENABLE"))->setPosition(-20, -20, ABottomRight)->setSize(280, 50);
     }
 
-    (new GuiCustomShipFunctions(this, weaponsOfficer, ""))->setPosition(-20, 120, ATopRight)->setSize(250, GuiElement::GuiSizeMax);
+    (new GuiCustomShipFunctions(this, weaponsOfficer, "", &targets))->setPosition(-20, 120, ATopRight)->setSize(250, GuiElement::GuiSizeMax);
 }
 
 void WeaponsScreen::onDraw(sf::RenderTarget& window)

--- a/src/screens/crewStationScreen.cpp
+++ b/src/screens/crewStationScreen.cpp
@@ -50,7 +50,7 @@ CrewStationScreen::CrewStationScreen()
             {
                 if (csf.crew_position == current_position && csf.type == PlayerSpaceship::CustomShipFunction::Type::Message)
                 {
-                    my_spaceship->commandCustomFunction(csf.name);
+                    my_spaceship->commandCustomFunction(csf.name, nullptr);
                     break;
                 }
             }

--- a/src/spaceObjects/playerSpaceship.cpp
+++ b/src/spaceObjects/playerSpaceship.cpp
@@ -63,6 +63,8 @@ REGISTER_SCRIPT_SUBCLASS(PlayerSpaceship, SpaceShip)
     REGISTER_SCRIPT_CLASS_FUNCTION(PlayerSpaceship, setMaxScanProbeCount);
     REGISTER_SCRIPT_CLASS_FUNCTION(PlayerSpaceship, getMaxScanProbeCount);
 
+    /// the callback gets two parameters: the PlayerSpaceship and - if any - the SpaceObject selected
+    /// by the station when the button was pressed.
     REGISTER_SCRIPT_CLASS_FUNCTION(PlayerSpaceship, addCustomButton);
     REGISTER_SCRIPT_CLASS_FUNCTION(PlayerSpaceship, addCustomInfo);
     REGISTER_SCRIPT_CLASS_FUNCTION(PlayerSpaceship, addCustomMessage);
@@ -1633,14 +1635,24 @@ void PlayerSpaceship::onReceiveClientCommand(int32_t client_id, sf::Packet& pack
     case CMD_CUSTOM_FUNCTION:
         {
             string name;
+            int32_t target_id;
             packet >> name;
+            packet >> target_id;
+
             for(CustomShipFunction& csf : custom_functions)
             {
                 if (csf.name == name)
                 {
                     if (csf.type == CustomShipFunction::Type::Button || csf.type == CustomShipFunction::Type::Message)
                     {
-                        csf.callback.call();
+                        P<SpaceObject> target = nullptr;
+                        if (target_id > -1)
+                        {
+                            target = game_server->getObjectById(target_id);
+                            csf.callback.call(P<PlayerSpaceship>(this), target);
+                        } else {
+                            csf.callback.call(P<PlayerSpaceship>(this));
+                        }
                     }
                     if (csf.type == CustomShipFunction::Type::Message)
                     {
@@ -1962,11 +1974,12 @@ void PlayerSpaceship::commandHackingFinished(P<SpaceObject> target, string targe
     sendClientCommand(packet);
 }
 
-void PlayerSpaceship::commandCustomFunction(string name)
+void PlayerSpaceship::commandCustomFunction(string name, P<SpaceObject> target)
 {
     sf::Packet packet;
     packet << CMD_CUSTOM_FUNCTION;
     packet << name;
+    packet << (target ? target->getMultiplayerId() : -1);
     sendClientCommand(packet);
 }
 

--- a/src/spaceObjects/playerSpaceship.h
+++ b/src/spaceObjects/playerSpaceship.h
@@ -281,7 +281,7 @@ public:
     void commandScanCancel();
     void commandSetAlertLevel(EAlertLevel level);
     void commandHackingFinished(P<SpaceObject> target, string target_system);
-    void commandCustomFunction(string name);
+    void commandCustomFunction(string name, P<SpaceObject> target);
 
     virtual void onReceiveServerCommand(sf::Packet& packet) override;
 


### PR DESCRIPTION
This is my second take on #1088 and works with multiple similar stations in the same ship.

It can be used like this in scripts:

´´´lua
local player = PlayerSpaceship():setFaction("Human Navy"):setCallSign("Alpha"):setTemplate("Atlantis"):setPosition(-1000, 0)
    CpuShip():setFaction("Kraylor"):setCallSign("Beta"):setTemplate("Personnel Freighter 2"):setPosition(1000, -1000):orderRoaming()
CpuShip():setFaction("Kraylor"):setCallSign("Gamma"):setTemplate("Personnel Freighter 2"):setPosition(1000, 0):orderRoaming()
CpuShip():setFaction("Kraylor"):setCallSign("Delta"):setTemplate("Personnel Freighter 2"):setPosition(1000, 1000):orderRoaming()

player:addCustomButton("weapons", "weapons", "weapons", function(self, target)
    print("weapons", self:getCallSign(), target and target:getCallSign() or nil)
end)
player:addCustomButton("science", "science", "science", function(self, target)
    print("science", self:getCallSign(), target and target:getCallSign() or nil)
end)
```