### PR TITLE
make links between ships and their database entry explicit

### DIFF
--- a/src/scienceDatabase.cpp
+++ b/src/scienceDatabase.cpp
@@ -372,6 +372,7 @@ void fillDefaultDatabaseData()
     {
         P<ShipTemplate> ship_template = ShipTemplate::getTemplate(template_name);
         P<ScienceDatabase> entry = class_database_entries[ship_template->getClass()]->addEntry(ship_template->getLocaleName());
+        ship_template->setScienceDatabaseEntry(entry);
 
         entry->setModelData(ship_template->model_data);
         entry->setImage(ship_template->radar_trace);

--- a/src/scienceDatabase.h
+++ b/src/scienceDatabase.h
@@ -2,7 +2,7 @@
 #define SCIENCE_DATABASE_H
 
 #include "engine.h"
-#include "shipTemplate.h"
+#include "modelData.h"
 
 /*!
  * \brief An entry for the science database that is formed by a number of key value pairs.

--- a/src/screenComponents/databaseView.cpp
+++ b/src/screenComponents/databaseView.cpp
@@ -59,6 +59,15 @@ bool DatabaseViewComponent::findAndDisplayEntry(string name)
     return false;
 }
 
+void DatabaseViewComponent::selectAndDisplay(P<ScienceDatabase> entry)
+{
+    if (entry)
+    {
+        selected_entry=entry;
+        display();
+    }
+}
+
 void DatabaseViewComponent::fillListBox()
 {
     item_list->setOptions({});

--- a/src/screenComponents/databaseView.h
+++ b/src/screenComponents/databaseView.h
@@ -12,6 +12,7 @@ public:
     DatabaseViewComponent(GuiContainer* owner);
 
     bool findAndDisplayEntry(string name);
+    void selectAndDisplay(P<ScienceDatabase>);
 
 private:
     P<ScienceDatabase> findEntryById(int32_t id);

--- a/src/screens/crew6/scienceScreen.cpp
+++ b/src/screens/crew6/scienceScreen.cpp
@@ -107,8 +107,10 @@ ScienceScreen::ScienceScreen(GuiContainer* owner, ECrewPosition crew_position)
         P<SpaceShip> ship = targets.get();
         if (ship)
         {
-            if (database_view->findAndDisplayEntry(ship->getTypeName()))
+            auto entry=ship->getScienceDatabaseEntry();
+            if (entry)
             {
+                database_view->selectAndDisplay(entry);
                 view_mode_selection->setSelectionIndex(1);
                 radar_view->hide();
                 background_gradient->hide();

--- a/src/shipTemplate.cpp
+++ b/src/shipTemplate.cpp
@@ -437,6 +437,11 @@ void ShipTemplate::setRepairDocked(bool enabled)
     repair_docked = enabled;
 }
 
+void ShipTemplate::setScienceDatabaseEntry(P<ScienceDatabase> entry)
+{
+    science_database_entry = entry->getMultiplayerId();
+}
+
 void ShipTemplate::setRestocksScanProbes(bool enabled)
 {
     restocks_scan_probes = enabled;

--- a/src/shipTemplate.h
+++ b/src/shipTemplate.h
@@ -5,6 +5,7 @@
 #include <unordered_set>
 #include "engine.h"
 #include "modelData.h"
+#include "scienceDatabase.h"
 
 #include "beamTemplate.h"
 #include "missileWeaponData.h"
@@ -118,6 +119,8 @@ public:
     float jump_drive_max_distance;
     int weapon_storage[MW_Count];
 
+    int32_t science_database_entry = -1;
+
     string radar_trace;
     float long_range_radar_range = 30000.0f;
     float short_range_radar_range = 5000.0f;
@@ -148,6 +151,7 @@ public:
     void setMesh(string model, string color_texture, string specular_texture, string illumination_texture);
     void setEnergyStorage(float energy_amount);
     void setRepairCrewCount(int amount);
+    void setScienceDatabaseEntry(P<ScienceDatabase> entry);
 
     void setBeam(int index, float arc, float direction, float range, float cycle_time, float damage);
     void setBeamWeapon(int index, float arc, float direction, float range, float cycle_time, float damage);

--- a/src/spaceObjects/shipTemplateBasedObject.cpp
+++ b/src/spaceObjects/shipTemplateBasedObject.cpp
@@ -71,6 +71,14 @@ REGISTER_SCRIPT_SUBCLASS_NO_CREATE(ShipTemplateBasedObject, SpaceObject)
     REGISTER_SCRIPT_CLASS_FUNCTION(ShipTemplateBasedObject, getRestocksMissilesDocked);
     REGISTER_SCRIPT_CLASS_FUNCTION(ShipTemplateBasedObject, setRestocksMissilesDocked);
 
+    /// gets the database entry for this ship
+    /// Example: local description = ship:getScienceDatabaseEntry():getLongDescription()
+    REGISTER_SCRIPT_CLASS_FUNCTION(ShipTemplateBasedObject, getScienceDatabaseEntry);
+    /// sets the database entry for this ship
+    /// Example: local db=ScienceDatabase():setName(_("Mysterious Ship")):setLongDescription(_("A very mysterious ship, maybe you will find out more later"))
+    /// ship:setScienceDatabaseEntry(db)
+    REGISTER_SCRIPT_CLASS_FUNCTION(ShipTemplateBasedObject, setScienceDatabaseEntry);
+
     /// [Depricated]
     REGISTER_SCRIPT_CLASS_FUNCTION(ShipTemplateBasedObject, getFrontShield);
     /// [Depricated]
@@ -374,6 +382,8 @@ void ShipTemplateBasedObject::setTemplate(string template_name)
     ship_template->setCollisionData(this);
     model_info.setData(ship_template->model_data);
 
+    science_database_entry = ship_template->science_database_entry;
+
     //Call the virtual applyTemplateValues function so subclasses can get extra values from the ship templates.
     applyTemplateValues();
 }
@@ -404,6 +414,23 @@ ESystem ShipTemplateBasedObject::getShieldSystemForShieldIndex(int index)
     if (std::abs(sf::angleDifference(angle, 0.0f)) < 90)
         return SYS_FrontShield;
     return SYS_RearShield;
+}
+
+void ShipTemplateBasedObject::setScienceDatabaseEntry(P<ScienceDatabase> entry)
+{
+    science_database_entry = entry->getMultiplayerId();
+}
+
+P<ScienceDatabase> ShipTemplateBasedObject::getScienceDatabaseEntry()
+{
+    if (game_server)
+    {
+        return game_server->getObjectById(science_database_entry);
+    }
+    else
+    {
+        return game_client->getObjectById(science_database_entry);
+    }
 }
 
 void ShipTemplateBasedObject::onTakingDamage(ScriptSimpleCallback callback)

--- a/src/spaceObjects/shipTemplateBasedObject.h
+++ b/src/spaceObjects/shipTemplateBasedObject.h
@@ -4,6 +4,7 @@
 #include "engine.h"
 #include "spaceObject.h"
 #include "shipTemplate.h"
+#include "scienceDatabase.h"
 
 /**
     An object which is based on a ship template. Contains generic behaviour for:
@@ -32,6 +33,8 @@ public:
     bool repair_docked;                   //[config]
     bool restocks_scan_probes;
     bool restocks_missiles_docked;        //only restocks cpuships; playerships should use comms
+
+    int32_t science_database_entry = -1;
 
     ScriptSimpleCallback on_destruction;
     ScriptSimpleCallback on_taking_damage;
@@ -102,6 +105,9 @@ public:
     void setRestocksScanProbes(bool enabled) { restocks_scan_probes = enabled; }
     bool getRestocksMissilesDocked() { return restocks_missiles_docked; }
     void setRestocksMissilesDocked(bool enabled) { restocks_missiles_docked = enabled; }
+
+    void setScienceDatabaseEntry(P<ScienceDatabase> entry);
+    P<ScienceDatabase> getScienceDatabaseEntry();
 
     void onTakingDamage(ScriptSimpleCallback callback);
     void onDestruction(ScriptSimpleCallback callback);


### PR DESCRIPTION
This changes the database entry to look up via the multiplayer id.

This in turn makes the locale issue with database solvable.

It allows ships to have different database entries per type, which could be used to give histories of named ships. I don't have a use for this currently, but I think that's a lack of imagination on my part.

It also allows multiple ships to point to the same database entry which seems more useful. As an example a new faction could all link to a page about the faction rather than the ship type, while not major I think it could be useful.



It does change the current behavior, as such the database button will stop working for custom ship types with new database entries. This behavior could be easily restored, but then we hit the same locale issues.

due to the newness of that feature I suspect the only scripts that rely on it are @Xansta (who I can help verify and update his scripts) and maybe @czenker (who I think originally wrote the remote science database feature)