### PR TITLE
Add remappable voice chat keys

### DIFF
--- a/src/gui/hotkeyConfig.cpp
+++ b/src/gui/hotkeyConfig.cpp
@@ -12,6 +12,8 @@ HotkeyConfig::HotkeyConfig()
     newKey("HELP", std::make_tuple("Show in-game help", "F1"));
     newKey("ESCAPE", std::make_tuple("Return to ship options menu", "Escape"));
     newKey("HOME", std::make_tuple("Return to ship options menu", "Home"));  // Remove this item as it does the same as Escape?
+    newKey("VOICE_CHAT_ALL", std::make_tuple("Broadcast voice chat to server", "Backspace"));
+    newKey("VOICE_CHAT_SHIP", std::make_tuple("Broadcast voice chat to ship", "Tilde"));
 
     newCategory("GENERAL", "General");
     newKey("NEXT_STATION", std::make_tuple("Switch to next crew station", "Tab"));

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -296,9 +296,11 @@ int main(int argc, char** argv)
             }
         }
     }
+
+    // Set up voice chat and key bindings.
     NetworkAudioRecorder* nar = new NetworkAudioRecorder();
-    nar->addKeyActivation(sf::Keyboard::Key::Tilde, 0);
-    nar->addKeyActivation(sf::Keyboard::Key::BackSpace, 1);
+    nar->addKeyActivation(hotkeys.getKeyByHotkey("BASIC", "VOICE_CHAT_ALL"), 0);
+    nar->addKeyActivation(hotkeys.getKeyByHotkey("BASIC", "VOICE_CHAT_SHIP"), 1);
 
     P<HardwareController> hardware_controller = new HardwareController();
 #ifdef CONFIG_DIR


### PR DESCRIPTION
Add HOTKEY.BASIC.VOICE_CHAT_ALL and HOTKEY.BASIC.VOICE_CHAT_SHIP
for broadcasting voice to the server and player's ship, respectively.
Set default hotkey bindings to their current hardcoded keys of
Backspace and Tilde, respectively.

The hotkey menu in Options doesn't have access to the
NetworkAudioRecorder object in `main()` where the keys are bound,
so they're put in the BASIC hotkey category, which can't be rebound
via the hotkeys menu. However, the keys can be rebound in
`options.ini`.

Resolves #930.