### PR TITLE
Allow resupply freighter an optional jump drive

### DIFF
--- a/scripts/supply_drop.lua
+++ b/scripts/supply_drop.lua
@@ -4,6 +4,9 @@
 
 function init()
 	my_ship = CpuShip():setCommsScript("comms_supply_drop.lua"):setFactionId(faction_id):setPosition(position_x, position_y):setTemplate("Flavia"):setScanned(true):orderFlyTowardsBlind(target_x, target_y)
+	if jump_freighter ~= nil and jump_freighter == "Yes" then
+		my_ship:setJumpDrive(true):setJumpDriveRange(5000,25000):setJumpDriveCharge(20000)
+	end
 	state = 0
 end
 

--- a/scripts/supply_drop.lua
+++ b/scripts/supply_drop.lua
@@ -4,7 +4,7 @@
 
 function init()
 	my_ship = CpuShip():setCommsScript("comms_supply_drop.lua"):setFactionId(faction_id):setPosition(position_x, position_y):setTemplate("Flavia"):setScanned(true):orderFlyTowardsBlind(target_x, target_y)
-	if jump_freighter ~= nil and jump_freighter == "Yes" then
+	if jump_freighter ~= nil and jump_freighter == "yes" then
 		my_ship:setJumpDrive(true):setJumpDriveRange(5000,25000):setJumpDriveCharge(20000)
 	end
 	state = 0


### PR DESCRIPTION
This change allows the scenario to ask for the freighter to have a jump drive

Example usage based on comms_station.lua excerpt:

```lua
local position_x, position_y = comms_target:getPosition()
local target_x, target_y = player:getWaypoint(n)
local script = Script()
script:setVariable("position_x", position_x):setVariable("position_y", position_y)
script:setVariable("target_x", target_x):setVariable("target_y", target_y)
script:setVariable("jump_freighter","Yes")  --this is the line to add
script:setVariable("faction_id", comms_target:getFactionId()):run("supply_drop.lua")
setCommsMessage("We have dispatched a supply ship toward WP" .. n);
```
