### PR TITLE
Comms: refactoring (comms_source, use parameters)

### DIFF
--- a/scripts/comms_ship.lua
+++ b/scripts/comms_ship.lua
@@ -41,7 +41,7 @@ function commsShipFriendly(comms_source, comms_target)
     end
     addCommsReply(
         "Defend a waypoint",
-        function()
+        function(comms_source, comms_target)
             if comms_source:getWaypointCount() == 0 then
                 setCommsMessage("No waypoints set. Please set a waypoint first.")
                 addCommsReply("Back", commsShipMainMenu)
@@ -50,7 +50,7 @@ function commsShipFriendly(comms_source, comms_target)
                 for n = 1, comms_source:getWaypointCount() do
                     addCommsReply(
                         "Defend WP" .. n,
-                        function()
+                        function(comms_source, comms_target)
                             comms_target:orderDefendLocation(comms_source:getWaypoint(n))
                             setCommsMessage("We are heading to assist at WP" .. n .. ".")
                             addCommsReply("Back", commsShipMainMenu)
@@ -63,7 +63,7 @@ function commsShipFriendly(comms_source, comms_target)
     if comms_data.friendlyness > 0.2 then
         addCommsReply(
             "Assist me",
-            function()
+            function(comms_source, comms_target)
                 setCommsMessage("Heading toward you to assist.")
                 comms_target:orderDefendTarget(comms_source)
                 addCommsReply("Back", commsShipMainMenu)
@@ -72,7 +72,7 @@ function commsShipFriendly(comms_source, comms_target)
     end
     addCommsReply(
         "Report status",
-        function()
+        function(comms_source, comms_target)
             local msg = "Hull: " .. math.floor(comms_target:getHull() / comms_target:getHullMax() * 100) .. "%\n"
             local shields = comms_target:getShieldCount()
             if shields == 1 then
@@ -100,7 +100,7 @@ function commsShipFriendly(comms_source, comms_target)
         if obj.typeName == "SpaceStation" and not comms_target:isEnemy(obj) then
             addCommsReply(
                 "Dock at " .. obj:getCallSign(),
-                function()
+                function(comms_source, comms_target)
                     setCommsMessage("Docking at " .. obj:getCallSign() .. ".")
                     comms_target:orderDock(obj)
                     addCommsReply("Back", commsShipMainMenu)
@@ -144,7 +144,7 @@ function commsShipEnemy(comms_source, comms_target)
         comms_data.friendlyness = comms_data.friendlyness - random(0, 10)
         addCommsReply(
             taunt_option,
-            function()
+            function(comms_source, comms_target)
                 if random(0, 100) < 30 then
                     comms_target:orderAttack(comms_source)
                     setCommsMessage(taunt_success_reply)

--- a/scripts/comms_ship.lua
+++ b/scripts/comms_ship.lua
@@ -3,8 +3,6 @@
 -- Simple ship comms that allows setting orders if friendly.
 -- Default script for any `CpuShip`.
 --
--- TODO `player` can be replaced by `comms_source`
---
 -- @script comms_ship
 
 -- NOTE this could be imported
@@ -18,10 +16,10 @@ function commsShipMainMenu()
         comms_target.comms_data = {friendlyness = random(0.0, 100.0)}
     end
 
-    if player:isFriendly(comms_target) then
+    if comms_source:isFriendly(comms_target) then
         return commsShipFriendly()
     end
-    if player:isEnemy(comms_target) and comms_target:isFriendOrFoeIdentifiedBy(player) then
+    if comms_source:isEnemy(comms_target) and comms_target:isFriendOrFoeIdentifiedBy(comms_source) then
         return commsShipEnemy()
     end
     return commsShipNeutral()
@@ -38,16 +36,16 @@ function commsShipFriendly()
     addCommsReply(
         "Defend a waypoint",
         function()
-            if player:getWaypointCount() == 0 then
+            if comms_source:getWaypointCount() == 0 then
                 setCommsMessage("No waypoints set. Please set a waypoint first.")
                 addCommsReply("Back", commsShipMainMenu)
             else
                 setCommsMessage("Which waypoint should we defend?")
-                for n = 1, player:getWaypointCount() do
+                for n = 1, comms_source:getWaypointCount() do
                     addCommsReply(
                         "Defend WP" .. n,
                         function()
-                            comms_target:orderDefendLocation(player:getWaypoint(n))
+                            comms_target:orderDefendLocation(comms_source:getWaypoint(n))
                             setCommsMessage("We are heading to assist at WP" .. n .. ".")
                             addCommsReply("Back", commsShipMainMenu)
                         end
@@ -61,7 +59,7 @@ function commsShipFriendly()
             "Assist me",
             function()
                 setCommsMessage("Heading toward you to assist.")
-                comms_target:orderDefendTarget(player)
+                comms_target:orderDefendTarget(comms_source)
                 addCommsReply("Back", commsShipMainMenu)
             end
         )
@@ -139,7 +137,7 @@ function commsShipEnemy()
             taunt_option,
             function()
                 if random(0, 100) < 30 then
-                    comms_target:orderAttack(player)
+                    comms_target:orderAttack(comms_source)
                     setCommsMessage(taunt_success_reply)
                 else
                     setCommsMessage(taunt_failed_reply)

--- a/scripts/comms_ship.lua
+++ b/scripts/comms_ship.lua
@@ -11,22 +11,28 @@ local MISSILE_TYPES = {"Homing", "Nuke", "Mine", "EMP", "HVLI"}
 --- Main menu of communication.
 --
 -- Uses one of `commsShipFriendly`, `commsShipNeutral`, `commsShipEnemy`.
-function commsShipMainMenu()
+--
+-- @tparam PlayerSpaceship comms_source
+-- @tparam SpaceStation comms_target
+function commsShipMainMenu(comms_source, comms_target)
     if comms_target.comms_data == nil then
         comms_target.comms_data = {friendlyness = random(0.0, 100.0)}
     end
 
     if comms_source:isFriendly(comms_target) then
-        return commsShipFriendly()
+        return commsShipFriendly(comms_source, comms_target)
     end
     if comms_source:isEnemy(comms_target) and comms_target:isFriendOrFoeIdentifiedBy(comms_source) then
-        return commsShipEnemy()
+        return commsShipEnemy(comms_source, comms_target)
     end
-    return commsShipNeutral()
+    return commsShipNeutral(comms_source, comms_target)
 end
 
 --- Handle friendly communication.
-function commsShipFriendly()
+--
+-- @tparam PlayerSpaceship comms_source
+-- @tparam SpaceStation comms_target
+function commsShipFriendly(comms_source, comms_target)
     local comms_data = comms_target.comms_data
     if comms_data.friendlyness < 20 then
         setCommsMessage("What do you want?")
@@ -106,7 +112,10 @@ function commsShipFriendly()
 end
 
 --- Handle enemy communication.
-function commsShipEnemy()
+--
+-- @tparam PlayerSpaceship comms_source
+-- @tparam SpaceStation comms_target
+function commsShipEnemy(comms_source, comms_target)
     local comms_data = comms_target.comms_data
     if comms_data.friendlyness > 50 then
         local faction = comms_target:getFaction()
@@ -150,7 +159,10 @@ function commsShipEnemy()
 end
 
 --- Handle neutral communication.
-function commsShipNeutral()
+--
+-- @tparam PlayerSpaceship comms_source
+-- @tparam SpaceStation comms_target
+function commsShipNeutral(comms_source, comms_target)
     if comms_target.comms_data.friendlyness > 50 then
         setCommsMessage("Sorry, we have no time to chat with you.\nWe are on an important mission.")
     else
@@ -159,4 +171,5 @@ function commsShipNeutral()
     return true
 end
 
-commsShipMainMenu()
+-- `comms_source` and `comms_target` are global in comms script.
+commsShipMainMenu(comms_source, comms_target)

--- a/scripts/comms_station.lua
+++ b/scripts/comms_station.lua
@@ -100,7 +100,7 @@ function commsStationDocked(comms_source, comms_target)
         if comms_source:getWeaponStorageMax(missile_type) > 0 then
             addCommsReply(
                 string.format("%s (%d rep each)", reply_messages[missile_type], getWeaponCost(comms_source, comms_target, missile_type)),
-                function()
+                function(comms_source, comms_target)
                     handleWeaponRestock(comms_source, comms_target, missile_type)
                 end
             )
@@ -169,7 +169,7 @@ function commsStationUndocked(comms_source, comms_target)
     if isAllowedTo(comms_source, comms_target, comms_target.comms_data.services.supplydrop) then
         addCommsReply(
             "Can you send a supply drop? (" .. getServiceCost(comms_source, comms_target, "supplydrop") .. "rep)",
-            function()
+            function(comms_source, comms_target)
                 if comms_source:getWaypointCount() < 1 then
                     setCommsMessage("You need to set a waypoint before you can request backup.")
                 else
@@ -177,7 +177,7 @@ function commsStationUndocked(comms_source, comms_target)
                     for n = 1, comms_source:getWaypointCount() do
                         addCommsReply(
                             "WP" .. n,
-                            function()
+                            function(comms_source, comms_target)
                                 if comms_source:takeReputationPoints(getServiceCost(comms_source, comms_target, "supplydrop")) then
                                     local position_x, position_y = comms_target:getPosition()
                                     local target_x, target_y = comms_source:getWaypoint(n)
@@ -203,7 +203,7 @@ function commsStationUndocked(comms_source, comms_target)
     if isAllowedTo(comms_source, comms_target, comms_target.comms_data.services.reinforcements) then
         addCommsReply(
             "Please send reinforcements! (" .. getServiceCost(comms_source, comms_target, "reinforcements") .. "rep)",
-            function()
+            function(comms_source, comms_target)
                 if comms_source:getWaypointCount() < 1 then
                     setCommsMessage("You need to set a waypoint before you can request reinforcements.")
                 else
@@ -211,7 +211,7 @@ function commsStationUndocked(comms_source, comms_target)
                     for n = 1, comms_source:getWaypointCount() do
                         addCommsReply(
                             "WP" .. n,
-                            function()
+                            function(comms_source, comms_target)
                                 if comms_source:takeReputationPoints(getServiceCost(comms_source, comms_target, "reinforcements")) then
                                     local ship = CpuShip():setFactionId(comms_target:getFactionId()):setPosition(comms_target:getPosition()):setTemplate("Adder MK5"):setScanned(true):orderDefendLocation(comms_source:getWaypoint(n))
                                     setCommsMessage("We have dispatched " .. ship:getCallSign() .. " to assist at WP" .. n)

--- a/scripts/comms_station_scenario_03_central_command.lua
+++ b/scripts/comms_station_scenario_03_central_command.lua
@@ -1,7 +1,5 @@
 --- Comms with stations for scenario 03.
 --
--- TODO `player` can be replaced by `comms_source`
---
 -- @script comms_station_scenario_03_central_command
 
 function commsStationMainMenu()
@@ -10,14 +8,14 @@ function commsStationMainMenu()
     end
     comms_data = comms_target.comms_data
 
-    if player:isEnemy(comms_target) then
+    if comms_source:isEnemy(comms_target) then
         return false
     end
 
-    if player:isFriendly(comms_target) then
+    if comms_source:isFriendly(comms_target) then
         -----------------------------------------------
         -- Edge of space additions
-        if comms_target:getCallSign() == "Central Command" and not player:isDocked(comms_target) then
+        if comms_target:getCallSign() == "Central Command" and not comms_source:isDocked(comms_target) then
             if comms_target.mission_state == 1 then
                 setCommsMessage("The E.O.S Scope is in sector H8, right on the edge of Kraylor territory.\n \nBe careful out there")
                 return true
@@ -74,22 +72,22 @@ function commsStationMainMenu()
             setCommsMessage("We are under attack! No time for chatting!")
             return true
         end
-        if not player:isDocked(comms_target) then
+        if not comms_source:isDocked(comms_target) then
             setCommsMessage("Good day officer,\nIf you need supplies please dock with us first.")
             addCommsReply(
                 "Can you send a supply drop? (100rep)",
                 function()
-                    if player:getWaypointCount() < 1 then
+                    if comms_source:getWaypointCount() < 1 then
                         setCommsMessage("You need to set a waypoint before you can request backup.")
                     else
                         setCommsMessage("Where do we need to drop off your supplies?")
-                        for n = 1, player:getWaypointCount() do
+                        for n = 1, comms_source:getWaypointCount() do
                             addCommsReply(
                                 "WP" .. n,
                                 function()
-                                    if player:takeReputationPoints(100) then
+                                    if comms_source:takeReputationPoints(100) then
                                         local position_x, position_y = comms_target:getPosition()
-                                        local target_x, target_y = player:getWaypoint(n)
+                                        local target_x, target_y = comms_source:getWaypoint(n)
                                         local script = Script()
                                         script:setVariable("position_x", position_x):setVariable("position_y", position_y)
                                         script:setVariable("target_x", target_x):setVariable("target_y", target_y)
@@ -109,16 +107,16 @@ function commsStationMainMenu()
             addCommsReply(
                 "Please send backup! (150rep)",
                 function()
-                    if player:getWaypointCount() < 1 then
+                    if comms_source:getWaypointCount() < 1 then
                         setCommsMessage("You need to set a waypoint before you can request backup.")
                     else
                         setCommsMessage("Where does the backup needs to go?")
-                        for n = 1, player:getWaypointCount() do
+                        for n = 1, comms_source:getWaypointCount() do
                             addCommsReply(
                                 "WP" .. n,
                                 function()
-                                    if player:takeReputationPoints(150) then
-                                        ship = CpuShip():setFactionId(comms_target:getFactionId()):setPosition(comms_target:getPosition()):setTemplate("Adder MK5"):setScanned(true):orderDefendLocation(player:getWaypoint(n))
+                                    if comms_source:takeReputationPoints(150) then
+                                        ship = CpuShip():setFactionId(comms_target:getFactionId()):setPosition(comms_target:getPosition()):setTemplate("Adder MK5"):setScanned(true):orderDefendLocation(comms_source:getWaypoint(n))
                                         setCommsMessage("We have dispatched " .. ship:getCallSign() .. " to assist at WP" .. n)
                                     else
                                         setCommsMessage("Not enough rep!")
@@ -139,19 +137,19 @@ function commsStationMainMenu()
         addCommsReply(
             "Do you have spare homing missiles for us? (2rep each)",
             function()
-                if not player:isDocked(comms_target) then
+                if not comms_source:isDocked(comms_target) then
                     setCommsMessage("You need to stay docked for that action.")
                     return
                 end
-                if not player:takeReputationPoints(2 * (player:getWeaponStorageMax("Homing") - player:getWeaponStorage("Homing"))) then
+                if not comms_source:takeReputationPoints(2 * (comms_source:getWeaponStorageMax("Homing") - comms_source:getWeaponStorage("Homing"))) then
                     setCommsMessage("Not enough reputation.")
                     return
                 end
-                if player:getWeaponStorage("Homing") >= player:getWeaponStorageMax("Homing") then
+                if comms_source:getWeaponStorage("Homing") >= comms_source:getWeaponStorageMax("Homing") then
                     setCommsMessage("Sorry sir, but you are fully stocked with homing missiles.")
                     addCommsReply("Back", commsStationMainMenu)
                 else
-                    player:setWeaponStorage("Homing", player:getWeaponStorageMax("Homing"))
+                    comms_source:setWeaponStorage("Homing", comms_source:getWeaponStorageMax("Homing"))
                     setCommsMessage("Filled up your missile supply.")
                     addCommsReply("Back", commsStationMainMenu)
                 end
@@ -160,19 +158,19 @@ function commsStationMainMenu()
         addCommsReply(
             "Please re-stock our mines. (2rep each)",
             function()
-                if not player:isDocked(comms_target) then
+                if not comms_source:isDocked(comms_target) then
                     setCommsMessage("You need to stay docked for that action.")
                     return
                 end
-                if not player:takeReputationPoints(2 * (player:getWeaponStorageMax("Mine") - player:getWeaponStorage("Mine"))) then
+                if not comms_source:takeReputationPoints(2 * (comms_source:getWeaponStorageMax("Mine") - comms_source:getWeaponStorage("Mine"))) then
                     setCommsMessage("Not enough reputation.")
                     return
                 end
-                if player:getWeaponStorage("Mine") >= player:getWeaponStorageMax("Mine") then
+                if comms_source:getWeaponStorage("Mine") >= comms_source:getWeaponStorageMax("Mine") then
                     setCommsMessage("Captain,\nYou have all the mines you can fit in that ship.")
                     addCommsReply("Back", commsStationMainMenu)
                 else
-                    player:setWeaponStorage("Mine", player:getWeaponStorageMax("Mine"))
+                    comms_source:setWeaponStorage("Mine", comms_source:getWeaponStorageMax("Mine"))
                     setCommsMessage("These mines, are yours.")
                     addCommsReply("Back", commsStationMainMenu)
                 end
@@ -181,19 +179,19 @@ function commsStationMainMenu()
         addCommsReply(
             "Can you supply us with some nukes. (15rep each)",
             function()
-                if not player:isDocked(comms_target) then
+                if not comms_source:isDocked(comms_target) then
                     setCommsMessage("You need to stay docked for that action.")
                     return
                 end
-                if not player:takeReputationPoints(15 * (player:getWeaponStorageMax("Nuke") - player:getWeaponStorage("Nuke"))) then
+                if not comms_source:takeReputationPoints(15 * (comms_source:getWeaponStorageMax("Nuke") - comms_source:getWeaponStorage("Nuke"))) then
                     setCommsMessage("Not enough reputation.")
                     return
                 end
-                if player:getWeaponStorage("Nuke") >= player:getWeaponStorageMax("Nuke") then
+                if comms_source:getWeaponStorage("Nuke") >= comms_source:getWeaponStorageMax("Nuke") then
                     setCommsMessage("All nukes are charged and primed for distruction.")
                     addCommsReply("Back", commsStationMainMenu)
                 else
-                    player:setWeaponStorage("Nuke", player:getWeaponStorageMax("Nuke"))
+                    comms_source:setWeaponStorage("Nuke", comms_source:getWeaponStorageMax("Nuke"))
                     setCommsMessage("You are fully loaded,\nand ready to explode things.")
                     addCommsReply("Back", commsStationMainMenu)
                 end
@@ -202,19 +200,19 @@ function commsStationMainMenu()
         addCommsReply(
             "Please re-stock our EMP Missiles. (10rep each)",
             function()
-                if not player:isDocked(comms_target) then
+                if not comms_source:isDocked(comms_target) then
                     setCommsMessage("You need to stay docked for that action.")
                     return
                 end
-                if not player:takeReputationPoints(10 * (player:getWeaponStorageMax("EMP") - player:getWeaponStorage("EMP"))) then
+                if not comms_source:takeReputationPoints(10 * (comms_source:getWeaponStorageMax("EMP") - comms_source:getWeaponStorage("EMP"))) then
                     setCommsMessage("Not enough reputation.")
                     return
                 end
-                if player:getWeaponStorage("EMP") >= player:getWeaponStorageMax("EMP") then
+                if comms_source:getWeaponStorage("EMP") >= comms_source:getWeaponStorageMax("EMP") then
                     setCommsMessage("All storage for EMP missiles is filled sir.")
                     addCommsReply("Back", commsStationMainMenu)
                 else
-                    player:setWeaponStorage("EMP", player:getWeaponStorageMax("EMP"))
+                    comms_source:setWeaponStorage("EMP", comms_source:getWeaponStorageMax("EMP"))
                     setCommsMessage("Recallibrated the electronics and\nfitted you with all the EMP missiles you can carry.")
                     addCommsReply("Back", commsStationMainMenu)
                 end
@@ -223,7 +221,7 @@ function commsStationMainMenu()
     else
         -- not friendly (and not enemy)
 
-        if not player:isDocked(comms_target) then
+        if not comms_source:isDocked(comms_target) then
             setCommsMessage("Greetings sir.\nIf you want to do business please dock with us first.")
             return true
         end
@@ -233,19 +231,19 @@ function commsStationMainMenu()
         addCommsReply(
             "Do you have spare homing missiles for us? (5rep each)",
             function()
-                if not player:isDocked(comms_target) then
+                if not comms_source:isDocked(comms_target) then
                     setCommsMessage("You need to stay docked for that action.")
                     return
                 end
-                if player:getWeaponStorage("Homing") >= player:getWeaponStorageMax("Homing") / 2 then
+                if comms_source:getWeaponStorage("Homing") >= comms_source:getWeaponStorageMax("Homing") / 2 then
                     setCommsMessage("You seem to have more then enough missiles")
                     addCommsReply("Back", commsStationMainMenu)
                 else
-                    if not player:takeReputationPoints(5 * ((player:getWeaponStorageMax("Homing") / 2) - player:getWeaponStorage("Homing"))) then
+                    if not comms_source:takeReputationPoints(5 * ((comms_source:getWeaponStorageMax("Homing") / 2) - comms_source:getWeaponStorage("Homing"))) then
                         setCommsMessage("Not enough reputation.")
                         return
                     end
-                    player:setWeaponStorage("Homing", player:getWeaponStorageMax("Homing") / 2)
+                    comms_source:setWeaponStorage("Homing", comms_source:getWeaponStorageMax("Homing") / 2)
                     setCommsMessage("We generously resupplied you with some free homing missiles.\nPut them to good use.")
                     addCommsReply("Back", commsStationMainMenu)
                 end
@@ -254,19 +252,19 @@ function commsStationMainMenu()
         addCommsReply(
             "Please re-stock our mines. (5rep each)",
             function()
-                if not player:isDocked(comms_target) then
+                if not comms_source:isDocked(comms_target) then
                     setCommsMessage("You need to stay docked for that action.")
                     return
                 end
-                if player:getWeaponStorage("Mine") >= player:getWeaponStorageMax("Mine") then
+                if comms_source:getWeaponStorage("Mine") >= comms_source:getWeaponStorageMax("Mine") then
                     setCommsMessage("You are fully stocked with mines.")
                     addCommsReply("Back", commsStationMainMenu)
                 else
-                    if not player:takeReputationPoints(5 * (player:getWeaponStorageMax("Mine") - player:getWeaponStorage("Mine"))) then
+                    if not comms_source:takeReputationPoints(5 * (comms_source:getWeaponStorageMax("Mine") - comms_source:getWeaponStorage("Mine"))) then
                         setCommsMessage("Not enough reputation.")
                         return
                     end
-                    player:setWeaponStorage("Mine", player:getWeaponStorageMax("Mine"))
+                    comms_source:setWeaponStorage("Mine", comms_source:getWeaponStorageMax("Mine"))
                     setCommsMessage("Here, have some mines.\nMines are good defensive weapons.")
                     addCommsReply("Back", commsStationMainMenu)
                 end

--- a/scripts/comms_supply_drop.lua
+++ b/scripts/comms_supply_drop.lua
@@ -3,20 +3,19 @@
 -- Stripped comms that do not allow any interaction.
 -- Used for transport ships spawned in `util_random_transports.lua`.
 --
--- TODO `player` can be replaced by `comms_source`
---
 -- @script comms_supply_drop
 
 --- Main menu.
-function commsShipMainMenu()
-    if player:isFriendly(comms_target) then
+function commsShipMainMenu(comms_source, comms_target)
+    if comms_source:isFriendly(comms_target) then
         setCommsMessage("Transporting goods.")
         return true
     end
-    if player:isEnemy(comms_target) then
+    if comms_source:isEnemy(comms_target) then
         return false
     end
     setCommsMessage("We have nothing for you.\nGood day.")
 end
 
-commsShipMainMenu()
+-- `comms_source` and `comms_target` are global in comms script
+commsShipMainMenu(comms_source, comms_target)


### PR DESCRIPTION
- Replace global `player` by `comms_source`.
- Pass `comms_source, comms_target`. (Make it work without globals - apart from last line.)
- Use parameters in `addCommsReply` instead of using the values from the closure.

