### PR TITLE
Scenario Scurvy Scavenger fix

### DIFF
--- a/scripts/scenario_47_scavenger.lua
+++ b/scripts/scenario_47_scavenger.lua
@@ -92,6 +92,7 @@ function init()
 	efficient_battery_diagnostic = false
 	prefix_length = 0
 	suffix_index = 0
+	accumulated_delta = 0
 	contract_eligible = false			--should start out as false
 	transition_contract_message = false	--should start out as false
 	contract_station = {}


### PR DESCRIPTION
Variable not initialized in init() function causes error when scenario starts in a headless server. I had not been testing with a headless server, so I missed this bug.