### PR TITLE
Fixing script_reference deb path

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -513,8 +513,7 @@ if(PYTHONINTERP_FOUND)
         COMMENT "Building script reference documentation.")
   add_custom_target(script_reference ALL DEPENDS ${CMAKE_BINARY_DIR}/script_reference.html)
   
-  set(SCRIPT_REFERENCE_INSTALL_DIR .)
-  # Matches what's above.
+  # Matches install logic above.
   if(WIN32)
   	install(FILES ${CMAKE_BINARY_DIR}/script_reference.html DESTINATION .)
   elseif(APPLE)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -512,7 +512,17 @@ if(PYTHONINTERP_FOUND)
         WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}
         COMMENT "Building script reference documentation.")
   add_custom_target(script_reference ALL DEPENDS ${CMAKE_BINARY_DIR}/script_reference.html)
-  install(FILES ${CMAKE_BINARY_DIR}/script_reference.html DESTINATION .)
+  
+  set(SCRIPT_REFERENCE_INSTALL_DIR .)
+  # Matches what's above.
+  if(WIN32)
+  	install(FILES ${CMAKE_BINARY_DIR}/script_reference.html DESTINATION .)
+  elseif(APPLE)
+  	install(FILES ${CMAKE_BINARY_DIR}/script_reference.html DESTINATION "EmptyEpsilon.app/Contents/Resources")
+  elseif(NOT ANDROID)
+	# DOCDIR already has PROJECT_NAME (EmptyEpsilon) appended (from CMake docs)
+  	install(FILES ${CMAKE_BINARY_DIR}/script_reference.html DESTINATION "${CMAKE_INSTALL_FULL_DOCDIR}")
+  endif()
 endif()
 
 add_custom_target(update_locale


### PR DESCRIPTION
Fix for #1168
Moved to the DOCDIR (which seemed... apt).
From my test on Buster, the path in the `.deb` becomes: `usr/local/share/doc/EmptyEpsilon/script_reference.html`.


On Apple, moved to the Resources folder.