### PR TITLE
Ignore encoding errors in compile_script_docs

### DIFF
--- a/compile_script_docs.py
+++ b/compile_script_docs.py
@@ -13,6 +13,10 @@
 import re
 import os
 import sys
+# Use io.open instead of open to ignore text encoding errors in both
+# Python 2 and 3.
+import io
+
 try:
 	from xml.etree import cElementTree as ElementTree
 except:
@@ -105,7 +109,7 @@ class DocumentationGenerator(object):
         self._files.add(filename)
         ext = os.path.splitext(filename)[1].lower()
         if ext == '.c' or ext == '.cpp' or ext == '.h':
-            for line in open(filename, "r"):
+            for line in io.open(filename, "r", errors="ignore"):
                 m = re.match('^# *include *[<"](.*)[>"]$', line)
                 if m is not None:
                     self.addFile(m.group(1))
@@ -117,7 +121,7 @@ class DocumentationGenerator(object):
                 continue
             description = ""
             current_class = None
-            with open(filename, "r") as f:
+            with io.open(filename, "r", errors="ignore") as f:
                 for line in f:
                     if line.startswith('#'):
                         continue
@@ -137,7 +141,7 @@ class DocumentationGenerator(object):
             description = ""
             current_class = None
             #print("Processing: %s" % (filename))
-            for line in open(filename, "r"):
+            for line in io.open(filename, "r", errors="ignore"):
                 if line.startswith('#'):
                     continue
                 res = re.search('///(.*)', line)


### PR DESCRIPTION
Specify `io.open` to discard unexpected characters when reading files during script docs compilation.

Required for Python 3 compatibility during builds, but doesn't change script compilation behavior in Python 2.