### PR TITLE
Avoid spawning black holes near stations in Basic

### DIFF
--- a/scripts/scenario_00_basic.lua
+++ b/scripts/scenario_00_basic.lua
@@ -252,21 +252,27 @@ function init()
     end
 
     -- Spawn a random black hole.
-    local a = random(0, 360)
-    local d = random(10000, 45000)
-    local x, y = vectorFromAngle(a, d)
-    -- Watching a station fall into a black hole to start the game never gets old,
-    -- but players hate it. Avoid spawning black holes too close to stations.
+    local x, y
     local spawn_hole = false
+
+    -- Avoid spawning black holes too close to stations.
     while not spawn_hole do
+        -- Generate random coordinates between 10U and 45U from the origin.
+        local a = random(0, 360)
+        local d = random(10000, 45000)
+        x, y = vectorFromAngle(a, d)
+
+        -- Check station distance from possible black hole locations.
+        -- If it's too close to a station, generate new coordinates.
         for _, station in ipairs(stationList) do
-            if distance(station, x, y) > 3000 then
+            if distance(station, x, y) > 5000 then
                 spawn_hole = true
             else
                 spawn_hole = false
             end
         end
     end
+
     BlackHole():setPosition(x, y)
 
     -- Spawn random neutral transports.


### PR DESCRIPTION
Black holes can be spawned in the Basic scenario close enough to destroy stations. Avoid this by having the loop that checks for nearby stations regenerate coordinates for the hole if it's too close to a station, and increase the acceptable distance from a 3U radius to a 5U radius.