### PR TITLE
Show rep in generic station comms

### DIFF
--- a/scripts/comms_station.lua
+++ b/scripts/comms_station.lua
@@ -83,12 +83,14 @@ end
 -- @tparam SpaceStation comms_target
 function commsStationDocked(comms_source, comms_target)
     local message
+
     if comms_source:isFriendly(comms_target) then
         message = string.format("Good day, officer! Welcome to %s.\nWhat can we do for you today?", comms_target:getCallSign())
     else
         message = string.format("Welcome to our lovely station %s.", comms_target:getCallSign())
     end
-    setCommsMessage(message)
+
+    setCommsMessage(message + string.format("\n\nReputation: %s", comms_source:getReputationPoints()))
 
     local reply_messages = {
         ["Homing"] = "Do you have spare homing missiles for us?",
@@ -168,12 +170,14 @@ end
 -- @tparam SpaceStation comms_target
 function commsStationUndocked(comms_source, comms_target)
     local message
+
     if comms_source:isFriendly(comms_target) then
         message = string.format("This is %s. Good day, officer.\nIf you need supplies, please dock with us first.", comms_target:getCallSign())
     else
         message = string.format("This is %s. Greetings.\nIf you want to do business, please dock with us first.", comms_target:getCallSign())
     end
-    setCommsMessage(message)
+
+    setCommsMessage(message .. string.format("\n\nReputation: %s", comms_source:getReputationPoints()))
 
     -- supply drop
     if isAllowedTo(comms_source, comms_target, comms_target.comms_data.services.supplydrop) then


### PR DESCRIPTION
Show reputation in generic station comms. Workaround/fix for #1162, and exposes reputation on single-pilot, ops, and comms-only screens, and the main screen with Show Comms enabled.

Does not update in real-time; doing so would probably require a dedicated UI element to show rep in the comms window.

<img width="1312" alt="Screen Shot 2021-01-01 at 4 29 50 PM" src="https://user-images.githubusercontent.com/19192104/103448470-04b48980-4c4f-11eb-92b4-cd28f689abda.png">
<img width="1312" alt="Screen Shot 2021-01-01 at 4 28 52 PM" src="https://user-images.githubusercontent.com/19192104/103448472-08e0a700-4c4f-11eb-82ab-7c10d0aa4df6.png">
<img width="1312" alt="Screen Shot 2021-01-01 at 4 28 44 PM" src="https://user-images.githubusercontent.com/19192104/103448473-09793d80-4c4f-11eb-9c50-8c889fdc62f4.png">
<img width="1312" alt="Screen Shot 2021-01-01 at 4 28 38 PM" src="https://user-images.githubusercontent.com/19192104/103448474-0a11d400-4c4f-11eb-9a21-01edf22b7417.png">
<img width="1312" alt="Screen Shot 2021-01-01 at 4 27 18 PM" src="https://user-images.githubusercontent.com/19192104/103448475-0a11d400-4c4f-11eb-8e1a-bccfe346edde.png">




