### PR TITLE
Increase sound effect attenuation

### DIFF
--- a/src/spaceObjects/beamEffect.cpp
+++ b/src/spaceObjects/beamEffect.cpp
@@ -126,7 +126,7 @@ void BeamEffect::update(float delta)
     {
         float volume = 50.0f + (beam_fire_sound_power * 75.0f);
         float pitch = (1.0f / beam_fire_sound_power) + random(-0.1f, 0.1f);
-        soundManager->playSound(beam_fire_sound, source->getPosition(), 200.0, 1.0, pitch, volume);
+        soundManager->playSound(beam_fire_sound, source->getPosition(), 400.0, 60.0, pitch, volume);
     }
 
     lifetime -= delta;

--- a/src/spaceObjects/electricExplosionEffect.cpp
+++ b/src/spaceObjects/electricExplosionEffect.cpp
@@ -99,7 +99,7 @@ void ElectricExplosionEffect::drawOnRadar(sf::RenderTarget& window, sf::Vector2f
 void ElectricExplosionEffect::update(float delta)
 {
     if (delta > 0 && lifetime == maxLifetime)
-        soundManager->playSound("sfx/emp_explosion.wav", getPosition(), size, 1.0);
+        soundManager->playSound("sfx/emp_explosion.wav", getPosition(), size * 2, 60.0);
     lifetime -= delta;
     if (lifetime < 0)
         destroy();

--- a/src/spaceObjects/explosionEffect.cpp
+++ b/src/spaceObjects/explosionEffect.cpp
@@ -116,7 +116,7 @@ void ExplosionEffect::drawOnRadar(sf::RenderTarget& window, sf::Vector2f positio
 void ExplosionEffect::update(float delta)
 {
     if (delta > 0 && lifetime == maxLifetime)
-        soundManager->playSound(explosion_sound, getPosition(), size, 1.0);
+        soundManager->playSound(explosion_sound, getPosition(), size * 2, 60.0);
     lifetime -= delta;
     if (lifetime < 0)
         destroy();

--- a/src/spaceObjects/missiles/missileWeapon.cpp
+++ b/src/spaceObjects/missiles/missileWeapon.cpp
@@ -39,7 +39,7 @@ void MissileWeapon::update(float delta)
 
     if (!launch_sound_played)
     {
-        soundManager->playSound(data.fire_sound, getPosition(), 200.0, 1.0, 1.0f + random(-0.2f, 0.2f));
+        soundManager->playSound(data.fire_sound, getPosition(), 400.0, 60.0, 1.0f + random(-0.2f, 0.2f));
         launch_sound_played = true;
     }
 


### PR DESCRIPTION
Sound effect attenuation in EE is such that positional sound effects
occuring more than 15U from the player sound very close.

Double the minimum distance for sounds to play at full volume, but
also dramatically increase the sound effect attenuation so that
distant effects don't overwhelm nearby effects.

Fixes #287.