### PR TITLE
Make destroyed gui elements invisible before they are destroyed

### DIFF
--- a/src/gui/gui2_autolayout.cpp
+++ b/src/gui/gui2_autolayout.cpp
@@ -37,12 +37,12 @@ void GuiAutoLayout::drawElements(sf::FloatRect parent_rect, sf::RenderTarget& wi
             int count = 0;
             for(GuiElement* element : elements)
             {
-                if (element->isVisible())
+                if (!element->isDestroyed() && element->isVisible())
                     count += 1;
             }
             for(GuiElement* element : elements)
             {
-                if (element->isVisible())
+                if (!element->isDestroyed() && element->isVisible())
                 {
                     element->setSize(GuiElement::GuiSizeMax, parent_rect.height / count);
                     element->setPosition(offset.x, offset.y);
@@ -57,12 +57,12 @@ void GuiAutoLayout::drawElements(sf::FloatRect parent_rect, sf::RenderTarget& wi
             int count = 0;
             for(GuiElement* element : elements)
             {
-                if (element->isVisible())
+                if (!element->isDestroyed() && element->isVisible())
                     count += 1;
             }
             for(GuiElement* element : elements)
             {
-                if (element->isVisible())
+                if (!element->isDestroyed() && element->isVisible())
                 {
                     element->setSize(parent_rect.width / count, GuiElement::GuiSizeMax);
                     element->setPosition(offset.x, offset.y);
@@ -75,7 +75,7 @@ void GuiAutoLayout::drawElements(sf::FloatRect parent_rect, sf::RenderTarget& wi
     }
     for(GuiElement* element : elements)
     {
-        if (element->isVisible())
+        if (!element->isDestroyed() && element->isVisible())
         {
             element->setPosition(offset, alignment);
             offset.x += element->getSize().x * scale.x;

--- a/src/gui/gui2_element.cpp
+++ b/src/gui/gui2_element.cpp
@@ -198,6 +198,7 @@ GuiContainer* GuiElement::getTopLevelContainer()
 
 void GuiElement::destroy()
 {
+    setVisible(false);
     destroyed = true;
 }
 

--- a/src/gui/gui2_element.cpp
+++ b/src/gui/gui2_element.cpp
@@ -198,8 +198,12 @@ GuiContainer* GuiElement::getTopLevelContainer()
 
 void GuiElement::destroy()
 {
-    setVisible(false);
     destroyed = true;
+}
+
+bool GuiElement::isDestroyed()
+{
+    return destroyed;
 }
 
 void GuiElement::updateRect(sf::FloatRect parent_rect)

--- a/src/gui/gui2_element.h
+++ b/src/gui/gui2_element.h
@@ -89,6 +89,8 @@ public:
     //Have this GuiElement destroyed, but at a safe point&time in the code. (handled by the container)
     void destroy();
 
+    bool isDestroyed();
+
     friend class GuiContainer;
     friend class GuiCanvas;
 private:


### PR DESCRIPTION
it feels kind of ugly doing it this way, but I couldn't think of a answer for when do you want a visible destroyed element

Other options for fixes that I can see are either
a) adding an isDestroyed function to elements and altering about half a dozen places in auto layout and maybe elsewhere
b) adding a GuiContainer::removeDestroyed function and calling that before anywhere that it is needed

If either of those would be preferred I can look into them, likewise if I am missing another better option