### PR TITLE
Asteroid fixes

### DIFF
--- a/src/screens/gm/gameMasterScreen.cpp
+++ b/src/screens/gm/gameMasterScreen.cpp
@@ -113,6 +113,10 @@ GameMasterScreen::GameMasterScreen()
             {
                 jammer_tweak_dialog->open(obj);
             }
+            else if (P<Asteroid>(obj))
+            {
+                asteroid_tweak_dialog->open(obj);
+            }
             else
             {
                 object_tweak_dialog->open(obj);
@@ -199,6 +203,8 @@ GameMasterScreen::GameMasterScreen()
     station_tweak_dialog->hide();
     jammer_tweak_dialog = new GuiObjectTweak(this, TW_Jammer);
     jammer_tweak_dialog->hide();
+    asteroid_tweak_dialog = new GuiObjectTweak(this, TW_Asteroid);
+    asteroid_tweak_dialog->hide();
 
     global_message_entry = new GuiGlobalMessageEntryView(this);
     global_message_entry->hide();

--- a/src/screens/gm/gameMasterScreen.h
+++ b/src/screens/gm/gameMasterScreen.h
@@ -41,6 +41,7 @@ private:
     GuiObjectTweak* object_tweak_dialog;
     GuiObjectTweak* station_tweak_dialog;
     GuiObjectTweak* jammer_tweak_dialog;
+    GuiObjectTweak* asteroid_tweak_dialog;
 
     GuiAutoLayout* info_layout;
     std::vector<GuiKeyValueDisplay*> info_items;

--- a/src/screens/gm/tweak.cpp
+++ b/src/screens/gm/tweak.cpp
@@ -286,7 +286,7 @@ GuiAsteroidTweak::GuiAsteroidTweak(GuiContainer* owner)
     right_col->setPosition(-25, 25, ATopRight)->setSize(300, GuiElement::GuiSizeMax);
 
     (new GuiLabel(left_col, "", tr("Asteroid Size:"), 30))->setSize(GuiElement::GuiSizeMax, 50);
-    asteroid_size_slider = new GuiSlider(left_col, "", 0, 1000, 0, [this](float value) {
+    asteroid_size_slider = new GuiSlider(left_col, "", 10, 500, 0, [this](float value) {
         target->setSize(value);
     });
     asteroid_size_slider->addOverlay()->setSize(GuiElement::GuiSizeMax, 40);

--- a/src/screens/gm/tweak.cpp
+++ b/src/screens/gm/tweak.cpp
@@ -37,6 +37,12 @@ GuiObjectTweak::GuiObjectTweak(GuiContainer* owner, ETweakType tweak_type)
         list->addEntry(tr("tab", "Ship"), "");
     }
 
+    if (tweak_type == TW_Asteroid)
+    {
+        pages.push_back(new GuiAsteroidTweak(this));
+        list->addEntry(tr("tab","Asteroid"), "");
+    }
+
     if (tweak_type == TW_Jammer)
     {
         pages.push_back(new GuiJammerTweak(this));
@@ -268,6 +274,33 @@ void GuiJammerTweak::open(P<SpaceObject> target)
 void GuiJammerTweak::onDraw(sf::RenderTarget& window)
 {
     jammer_range_slider->setValue(target->getRange());
+}
+
+GuiAsteroidTweak::GuiAsteroidTweak(GuiContainer* owner)
+: GuiTweakPage(owner)
+{
+    GuiAutoLayout* left_col = new GuiAutoLayout(this, "LEFT_LAYOUT", GuiAutoLayout::LayoutVerticalTopToBottom);
+    left_col->setPosition(50, 25, ATopLeft)->setSize(300, GuiElement::GuiSizeMax);
+
+    GuiAutoLayout* right_col = new GuiAutoLayout(this, "RIGHT_LAYOUT", GuiAutoLayout::LayoutVerticalTopToBottom);
+    right_col->setPosition(-25, 25, ATopRight)->setSize(300, GuiElement::GuiSizeMax);
+
+    (new GuiLabel(left_col, "", tr("Asteroid Size:"), 30))->setSize(GuiElement::GuiSizeMax, 50);
+    asteroid_size_slider = new GuiSlider(left_col, "", 0, 1000, 0, [this](float value) {
+        target->setSize(value);
+    });
+    asteroid_size_slider->addOverlay()->setSize(GuiElement::GuiSizeMax, 40);
+}
+
+void GuiAsteroidTweak::open(P<SpaceObject> target)
+{
+    P<Asteroid> asteroid = target;
+    this->target = asteroid;
+}
+
+void GuiAsteroidTweak::onDraw(sf::RenderTarget& window)
+{
+    asteroid_size_slider->setValue(target->getSize());
 }
 
 void GuiShipTweakMissileWeapons::onDraw(sf::RenderTarget& window)

--- a/src/screens/gm/tweak.h
+++ b/src/screens/gm/tweak.h
@@ -7,6 +7,7 @@
 #include "playerInfo.h"
 #include "spaceObjects/playerSpaceship.h"
 #include "spaceObjects/warpJammer.h"
+#include "spaceObjects/asteroid.h"
 
 class SpaceShip;
 class GuiKeyValueDisplay;
@@ -22,7 +23,8 @@ enum ETweakType
     TW_Jammer,  // WarpJammer
     TW_Ship,    // Ships
     TW_Station, // TODO: Space stations
-    TW_Player   // Player ships
+    TW_Player,  // Player ships
+    TW_Asteroid // Asteroid
 };
 
 class GuiTweakPage : public GuiElement
@@ -78,6 +80,20 @@ private:
     GuiSlider* jammer_range_slider;
 public:
     GuiJammerTweak(GuiContainer* owner);
+
+    virtual void onDraw(sf::RenderTarget& window) override;
+
+    virtual void open(P<SpaceObject> target) override;
+};
+
+class GuiAsteroidTweak : public GuiTweakPage
+{
+private:
+    P<Asteroid> target;
+
+    GuiSlider* asteroid_size_slider;
+public:
+    GuiAsteroidTweak(GuiContainer* owner);
 
     virtual void onDraw(sf::RenderTarget& window) override;
 

--- a/src/spaceObjects/asteroid.cpp
+++ b/src/spaceObjects/asteroid.cpp
@@ -9,8 +9,13 @@
 /// An asteroid in space. Which you can fly into and hit. Will do damage.
 REGISTER_SCRIPT_SUBCLASS(Asteroid, SpaceObject)
 {
-    /// Set the size of this asteroid, per default asteroids have a size of 120
+    /// Set the radius of this asteroid
+    /// The default radius for an asteroid is between 110 and 130
+    /// Example: Asteroid():setSize(50)
     REGISTER_SCRIPT_CLASS_FUNCTION(Asteroid, setSize);
+    /// Gets the current radius of this asteroid
+    /// Example: local size=Asteroid():getSize()
+    REGISTER_SCRIPT_CLASS_FUNCTION(Asteroid, getSize);
 }
 
 REGISTER_MULTIPLAYER_CLASS(Asteroid, "Asteroid");
@@ -89,11 +94,21 @@ void Asteroid::setSize(float size)
     setRadius(size);
 }
 
+float Asteroid::getSize()
+{
+    return size;
+}
+
 /// An asteroid in space. Outside of hit range, just for visuals.
 REGISTER_SCRIPT_SUBCLASS(VisualAsteroid, SpaceObject)
 {
-    /// Set the size of this asteroid, per default asteroids have a size of 120
+    /// Set the radius of this asteroid
+    /// The default radius for an VisualAsteroid is between 110 and 130
+    /// Example: VisualAsteroid():setSize(50)
     REGISTER_SCRIPT_CLASS_FUNCTION(VisualAsteroid, setSize);
+    /// Gets the current radius of this asteroid
+    /// Example: local size=VisualAsteroid():getSize()
+    REGISTER_SCRIPT_CLASS_FUNCTION(VisualAsteroid, getSize);
 }
 
 REGISTER_MULTIPLAYER_CLASS(VisualAsteroid, "VisualAsteroid");
@@ -137,4 +152,9 @@ void VisualAsteroid::setSize(float size)
     setRadius(size);
     while(fabs(z) < size * 2)
         z *= random(1.2, 2.0);
+}
+
+float VisualAsteroid::getSize()
+{
+    return size;
 }

--- a/src/spaceObjects/asteroid.h
+++ b/src/spaceObjects/asteroid.h
@@ -20,6 +20,7 @@ public:
     virtual void collide(Collisionable* target, float force) override;
 
     void setSize(float size);
+    float getSize();
 
     virtual string getExportLine() override { return "Asteroid():setPosition(" + string(getPosition().x, 0) + ", " + string(getPosition().y, 0) + ")"; }
 };
@@ -37,6 +38,7 @@ public:
     virtual void draw3D() override;
 
     void setSize(float size);
+    float getSize();
 
     virtual string getExportLine() override { return "VisualAsteroid():setPosition(" + string(getPosition().x, 0) + ", " + string(getPosition().y, 0) + ")"; }
 };

--- a/src/spaceObjects/asteroid.h
+++ b/src/spaceObjects/asteroid.h
@@ -22,7 +22,7 @@ public:
     void setSize(float size);
     float getSize();
 
-    virtual string getExportLine() override { return "Asteroid():setPosition(" + string(getPosition().x, 0) + ", " + string(getPosition().y, 0) + ")"; }
+    virtual string getExportLine() override { return "Asteroid():setPosition(" + string(getPosition().x, 0) + ", " + string(getPosition().y, 0) + ")" + ":setSize(" + string(getSize(),0) + ")"; }
 };
 
 class VisualAsteroid : public SpaceObject
@@ -40,7 +40,7 @@ public:
     void setSize(float size);
     float getSize();
 
-    virtual string getExportLine() override { return "VisualAsteroid():setPosition(" + string(getPosition().x, 0) + ", " + string(getPosition().y, 0) + ")"; }
+    virtual string getExportLine() override { return "VisualAsteroid():setPosition(" + string(getPosition().x, 0) + ", " + string(getPosition().y, 0) + ")" ":setSize(" + string(getSize(),0) + ")"; }
 };
 
 #endif//ASTEROID_H


### PR DESCRIPTION
add a gm tab for asteroids, with size exposed
getSize for both visual and non visual asteroids for use in lua
export string works with size of asteroids
scripting doc makes it clear size = radius rather than diameter