### PR TITLE
Damage info on callback

### DIFF
--- a/src/shipTemplate.h
+++ b/src/shipTemplate.h
@@ -29,7 +29,7 @@ enum ESystem
 
 /* Define script conversion function for the ESystem enum. */
 template<> void convert<ESystem>::param(lua_State* L, int& idx, ESystem& es);
-
+template<> int convert<ESystem>::returnType(lua_State* L, ESystem es);
 class ShipRoomTemplate
 {
 public:

--- a/src/shipTemplate.hpp
+++ b/src/shipTemplate.hpp
@@ -34,9 +34,6 @@ template<> int convert<ESystem>::returnType(lua_State* L, ESystem es)
     case SYS_Reactor:
         lua_pushstring(L, "reactor");
         return 1;
-    case SYS_Cloaking: 
-        lua_pushstring(L, "cloaking");
-        return 1;
     case SYS_BeamWeapons:  
         lua_pushstring(L, "beamweapons");
         return 1;
@@ -60,15 +57,6 @@ template<> int convert<ESystem>::returnType(lua_State* L, ESystem es)
         return 1;
     case SYS_RearShield: 
         lua_pushstring(L, "rearshield");
-        return 1;
-    case SYS_Docks: 
-        lua_pushstring(L, "docks");
-        return 1;
-    case SYS_Drones: 
-        lua_pushstring(L, "drones");
-        return 1;
-    case SYS_Door:  
-        lua_pushstring(L, "door");
         return 1;
     case SYS_None:  
         lua_pushstring(L, "none");

--- a/src/shipTemplate.hpp
+++ b/src/shipTemplate.hpp
@@ -27,6 +27,57 @@ template<> void convert<ESystem>::param(lua_State* L, int& idx, ESystem& es)
         es = SYS_None;
 }
 
+template<> int convert<ESystem>::returnType(lua_State* L, ESystem es)
+{
+    switch(es)
+    {
+    case SYS_Reactor:
+        lua_pushstring(L, "reactor");
+        return 1;
+    case SYS_Cloaking: 
+        lua_pushstring(L, "cloaking");
+        return 1;
+    case SYS_BeamWeapons:  
+        lua_pushstring(L, "beamweapons");
+        return 1;
+    case SYS_MissileSystem: 
+        lua_pushstring(L, "missilesystem");
+        return 1;
+    case SYS_Maneuver: 
+        lua_pushstring(L, "maneuver");
+        return 1;
+    case SYS_Impulse: 
+        lua_pushstring(L, "impulse");
+        return 1;
+    case SYS_Warp: 
+        lua_pushstring(L, "warp");
+        return 1;
+    case SYS_JumpDrive: 
+        lua_pushstring(L, "jumpdrive");
+        return 1;
+    case SYS_FrontShield: 
+        lua_pushstring(L, "frontshield");
+        return 1;
+    case SYS_RearShield: 
+        lua_pushstring(L, "rearshield");
+        return 1;
+    case SYS_Docks: 
+        lua_pushstring(L, "docks");
+        return 1;
+    case SYS_Drones: 
+        lua_pushstring(L, "drones");
+        return 1;
+    case SYS_Door:  
+        lua_pushstring(L, "door");
+        return 1;
+    case SYS_None:  
+        lua_pushstring(L, "none");
+        return 1;
+    default:
+        return 0;
+    }
+}
+
 /* Define script conversion function for the ShipTemplate::TemplateType enum. */
 template<> void convert<ShipTemplate::TemplateType>::param(lua_State* L, int& idx, ShipTemplate::TemplateType& tt)
 {

--- a/src/spaceObjects/shipTemplateBasedObject.cpp
+++ b/src/spaceObjects/shipTemplateBasedObject.cpp
@@ -260,6 +260,7 @@ bool ShipTemplateBasedObject::hasShield()
 
 void ShipTemplateBasedObject::takeDamage(float damage_amount, DamageInfo info)
 {
+    signed int hit_shield_index = -1;
     if (shield_count > 0 && getShieldsActive())
     {
         float angle = sf::angleDifference(getRotation(), sf::vector2ToAngle(info.location - getPosition()));
@@ -272,6 +273,8 @@ void ShipTemplateBasedObject::takeDamage(float damage_amount, DamageInfo info)
         float shield_damage = damage_amount * getShieldDamageFactor(info, shield_index);
         damage_amount -= shield_level[shield_index];
         shield_level[shield_index] -= shield_damage;
+        hit_shield_index = shield_index;
+
         if (shield_level[shield_index] < 0)
         {
             shield_level[shield_index] = 0.0;
@@ -295,7 +298,7 @@ void ShipTemplateBasedObject::takeDamage(float damage_amount, DamageInfo info)
         {
             if (info.instigator)
             {
-                on_taking_damage.call(P<ShipTemplateBasedObject>(this), P<SpaceObject>(info.instigator));
+                on_taking_damage.call(P<ShipTemplateBasedObject>(this), P<SpaceObject>(info.instigator), info.type, info.frequency, info.system_target, hit_shield_index);
             } else {
                 on_taking_damage.call(P<ShipTemplateBasedObject>(this));
             }

--- a/src/spaceObjects/shipTemplateBasedObject.cpp
+++ b/src/spaceObjects/shipTemplateBasedObject.cpp
@@ -83,6 +83,10 @@ REGISTER_SCRIPT_SUBCLASS_NO_CREATE(ShipTemplateBasedObject, SpaceObject)
     REGISTER_SCRIPT_CLASS_FUNCTION(ShipTemplateBasedObject, setRearShieldMax);
     /// Set a function that will be called if the object is taking damage.
     /// First argument given to the function will be the object taking damage, the second the instigator SpaceObject (or nil).
+    /// If instigator is not nil, you will get in this order :
+    /// a string which is the damage type as defined in EDamageType, 
+    /// an integer which is the frequency used, a string which is the subsystem hit, 
+    /// and an integer which is the shield index if shield is hit, -1 if no shield is hit
     REGISTER_SCRIPT_CLASS_FUNCTION(ShipTemplateBasedObject, onTakingDamage);
     /// Set a function that will be called if the object is destroyed by taking damage.
     /// First argument given to the function will be the object taking damage, the second the instigator SpaceObject that gave the final blow (or nil).

--- a/src/spaceObjects/shipTemplateBasedObject.cpp
+++ b/src/spaceObjects/shipTemplateBasedObject.cpp
@@ -302,7 +302,7 @@ void ShipTemplateBasedObject::takeDamage(float damage_amount, DamageInfo info)
         {
             if (info.instigator)
             {
-                on_taking_damage.call(P<ShipTemplateBasedObject>(this), P<SpaceObject>(info.instigator), info.type, info.frequency, info.system_target, hit_shield_index);
+                on_taking_damage.call(P<ShipTemplateBasedObject>(this), P<SpaceObject>(info.instigator), info.type, frequencyToDisplayNumber(info.frequency), info.system_target, hit_shield_index);
             } else {
                 on_taking_damage.call(P<ShipTemplateBasedObject>(this));
             }
@@ -416,4 +416,9 @@ string ShipTemplateBasedObject::getShieldDataString()
         data += string(int(shield_level[n]));
     }
     return data;
+}
+
+int frequencyToDisplayNumber(int frequency)
+{
+    return 400 + (frequency * 20);
 }

--- a/src/spaceObjects/shipTemplateBasedObject.h
+++ b/src/spaceObjects/shipTemplateBasedObject.h
@@ -107,6 +107,9 @@ public:
     void onDestruction(ScriptSimpleCallback callback);
 
     string getShieldDataString();
+
 };
+
+int frequencyToDisplayNumber(int frequency);
 
 #endif//SHIP_TEMPLATE_BASED_OBJECT_H

--- a/src/spaceObjects/spaceObject.cpp
+++ b/src/spaceObjects/spaceObject.cpp
@@ -1,6 +1,7 @@
 #include "spaceObject.h"
 #include "factionInfo.h"
 #include "gameGlobalInfo.h"
+#include "shipTemplate.h"
 
 #include "scriptInterface.h"
 /// SpaceObject is the base for every object which can be seen in space.
@@ -628,4 +629,22 @@ template<> void convert<EScannedState>::param(lua_State* L, int& idx, EScannedSt
         ss = SS_SimpleScan;
     else if (str == "full" || str == "fullscan")
         ss = SS_FullScan;
+}
+
+template<> int convert<EDamageType>::returnType(lua_State* L, EDamageType es)
+{
+    switch(es)
+    {
+    case DT_Kinetic:
+        lua_pushstring(L, "kinetic");
+        return 1;
+    case DT_EMP:
+        lua_pushstring(L, "emp");
+        return 1;
+    case DT_Energy:
+        lua_pushstring(L, "energy");
+        return 1;
+    default:
+        return 0;
+    }
 }

--- a/src/spaceObjects/spaceObject.h
+++ b/src/spaceObjects/spaceObject.h
@@ -14,6 +14,8 @@ enum EDamageType
     DT_EMP
 };
 
+template<> int convert<EDamageType>::returnType(lua_State* L, EDamageType es);
+
 class DamageInfo
 {
 public:

--- a/src/spaceObjects/spaceship.cpp
+++ b/src/spaceObjects/spaceship.cpp
@@ -1525,7 +1525,7 @@ float frequencyVsFrequencyDamageFactor(int beam_frequency, int shield_frequency)
 
 string frequencyToString(int frequency)
 {
-    return string(400 + (frequency * 20)) + "THz";
+    return string(frequencyToDisplayNumber(frequency)) + "THz";
 }
 
 #ifndef _MSC_VER


### PR DESCRIPTION
Additional parameters for using onTakingDamage in LUA scripts.
(on_taking_damage on shipTemplateBasedObject)

This allows scripters to take actions based on damage type, frequency, sub system and hit shield.
These informations are only available if an instigator exists on the DamageInfo.