### PR TITLE
Close hacking dialog when target not visible

### DIFF
--- a/src/screens/crew6/relayScreen.cpp
+++ b/src/screens/crew6/relayScreen.cpp
@@ -233,7 +233,10 @@ void RelayScreen::onDraw(sf::RenderTarget& window)
             }
         }
         if (!near_friendly)
+        {
             targets.clear();
+            hacking_dialog->hide();
+        }
     }
 
     if (targets.get())


### PR DESCRIPTION
As soon as a hacking target is not visible on relay anymore, the hacking window will now be closed.
