### PR TITLE
Fix beam sound playback on remote clients

### DIFF
--- a/src/spaceObjects/beamEffect.cpp
+++ b/src/spaceObjects/beamEffect.cpp
@@ -30,6 +30,7 @@ BeamEffect::BeamEffect()
     beam_texture = "beam_orange.png";
     beam_fire_sound = "sfx/laser_fire.wav";
     beam_fire_sound_power = 1;
+    beam_sound_played = false;
     fire_ring = true;
     registerMemberReplication(&lifetime, 0.1);
     registerMemberReplication(&sourceId);
@@ -122,11 +123,12 @@ void BeamEffect::update(float delta)
     if (target)
         targetLocation = target->getPosition() + sf::Vector2f(targetOffset.x, targetOffset.y);
 
-    if (source && delta > 0 && lifetime == 1.0)
+    if (source && delta > 0 && !beam_sound_played)
     {
         float volume = 50.0f + (beam_fire_sound_power * 75.0f);
         float pitch = (1.0f / beam_fire_sound_power) + random(-0.1f, 0.1f);
         soundManager->playSound(beam_fire_sound, source->getPosition(), 200.0, 1.0, pitch, volume);
+        beam_sound_played = true;
     }
 
     lifetime -= delta;

--- a/src/spaceObjects/beamEffect.h
+++ b/src/spaceObjects/beamEffect.h
@@ -37,6 +37,8 @@ public:
     ///Control Duration of the beam. Default is 1 second
     void setDuration(float duration) {this->lifetime = duration;}
     void setRing(bool ring) {this->fire_ring = ring;}
+protected:
+    bool beam_sound_played;
 };
 
 #endif//BEAM_EFFECT_H


### PR DESCRIPTION
Beam sounds would not play if the main screen was on a remote client,
because the `lifetime` was never `1.0` due to network latency.

Reuse the missile weapon pattern of setting a Boolean value instead.

Fixes #1224.