### PR TITLE
 Improve GitHub Actions to Build Artifacts

### DIFF
--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -6,15 +6,81 @@ on:
       - master
   pull_request:
 jobs:
-  build:
-    name: Build and test
+  ubuntu:
+    name: Build Linux Deb on Ubuntu
     runs-on: ubuntu-latest
     steps:
-    - name: Update apt index
+    - name: Update Container
       run: sudo apt-get update -qq
     - name: Instal SFML
       run: sudo apt-get install libsfml-dev
     - name: Checkout EmptyEpsilon
       uses: actions/checkout@v2
-    - name: Build and test
-      run: docker/build.sh
+    - name: Build
+      run: docker/build.sh linux
+    - name: Upload EmptyEpsilon.deb artifact
+      uses: actions/upload-artifact@v2
+      with:
+        name: Linux Debian
+        path: /home/runner/work/EmptyEpsilon/EmptyEpsilon/build/EmptyEpsilon.deb
+        if-no-files-found: error
+    - name: Upload script_reference.html artifact
+      uses: actions/upload-artifact@v2
+      with:
+        name: Script Reference
+        path: /home/runner/work/EmptyEpsilon/EmptyEpsilon/build/script_reference.html
+        if-no-files-found: error
+  win32:
+    name: Build Win32 Exe on Ubuntu
+    runs-on: ubuntu-latest
+    steps:
+    - name: Update Container
+      run: sudo apt-get update -qq
+    - name: Install Build Tools Including SFML
+      run: sudo apt-get install build-essential cmake python3-minimal mingw-w64 ninja-build p7zip-full libsfml-dev
+    - name: Checkout EmptyEpsilon
+      uses: actions/checkout@v2
+    - name: Build
+      run: docker/build.sh win32
+    - name: Upload Win32 Artifact
+      uses: actions/upload-artifact@v2
+      with:
+        name: Windows 32-bit
+        path: /home/runner/work/EmptyEpsilon/EmptyEpsilon/_build_win32/upload/
+        if-no-files-found: error
+  macos:
+    name: Build MacOS App on MacOS
+    runs-on: macos-latest
+    steps:
+    - name: Update Container
+      run: sudo softwareupdate -ia
+    - name: Install SFML
+      run: brew install cmake sfml
+    - name: Checkout EmptyEpsilon
+      uses: actions/checkout@v2
+    - name: Build
+      run: docker/build.sh macos
+    - name: Upload MacOS Artifact
+      uses: actions/upload-artifact@v2
+      with:
+        name: MacOS
+        path: /Users/runner/work/EmptyEpsilon/EmptyEpsilon/_build/EmptyEpsilon.dmg
+        if-no-files-found: error
+  android:
+    name: Build Android Apk on Ubuntu
+    runs-on: ubuntu-latest
+    steps:
+    - name: Update Container
+      run: sudo apt-get update -qq
+    - name: Install Build Tools Including SFML
+      run: sudo apt-get install build-essential cmake python3-minimal mingw-w64 ninja-build p7zip-full libsfml-dev
+    - name: Checkout EmptyEpsilon
+      uses: actions/checkout@v2
+    - name: Build
+      run: docker/build.sh android
+    - name: Upload Android Artifact
+      uses: actions/upload-artifact@v2
+      with:
+        name: Android
+        path: /home/runner/work/EmptyEpsilon/EmptyEpsilon/_build_android/EmptyEpsilon.apk
+        if-no-files-found: error

--- a/docker/build.sh
+++ b/docker/build.sh
@@ -4,9 +4,9 @@
 set -e
 
 SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
-PROJECT_DIR="$( cd "${SCRIPT_DIR}/.." && pwd )"
-
+PROJECT_DIR=$HOME/work/EmptyEpsilon
 # For debugging.
+echo "PROJECT_DIR set to {$PROJECT_DIR}"
 echo "GITHUB_REF: ${GITHUB_REF}"
 echo "GITHUB_HEAD_REF: ${GITHUB_HEAD_REF}"
 echo "GITHUB_BASE_REF: ${GITHUB_BASE_REF}"
@@ -37,8 +37,59 @@ echo "Using SeriousProton branch ${SERIOUS_PROTON_BRANCH} ..."
 
 git clone --depth=1 -b "${SERIOUS_PROTON_BRANCH}" https://github.com/Daid/SeriousProton.git "${PROJECT_DIR}"/SeriousProton
 
+if [[ $1 == 'win32' ]]; then
+sudo ln -s /usr/i686-w64-mingw32/include/windows.h /usr/i686-w64-mingw32/include/Windows.h
+# This is a workaround for a Discord SDK bug
+
+mkdir -p _build_win32
+cd _build_win32
+cmake .. -G Ninja -DCMAKE_MAKE_PROGRAM=ninja -DCMAKE_TOOLCHAIN_FILE=../cmake/mingw.toolchain -DSERIOUS_PROTON_DIR=$PROJECT_DIR/SeriousProton/
+ninja package
+
+# Make EmptyEpsilon show up in a folder inside the ZIP
+mkdir upload
+cd upload
+mv ../EmptyEpsilon.zip .
+unzip -q EmptyEpsilon.zip
+rm EmptyEpsilon.zip
+
+elif [[ $1 == 'linux' ]]; then
 mkdir build
 cd build
 cmake .. -DSERIOUS_PROTON_DIR=$PROJECT_DIR/SeriousProton/
 make
+cmake --build . --target package 
+# "make package" could also be used instead of the "cmake --build" command.
 
+elif [[ $1 == 'macos' ]]; then
+cd $PROJECT_DIR/EmptyEpsilon
+mkdir _build
+cd _build
+cmake .. -DSERIOUS_PROTON_DIR=$PROJECT_DIR/SeriousProton/
+make && make install
+
+cd $PROJECT_DIR
+git clone https://github.com/auriamg/macdylibbundler.git
+cd macdylibbundler
+make && make install
+dylibbundler --overwrite-dir --bundle-deps --search-path "/usr/local/lib" --fix-file "$PROJECT_DIR/EmptyEpsilon/_build/EmptyEpsilon.app/Contents/MacOS/EmptyEpsilon" --dest-dir "$PROJECT_DIR/EmptyEpsilon/_build/EmptyEpsilon.app/Contents/libs"
+
+cd $PROJECT_DIR/EmptyEpsilon/_build
+mkdir ../_staging
+cp -r EmptyEpsilon.app script_reference.html ../_staging
+mkdir ../tmp
+hdiutil create "../tmp/tmp.dmg" -ov -volname "EmptyEpsilon" -fs HFS+ -srcfolder "../_staging"
+hdiutil convert "../tmp/tmp.dmg" -format UDZO -o "EmptyEpsilon.dmg"
+
+elif [[ $1 == 'android' ]]; then
+
+keytool -noprompt -genkey -alias Android -keyalg RSA -keysize 2048 -validity 10000 -storepass password -keypass password -dname "CN=daid.github.io, OU=EmptyEpsilon, O=EmptyEpsilon, L=None, ST=None, C=None"
+mkdir _build_android
+cd _build_android
+cmake .. -DCMAKE_TOOLCHAIN_FILE=$PROJECT_DIR/EmptyEpsilon/cmake/android.toolchain -DSERIOUS_PROTON_DIR=$PROJECT_DIR/SeriousProton -DCMAKE_MAKE_PROGRAM=$(which make)
+make -j 5
+
+else
+echo "Error! No valid args passed!"
+exit 1 
+fi


### PR DESCRIPTION
Change: This change uses GitHub Actions to build "testing" target releases on every commit/with every pull request.

It uses ubuntu-latest (18.04, soon to be 20.04 within the next day or two) to build Windows, Android, and Linux targets. It also builds a testing MacOS release, even though it is to be expected that MacOS will not be ever officially supported.

My proposal is this: Include this in your repository to encourage testing, and make it clear that these builds are NOT supported in any fashion unlike the official release builds. The MacOS build is helpful so those who have a Mac can use EmptyEpsilon even if it is not officially supported. You could potentially consider putting it on the main site as [UNTESTED, UNSUPPORTED] like Android is [BETA], just to provide easy access to the Mac builds, though the downside is people might still think it's "officially supported".

You need to be logged into GitHub to download the artifacts produced by these actions, so this will help prevent random people from downloading them thinking they are an official release. I hope that you will consider this Pull Request! Especially since GitHub Actions (including MacOS time) and Artifact Storage both are free to Public Repositories. Thanks!