### PR TITLE
Expose ScienceDatabase multiplayer_ids to scripting

### DIFF
--- a/src/scienceDatabase.cpp
+++ b/src/scienceDatabase.cpp
@@ -172,6 +172,21 @@ P<ScienceDatabase> ScienceDatabase::getEntryByName(string name)
     return queryScienceDatabase(name, this->getId());
 }
 
+P<ScienceDatabase> ScienceDatabase::getEntryById(int32_t id)
+{
+    P<ScienceDatabase> entry;
+
+    for(auto sd : ScienceDatabase::science_databases)
+    {
+        if (sd->getId() == id)
+        {
+            entry = sd;
+        }
+    }
+
+    return entry;
+}
+
 bool ScienceDatabase::hasEntries()
 {
     for(auto sd : ScienceDatabase::science_databases)
@@ -213,6 +228,30 @@ P<ScienceDatabase> ScienceDatabase::queryScienceDatabase(string name, int32_t pa
 
     return nullptr;
 }
+
+static int queryScienceDatabaseById(lua_State* L)
+{
+    P<ScienceDatabase> entry = nullptr;
+
+    for(int i = 1; i <= lua_gettop(L); i++)
+    {
+        string segment = string(luaL_checkstring(L, i));
+        entry = ScienceDatabase::getEntryById(segment.toInt());
+
+        if (!entry)
+        {
+            // No entry with this multiplayer_id.
+            return 0;
+        }
+    }
+
+    return convert<P<ScienceDatabase> >::returnType(L, entry);
+}
+
+/// Return a ScienceDatabase entry by its unique multiplayer_id.
+/// Returns nil if no entry is found.
+/// Example: local mine_db = queryScienceDatabaseById(4);
+REGISTER_SCRIPT_FUNCTION(queryScienceDatabaseById);
 
 static int queryScienceDatabase(lua_State* L)
 {

--- a/src/scienceDatabase.cpp
+++ b/src/scienceDatabase.cpp
@@ -232,17 +232,12 @@ P<ScienceDatabase> ScienceDatabase::queryScienceDatabase(string name, int32_t pa
 static int queryScienceDatabaseById(lua_State* L)
 {
     P<ScienceDatabase> entry = nullptr;
+    entry = ScienceDatabase::getEntryById(luaL_checknumber(L, 1));
 
-    for(int i = 1; i <= lua_gettop(L); i++)
+    if (!entry)
     {
-        string segment = string(luaL_checkstring(L, i));
-        entry = ScienceDatabase::getEntryById(segment.toInt());
-
-        if (!entry)
-        {
-            // No entry with this multiplayer_id.
-            return 0;
-        }
+        // No entry with this multiplayer_id.
+        return 0;
     }
 
     return convert<P<ScienceDatabase> >::returnType(L, entry);

--- a/src/scienceDatabase.cpp
+++ b/src/scienceDatabase.cpp
@@ -9,6 +9,10 @@ REGISTER_SCRIPT_CLASS(ScienceDatabase)
 {
     REGISTER_SCRIPT_CLASS_FUNCTION(ScienceDatabase, setName);
     REGISTER_SCRIPT_CLASS_FUNCTION(ScienceDatabase, getName);
+    // Return an entry's unique multiplayer_id.
+    REGISTER_SCRIPT_CLASS_FUNCTION(ScienceDatabase, getId);
+    // Return an entry's parent's unique multiplayer_id.
+    REGISTER_SCRIPT_CLASS_FUNCTION(ScienceDatabase, getParentId);
     REGISTER_SCRIPT_CLASS_FUNCTION(ScienceDatabase, addEntry);
     /// returns a child entry by its case-insensitive name
     REGISTER_SCRIPT_CLASS_FUNCTION(ScienceDatabase, getEntryByName);

--- a/src/scienceDatabase.h
+++ b/src/scienceDatabase.h
@@ -100,6 +100,7 @@ public:
     bool hasEntries();
     PVector<ScienceDatabase> getEntries();
     static P<ScienceDatabase> queryScienceDatabase(string name, int32_t parent_id);
+    static P<ScienceDatabase> getEntryById(int32_t id);
 private:
     string normalized_name; // used for sorting and querying
     string directionLabel(float direction);


### PR DESCRIPTION
- Expose `ScienceDatabase:getId()` and `::getParentId()` to scripting.
- Add `queryScienceDatabaseById()` function to return an entry given its multiplayer_id.

**Examples in use**

Return the multiplayer_id of a database entry given its name:

```
$ curl --data 'return queryScienceDatabase("Factions"):getId()' localhost:8080/exec.lua
4.000
```

Return the name of a database entry given its multiplayer_id:

```
$ curl --data 'return queryScienceDatabaseById(4):getName()' localhost:8080/exec.lua
"Factions"
```

Return an object containing top-level database entries indexed by multiplayer_id:

```
$ curl --data 'results = {}; for i,v in ipairs(getScienceDatabases()) do results[v:getId()] = v:getName() end; return results' localhost:8080/exec.lua
{"4": "Factions", "148": "Weapons", "143": "Natural", "15": "Ships"}
```

Return the child entries of a database entry given its multiplayer_id:

```
$ curl --data 'results = {}; for i,v in ipairs(queryScienceDatabaseById(4):getEntries()) do results[v:getId()] = v:getName() end; return results' localhost:8080/exec.lua
{"5": "Independent", "6": "Human Navy", "7": "Kraylor", "8": "Arlenians", "9": "Exuari", "10": "Ghosts", "11": "Ktlitans", "12": "TSN", "13": "USN", "14": "CUF"}
```

Return the name of a child entry given its multiplayer_id:

```
$ curl --data 'return queryScienceDatabaseById(14):getName()' localhost:8080/exec.lua
"CUF"
```

Return the multiplayer_id of a child entry given the child entry's multiplayer_id:

```
$ curl --data 'return queryScienceDatabaseById(14):getParentId()' localhost:8080/exec.lua
4.000
```