### PR TITLE
Remove extraneous get/setWeaponTubeSize functions

### DIFF
--- a/src/spaceObjects/spaceship.cpp
+++ b/src/spaceObjects/spaceship.cpp
@@ -1221,20 +1221,6 @@ EMissileWeapons SpaceShip::getWeaponTubeLoadType(int index)
     return weapon_tube[index].getLoadType();
 }
 
-EMissileSizes SpaceShip::getWeaponTubeSize(int index)
-{
-    if (index < 0 || index >= weapon_tube_count)
-        return MS_Small;
-    return weapon_tube[index].getSize();
-}
-
-void SpaceShip::setWeaponTubeSize(int index, EMissileSizes size)
-{
-    if (index < 0 || index >= weapon_tube_count)
-        return;
-    weapon_tube[index].setSize(size);
-}
-
 void SpaceShip::weaponTubeAllowMissle(int index, EMissileWeapons type)
 {
     if (index < 0 || index >= weapon_tube_count)
@@ -1267,21 +1253,21 @@ void SpaceShip::setWeaponTubeDirection(int index, float direction)
 
 void SpaceShip::setTubeSize(int index, EMissileSizes size)
 {
-    if (index < 0 || index >= max_weapon_tubes)
+    if (index < 0 || index >= weapon_tube_count)
         return;
     weapon_tube[index].setSize(size);
 }
 
 EMissileSizes SpaceShip::getTubeSize(int index)
 {
-    if (index < 0 || index >= max_weapon_tubes)
+    if (index < 0 || index >= weapon_tube_count)
         return MS_Medium;
     return weapon_tube[index].getSize();
 }
 
 float SpaceShip::getTubeLoadTime(int index)
 {
-    if (index < 0 || index >= max_weapon_tubes) {
+    if (index < 0 || index >= weapon_tube_count) {
         return 0;
     }
     return weapon_tube[index].getLoadTimeConfig();
@@ -1289,7 +1275,7 @@ float SpaceShip::getTubeLoadTime(int index)
 
 void SpaceShip::setTubeLoadTime(int index, float time)
 {
-    if (index < 0 || index >= max_weapon_tubes) {
+    if (index < 0 || index >= weapon_tube_count) {
         return;
     }
     weapon_tube[index].setLoadTimeConfig(time);

--- a/src/spaceObjects/spaceship.h
+++ b/src/spaceObjects/spaceship.h
@@ -427,13 +427,11 @@ public:
     void setWeaponTubeCount(int amount);
     int getWeaponTubeCount();
     EMissileWeapons getWeaponTubeLoadType(int index);
-    EMissileSizes getWeaponTubeSize(int index);
 
     void weaponTubeAllowMissle(int index, EMissileWeapons type);
     void weaponTubeDisallowMissle(int index, EMissileWeapons type);
     void setWeaponTubeExclusiveFor(int index, EMissileWeapons type);
     void setWeaponTubeDirection(int index, float direction);
-    void setWeaponTubeSize(int index, EMissileSizes size);
     void setTubeSize(int index, EMissileSizes size);
     EMissileSizes getTubeSize(int index);
     void setTubeLoadTime(int index, float time);


### PR DESCRIPTION
PR #933 added the current get/setTubeSize to spaceShip.

PR #679 added get/setWeaponTubeSize to spaceShip, as well as
setTubeSize to shipTemplate.

setTubeSize and setWeaponTubeSize are redundant. setTubeSize is
exposed to scripting, setWeaponTubeSize is not.

get/setWeaponTubeSize is not used anywhere in EmptyEpsilon. Because
it is redundant and unused, it should be removed.

get/setTubeSize and get/setTubeLoadTime loop through to `max_weapon_tubes` instead of `weapon_tube_count`, which is inconsistent with other weapon tube functions. Align these functions on `weapon_tube_count`, since there's no reason to iterate those functions over unusued tubes.

Closes #1025.