### PR TITLE
MSVC native support

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -46,8 +46,12 @@ if(CMAKE_C_COMPILER_ID STREQUAL "GNU")
     endif()
 endif()
 
-set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Wall -Werror=return-type")
-set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall -Werror=return-type")
+if(MSVC)
+	add_definitions(-DNOMINMAX)
+else()
+	set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Wall -Werror=return-type")
+	set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall -Werror=return-type")
+endif()
 
 # install resources, scripts, and packs to app bundle instead of system dir.
 if(APPLE)

--- a/src/hardware/devices/philipsHueDevice.cpp
+++ b/src/hardware/devices/philipsHueDevice.cpp
@@ -3,7 +3,6 @@
 #include "philipsHueDevice.h"
 #include "hardware/serialDriver.h"
 #include "logging.h"
-#include <unistd.h>
 #include <json11/json11.hpp>
 
 using namespace json11;

--- a/src/hardware/devices/philipsHueDevice.cpp
+++ b/src/hardware/devices/philipsHueDevice.cpp
@@ -3,6 +3,9 @@
 #include "philipsHueDevice.h"
 #include "hardware/serialDriver.h"
 #include "logging.h"
+#ifndef _MSC_VER
+#include <unistd.h>
+#endif
 #include <json11/json11.hpp>
 
 using namespace json11;

--- a/src/hardware/devices/uDMXDevice.cpp
+++ b/src/hardware/devices/uDMXDevice.cpp
@@ -1,48 +1,48 @@
 #include "uDMXDevice.h"
 #include "logging.h"
 
-#ifdef __WIN32__
+#ifdef _WIN32
     #include <windows.h>
 
     HMODULE UDMX_dll;
 
     extern "C" {
-    bool __stdcall (*UDMX_Configure)();
-    bool __stdcall (*UDMX_Connected)();
-    bool __stdcall (*UDMX_ChannelSet)(long Channel, long Value);
-    bool __stdcall (*UDMX_ChannelsSet)(long ChannelCnt, long Channel, long* Value);
+    bool (__stdcall *UDMX_Configure)();
+    bool (__stdcall *UDMX_Connected)();
+    bool (__stdcall *UDMX_ChannelSet)(long Channel, long Value);
+    bool (__stdcall *UDMX_ChannelsSet)(long ChannelCnt, long Channel, long* Value);
     }
 #endif
 
 //Configure the device.
 bool UDMXDevice::configure(std::unordered_map<string, string> settings)
 {
-#ifdef __WIN32__
+#ifdef _WIN32
     UDMX_dll = LoadLibrary("uDMX.dll");
     if (UDMX_dll == NULL)
     {
         LOG(ERROR) << "Failed to load uDMX.dll for uDMX hardware";
         return false;
     }
-    UDMX_Configure = (bool __stdcall (*)())GetProcAddress(UDMX_dll, "Configure");
+    UDMX_Configure = (bool (__stdcall *)())GetProcAddress(UDMX_dll, "Configure");
     if (UDMX_Configure == NULL)
     {
         LOG(ERROR) << "Failed to find Configure function in uDMX.dll";
         return false;
     }
-    UDMX_Connected = (bool __stdcall (*)())GetProcAddress(UDMX_dll, "Connected");
+    UDMX_Connected = (bool (__stdcall *)())GetProcAddress(UDMX_dll, "Connected");
     if (UDMX_Connected == NULL)
     {
         LOG(ERROR) << "Failed to find Connected function in uDMX.dll";
         return false;
     }
-    UDMX_ChannelSet = (bool __stdcall (*)(long Channel, long Value))GetProcAddress(UDMX_dll, "ChannelSet");
+    UDMX_ChannelSet = (bool (__stdcall *)(long Channel, long Value))GetProcAddress(UDMX_dll, "ChannelSet");
     if (UDMX_ChannelSet == NULL)
     {
         LOG(ERROR) << "Failed to find ChannelSet function in uDMX.dll";
         return false;
     }
-    UDMX_ChannelsSet = (bool __stdcall (*)(long ChannelCnt, long Channel, long* Value))GetProcAddress(UDMX_dll, "ChannelsSet");
+    UDMX_ChannelsSet = (bool (__stdcall *)(long ChannelCnt, long Channel, long* Value))GetProcAddress(UDMX_dll, "ChannelsSet");
     if (UDMX_ChannelsSet == NULL)
     {
         LOG(ERROR) << "Failed to find ChannelsSet function in uDMX.dll";
@@ -66,7 +66,7 @@ bool UDMXDevice::configure(std::unordered_map<string, string> settings)
 //Set a hardware channel output. Value is 0.0 to 1.0 for no to max output.
 void UDMXDevice::setChannelData(int channel, float value)
 {
-#ifdef __WIN32__
+#ifdef _WIN32
     UDMX_ChannelSet(channel, value * 255);
 #endif
 }

--- a/src/hardware/serialDriver.cpp
+++ b/src/hardware/serialDriver.cpp
@@ -1,5 +1,5 @@
 #include "logging.h"
-#ifdef __WIN32__
+#ifdef _WIN32
     #include <windows.h>
 #endif
 #ifdef __gnu_linux__
@@ -40,7 +40,7 @@ SerialPort::SerialPort(string name)
         LOG(INFO) << "Selected port: " << ports[0] << " for pseudo name: " << name;
         name = ports[0];
     }
-#ifdef __WIN32__
+#ifdef _WIN32
     handle = CreateFile(("\\\\.\\" + name).c_str(), GENERIC_READ | GENERIC_WRITE, 0, NULL, OPEN_EXISTING, FILE_ATTRIBUTE_NORMAL, NULL);
     if (isOpen())
     {
@@ -72,7 +72,7 @@ SerialPort::~SerialPort()
     if (!isOpen())
         return;
 
-#ifdef __WIN32__
+#ifdef _WIN32
     CloseHandle(handle);
     handle = INVALID_HANDLE_VALUE;
 #endif
@@ -84,7 +84,7 @@ SerialPort::~SerialPort()
 
 bool SerialPort::isOpen()
 {
-#ifdef __WIN32__
+#ifdef _WIN32
     return handle != INVALID_HANDLE_VALUE;
 #endif
 #if defined(__gnu_linux__) || (defined(__APPLE__) && defined(__MACH__))
@@ -97,7 +97,7 @@ void SerialPort::configure(int baudrate, int databits, EParity parity, EStopBits
 {
     if (!isOpen())
         return;
-#ifdef __WIN32__
+#ifdef _WIN32
     FlushFileBuffers(handle);
 
     DCB dcb;
@@ -302,7 +302,7 @@ void SerialPort::send(void* data, int data_size)
 {
     if (!isOpen())
         return;
-#ifdef __WIN32__
+#ifdef _WIN32
     while(data_size > 0)
     {
         DWORD written = 0;
@@ -334,7 +334,7 @@ int SerialPort::recv(void* data, int data_size)
     if (!isOpen())
         return 0;
 
-#ifdef __WIN32__
+#ifdef _WIN32
     DWORD read_size = 0;
     if (!ReadFile(handle, data, data_size, &read_size, NULL))
     {
@@ -358,7 +358,7 @@ void SerialPort::setDTR()
 {
     if (!isOpen())
         return;
-#ifdef __WIN32__
+#ifdef _WIN32
     EscapeCommFunction(handle, SETDTR);
 #endif
 #ifdef __gnu_linux__
@@ -374,7 +374,7 @@ void SerialPort::clearDTR()
 {
     if (!isOpen())
         return;
-#ifdef __WIN32__
+#ifdef _WIN32
     EscapeCommFunction(handle, CLRDTR);
 #endif
 #ifdef __gnu_linux__
@@ -390,7 +390,7 @@ void SerialPort::setRTS()
 {
     if (!isOpen())
         return;
-#ifdef __WIN32__
+#ifdef _WIN32
     EscapeCommFunction(handle, SETRTS);
 #endif
 #ifdef __gnu_linux__
@@ -406,7 +406,7 @@ void SerialPort::clearRTS()
 {
     if (!isOpen())
         return;
-#ifdef __WIN32__
+#ifdef _WIN32
     EscapeCommFunction(handle, CLRRTS);
 #endif
 #ifdef __gnu_linux__
@@ -420,7 +420,7 @@ void SerialPort::clearRTS()
 
 void SerialPort::sendBreak()
 {
-#ifdef __WIN32__
+#ifdef _WIN32
     SetCommBreak(handle);
     Sleep(1);
     ClearCommBreak(handle);
@@ -433,7 +433,7 @@ void SerialPort::sendBreak()
 std::vector<string> SerialPort::getAvailablePorts()
 {
     std::vector<string> names;
-#ifdef __WIN32__
+#ifdef _WIN32
     HKEY key;
     if (RegOpenKeyEx(HKEY_LOCAL_MACHINE, "HARDWARE\\DEVICEMAP\\SERIALCOMM", 0, KEY_READ | KEY_QUERY_VALUE, &key) == ERROR_SUCCESS)
     {
@@ -479,7 +479,7 @@ std::vector<string> SerialPort::getAvailablePorts()
 
 string SerialPort::getPseudoDriverName(string port)
 {
-#ifdef __WIN32__
+#ifdef _WIN32
     string ret;
     HKEY key;
     if (RegOpenKeyEx(HKEY_LOCAL_MACHINE, "HARDWARE\\DEVICEMAP\\SERIALCOMM", 0, KEY_READ | KEY_QUERY_VALUE, &key) == ERROR_SUCCESS)

--- a/src/hardware/serialDriver.h
+++ b/src/hardware/serialDriver.h
@@ -1,7 +1,7 @@
 #ifndef SERIAL_DRIVER_H
 #define SERIAL_DRIVER_H
 
-#ifdef __WIN32__
+#ifdef _WIN32
 #include <windows.h>
 #endif
 #include "stringImproved.h"
@@ -11,7 +11,7 @@
 class SerialPort
 {
 private:
-#ifdef __WIN32__
+#ifdef _WIN32
     HANDLE handle;
 #endif
 #if defined(__gnu_linux__) || (defined(__APPLE__) && defined(__MACH__))

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -28,7 +28,7 @@
 #include "tutorialGame.h"
 
 #include "hardware/hardwareController.h"
-#ifdef __WIN32__
+#ifdef _WIN32
 #include "discord.h"
 #endif
 
@@ -100,7 +100,7 @@ int main(int argc, char** argv)
 #else
     Logging::setLogLevel(LOGLEVEL_INFO);
 #endif
-#if defined(__WIN32__) && !defined(DEBUG)
+#if defined(_WIN32) && !defined(DEBUG)
     Logging::setLogFile("EmptyEpsilon.log");
 #endif
 #ifdef CONFIG_DIR
@@ -306,7 +306,7 @@ int main(int argc, char** argv)
     else
         hardware_controller->loadConfiguration("hardware.ini");
 
-#ifdef __WIN32__
+#ifdef _WIN32
     new DiscordRichPresence();
 #endif
 
@@ -342,7 +342,7 @@ int main(int argc, char** argv)
         // MFC TODO: Fix me -- save prefs to user prefs dir on Windows.
         if (getenv("HOME"))
         {
-#ifdef __WIN32__
+#ifdef _WIN32
             mkdir((string(getenv("HOME")) + "/.emptyepsilon").c_str());
 #else
             mkdir((string(getenv("HOME")) + "/.emptyepsilon").c_str(), S_IRWXU | S_IRWXG | S_IROTH | S_IXOTH);

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -157,7 +157,7 @@ int main(int argc, char** argv)
     new DirectoryResourceProvider("resources/");
     new DirectoryResourceProvider("scripts/");
     new DirectoryResourceProvider("packs/SolCommand/");
-    PackResourceProvider::addPackResourcesForDirectory("packs");
+    PackResourceProvider::addPackResourcesForDirectory("packs/");
     if (getenv("HOME"))
     {
         new DirectoryResourceProvider(string(getenv("HOME")) + "/.emptyepsilon/resources/");

--- a/src/missileWeaponData.cpp
+++ b/src/missileWeaponData.cpp
@@ -37,7 +37,4 @@ string getMissileSizeString(EMissileSizes size)
     }
 }
 
-#ifndef _MSC_VER
-// MFC: GCC does proper external template instantiation, VC++ doesn't.
 #include "missileWeaponData.hpp"
-#endif

--- a/src/missileWeaponData.h
+++ b/src/missileWeaponData.h
@@ -47,10 +47,4 @@ public:
 
     static const MissileWeaponData& getDataFor(EMissileWeapons type);
 };
-
-#ifdef _MSC_VER
-// MFC: GCC does proper external template instantiation, VC++ doesn't.
-#include "missileWeaponData.hpp"
-#endif
-
 #endif//MISSILE_WEAPON_DATA_H

--- a/src/packResourceProvider.cpp
+++ b/src/packResourceProvider.cpp
@@ -71,8 +71,12 @@ void PackResourceProvider::addPackResourcesForDirectory(const string directory)
 {
 #ifdef _WIN32
     WIN32_FIND_DATAA data;
-    assert(directory.endswith("/"));
-    HANDLE handle = FindFirstFileA((directory + "*").c_str(), &data);
+    auto search_root = directory;
+    if (!search_root.endswith("/"))
+    {
+        search_root += "/";
+    }
+    HANDLE handle = FindFirstFileA((search_root + "*").c_str(), &data);
     if (handle == INVALID_HANDLE_VALUE)
         return;
 

--- a/src/screens/extra/databaseScreen.cpp
+++ b/src/screens/extra/databaseScreen.cpp
@@ -1,4 +1,5 @@
 #include "databaseScreen.h"
+#include "shipTemplate.h"
 #include "scienceDatabase.h"
 
 #include "screenComponents/databaseView.h"

--- a/src/screens/extra/powerManagement.cpp
+++ b/src/screens/extra/powerManagement.cpp
@@ -1,4 +1,5 @@
 #include "powerManagement.h"
+#include "missileWeaponData.h"
 
 #include "playerInfo.h"
 #include "spaceObjects/playerSpaceship.h"

--- a/src/screens/extra/shipLogScreen.cpp
+++ b/src/screens/extra/shipLogScreen.cpp
@@ -1,4 +1,5 @@
 #include "shipLogScreen.h"
+#include "shipTemplate.h"
 #include "playerInfo.h"
 #include "spaceObjects/playerSpaceship.h"
 

--- a/src/screens/gm/gameMasterScreen.cpp
+++ b/src/screens/gm/gameMasterScreen.cpp
@@ -1,6 +1,7 @@
+#include "gameMasterScreen.h"
+#include "shipTemplate.h"
 #include "main.h"
 #include "gameGlobalInfo.h"
-#include "gameMasterScreen.h"
 #include "objectCreationView.h"
 #include "globalMessageEntryView.h"
 #include "tweak.h"

--- a/src/shipTemplate.cpp
+++ b/src/shipTemplate.cpp
@@ -598,6 +598,4 @@ ShipTemplate::TemplateType ShipTemplate::getType()
     return type;
 }
 
-#ifndef _MSC_VER
 #include "shipTemplate.hpp"
-#endif /* _MSC_VER */

--- a/src/shipTemplate.h
+++ b/src/shipTemplate.h
@@ -202,10 +202,4 @@ REGISTER_MULTIPLAYER_ENUM(ESystem);
 
 /* Define script conversion function for the ShipTemplate::TemplateType enum. */
 template<> void convert<ShipTemplate::TemplateType>::param(lua_State* L, int& idx, ShipTemplate::TemplateType& tt);
-
-#ifdef _MSC_VER
-// MFC: GCC does proper external template instantiation, VC++ doesn't.
-#include "shipTemplate.hpp"
-#endif /* _MSC_VER */
-
 #endif//SHIP_TEMPLATE_H

--- a/src/spaceObjects/playerSpaceship.cpp
+++ b/src/spaceObjects/playerSpaceship.cpp
@@ -2081,6 +2081,4 @@ void PlayerSpaceship::onProbeLaunch(ScriptSimpleCallback callback)
     this->on_probe_launch = callback;
 }
 
-#ifndef _MSC_VER
 #include "playerSpaceship.hpp"
-#endif /* _MSC_VER */

--- a/src/spaceObjects/playerSpaceship.h
+++ b/src/spaceObjects/playerSpaceship.h
@@ -352,9 +352,4 @@ static inline sf::Packet& operator >> (sf::Packet& packet, PlayerSpaceship::Cust
 
 string alertLevelToString(EAlertLevel level);
 string alertLevelToLocaleString(EAlertLevel level);
-
-#ifdef _MSC_VER
-#include "playerSpaceship.hpp"
-#endif /* _MSC_VER */
-
 #endif//PLAYER_SPACESHIP_H

--- a/src/spaceObjects/spaceship.cpp
+++ b/src/spaceObjects/spaceship.cpp
@@ -1528,6 +1528,4 @@ string frequencyToString(int frequency)
     return string(400 + (frequency * 20)) + "THz";
 }
 
-#ifndef _MSC_VER
 #include "spaceship.hpp"
-#endif

--- a/src/spaceObjects/spaceship.h
+++ b/src/spaceObjects/spaceship.h
@@ -461,9 +461,4 @@ REGISTER_MULTIPLAYER_ENUM(EScannedState);
 
 string frequencyToString(int frequency);
 
-#ifdef _MSC_VER
-// MFC: GCC does proper external template instantiation, VC++ doesn't.
-#include "spaceship.hpp"
-#endif
-
 #endif//SPACESHIP_H


### PR DESCRIPTION
Native support for MSVC (2017 toolchain, matching SFML).

Currently focusing on 32b only.

Most of was just conformance (now that MS is doing a much better job at it, it's a lot easier).

CMake install targets would need an update (doesn't need all the DLLs from MinGW, requires the SFML ones to be copied over).