### PR TITLE
Add getter for sf::Keyboard::Key from hotkey

### DIFF
--- a/src/gui/hotkeyConfig.cpp
+++ b/src/gui/hotkeyConfig.cpp
@@ -307,6 +307,26 @@ std::vector<std::pair<string, string>> HotkeyConfig::listHotkeysByCategory(strin
     return ret;
 }
 
+sf::Keyboard::Key HotkeyConfig::getKeyByHotkey(string hotkey_category, string hotkey_name)
+{
+    for(HotkeyConfigCategory& cat : categories)
+    {
+        if (cat.key == hotkey_category)
+        {
+            for(HotkeyConfigItem& item : cat.hotkeys)
+            {
+                if (item.key == hotkey_name)
+                {
+                    return item.hotkey.code;
+                }
+            }
+        }
+    }
+
+    LOG(WARNING) << "Requested an SFML Key from hotkey " << hotkey_category << ", " << hotkey_name << ", but none was found.";
+    return sf::Keyboard::KeyCount;
+}
+
 HotkeyConfigItem::HotkeyConfigItem(string key, std::tuple<string, string> value)
 {
     this->key = key;

--- a/src/gui/hotkeyConfig.h
+++ b/src/gui/hotkeyConfig.h
@@ -46,6 +46,7 @@ public:
     std::vector<std::pair<string, string>> listHotkeysByCategory(string hotkey_category);
 
     std::vector<HotkeyResult> getHotkey(sf::Event::KeyEvent key);
+    sf::Keyboard::Key getKeyByHotkey(string hotkey_category, string hotkey_name);
 private:
     std::vector<HotkeyConfigCategory> categories;
 


### PR DESCRIPTION
Add `HotkeyConfig::getKeyByHotkey()`, which takes category and
item string keys and returns the assigned sf::Keyboard::Key binding (or
sf::Keyboard::KeyCount if no match).

This allows hotkey bindings to be used outside of `onHotkey()`.

Example: Apply `commandTurnSpeed()` via `sf::Keyboard::isKeyPressed()`, by using the `TURN_LEFT` hotkey from the `HELMS` category.

```
if (sf::Keyboard::isKeyPressed(hotkeys.getKeyByHotkey("HELMS", "TURN_LEFT")))
{
    if (turn_speed != -10.0f)
    {
        turn_speed = -10.0f;
        my_spaceship->commandTurnSpeed(turn_speed);
    }

    target_rotation = my_spaceship->getRotation();
}
```