### PR TITLE
Make radar tigs responsive to radar size

### DIFF
--- a/src/screenComponents/radarView.cpp
+++ b/src/screenComponents/radarView.cpp
@@ -706,21 +706,45 @@ void GuiRadarView::drawHeadingIndicators(sf::RenderTarget& window)
     sf::Vector2f radar_screen_center(rect.left + rect.width / 2.0f, rect.top + rect.height / 2.0f);
     float scale = std::min(rect.width, rect.height) / 2.0f;
 
-    sf::VertexArray tigs(sf::Lines, 360/20*2);
-    for(unsigned int n=0; n<360; n+=20)
+    // If radar is 600-800px then tigs run every 20 degrees, small tigs every 5.
+    // So if radar is 400-600x then the tigs should run every 45 degrees and smalls every 5.
+    // If radar is <400px, tigs every 90, smalls every 10.
+    unsigned int tig_interval = 20;
+    unsigned int small_tig_interval = 5;
+
+    if (scale >= 300.0f)
     {
-        tigs[n/20*2].position = radar_screen_center + sf::vector2FromAngle(float(n) - 90 - view_rotation) * (scale - 20);
-        tigs[n/20*2+1].position = radar_screen_center + sf::vector2FromAngle(float(n) - 90 - view_rotation) * (scale - 40);
+        tig_interval = 20;
+        small_tig_interval = 5;
+    }
+    else if (scale > 200.0f && scale <= 300.0f)
+    {
+        tig_interval = 45;
+        small_tig_interval = 5;
+    }
+    else if (scale <= 200.0f)
+    {
+        tig_interval = 90;
+        small_tig_interval = 10;
+    }
+
+    sf::VertexArray tigs(sf::Lines, 360 / tig_interval * 2);
+    for(unsigned int n = 0; n < 360; n += tig_interval)
+    {
+        tigs[n / tig_interval * 2].position = radar_screen_center + sf::vector2FromAngle(float(n) - 90 - view_rotation) * (scale - 20);
+        tigs[n / tig_interval * 2 + 1].position = radar_screen_center + sf::vector2FromAngle(float(n) - 90 - view_rotation) * (scale - 40);
     }
     window.draw(tigs);
-    sf::VertexArray small_tigs(sf::Lines, 360/5*2);
-    for(unsigned int n=0; n<360; n+=5)
+
+    sf::VertexArray small_tigs(sf::Lines, 360 / small_tig_interval * 2);
+    for(unsigned int n = 0; n < 360; n += small_tig_interval)
     {
-        small_tigs[n/5*2].position = radar_screen_center + sf::vector2FromAngle(float(n) - 90 - view_rotation) * (scale - 20);
-        small_tigs[n/5*2+1].position = radar_screen_center + sf::vector2FromAngle(float(n) - 90 - view_rotation) * (scale - 30);
+        small_tigs[n / small_tig_interval * 2].position = radar_screen_center + sf::vector2FromAngle(float(n) - 90 - view_rotation) * (scale - 20);
+        small_tigs[n / small_tig_interval * 2 + 1].position = radar_screen_center + sf::vector2FromAngle(float(n) - 90 - view_rotation) * (scale - 30);
     }
     window.draw(small_tigs);
-    for(unsigned int n=0; n<360; n+=20)
+
+    for(unsigned int n = 0; n < 360; n += tig_interval)
     {
         sf::Text text(string(n), *main_font, 15);
         text.setPosition(radar_screen_center + sf::vector2FromAngle(float(n) - 90 - view_rotation) * (scale - 45));


### PR DESCRIPTION
Radars have tigs (heading marks along the outer edge of circular radars), some on an interval also labelled with the numeric heading.

Change the intervals of radar tigs when radars are smaller than 300px in radius, to improve clarity on smaller-sized radars.

- At a radius of 300px+ (scale value of 600+), major tigs are added every 20 degrees, minor tigs every 5.
- At a radius of 200-300px, major tigs are added every 45 degrees, minor tigs every 5.
- At a radius of <200px, major tigs are added every 90 degrees, minor tigs every 10.

No currently implemented screens take advantage of this, but this would ease implementation of new screen types, like this 300px cockpit radar with a 90-degree major tig interval and 10-degree minor tig interval:

<img width="480" alt="Screen Shot 2021-01-15 at 10 00 27 PM" src="https://user-images.githubusercontent.com/19192104/104798604-1af93400-577d-11eb-9c2b-3f480e693385.png">
