### PR TITLE
Implement TextEvent handling.

### DIFF
--- a/src/gui/debugRenderer.cpp
+++ b/src/gui/debugRenderer.cpp
@@ -112,3 +112,7 @@ void DebugRenderer::handleKeyPress(sf::Event::KeyEvent key, int unicode)
             P<WindowManager>(engine->getObject("windowManager"))->setFrameLimit(60);
     }
 }
+
+void DebugRenderer::handleTextEntered(sf::Event::TextEvent text, int unicode)
+{
+}

--- a/src/gui/debugRenderer.h
+++ b/src/gui/debugRenderer.h
@@ -19,6 +19,7 @@ public:
     DebugRenderer();
 
     virtual void render(sf::RenderTarget& window);
+    virtual void handleTextEntered(sf::Event::TextEvent text, int unicode);
     virtual void handleKeyPress(sf::Event::KeyEvent key, int unicode);
 };
 

--- a/src/gui/gui2_canvas.cpp
+++ b/src/gui/gui2_canvas.cpp
@@ -64,6 +64,21 @@ void GuiCanvas::handleKeyPress(sf::Event::KeyEvent key, int unicode)
     onKey(key, unicode);
 }
 
+void GuiCanvas::handleTextEntered(sf::Event::TextEvent text, int unicode)
+{
+    // If a GUI element is focused, pass the input to its onTextEntered.
+    if (focus_element)
+    {
+        if (focus_element->onTextEntered(text, unicode))
+        {
+            return;
+        }
+    }
+
+    // Otherwise, handle it in this canvas.
+    onTextEntered(text, unicode);
+}
+
 void GuiCanvas::handleJoystickAxis(unsigned int joystickId, sf::Joystick::Axis axis, float position){
     for(AxisAction action : joystick.getAxisAction(joystickId, axis, position)){
         forwardJoystickAxisToElements(action);
@@ -88,6 +103,10 @@ void GuiCanvas::onHotkey(const HotkeyResult& key)
 }
 
 void GuiCanvas::onKey(sf::Event::KeyEvent key, int unicode)
+{
+}
+
+void GuiCanvas::onTextEntered(sf::Event::TextEvent text, int unicode)
 {
 }
 

--- a/src/gui/gui2_canvas.h
+++ b/src/gui/gui2_canvas.h
@@ -17,12 +17,14 @@ public:
 
     virtual void render(sf::RenderTarget& window) override;
     virtual void handleKeyPress(sf::Event::KeyEvent key, int unicode) override;
+    virtual void handleTextEntered(sf::Event::TextEvent text, int unicode) override;
     virtual void handleJoystickAxis(unsigned int joystickId, sf::Joystick::Axis axis, float position) override;
     virtual void handleJoystickButton(unsigned int joystickId, unsigned int button, bool state) override;
 
     virtual void onClick(sf::Vector2f mouse_position);
     virtual void onHotkey(const HotkeyResult& key);
     virtual void onKey(sf::Event::KeyEvent key, int unicode);
+    virtual void onTextEntered(sf::Event::TextEvent text, int unicode);
 
     void focus(GuiElement* element);
     //Called when an element is destroyed in this tree. Recursive tests if the given element or any of it's children currently has focus, and unsets that focus.

--- a/src/gui/gui2_element.cpp
+++ b/src/gui/gui2_element.cpp
@@ -34,6 +34,11 @@ bool GuiElement::onKey(sf::Event::KeyEvent key, int unicode)
     return false;
 }
 
+bool GuiElement::onTextEntered(sf::Event::TextEvent text, int unicode)
+{
+    return false;
+}
+
 void GuiElement::onHotkey(const HotkeyResult& key)
 {
 }

--- a/src/gui/gui2_element.h
+++ b/src/gui/gui2_element.h
@@ -52,6 +52,7 @@ public:
     virtual void onMouseDrag(sf::Vector2f position);
     virtual void onMouseUp(sf::Vector2f position);
     virtual bool onKey(sf::Event::KeyEvent key, int unicode);
+    virtual bool onTextEntered(sf::Event::TextEvent text, int unicode);
     virtual void onHotkey(const HotkeyResult& key);
     virtual bool onJoystickAxis(const AxisAction& axisAction);
     virtual void onFocusGained() {}


### PR DESCRIPTION
Some KeyEvents won't get passed from SP because they don't have a
matching key code in SFML

Implement TextEvent handling functions in GuiCanvas, GuiElement,
and DebugRenderer to receive the event and unicode value for the
entered text.

Requires  daid/SeriousProton#61.