### PR TITLE
Allow configurable radar transparency

### DIFF
--- a/src/screenComponents/radarView.cpp
+++ b/src/screenComponents/radarView.cpp
@@ -29,6 +29,7 @@ GuiRadarView::GuiRadarView(GuiContainer* owner, string id, TargetsContainer* tar
     show_heading_indicators(false),
     show_game_master_data(false),
     range_indicator_step_size(0.0f),
+    background_alpha(255),
     style(Circular),
     fog_style(NoFogOfWar),
     mouse_down_func(nullptr),
@@ -56,6 +57,7 @@ GuiRadarView::GuiRadarView(GuiContainer* owner, string id, float distance, Targe
     show_heading_indicators(false),
     show_game_master_data(false),
     range_indicator_step_size(0.0f),
+    background_alpha(255),
     style(Circular),
     fog_style(NoFogOfWar),
     mouse_down_func(nullptr),
@@ -224,7 +226,7 @@ void GuiRadarView::updateGhostDots()
 
 void GuiRadarView::drawBackground(sf::RenderTarget& window)
 {
-    window.clear(sf::Color(20, 20, 20, 255));
+    window.clear(sf::Color(20, 20, 20, background_alpha));
 }
 
 void GuiRadarView::drawNoneFriendlyBlockedAreas(sf::RenderTarget& window)

--- a/src/screenComponents/radarView.h
+++ b/src/screenComponents/radarView.h
@@ -60,6 +60,7 @@ private:
     bool show_heading_indicators;
     bool show_game_master_data;
     float range_indicator_step_size;
+    uint8_t background_alpha;
     ERadarStyle style;
     EFogOfWarStyle fog_style;
     func_t mouse_down_func;
@@ -91,6 +92,7 @@ public:
     GuiRadarView* enableHeadingIndicators() { show_heading_indicators = true; return this; }
     GuiRadarView* disableHeadingIndicators() { show_heading_indicators = false; return this; }
     GuiRadarView* gameMaster() { show_game_master_data = true; return this; }
+    GuiRadarView* setBackgroundAlpha(uint8_t background_alpha) { this->background_alpha = background_alpha; return this; }
     GuiRadarView* setStyle(ERadarStyle style) { this->style = style; return this; }
     GuiRadarView* setFogOfWarStyle(EFogOfWarStyle style) { this->fog_style = style; return this; }
     bool getAutoCentering() { return auto_center_on_my_ship; }


### PR DESCRIPTION
Add `setBackgroundAlpha()` to set a GuiRadarView background's
transparency.

No currently implemented screens take advantage of this, but this would ease implementation of new screen types, like this cockpit radar overlaid on a Viewport3D with a radar background alpha value of 192:

```
radar->setBackgroundAlpha(192);
```

<img width="480" alt="Screen Shot 2021-01-15 at 10 00 27 PM" src="https://user-images.githubusercontent.com/19192104/104798882-41b86a00-577f-11eb-853a-016b5a1f32a7.png">
