### PR TITLE
Use HOME env for scriptstorage.json path if available

### DIFF
--- a/src/scriptDataStorage.cpp
+++ b/src/scriptDataStorage.cpp
@@ -8,7 +8,13 @@ class ScriptStorage : public PObject
 public:
     ScriptStorage()
     {
-        FILE* f = fopen("scriptstorage.json", "rt");
+        if (getenv("HOME"))
+        {
+            scriptstorage_path = string(getenv("HOME")) + "/.emptyepsilon/" + scriptstorage_path;
+        }
+
+        FILE* f = fopen(scriptstorage_path.c_str(), "rt");
+
         if (f)
         {
             std::string s;
@@ -32,10 +38,13 @@ public:
     void set(string key, string value)
     {
         if (data[key] == value)
+        {
             return;
-        data[key] = value;
+        }
 
-        FILE* f = fopen("scriptstorage.json", "wt");
+        data[key] = value;
+        FILE* f = fopen(scriptstorage_path.c_str(), "wt");
+
         if (f)
         {
             json11::Json json{data};
@@ -54,6 +63,7 @@ public:
     }
 
 private:
+    string scriptstorage_path = "scriptstorage.json";
     std::unordered_map<std::string, std::string> data;
 };
 


### PR DESCRIPTION
Otherwise, default to the existing behavior of the working path.

On macOS and Linux, this saves `scriptstorage.json` in `~/.emptyepsilon/scriptstorage.json`.

On Windows, this saves `scriptstorage.json` in the same directory as `EmptyEpsilon.exe`.

Fixes #1090.