### PR TITLE
Fixed typo in options.ini comment

### DIFF
--- a/src/preferenceManager.cpp
+++ b/src/preferenceManager.cpp
@@ -45,7 +45,7 @@ void PreferencesManager::save(string filename)
         fprintf(f, "# Empty Epsilon Settings\n# This file will be overwritten by EE.\n\n");
         fprintf(f, "# Include the following line to enable an experimental http server:\n# httpserver=8080\n\n");
         fprintf(f, "# For possible hotkey values check: http://www.sfml-dev.org/documentation/2.3.1/classsf_1_1Keyboard.php#acb4cacd7cc5802dec45724cf3314a142\n\n");
-        fprintf(f, "# Values for ship_window_flags are: spacedust:1, headings:2, callsigns:4 \n# Add them for any combination. Example: ship_window_caption=7 for all three\n\n");
+        fprintf(f, "# Values for ship_window_flags are: spacedust:1, headings:2, callsigns:4 \n# Add them for any combination. Example: ship_window_flags=7 for all three\n\n");
         std::vector<string> keys;
         for(std::unordered_map<string, string>::iterator i = preference.begin(); i != preference.end(); i++)
         {


### PR DESCRIPTION
I missed one spot in 9c3dd9ea8f17296e37dbae8156e46ea336aa261f