### PR TITLE
Update player ship names on gm screen if ships are renamed

### DIFF
--- a/src/screens/gm/gameMasterScreen.cpp
+++ b/src/screens/gm/gameMasterScreen.cpp
@@ -253,7 +253,11 @@ void GameMasterScreen::update(float delta)
         if (ship)
         {
             if (player_ship_selector->indexByValue(string(n)) == -1)
+            {
                 player_ship_selector->addEntry(ship->getTypeName() + " " + ship->getCallSign(), string(n));
+            } else {
+                player_ship_selector->setEntryName(player_ship_selector->indexByValue(string(n)),ship->getCallSign());
+            }
 
             if (ship->isCommsBeingHailedByGM() || ship->isCommsChatOpenToGM())
             {


### PR DESCRIPTION
Currently if a player ship is renamed by scripts or by the tweak menu the bar at the bottom doesn't update until the gm screen is closed and opened again