### PR TITLE
Don't check non-existent missile owners

### DIFF
--- a/src/gameStateLogger.cpp
+++ b/src/gameStateLogger.cpp
@@ -535,9 +535,7 @@ void GameStateLogger::writeMissileEntry(JSONGenerator& json, P<MissileWeapon> mi
     json.write("category_modifier", missile->category_modifier);
 
     // A missile's owner might not exist when we log data. Skip the owner_id if so.
-    P<SpaceObject> owner = missile->owner;
-
-    if (owner)
+    if (missile->owner)
     {
         json.write("owner_id", missile->owner->getMultiplayerId());
     }

--- a/src/gameStateLogger.cpp
+++ b/src/gameStateLogger.cpp
@@ -533,7 +533,14 @@ void GameStateLogger::writeStationEntry(JSONGenerator& json, P<SpaceStation> sta
 void GameStateLogger::writeMissileEntry(JSONGenerator& json, P<MissileWeapon> missile)
 {
     json.write("category_modifier", missile->category_modifier);
-    json.write("owner_id", missile->owner->getMultiplayerId());
+
+    // A missile's owner might not exist when we log data. Skip the owner_id if so.
+    P<SpaceObject> owner = missile->owner;
+
+    if (owner)
+    {
+        json.write("owner_id", missile->owner->getMultiplayerId());
+    }
 
     // Don't bother writing a target ID if it's unguided or targetless.
     if (missile->target_id != -1)


### PR DESCRIPTION
When game state logging is enabled, EE might crash when checking
the multiplayer_id of a missile's owner who longer exists.

Write the owner ID only if it still exists.