### PR TITLE
Comms: further improvements

### DIFF
--- a/scripts/comms_ship.lua
+++ b/scripts/comms_ship.lua
@@ -28,6 +28,8 @@ function mainMenu()
 end
 
 --- Handle friendly communication.
+--
+-- @tparam table comms_data
 function friendlyComms(comms_data)
     if comms_data.friendlyness < 20 then
         setCommsMessage("What do you want?")
@@ -107,6 +109,8 @@ function friendlyComms(comms_data)
 end
 
 --- Handle enemy communication.
+--
+-- @tparam table comms_data
 function enemyComms(comms_data)
     if comms_data.friendlyness > 50 then
         local faction = comms_target:getFaction()
@@ -150,6 +154,8 @@ function enemyComms(comms_data)
 end
 
 --- Handle neutral communication.
+--
+-- @tparam table comms_data
 function neutralComms(comms_data)
     if comms_data.friendlyness > 50 then
         setCommsMessage("Sorry, we have no time to chat with you.\nWe are on an important mission.")

--- a/scripts/comms_ship.lua
+++ b/scripts/comms_ship.lua
@@ -3,6 +3,8 @@
 -- Simple ship comms that allows setting orders if friendly.
 -- Default script for any `CpuShip`.
 --
+-- TODO `player` can be replaced by `comms_source`
+--
 -- @script comms_ship
 
 -- NOTE this could be imported

--- a/scripts/comms_ship.lua
+++ b/scripts/comms_ship.lua
@@ -13,7 +13,7 @@ local MISSILE_TYPES = {"Homing", "Nuke", "Mine", "EMP", "HVLI"}
 --- Main menu of communication.
 --
 -- Uses one of `friendlyComms`, `neutralComms`, `enemyComms`.
-function mainMenu()
+function commsShipMainMenu()
     if comms_target.comms_data == nil then
         comms_target.comms_data = {friendlyness = random(0.0, 100.0)}
     end
@@ -43,7 +43,7 @@ function friendlyComms(comms_data)
         function()
             if player:getWaypointCount() == 0 then
                 setCommsMessage("No waypoints set. Please set a waypoint first.")
-                addCommsReply("Back", mainMenu)
+                addCommsReply("Back", commsShipMainMenu)
             else
                 setCommsMessage("Which waypoint should we defend?")
                 for n = 1, player:getWaypointCount() do
@@ -52,7 +52,7 @@ function friendlyComms(comms_data)
                         function()
                             comms_target:orderDefendLocation(player:getWaypoint(n))
                             setCommsMessage("We are heading to assist at WP" .. n .. ".")
-                            addCommsReply("Back", mainMenu)
+                            addCommsReply("Back", commsShipMainMenu)
                         end
                     )
                 end
@@ -65,7 +65,7 @@ function friendlyComms(comms_data)
             function()
                 setCommsMessage("Heading toward you to assist.")
                 comms_target:orderDefendTarget(player)
-                addCommsReply("Back", mainMenu)
+                addCommsReply("Back", commsShipMainMenu)
             end
         )
     end
@@ -92,7 +92,7 @@ function friendlyComms(comms_data)
             end
 
             setCommsMessage(msg)
-            addCommsReply("Back", mainMenu)
+            addCommsReply("Back", commsShipMainMenu)
         end
     )
     for _, obj in ipairs(comms_target:getObjectsInRange(5000)) do
@@ -102,7 +102,7 @@ function friendlyComms(comms_data)
                 function()
                     setCommsMessage("Docking at " .. obj:getCallSign() .. ".")
                     comms_target:orderDock(obj)
-                    addCommsReply("Back", mainMenu)
+                    addCommsReply("Back", commsShipMainMenu)
                 end
             )
         end
@@ -167,4 +167,4 @@ function neutralComms(comms_data)
     return true
 end
 
-mainMenu()
+commsShipMainMenu()

--- a/scripts/comms_ship.lua
+++ b/scripts/comms_ship.lua
@@ -34,58 +34,73 @@ function friendlyComms(comms_data)
     else
         setCommsMessage("Sir, how can we assist?")
     end
-    addCommsReply("Defend a waypoint", function()
-        if player:getWaypointCount() == 0 then
-            setCommsMessage("No waypoints set. Please set a waypoint first.")
-            addCommsReply("Back", mainMenu)
-        else
-            setCommsMessage("Which waypoint should we defend?")
-            for n=1,player:getWaypointCount() do
-                addCommsReply("Defend WP" .. n, function()
-                    comms_target:orderDefendLocation(player:getWaypoint(n))
-                    setCommsMessage("We are heading to assist at WP" .. n ..".")
-                    addCommsReply("Back", mainMenu)
-                end)
+    addCommsReply(
+        "Defend a waypoint",
+        function()
+            if player:getWaypointCount() == 0 then
+                setCommsMessage("No waypoints set. Please set a waypoint first.")
+                addCommsReply("Back", mainMenu)
+            else
+                setCommsMessage("Which waypoint should we defend?")
+                for n = 1, player:getWaypointCount() do
+                    addCommsReply(
+                        "Defend WP" .. n,
+                        function()
+                            comms_target:orderDefendLocation(player:getWaypoint(n))
+                            setCommsMessage("We are heading to assist at WP" .. n .. ".")
+                            addCommsReply("Back", mainMenu)
+                        end
+                    )
+                end
             end
         end
-    end)
+    )
     if comms_data.friendlyness > 0.2 then
-        addCommsReply("Assist me", function()
-            setCommsMessage("Heading toward you to assist.")
-            comms_target:orderDefendTarget(player)
-            addCommsReply("Back", mainMenu)
-        end)
+        addCommsReply(
+            "Assist me",
+            function()
+                setCommsMessage("Heading toward you to assist.")
+                comms_target:orderDefendTarget(player)
+                addCommsReply("Back", mainMenu)
+            end
+        )
     end
-    addCommsReply("Report status", function()
-        local msg = "Hull: " .. math.floor(comms_target:getHull() / comms_target:getHullMax() * 100) .. "%\n"
-        local shields = comms_target:getShieldCount()
-        if shields == 1 then
-            msg = msg .. "Shield: " .. math.floor(comms_target:getShieldLevel(0) / comms_target:getShieldMax(0) * 100) .. "%\n"
-        elseif shields == 2 then
-            msg = msg .. "Front Shield: " .. math.floor(comms_target:getShieldLevel(0) / comms_target:getShieldMax(0) * 100) .. "%\n"
-            msg = msg .. "Rear Shield: " .. math.floor(comms_target:getShieldLevel(1) / comms_target:getShieldMax(1) * 100) .. "%\n"
-        else
-            for n=0,shields-1 do
-                msg = msg .. "Shield " .. n .. ": " .. math.floor(comms_target:getShieldLevel(n) / comms_target:getShieldMax(n) * 100) .. "%\n"
+    addCommsReply(
+        "Report status",
+        function()
+            local msg = "Hull: " .. math.floor(comms_target:getHull() / comms_target:getHullMax() * 100) .. "%\n"
+            local shields = comms_target:getShieldCount()
+            if shields == 1 then
+                msg = msg .. "Shield: " .. math.floor(comms_target:getShieldLevel(0) / comms_target:getShieldMax(0) * 100) .. "%\n"
+            elseif shields == 2 then
+                msg = msg .. "Front Shield: " .. math.floor(comms_target:getShieldLevel(0) / comms_target:getShieldMax(0) * 100) .. "%\n"
+                msg = msg .. "Rear Shield: " .. math.floor(comms_target:getShieldLevel(1) / comms_target:getShieldMax(1) * 100) .. "%\n"
+            else
+                for n = 0, shields - 1 do
+                    msg = msg .. "Shield " .. n .. ": " .. math.floor(comms_target:getShieldLevel(n) / comms_target:getShieldMax(n) * 100) .. "%\n"
+                end
             end
-        end
 
-        for i, missile_type in ipairs(MISSILE_TYPES) do
-            if comms_target:getWeaponStorageMax(missile_type) > 0 then
+            for i, missile_type in ipairs(MISSILE_TYPES) do
+                if comms_target:getWeaponStorageMax(missile_type) > 0 then
                     msg = msg .. missile_type .. " Missiles: " .. math.floor(comms_target:getWeaponStorage(missile_type)) .. "/" .. math.floor(comms_target:getWeaponStorageMax(missile_type)) .. "\n"
+                end
             end
-        end
 
-        setCommsMessage(msg)
-        addCommsReply("Back", mainMenu)
-    end)
+            setCommsMessage(msg)
+            addCommsReply("Back", mainMenu)
+        end
+    )
     for _, obj in ipairs(comms_target:getObjectsInRange(5000)) do
         if obj.typeName == "SpaceStation" and not comms_target:isEnemy(obj) then
-            addCommsReply("Dock at " .. obj:getCallSign(), function()
-                setCommsMessage("Docking at " .. obj:getCallSign() .. ".")
-                comms_target:orderDock(obj)
-                addCommsReply("Back", mainMenu)
-            end)
+            addCommsReply(
+                "Dock at " .. obj:getCallSign(),
+                function()
+                    setCommsMessage("Docking at " .. obj:getCallSign() .. ".")
+                    comms_target:orderDock(obj)
+                    addCommsReply("Back", mainMenu)
+                end
+            )
         end
     end
     return true
@@ -118,14 +133,17 @@ function enemyComms(comms_data)
             setCommsMessage("Mind your own business!")
         end
         comms_data.friendlyness = comms_data.friendlyness - random(0, 10)
-        addCommsReply(taunt_option, function()
-            if random(0, 100) < 30 then
-                comms_target:orderAttack(player)
-                setCommsMessage(taunt_success_reply)
-            else
-                setCommsMessage(taunt_failed_reply)
+        addCommsReply(
+            taunt_option,
+            function()
+                if random(0, 100) < 30 then
+                    comms_target:orderAttack(player)
+                    setCommsMessage(taunt_success_reply)
+                else
+                    setCommsMessage(taunt_failed_reply)
+                end
             end
-        end)
+        )
         return true
     end
     return false

--- a/scripts/comms_ship.lua
+++ b/scripts/comms_ship.lua
@@ -17,8 +17,8 @@ function commsShipMainMenu()
     if comms_target.comms_data == nil then
         comms_target.comms_data = {friendlyness = random(0.0, 100.0)}
     end
-    -- comms_data is used globally
-    comms_data = comms_target.comms_data
+
+    local comms_data = comms_target.comms_data
 
     if player:isFriendly(comms_target) then
         return friendlyComms(comms_data)

--- a/scripts/comms_station.lua
+++ b/scripts/comms_station.lua
@@ -55,7 +55,7 @@ function commsStationMainMenu()
         }
     )
 
-    -- comms_data is used globally
+    -- comms_data is used globally (could be avoided, compare comms_ship)
     comms_data = comms_target.comms_data
 
     if player:isEnemy(comms_target) then

--- a/scripts/comms_station.lua
+++ b/scripts/comms_station.lua
@@ -8,6 +8,9 @@
 -- uses `mergeTables`
 require("utils.lua")
 
+-- NOTE this could be imported
+local MISSILE_TYPES = {"Homing", "Nuke", "Mine", "EMP", "HVLI"}
+
 --- Main menu of communication.
 function mainMenu()
     if comms_target.comms_data == nil then
@@ -77,45 +80,23 @@ function handleDockedState()
         setCommsMessage("Welcome to our lovely station " .. comms_target:getCallSign() .. ".")
     end
 
-    if player:getWeaponStorageMax("Homing") > 0 then
-        addCommsReply(
-            "Do you have spare homing missiles for us? (" .. getWeaponCost("Homing") .. "rep each)",
-            function()
-                handleWeaponRestock("Homing")
-            end
-        )
-    end
-    if player:getWeaponStorageMax("HVLI") > 0 then
-        addCommsReply(
-            "Can you restock us with HVLI? (" .. getWeaponCost("HVLI") .. "rep each)",
-            function()
-                handleWeaponRestock("HVLI")
-            end
-        )
-    end
-    if player:getWeaponStorageMax("Mine") > 0 then
-        addCommsReply(
-            "Please re-stock our mines. (" .. getWeaponCost("Mine") .. "rep each)",
-            function()
-                handleWeaponRestock("Mine")
-            end
-        )
-    end
-    if player:getWeaponStorageMax("Nuke") > 0 then
-        addCommsReply(
-            "Can you supply us with some nukes? (" .. getWeaponCost("Nuke") .. "rep each)",
-            function()
-                handleWeaponRestock("Nuke")
-            end
-        )
-    end
-    if player:getWeaponStorageMax("EMP") > 0 then
-        addCommsReply(
-            "Please re-stock our EMP missiles. (" .. getWeaponCost("EMP") .. "rep each)",
-            function()
-                handleWeaponRestock("EMP")
-            end
-        )
+    local reply_messages = {
+        ["Homing"] = "Do you have spare homing missiles for us?",
+        ["HVLI"] = "Can you restock us with HVLI?",
+        ["Mine"] = "Please re-stock our mines.",
+        ["Nuke"] = "Can you supply us with some nukes?",
+        ["EMP"] = "Please re-stock our EMP missiles."
+    }
+
+    for _, missile_type in ipairs(MISSILE_TYPES) do
+        if player:getWeaponStorageMax(missile_type) > 0 then
+            addCommsReply(
+                string.format("%s (%d rep each)", reply_messages[missile_type], getWeaponCost(missile_type)),
+                function()
+                    handleWeaponRestock(missile_type)
+                end
+            )
+        end
     end
 end
 

--- a/scripts/comms_station.lua
+++ b/scripts/comms_station.lua
@@ -14,7 +14,7 @@ require("utils.lua")
 local MISSILE_TYPES = {"Homing", "Nuke", "Mine", "EMP", "HVLI"}
 
 --- Main menu of communication.
-function mainMenu()
+function commsStationMainMenu()
     if comms_target.comms_data == nil then
         comms_target.comms_data = {}
     end
@@ -130,7 +130,7 @@ function handleWeaponRestock(weapon)
         else
             setCommsMessage("Sorry, sir, but you are as fully stocked as I can allow.")
         end
-        addCommsReply("Back", mainMenu)
+        addCommsReply("Back", commsStationMainMenu)
     else
         if not player:takeReputationPoints(points_per_item * item_amount) then
             setCommsMessage("Not enough reputation.")
@@ -142,7 +142,7 @@ function handleWeaponRestock(weapon)
         else
             setCommsMessage("We generously resupplied you with some weapon charges.\nPut them to good use.")
         end
-        addCommsReply("Back", mainMenu)
+        addCommsReply("Back", commsStationMainMenu)
     end
 end
 
@@ -178,12 +178,12 @@ function handleUndockedState()
                                 else
                                     setCommsMessage("Not enough reputation!")
                                 end
-                                addCommsReply("Back", mainMenu)
+                                addCommsReply("Back", commsStationMainMenu)
                             end
                         )
                     end
                 end
-                addCommsReply("Back", mainMenu)
+                addCommsReply("Back", commsStationMainMenu)
             end
         )
     end
@@ -207,12 +207,12 @@ function handleUndockedState()
                                 else
                                     setCommsMessage("Not enough reputation!")
                                 end
-                                addCommsReply("Back", mainMenu)
+                                addCommsReply("Back", commsStationMainMenu)
                             end
                         )
                     end
                 end
-                addCommsReply("Back", mainMenu)
+                addCommsReply("Back", commsStationMainMenu)
             end
         )
     end
@@ -260,4 +260,4 @@ function getFriendStatus()
     end
 end
 
-mainMenu()
+commsStationMainMenu()

--- a/scripts/comms_station.lua
+++ b/scripts/comms_station.lua
@@ -120,11 +120,14 @@ function handleDockedState()
 end
 
 --- handleWeaponRestock
+--
+-- @tparam string weapon the missile type
 function handleWeaponRestock(weapon)
     if not player:isDocked(comms_target) then
         setCommsMessage("You need to stay docked for that action.")
         return
     end
+
     if not isAllowedTo(comms_data.weapons[weapon]) then
         if weapon == "Nuke" then
             setCommsMessage("We do not deal in weapons of mass destruction.")
@@ -135,6 +138,7 @@ function handleWeaponRestock(weapon)
         end
         return
     end
+
     local points_per_item = getWeaponCost(weapon)
     local item_amount = math.floor(player:getWeaponStorageMax(weapon) * comms_data.max_weapon_refill_amount[getFriendStatus()]) - player:getWeaponStorage(weapon)
     if item_amount <= 0 then
@@ -166,6 +170,8 @@ function handleUndockedState()
     else
         setCommsMessage("This is " .. comms_target:getCallSign() .. ". Greetings.\nIf you want to do business, please dock with us first.")
     end
+
+    -- supplydrop
     if isAllowedTo(comms_target.comms_data.services.supplydrop) then
         addCommsReply(
             "Can you send a supply drop? (" .. getServiceCost("supplydrop") .. "rep)",
@@ -198,6 +204,8 @@ function handleUndockedState()
             end
         )
     end
+
+    -- reinforcements
     if isAllowedTo(comms_target.comms_data.services.reinforcements) then
         addCommsReply(
             "Please send reinforcements! (" .. getServiceCost("reinforcements") .. "rep)",
@@ -228,6 +236,8 @@ function handleUndockedState()
 end
 
 --- isAllowedTo
+--
+-- @treturn boolean
 function isAllowedTo(state)
     if state == "friend" and player:isFriendly(comms_target) then
         return true
@@ -240,17 +250,25 @@ end
 
 --- Return the number of reputation points that a specified weapon costs for the
 -- current player.
+--
+-- @tparam string weapon the missile type
+-- @treturn integer
 function getWeaponCost(weapon)
     return math.ceil(comms_data.weapon_cost[weapon] * comms_data.reputation_cost_multipliers[getFriendStatus()])
 end
 
 --- Return the number of reputation points that a specified service costs for
 -- the current player.
+--
+-- @tparam string service the service
+-- @treturn integer
 function getServiceCost(service)
     return math.ceil(comms_data.service_cost[service])
 end
 
 --- Return "friend" or "neutral".
+--
+-- @treturn string
 function getFriendStatus()
     if player:isFriendly(comms_target) then
         return "friend"

--- a/scripts/comms_station.lua
+++ b/scripts/comms_station.lua
@@ -78,29 +78,44 @@ function handleDockedState()
     end
 
     if player:getWeaponStorageMax("Homing") > 0 then
-        addCommsReply("Do you have spare homing missiles for us? ("..getWeaponCost("Homing").."rep each)", function()
-            handleWeaponRestock("Homing")
-        end)
+        addCommsReply(
+            "Do you have spare homing missiles for us? (" .. getWeaponCost("Homing") .. "rep each)",
+            function()
+                handleWeaponRestock("Homing")
+            end
+        )
     end
     if player:getWeaponStorageMax("HVLI") > 0 then
-        addCommsReply("Can you restock us with HVLI? ("..getWeaponCost("HVLI").."rep each)", function()
-            handleWeaponRestock("HVLI")
-        end)
+        addCommsReply(
+            "Can you restock us with HVLI? (" .. getWeaponCost("HVLI") .. "rep each)",
+            function()
+                handleWeaponRestock("HVLI")
+            end
+        )
     end
     if player:getWeaponStorageMax("Mine") > 0 then
-        addCommsReply("Please re-stock our mines. ("..getWeaponCost("Mine").."rep each)", function()
-            handleWeaponRestock("Mine")
-        end)
+        addCommsReply(
+            "Please re-stock our mines. (" .. getWeaponCost("Mine") .. "rep each)",
+            function()
+                handleWeaponRestock("Mine")
+            end
+        )
     end
     if player:getWeaponStorageMax("Nuke") > 0 then
-        addCommsReply("Can you supply us with some nukes? ("..getWeaponCost("Nuke").."rep each)", function()
-            handleWeaponRestock("Nuke")
-        end)
+        addCommsReply(
+            "Can you supply us with some nukes? (" .. getWeaponCost("Nuke") .. "rep each)",
+            function()
+                handleWeaponRestock("Nuke")
+            end
+        )
     end
     if player:getWeaponStorageMax("EMP") > 0 then
-        addCommsReply("Please re-stock our EMP missiles. ("..getWeaponCost("EMP").."rep each)", function()
-            handleWeaponRestock("EMP")
-        end)
+        addCommsReply(
+            "Please re-stock our EMP missiles. (" .. getWeaponCost("EMP") .. "rep each)",
+            function()
+                handleWeaponRestock("EMP")
+            end
+        )
     end
 end
 
@@ -152,51 +167,63 @@ function handleUndockedState()
         setCommsMessage("This is " .. comms_target:getCallSign() .. ". Greetings.\nIf you want to do business, please dock with us first.")
     end
     if isAllowedTo(comms_target.comms_data.services.supplydrop) then
-        addCommsReply("Can you send a supply drop? ("..getServiceCost("supplydrop").."rep)", function()
-            if player:getWaypointCount() < 1 then
-                setCommsMessage("You need to set a waypoint before you can request backup.")
-            else
-                setCommsMessage("To which waypoint should we deliver your supplies?")
-                for n=1,player:getWaypointCount() do
-                    addCommsReply("WP" .. n, function()
-                        if player:takeReputationPoints(getServiceCost("supplydrop")) then
-                            local position_x, position_y = comms_target:getPosition()
-                            local target_x, target_y = player:getWaypoint(n)
-                            local script = Script()
-                            script:setVariable("position_x", position_x):setVariable("position_y", position_y)
-                            script:setVariable("target_x", target_x):setVariable("target_y", target_y)
-                            script:setVariable("faction_id", comms_target:getFactionId()):run("supply_drop.lua")
-                            setCommsMessage("We have dispatched a supply ship toward WP" .. n)
-                        else
-                            setCommsMessage("Not enough reputation!")
-                        end
-                        addCommsReply("Back", mainMenu)
-                    end)
+        addCommsReply(
+            "Can you send a supply drop? (" .. getServiceCost("supplydrop") .. "rep)",
+            function()
+                if player:getWaypointCount() < 1 then
+                    setCommsMessage("You need to set a waypoint before you can request backup.")
+                else
+                    setCommsMessage("To which waypoint should we deliver your supplies?")
+                    for n = 1, player:getWaypointCount() do
+                        addCommsReply(
+                            "WP" .. n,
+                            function()
+                                if player:takeReputationPoints(getServiceCost("supplydrop")) then
+                                    local position_x, position_y = comms_target:getPosition()
+                                    local target_x, target_y = player:getWaypoint(n)
+                                    local script = Script()
+                                    script:setVariable("position_x", position_x):setVariable("position_y", position_y)
+                                    script:setVariable("target_x", target_x):setVariable("target_y", target_y)
+                                    script:setVariable("faction_id", comms_target:getFactionId()):run("supply_drop.lua")
+                                    setCommsMessage("We have dispatched a supply ship toward WP" .. n)
+                                else
+                                    setCommsMessage("Not enough reputation!")
+                                end
+                                addCommsReply("Back", mainMenu)
+                            end
+                        )
+                    end
                 end
+                addCommsReply("Back", mainMenu)
             end
-            addCommsReply("Back", mainMenu)
-        end)
+        )
     end
     if isAllowedTo(comms_target.comms_data.services.reinforcements) then
-        addCommsReply("Please send reinforcements! ("..getServiceCost("reinforcements").."rep)", function()
-            if player:getWaypointCount() < 1 then
-                setCommsMessage("You need to set a waypoint before you can request reinforcements.")
-            else
-                setCommsMessage("To which waypoint should we dispatch the reinforcements?")
-                for n=1,player:getWaypointCount() do
-                    addCommsReply("WP" .. n, function()
-                        if player:takeReputationPoints(getServiceCost("reinforcements")) then
-                            local ship = CpuShip():setFactionId(comms_target:getFactionId()):setPosition(comms_target:getPosition()):setTemplate("Adder MK5"):setScanned(true):orderDefendLocation(player:getWaypoint(n))
-                            setCommsMessage("We have dispatched " .. ship:getCallSign() .. " to assist at WP" .. n)
-                        else
-                            setCommsMessage("Not enough reputation!")
-                        end
-                        addCommsReply("Back", mainMenu)
-                    end)
+        addCommsReply(
+            "Please send reinforcements! (" .. getServiceCost("reinforcements") .. "rep)",
+            function()
+                if player:getWaypointCount() < 1 then
+                    setCommsMessage("You need to set a waypoint before you can request reinforcements.")
+                else
+                    setCommsMessage("To which waypoint should we dispatch the reinforcements?")
+                    for n = 1, player:getWaypointCount() do
+                        addCommsReply(
+                            "WP" .. n,
+                            function()
+                                if player:takeReputationPoints(getServiceCost("reinforcements")) then
+                                    local ship = CpuShip():setFactionId(comms_target:getFactionId()):setPosition(comms_target:getPosition()):setTemplate("Adder MK5"):setScanned(true):orderDefendLocation(player:getWaypoint(n))
+                                    setCommsMessage("We have dispatched " .. ship:getCallSign() .. " to assist at WP" .. n)
+                                else
+                                    setCommsMessage("Not enough reputation!")
+                                end
+                                addCommsReply("Back", mainMenu)
+                            end
+                        )
+                    end
                 end
+                addCommsReply("Back", mainMenu)
             end
-            addCommsReply("Back", mainMenu)
-        end)
+        )
     end
 end
 

--- a/scripts/comms_station.lua
+++ b/scripts/comms_station.lua
@@ -3,6 +3,8 @@
 -- Station comms that allows buying ordnance, supply drop, and reinforcements.
 -- Default script for any `SpaceStation`.
 --
+-- TODO `player` can be replaced by `comms_source`
+--
 -- @script comms_station
 
 -- uses `mergeTables`

--- a/scripts/comms_station_scenario_03_central_command.lua
+++ b/scripts/comms_station_scenario_03_central_command.lua
@@ -76,102 +76,150 @@ function mainMenu()
         end
         if not player:isDocked(comms_target) then
             setCommsMessage("Good day officer,\nIf you need supplies please dock with us first.")
-            addCommsReply("Can you send a supply drop? (100rep)", function()
-                if player:getWaypointCount() < 1 then
-                    setCommsMessage("You need to set a waypoint before you can request backup.")
-                else
-                    setCommsMessage("Where do we need to drop off your supplies?")
-                    for n=1,player:getWaypointCount() do
-                        addCommsReply("WP" .. n, function()
-                            if player:takeReputationPoints(100) then
-                                local position_x, position_y = comms_target:getPosition()
-                                local target_x, target_y = player:getWaypoint(n)
-                                local script = Script()
-                                script:setVariable("position_x", position_x):setVariable("position_y", position_y)
-                                script:setVariable("target_x", target_x):setVariable("target_y", target_y)
-                                script:setVariable("faction_id", comms_target:getFactionId()):run("supply_drop.lua")
-                                setCommsMessage("We have dispatched a supply ship towards WP" .. n)
-                            else
-                                setCommsMessage("Not enough rep!")
-                            end
-                            addCommsReply("Back", mainMenu)
-                        end)
+            addCommsReply(
+                "Can you send a supply drop? (100rep)",
+                function()
+                    if player:getWaypointCount() < 1 then
+                        setCommsMessage("You need to set a waypoint before you can request backup.")
+                    else
+                        setCommsMessage("Where do we need to drop off your supplies?")
+                        for n = 1, player:getWaypointCount() do
+                            addCommsReply(
+                                "WP" .. n,
+                                function()
+                                    if player:takeReputationPoints(100) then
+                                        local position_x, position_y = comms_target:getPosition()
+                                        local target_x, target_y = player:getWaypoint(n)
+                                        local script = Script()
+                                        script:setVariable("position_x", position_x):setVariable("position_y", position_y)
+                                        script:setVariable("target_x", target_x):setVariable("target_y", target_y)
+                                        script:setVariable("faction_id", comms_target:getFactionId()):run("supply_drop.lua")
+                                        setCommsMessage("We have dispatched a supply ship towards WP" .. n)
+                                    else
+                                        setCommsMessage("Not enough rep!")
+                                    end
+                                    addCommsReply("Back", mainMenu)
+                                end
+                            )
+                        end
                     end
+                    addCommsReply("Back", mainMenu)
                 end
-                addCommsReply("Back", mainMenu)
-            end)
-            addCommsReply("Please send backup! (150rep)", function()
-                if player:getWaypointCount() < 1 then
-                    setCommsMessage("You need to set a waypoint before you can request backup.")
-                else
-                    setCommsMessage("Where does the backup needs to go?")
-                    for n=1,player:getWaypointCount() do
-                        addCommsReply("WP" .. n, function()
-                            if player:takeReputationPoints(150) then
-                                ship = CpuShip():setFactionId(comms_target:getFactionId()):setPosition(comms_target:getPosition()):setTemplate("Adder MK5"):setScanned(true):orderDefendLocation(player:getWaypoint(n))
-                                setCommsMessage("We have dispatched " .. ship:getCallSign() .. " to assist at WP" .. n)
-                            else
-                                setCommsMessage("Not enough rep!")
-                            end
-                            addCommsReply("Back", mainMenu)
-                        end)
+            )
+            addCommsReply(
+                "Please send backup! (150rep)",
+                function()
+                    if player:getWaypointCount() < 1 then
+                        setCommsMessage("You need to set a waypoint before you can request backup.")
+                    else
+                        setCommsMessage("Where does the backup needs to go?")
+                        for n = 1, player:getWaypointCount() do
+                            addCommsReply(
+                                "WP" .. n,
+                                function()
+                                    if player:takeReputationPoints(150) then
+                                        ship = CpuShip():setFactionId(comms_target:getFactionId()):setPosition(comms_target:getPosition()):setTemplate("Adder MK5"):setScanned(true):orderDefendLocation(player:getWaypoint(n))
+                                        setCommsMessage("We have dispatched " .. ship:getCallSign() .. " to assist at WP" .. n)
+                                    else
+                                        setCommsMessage("Not enough rep!")
+                                    end
+                                    addCommsReply("Back", mainMenu)
+                                end
+                            )
+                        end
                     end
+                    addCommsReply("Back", mainMenu)
                 end
-                addCommsReply("Back", mainMenu)
-            end)
+            )
             return true
         end
 
         -- Friendly station, docked.
         setCommsMessage("Good day officer,\nWhat can we do for you today?")
-        addCommsReply("Do you have spare homing missiles for us? (2rep each)", function()
-            if not player:isDocked(comms_target) then setCommsMessage("You need to stay docked for that action."); return end
-            if not player:takeReputationPoints(2 * (player:getWeaponStorageMax("Homing") - player:getWeaponStorage("Homing"))) then setCommsMessage("Not enough reputation."); return end
-            if player:getWeaponStorage("Homing") >= player:getWeaponStorageMax("Homing") then
-                setCommsMessage("Sorry sir, but you are fully stocked with homing missiles.")
-                addCommsReply("Back", mainMenu)
-            else
-                player:setWeaponStorage("Homing", player:getWeaponStorageMax("Homing"))
-                setCommsMessage("Filled up your missile supply.")
-                addCommsReply("Back", mainMenu)
+        addCommsReply(
+            "Do you have spare homing missiles for us? (2rep each)",
+            function()
+                if not player:isDocked(comms_target) then
+                    setCommsMessage("You need to stay docked for that action.")
+                    return
+                end
+                if not player:takeReputationPoints(2 * (player:getWeaponStorageMax("Homing") - player:getWeaponStorage("Homing"))) then
+                    setCommsMessage("Not enough reputation.")
+                    return
+                end
+                if player:getWeaponStorage("Homing") >= player:getWeaponStorageMax("Homing") then
+                    setCommsMessage("Sorry sir, but you are fully stocked with homing missiles.")
+                    addCommsReply("Back", mainMenu)
+                else
+                    player:setWeaponStorage("Homing", player:getWeaponStorageMax("Homing"))
+                    setCommsMessage("Filled up your missile supply.")
+                    addCommsReply("Back", mainMenu)
+                end
             end
-        end)
-        addCommsReply("Please re-stock our mines. (2rep each)", function()
-            if not player:isDocked(comms_target) then setCommsMessage("You need to stay docked for that action."); return end
-            if not player:takeReputationPoints(2 * (player:getWeaponStorageMax("Mine") - player:getWeaponStorage("Mine"))) then setCommsMessage("Not enough reputation."); return end
-            if player:getWeaponStorage("Mine") >= player:getWeaponStorageMax("Mine") then
-                setCommsMessage("Captain,\nYou have all the mines you can fit in that ship.")
-                addCommsReply("Back", mainMenu)
-            else
-                player:setWeaponStorage("Mine", player:getWeaponStorageMax("Mine"))
-                setCommsMessage("These mines, are yours.")
-                addCommsReply("Back", mainMenu)
+        )
+        addCommsReply(
+            "Please re-stock our mines. (2rep each)",
+            function()
+                if not player:isDocked(comms_target) then
+                    setCommsMessage("You need to stay docked for that action.")
+                    return
+                end
+                if not player:takeReputationPoints(2 * (player:getWeaponStorageMax("Mine") - player:getWeaponStorage("Mine"))) then
+                    setCommsMessage("Not enough reputation.")
+                    return
+                end
+                if player:getWeaponStorage("Mine") >= player:getWeaponStorageMax("Mine") then
+                    setCommsMessage("Captain,\nYou have all the mines you can fit in that ship.")
+                    addCommsReply("Back", mainMenu)
+                else
+                    player:setWeaponStorage("Mine", player:getWeaponStorageMax("Mine"))
+                    setCommsMessage("These mines, are yours.")
+                    addCommsReply("Back", mainMenu)
+                end
             end
-        end)
-        addCommsReply("Can you supply us with some nukes. (15rep each)", function()
-            if not player:isDocked(comms_target) then setCommsMessage("You need to stay docked for that action."); return end
-            if not player:takeReputationPoints(15 * (player:getWeaponStorageMax("Nuke") - player:getWeaponStorage("Nuke"))) then setCommsMessage("Not enough reputation."); return end
-            if player:getWeaponStorage("Nuke") >= player:getWeaponStorageMax("Nuke") then
-                setCommsMessage("All nukes are charged and primed for distruction.")
-                addCommsReply("Back", mainMenu)
-            else
-                player:setWeaponStorage("Nuke", player:getWeaponStorageMax("Nuke"))
-                setCommsMessage("You are fully loaded,\nand ready to explode things.")
-                addCommsReply("Back", mainMenu)
+        )
+        addCommsReply(
+            "Can you supply us with some nukes. (15rep each)",
+            function()
+                if not player:isDocked(comms_target) then
+                    setCommsMessage("You need to stay docked for that action.")
+                    return
+                end
+                if not player:takeReputationPoints(15 * (player:getWeaponStorageMax("Nuke") - player:getWeaponStorage("Nuke"))) then
+                    setCommsMessage("Not enough reputation.")
+                    return
+                end
+                if player:getWeaponStorage("Nuke") >= player:getWeaponStorageMax("Nuke") then
+                    setCommsMessage("All nukes are charged and primed for distruction.")
+                    addCommsReply("Back", mainMenu)
+                else
+                    player:setWeaponStorage("Nuke", player:getWeaponStorageMax("Nuke"))
+                    setCommsMessage("You are fully loaded,\nand ready to explode things.")
+                    addCommsReply("Back", mainMenu)
+                end
             end
-        end)
-        addCommsReply("Please re-stock our EMP Missiles. (10rep each)", function()
-            if not player:isDocked(comms_target) then setCommsMessage("You need to stay docked for that action."); return end
-            if not player:takeReputationPoints(10 * (player:getWeaponStorageMax("EMP") - player:getWeaponStorage("EMP"))) then setCommsMessage("Not enough reputation."); return end
-            if player:getWeaponStorage("EMP") >= player:getWeaponStorageMax("EMP") then
-                setCommsMessage("All storage for EMP missiles is filled sir.")
-                addCommsReply("Back", mainMenu)
-            else
-                player:setWeaponStorage("EMP", player:getWeaponStorageMax("EMP"))
-                setCommsMessage("Recallibrated the electronics and\nfitted you with all the EMP missiles you can carry.")
-                addCommsReply("Back", mainMenu)
+        )
+        addCommsReply(
+            "Please re-stock our EMP Missiles. (10rep each)",
+            function()
+                if not player:isDocked(comms_target) then
+                    setCommsMessage("You need to stay docked for that action.")
+                    return
+                end
+                if not player:takeReputationPoints(10 * (player:getWeaponStorageMax("EMP") - player:getWeaponStorage("EMP"))) then
+                    setCommsMessage("Not enough reputation.")
+                    return
+                end
+                if player:getWeaponStorage("EMP") >= player:getWeaponStorageMax("EMP") then
+                    setCommsMessage("All storage for EMP missiles is filled sir.")
+                    addCommsReply("Back", mainMenu)
+                else
+                    player:setWeaponStorage("EMP", player:getWeaponStorageMax("EMP"))
+                    setCommsMessage("Recallibrated the electronics and\nfitted you with all the EMP missiles you can carry.")
+                    addCommsReply("Back", mainMenu)
+                end
             end
-        end)
+        )
     else
         -- not friendly (and not enemy)
 
@@ -182,38 +230,62 @@ function mainMenu()
 
         -- Neutral station, docked
         setCommsMessage("Welcome to our lovely station")
-        addCommsReply("Do you have spare homing missiles for us? (5rep each)", function()
-            if not player:isDocked(comms_target) then setCommsMessage("You need to stay docked for that action."); return end
-            if player:getWeaponStorage("Homing") >= player:getWeaponStorageMax("Homing") / 2 then
-                setCommsMessage("You seem to have more then enough missiles")
-                addCommsReply("Back", mainMenu)
-            else
-                if not player:takeReputationPoints(5 * ((player:getWeaponStorageMax("Homing") / 2) - player:getWeaponStorage("Homing"))) then setCommsMessage("Not enough reputation."); return end
-                player:setWeaponStorage("Homing", player:getWeaponStorageMax("Homing") / 2)
-                setCommsMessage("We generously resupplied you with some free homing missiles.\nPut them to good use.")
+        addCommsReply(
+            "Do you have spare homing missiles for us? (5rep each)",
+            function()
+                if not player:isDocked(comms_target) then
+                    setCommsMessage("You need to stay docked for that action.")
+                    return
+                end
+                if player:getWeaponStorage("Homing") >= player:getWeaponStorageMax("Homing") / 2 then
+                    setCommsMessage("You seem to have more then enough missiles")
+                    addCommsReply("Back", mainMenu)
+                else
+                    if not player:takeReputationPoints(5 * ((player:getWeaponStorageMax("Homing") / 2) - player:getWeaponStorage("Homing"))) then
+                        setCommsMessage("Not enough reputation.")
+                        return
+                    end
+                    player:setWeaponStorage("Homing", player:getWeaponStorageMax("Homing") / 2)
+                    setCommsMessage("We generously resupplied you with some free homing missiles.\nPut them to good use.")
+                    addCommsReply("Back", mainMenu)
+                end
+            end
+        )
+        addCommsReply(
+            "Please re-stock our mines. (5rep each)",
+            function()
+                if not player:isDocked(comms_target) then
+                    setCommsMessage("You need to stay docked for that action.")
+                    return
+                end
+                if player:getWeaponStorage("Mine") >= player:getWeaponStorageMax("Mine") then
+                    setCommsMessage("You are fully stocked with mines.")
+                    addCommsReply("Back", mainMenu)
+                else
+                    if not player:takeReputationPoints(5 * (player:getWeaponStorageMax("Mine") - player:getWeaponStorage("Mine"))) then
+                        setCommsMessage("Not enough reputation.")
+                        return
+                    end
+                    player:setWeaponStorage("Mine", player:getWeaponStorageMax("Mine"))
+                    setCommsMessage("Here, have some mines.\nMines are good defensive weapons.")
+                    addCommsReply("Back", mainMenu)
+                end
+            end
+        )
+        addCommsReply(
+            "Can you supply us with some nukes.",
+            function()
+                setCommsMessage("We do not deal in weapons of mass destruction.")
                 addCommsReply("Back", mainMenu)
             end
-        end)
-        addCommsReply("Please re-stock our mines. (5rep each)", function()
-            if not player:isDocked(comms_target) then setCommsMessage("You need to stay docked for that action."); return end
-            if player:getWeaponStorage("Mine") >= player:getWeaponStorageMax("Mine") then
-                setCommsMessage("You are fully stocked with mines.")
-                addCommsReply("Back", mainMenu)
-            else
-                if not player:takeReputationPoints(5 * (player:getWeaponStorageMax("Mine") - player:getWeaponStorage("Mine"))) then setCommsMessage("Not enough reputation."); return end
-                player:setWeaponStorage("Mine", player:getWeaponStorageMax("Mine"))
-                setCommsMessage("Here, have some mines.\nMines are good defensive weapons.")
+        )
+        addCommsReply(
+            "Please re-stock our EMP Missiles.",
+            function()
+                setCommsMessage("We do not deal in weapons of mass disruption.")
                 addCommsReply("Back", mainMenu)
             end
-        end)
-        addCommsReply("Can you supply us with some nukes.", function()
-            setCommsMessage("We do not deal in weapons of mass destruction.")
-            addCommsReply("Back", mainMenu)
-        end)
-        addCommsReply("Please re-stock our EMP Missiles.", function()
-            setCommsMessage("We do not deal in weapons of mass disruption.")
-            addCommsReply("Back", mainMenu)
-        end)
+        )
     end
 end
 

--- a/scripts/comms_station_scenario_03_central_command.lua
+++ b/scripts/comms_station_scenario_03_central_command.lua
@@ -4,7 +4,7 @@
 --
 -- @script comms_station_scenario_03_central_command
 
-function mainMenu()
+function commsStationMainMenu()
     if comms_target.comms_data == nil then
         comms_target.comms_data = {friendlyness = random(0.0, 100.0)}
     end
@@ -98,12 +98,12 @@ function mainMenu()
                                     else
                                         setCommsMessage("Not enough rep!")
                                     end
-                                    addCommsReply("Back", mainMenu)
+                                    addCommsReply("Back", commsStationMainMenu)
                                 end
                             )
                         end
                     end
-                    addCommsReply("Back", mainMenu)
+                    addCommsReply("Back", commsStationMainMenu)
                 end
             )
             addCommsReply(
@@ -123,12 +123,12 @@ function mainMenu()
                                     else
                                         setCommsMessage("Not enough rep!")
                                     end
-                                    addCommsReply("Back", mainMenu)
+                                    addCommsReply("Back", commsStationMainMenu)
                                 end
                             )
                         end
                     end
-                    addCommsReply("Back", mainMenu)
+                    addCommsReply("Back", commsStationMainMenu)
                 end
             )
             return true
@@ -149,11 +149,11 @@ function mainMenu()
                 end
                 if player:getWeaponStorage("Homing") >= player:getWeaponStorageMax("Homing") then
                     setCommsMessage("Sorry sir, but you are fully stocked with homing missiles.")
-                    addCommsReply("Back", mainMenu)
+                    addCommsReply("Back", commsStationMainMenu)
                 else
                     player:setWeaponStorage("Homing", player:getWeaponStorageMax("Homing"))
                     setCommsMessage("Filled up your missile supply.")
-                    addCommsReply("Back", mainMenu)
+                    addCommsReply("Back", commsStationMainMenu)
                 end
             end
         )
@@ -170,11 +170,11 @@ function mainMenu()
                 end
                 if player:getWeaponStorage("Mine") >= player:getWeaponStorageMax("Mine") then
                     setCommsMessage("Captain,\nYou have all the mines you can fit in that ship.")
-                    addCommsReply("Back", mainMenu)
+                    addCommsReply("Back", commsStationMainMenu)
                 else
                     player:setWeaponStorage("Mine", player:getWeaponStorageMax("Mine"))
                     setCommsMessage("These mines, are yours.")
-                    addCommsReply("Back", mainMenu)
+                    addCommsReply("Back", commsStationMainMenu)
                 end
             end
         )
@@ -191,11 +191,11 @@ function mainMenu()
                 end
                 if player:getWeaponStorage("Nuke") >= player:getWeaponStorageMax("Nuke") then
                     setCommsMessage("All nukes are charged and primed for distruction.")
-                    addCommsReply("Back", mainMenu)
+                    addCommsReply("Back", commsStationMainMenu)
                 else
                     player:setWeaponStorage("Nuke", player:getWeaponStorageMax("Nuke"))
                     setCommsMessage("You are fully loaded,\nand ready to explode things.")
-                    addCommsReply("Back", mainMenu)
+                    addCommsReply("Back", commsStationMainMenu)
                 end
             end
         )
@@ -212,11 +212,11 @@ function mainMenu()
                 end
                 if player:getWeaponStorage("EMP") >= player:getWeaponStorageMax("EMP") then
                     setCommsMessage("All storage for EMP missiles is filled sir.")
-                    addCommsReply("Back", mainMenu)
+                    addCommsReply("Back", commsStationMainMenu)
                 else
                     player:setWeaponStorage("EMP", player:getWeaponStorageMax("EMP"))
                     setCommsMessage("Recallibrated the electronics and\nfitted you with all the EMP missiles you can carry.")
-                    addCommsReply("Back", mainMenu)
+                    addCommsReply("Back", commsStationMainMenu)
                 end
             end
         )
@@ -239,7 +239,7 @@ function mainMenu()
                 end
                 if player:getWeaponStorage("Homing") >= player:getWeaponStorageMax("Homing") / 2 then
                     setCommsMessage("You seem to have more then enough missiles")
-                    addCommsReply("Back", mainMenu)
+                    addCommsReply("Back", commsStationMainMenu)
                 else
                     if not player:takeReputationPoints(5 * ((player:getWeaponStorageMax("Homing") / 2) - player:getWeaponStorage("Homing"))) then
                         setCommsMessage("Not enough reputation.")
@@ -247,7 +247,7 @@ function mainMenu()
                     end
                     player:setWeaponStorage("Homing", player:getWeaponStorageMax("Homing") / 2)
                     setCommsMessage("We generously resupplied you with some free homing missiles.\nPut them to good use.")
-                    addCommsReply("Back", mainMenu)
+                    addCommsReply("Back", commsStationMainMenu)
                 end
             end
         )
@@ -260,7 +260,7 @@ function mainMenu()
                 end
                 if player:getWeaponStorage("Mine") >= player:getWeaponStorageMax("Mine") then
                     setCommsMessage("You are fully stocked with mines.")
-                    addCommsReply("Back", mainMenu)
+                    addCommsReply("Back", commsStationMainMenu)
                 else
                     if not player:takeReputationPoints(5 * (player:getWeaponStorageMax("Mine") - player:getWeaponStorage("Mine"))) then
                         setCommsMessage("Not enough reputation.")
@@ -268,7 +268,7 @@ function mainMenu()
                     end
                     player:setWeaponStorage("Mine", player:getWeaponStorageMax("Mine"))
                     setCommsMessage("Here, have some mines.\nMines are good defensive weapons.")
-                    addCommsReply("Back", mainMenu)
+                    addCommsReply("Back", commsStationMainMenu)
                 end
             end
         )
@@ -276,17 +276,17 @@ function mainMenu()
             "Can you supply us with some nukes.",
             function()
                 setCommsMessage("We do not deal in weapons of mass destruction.")
-                addCommsReply("Back", mainMenu)
+                addCommsReply("Back", commsStationMainMenu)
             end
         )
         addCommsReply(
             "Please re-stock our EMP Missiles.",
             function()
                 setCommsMessage("We do not deal in weapons of mass disruption.")
-                addCommsReply("Back", mainMenu)
+                addCommsReply("Back", commsStationMainMenu)
             end
         )
     end
 end
 
-mainMenu()
+commsStationMainMenu()

--- a/scripts/comms_station_scenario_03_central_command.lua
+++ b/scripts/comms_station_scenario_03_central_command.lua
@@ -1,5 +1,7 @@
 --- Comms with stations for scenario 03.
 --
+-- TODO `player` can be replaced by `comms_source`
+--
 -- @script comms_station_scenario_03_central_command
 
 function mainMenu()

--- a/scripts/comms_supply_drop.lua
+++ b/scripts/comms_supply_drop.lua
@@ -3,6 +3,8 @@
 -- Stripped comms that do not allow any interaction.
 -- Used for transport ships spawned in `util_random_transports.lua`.
 --
+-- TODO `player` can be replaced by `comms_source`
+--
 -- @script comms_supply_drop
 
 --- Main menu.

--- a/scripts/comms_supply_drop.lua
+++ b/scripts/comms_supply_drop.lua
@@ -8,7 +8,7 @@
 -- @script comms_supply_drop
 
 --- Main menu.
-function mainMenu()
+function commsShipMainMenu()
     if player:isFriendly(comms_target) then
         setCommsMessage("Transporting goods.")
         return true
@@ -18,4 +18,5 @@ function mainMenu()
     end
     setCommsMessage("We have nothing for you.\nGood day.")
 end
-mainMenu()
+
+commsShipMainMenu()


### PR DESCRIPTION
Further improve the comms files, mainly `comms_ship.lua` and `comms_station.lua`.

`comms_station_scenario_03_central_command.lua` is included to prevent the file from diverging even more. It might later be possible to share some code with `comms_station.lua`.

The functionality of comms is unchanged apart from the following:
The order of the missiles for Relay is now the one for Weapons. This could easily be changed back (or to any other order).

The goal is to be able to reuse comms code in scenario-specific dialogues. This in not part of this pull request. Even without this goal, this should be a valuable contribution.