### PR TITLE
Set boolean on minesweeper game end

### DIFF
--- a/src/screenComponents/mineSweeper.cpp
+++ b/src/screenComponents/mineSweeper.cpp
@@ -66,7 +66,6 @@ void MineSweeper::reset()
     }
     error_count = 0;
     correct_count = 0;
-
 }
 
 float MineSweeper::getProgress()
@@ -78,7 +77,7 @@ void MineSweeper::gameComplete()
 {
     bool success = correct_count == (field_size * field_size) - bomb_count;
     parent->onMiniGameComplete(success);
-    game_complete = success;
+    game_complete = true;
 }
 
 sf::Vector2f MineSweeper::getBoardSize()
@@ -140,7 +139,6 @@ void MineSweeper::onFieldClick(int x, int y)
         gameComplete();
     }
 }
-
 
 MineSweeper::FieldItem* MineSweeper::getFieldItem(int x, int y)
 {


### PR DESCRIPTION
Fixes #1174

Setting `game_complete` to true indicates that the mini game has finished.  Has nothing to do with win / loss.