### PR TITLE
Optional condensed GuiShieldsEnable with icon

### DIFF
--- a/src/screenComponents/shieldsEnableButton.cpp
+++ b/src/screenComponents/shieldsEnableButton.cpp
@@ -11,17 +11,26 @@
 #include <string>
 
 GuiShieldsEnableButton::GuiShieldsEnableButton(GuiContainer* owner, string id)
-: GuiElement(owner, id)
+: GuiElement(owner, id),
+  icon_only(false)
 {
+    // Recommended minimum button size with default text size: 130, 40
+
+    // Shield toggle button.
     button = new GuiToggleButton(this, id + "_BUTTON", "Shields: ON", [](bool value) {
         if (my_spaceship)
+        {
             my_spaceship->commandSetShields(!my_spaceship->shields_active);
+        }
     });
     button->setSize(GuiElement::GuiSizeMax, GuiElement::GuiSizeMax);
+
+    // Progress bar during calibration.
     bar = new GuiProgressbar(this, id + "_BAR", 0.0, PlayerSpaceship::shield_calibration_time, 0);
     bar->setSize(GuiElement::GuiSizeMax, GuiElement::GuiSizeMax);
-    (new GuiLabel(bar, id + "_CALIBRATING_LABEL", tr("shields","Calibrating"), 30))->setSize(GuiElement::GuiSizeMax, GuiElement::GuiSizeMax);
+    (new GuiLabel(bar, id + "_CALIBRATING_LABEL", tr("shields", "Calibrating"), 30))->setSize(GuiElement::GuiSizeMax, GuiElement::GuiSizeMax);
 
+    // Show power/damage indicator overlay.
     (new GuiPowerDamageIndicator(this, id + "_PDI", SYS_FrontShield, ACenterLeft))->setSize(GuiElement::GuiSizeMax, GuiElement::GuiSizeMax);
 }
 
@@ -31,20 +40,46 @@ void GuiShieldsEnableButton::onDraw(sf::RenderTarget& window)
     {
         if (my_spaceship->shield_calibration_delay > 0.0)
         {
+            // If the shields are calibrating, show a progress bar.
             button->hide();
             bar->show();
             bar->setValue(my_spaceship->shield_calibration_delay);
         }
         else
         {
+            // Show the button, hide the bar, set button state to shield activation state.
             button->show();
             button->setValue(my_spaceship->shields_active);
             bar->hide();
-            string shield_status=my_spaceship->shields_active ? tr("shields","ON") : tr("shields","OFF");
+
+            // Format strings based on settings and shield activation state.
+            string shield_frequency = icon_only ? frequencyToString(my_spaceship->shield_frequency) : tr("{frequency} Shields: ").format({{"frequency", frequencyToString(my_spaceship->shield_frequency)}});
+            string shield_status = my_spaceship->shields_active ? tr("shields", "ON") : tr("shields", "OFF");
+
+            // If the game's using beam frequencies, show the shield's current frequency setting.
+            // If the button's only showing the icon, don't bother with long, formatted strings.
             if (gameGlobalInfo->use_beam_shield_frequencies)
-                button->setText(tr("{frequency} Shields: {status}").format({{"frequency", frequencyToString(my_spaceship->shield_frequency)}, {"status", shield_status}}));
+            {
+                if (icon_only)
+                {
+                    button->setText(shield_frequency);
+                }
+                else
+                {
+                    button->setText(string("{frequency} {status}").format({{"frequency", shield_frequency}, {"status", shield_status}}));
+                }
+            }
             else
-                button->setText(tr("Shields: {status}").format({{"status", shield_status}}));
+            {
+                if (icon_only)
+                {
+                    button->setText(shield_status);
+                }
+                else
+                {
+                    button->setText(tr("Shields: {status}").format({{"status", shield_status}}));
+                }
+            }
         }
     }
 }
@@ -60,4 +95,21 @@ void GuiShieldsEnableButton::onHotkey(const HotkeyResult& key)
         if (key.hotkey == "DISABLE_SHIELDS")
             my_spaceship->commandSetShields(false);
     }
+}
+
+GuiShieldsEnableButton* GuiShieldsEnableButton::showIconOnly(bool icon_only)
+{
+    if (icon_only && button->getIcon() == "")
+    {
+        // If the button should have an icon instead of long strings, and it
+        // doesn't already have an icon, then add an icon to the button.
+        button->setIcon("gui/icons/shields");
+    }
+    else
+    {
+        button->setIcon("");
+    }
+
+    this->icon_only = icon_only;
+    return this;
 }

--- a/src/screenComponents/shieldsEnableButton.cpp
+++ b/src/screenComponents/shieldsEnableButton.cpp
@@ -14,23 +14,15 @@ GuiShieldsEnableButton::GuiShieldsEnableButton(GuiContainer* owner, string id)
 : GuiElement(owner, id),
   icon_only(false)
 {
-    // Recommended minimum button size with default text size: 130, 40
-
-    // Shield toggle button.
     button = new GuiToggleButton(this, id + "_BUTTON", "Shields: ON", [](bool value) {
         if (my_spaceship)
-        {
             my_spaceship->commandSetShields(!my_spaceship->shields_active);
-        }
     });
     button->setSize(GuiElement::GuiSizeMax, GuiElement::GuiSizeMax);
-
-    // Progress bar during calibration.
     bar = new GuiProgressbar(this, id + "_BAR", 0.0, PlayerSpaceship::shield_calibration_time, 0);
     bar->setSize(GuiElement::GuiSizeMax, GuiElement::GuiSizeMax);
-    (new GuiLabel(bar, id + "_CALIBRATING_LABEL", tr("shields", "Calibrating"), 30))->setSize(GuiElement::GuiSizeMax, GuiElement::GuiSizeMax);
+    (new GuiLabel(bar, id + "_CALIBRATING_LABEL", tr("shields","Calibrating"), 30))->setSize(GuiElement::GuiSizeMax, GuiElement::GuiSizeMax);
 
-    // Show power/damage indicator overlay.
     (new GuiPowerDamageIndicator(this, id + "_PDI", SYS_FrontShield, ACenterLeft))->setSize(GuiElement::GuiSizeMax, GuiElement::GuiSizeMax);
 }
 
@@ -40,40 +32,34 @@ void GuiShieldsEnableButton::onDraw(sf::RenderTarget& window)
     {
         if (my_spaceship->shield_calibration_delay > 0.0)
         {
-            // If the shields are calibrating, show a progress bar.
             button->hide();
             bar->show();
             bar->setValue(my_spaceship->shield_calibration_delay);
         }
         else
         {
-            // Show the button, hide the bar, set button state to shield activation state.
             button->show();
             button->setValue(my_spaceship->shields_active);
             bar->hide();
-
-            // Format strings based on settings and shield activation state.
-            string shield_frequency = icon_only ? frequencyToString(my_spaceship->shield_frequency) : tr("{frequency} Shields: ").format({{"frequency", frequencyToString(my_spaceship->shield_frequency)}});
-            string shield_status = my_spaceship->shields_active ? tr("shields", "ON") : tr("shields", "OFF");
-
-            // If the game's using beam frequencies, show the shield's current frequency setting.
-            // If the button's only showing the icon, don't bother with long, formatted strings.
+            string shield_status=my_spaceship->shields_active ? tr("shields","ON") : tr("shields","OFF");
             if (gameGlobalInfo->use_beam_shield_frequencies)
             {
                 if (icon_only)
                 {
-                    button->setText(shield_frequency);
+                    // Use compact string.
+                    button->setText(tr("{frequency}").format({{"frequency", frequencyToString(my_spaceship->shield_frequency)}}));
                 }
                 else
                 {
-                    button->setText(string("{frequency} {status}").format({{"frequency", shield_frequency}, {"status", shield_status}}));
+                    // Use long string.
+                    button->setText(tr("{frequency} Shields: {status}").format({{"frequency", frequencyToString(my_spaceship->shield_frequency)}, {"status", shield_status}}));
                 }
             }
             else
             {
                 if (icon_only)
                 {
-                    button->setText(shield_status);
+                    button->setText(tr("{status}").format({{"status", shield_status}}));
                 }
                 else
                 {

--- a/src/screenComponents/shieldsEnableButton.h
+++ b/src/screenComponents/shieldsEnableButton.h
@@ -11,11 +11,14 @@ class GuiShieldsEnableButton : public GuiElement
 private:
     GuiToggleButton* button;
     GuiProgressbar* bar;
+    bool icon_only;
 public:
     GuiShieldsEnableButton(GuiContainer* owner, string id);
 
     virtual void onDraw(sf::RenderTarget& window) override;
     virtual void onHotkey(const HotkeyResult& key) override;
+
+    GuiShieldsEnableButton* showIconOnly(bool icon_only);
 };
 
 #endif//SHIELDS_ENABLE_BUTTON_H


### PR DESCRIPTION
Add a `showIconOnly()` function that adds `gui/icons/shields` as the button icon and limits the button text to only the frequency if in use or `ON`/`OFF` if not.

Allows for `GuiShieldsEnableButton`s as small as 130, 40. No change in default behavior; `icon_only` defaults to `false`.

Rearranges some localized strings, but doesn't change their meaning.

Default behavior / `(new GuiShieldsEnableButton(this, "SHIELDS_ENABLE"))->showIconOnly(false)`:

<img width="254" alt="Screen Shot 2021-01-16 at 9 21 19 PM" src="https://user-images.githubusercontent.com/19192104/104831808-f1094580-5840-11eb-8dda-34a10d1565ca.png">

<img width="291" alt="Screen Shot 2021-01-16 at 9 19 49 PM" src="https://user-images.githubusercontent.com/19192104/104831811-f4043600-5840-11eb-98f3-c38f12207346.png">

`(new GuiShieldsEnableButton(this, "SHIELDS_ENABLE"))->showIconOnly(true)`:

<img width="294" alt="Screen Shot 2021-01-16 at 9 21 06 PM" src="https://user-images.githubusercontent.com/19192104/104831829-1433f500-5841-11eb-8428-17724277dc27.png">

<img width="256" alt="Screen Shot 2021-01-16 at 9 22 00 PM" src="https://user-images.githubusercontent.com/19192104/104831832-172ee580-5841-11eb-8250-81c37fcda28b.png">
