### PR TITLE
Expose mine/missile ownership to scripting and GM info

### DIFF
--- a/src/spaceObjects/mine.cpp
+++ b/src/spaceObjects/mine.cpp
@@ -21,7 +21,6 @@ REGISTER_MULTIPLAYER_CLASS(Mine, "Mine");
 Mine::Mine()
 : SpaceObject(50, "Mine"), data(MissileWeaponData::getDataFor(MW_Mine))
 {
-    owner_id = -1;
     setCollisionRadius(trigger_range);
     triggered = false;
     triggerTimeout = triggerDelay;
@@ -30,8 +29,6 @@ Mine::Mine()
     setRadarSignatureInfo(0.0, 0.05, 0.0);
 
     PathPlannerManager::getInstance()->addAvoidObject(this, blastRange * 1.2f);
-
-    registerMemberReplication(&owner_id);
 }
 
 void Mine::draw3D()
@@ -141,10 +138,11 @@ P<SpaceObject> Mine::getOwner()
 {
     if (game_server)
     {
-        return game_server->getObjectById(owner_id);
+        return owner;
     }
 
-    return game_client->getObjectById(owner_id);
+    LOG(ERROR) << "Mine::getOwner(): owner not replicated to clients."
+    return nullptr;
 }
 
 std::unordered_map<string, string> Mine::getGMInfo()

--- a/src/spaceObjects/mine.cpp
+++ b/src/spaceObjects/mine.cpp
@@ -141,7 +141,7 @@ P<SpaceObject> Mine::getOwner()
         return owner;
     }
 
-    LOG(ERROR) << "Mine::getOwner(): owner not replicated to clients."
+    LOG(ERROR) << "Mine::getOwner(): owner not replicated to clients.";
     return nullptr;
 }
 

--- a/src/spaceObjects/mine.cpp
+++ b/src/spaceObjects/mine.cpp
@@ -10,6 +10,8 @@
 /// A mine object. Simple, effective, deadly.
 REGISTER_SCRIPT_SUBCLASS(Mine, SpaceObject)
 {
+  // Get the mine's owner's object.
+  REGISTER_SCRIPT_CLASS_FUNCTION(Mine, getOwner);
   // Set a function that will be called if the mine explodes.
   // First argument is the mine, second argument is the mine's owner/instigator (or nil).
   REGISTER_SCRIPT_CLASS_FUNCTION(Mine, onDestruction);
@@ -19,6 +21,7 @@ REGISTER_MULTIPLAYER_CLASS(Mine, "Mine");
 Mine::Mine()
 : SpaceObject(50, "Mine"), data(MissileWeaponData::getDataFor(MW_Mine))
 {
+    owner_id = -1;
     setCollisionRadius(trigger_range);
     triggered = false;
     triggerTimeout = triggerDelay;
@@ -27,6 +30,8 @@ Mine::Mine()
     setRadarSignatureInfo(0.0, 0.05, 0.0);
 
     PathPlannerManager::getInstance()->addAvoidObject(this, blastRange * 1.2f);
+
+    registerMemberReplication(&owner_id);
 }
 
 void Mine::draw3D()
@@ -130,4 +135,28 @@ void Mine::explode()
 void Mine::onDestruction(ScriptSimpleCallback callback)
 {
     this->on_destruction = callback;
+}
+
+P<SpaceObject> Mine::getOwner()
+{
+    if (game_server)
+    {
+        return game_server->getObjectById(owner_id);
+    }
+
+    return game_client->getObjectById(owner_id);
+}
+
+std::unordered_map<string, string> Mine::getGMInfo()
+{
+    std::unordered_map<string, string> ret;
+
+    if (owner)
+    {
+        ret["Owner"] = owner->getCallSign();
+    }
+
+    ret["Faction"] = getLocaleFaction();
+
+    return ret;
 }

--- a/src/spaceObjects/mine.h
+++ b/src/spaceObjects/mine.h
@@ -15,7 +15,6 @@ class Mine : public SpaceObject, public Updatable
 
 public:
     P<SpaceObject> owner;
-    int32_t owner_id;
     bool triggered;       //Only valid on server.
     float triggerTimeout; //Only valid on server.
     float ejectTimeout;   //Only valid on server.

--- a/src/spaceObjects/mine.h
+++ b/src/spaceObjects/mine.h
@@ -15,6 +15,7 @@ class Mine : public SpaceObject, public Updatable
 
 public:
     P<SpaceObject> owner;
+    int32_t owner_id;
     bool triggered;       //Only valid on server.
     float triggerTimeout; //Only valid on server.
     float ejectTimeout;   //Only valid on server.
@@ -33,6 +34,8 @@ public:
     void explode();
     void onDestruction(ScriptSimpleCallback callback);
 
+    P<SpaceObject> getOwner();
+    virtual std::unordered_map<string, string> getGMInfo() override;
     virtual string getExportLine() override { return "Mine():setPosition(" + string(getPosition().x, 0) + ", " + string(getPosition().y, 0) + ")"; }
 
 private:

--- a/src/spaceObjects/missiles/missileWeapon.cpp
+++ b/src/spaceObjects/missiles/missileWeapon.cpp
@@ -8,6 +8,9 @@
 /// like HomingMissile, HVLI etc.
 REGISTER_SCRIPT_SUBCLASS_NO_CREATE(MissileWeapon, SpaceObject)
 {
+  /// Get the missile's owner's object.
+  REGISTER_SCRIPT_CLASS_FUNCTION(MissileWeapon, getOwner);
+  /// Get the missile's target object.
   REGISTER_SCRIPT_CLASS_FUNCTION(MissileWeapon, getTarget);
   /// Must be an existing target, else does nothing. It does not check if really targetable or not.
   REGISTER_SCRIPT_CLASS_FUNCTION(MissileWeapon, setTarget);
@@ -130,13 +133,26 @@ void MissileWeapon::updateMovement()
     }
 }
 
+P<SpaceObject> MissileWeapon::getOwner()
+{
+    if (game_server)
+    {
+        return owner;
+    }
+    else
+    {
+        LOG(WARNING) << "Tried to get a missile's owner on a client, but the owner isn't replicated over the network.";
+    }
+
+    return nullptr;
+}
+
 P<SpaceObject> MissileWeapon::getTarget()
 {
     if (game_server)
         return game_server->getObjectById(target_id);
     return game_client->getObjectById(target_id);
 }
-
 
 void MissileWeapon::setTarget(P<SpaceObject> target)
 {

--- a/src/spaceObjects/missiles/missileWeapon.cpp
+++ b/src/spaceObjects/missiles/missileWeapon.cpp
@@ -141,7 +141,7 @@ P<SpaceObject> MissileWeapon::getOwner()
         return owner;
     }
 
-    LOG(ERROR) << "MissileWeapon::getOwner(): owner not replicated to clients."
+    LOG(ERROR) << "MissileWeapon::getOwner(): owner not replicated to clients.";
     return nullptr;
 }
 

--- a/src/spaceObjects/missiles/missileWeapon.cpp
+++ b/src/spaceObjects/missiles/missileWeapon.cpp
@@ -29,13 +29,11 @@ REGISTER_SCRIPT_SUBCLASS_NO_CREATE(MissileWeapon, SpaceObject)
 MissileWeapon::MissileWeapon(string multiplayer_name, const MissileWeaponData& data)
 : SpaceObject(10, multiplayer_name), data(data)
 {
-    owner_id = -1;
     target_id = -1;
     target_angle = 0;
     category_modifier = 1;
     lifetime = data.lifetime;
 
-    registerMemberReplication(&owner_id);
     registerMemberReplication(&target_id);
     registerMemberReplication(&target_angle);
     registerMemberReplication(&category_modifier);
@@ -137,13 +135,14 @@ void MissileWeapon::updateMovement()
 
 P<SpaceObject> MissileWeapon::getOwner()
 {
-    // Owner and owner_id are assigned by the weapon tube upon firing.
+    // Owner is assigned by the weapon tube upon firing.
     if (game_server)
     {
-        return game_server->getObjectById(owner_id);
+        return owner;
     }
 
-    return game_client->getObjectById(owner_id);
+    LOG(ERROR) << "MissileWeapon::getOwner(): owner not replicated to clients."
+    return nullptr;
 }
 
 P<SpaceObject> MissileWeapon::getTarget()

--- a/src/spaceObjects/missiles/missileWeapon.h
+++ b/src/spaceObjects/missiles/missileWeapon.h
@@ -15,6 +15,7 @@ protected:
 
 public:
     P<SpaceObject> owner; //Only valid on server.
+    int32_t owner_id;
     int32_t target_id;
     float target_angle;
     // Damage modifier for this missile which indicates it's size. (eg; Missiles by fighters have a low modifier), missiles from
@@ -45,6 +46,7 @@ public:
     EMissileSizes getMissileSize();
     void setMissileSize(EMissileSizes missile_size);
 
+    virtual std::unordered_map<string, string> getGMInfo() override;
 private:
     void updateMovement();
 };

--- a/src/spaceObjects/missiles/missileWeapon.h
+++ b/src/spaceObjects/missiles/missileWeapon.h
@@ -37,6 +37,7 @@ public:
     //Called when the missile's lifetime is up. Missile is destroyed afterwards.
     virtual void lifeEnded() {}
     
+    P<SpaceObject> getOwner();
     P<SpaceObject> getTarget();
     void setTarget(P<SpaceObject> target);
     float getLifetime();

--- a/src/spaceObjects/missiles/missileWeapon.h
+++ b/src/spaceObjects/missiles/missileWeapon.h
@@ -15,7 +15,6 @@ protected:
 
 public:
     P<SpaceObject> owner; //Only valid on server.
-    int32_t owner_id;
     int32_t target_id;
     float target_angle;
     // Damage modifier for this missile which indicates it's size. (eg; Missiles by fighters have a low modifier), missiles from

--- a/src/spaceObjects/spaceshipParts/weaponTube.cpp
+++ b/src/spaceObjects/spaceshipParts/weaponTube.cpp
@@ -115,6 +115,7 @@ void WeaponTube::spawnProjectile(float target_angle)
         {
             P<HomingMissile> missile = new HomingMissile();
             missile->owner = parent;
+            missile->owner_id = parent->getMultiplayerId();
             missile->setFactionId(parent->getFactionId());
             missile->target_id = parent->target_id;
             missile->setPosition(fireLocation);
@@ -127,6 +128,7 @@ void WeaponTube::spawnProjectile(float target_angle)
         {
             P<Nuke> missile = new Nuke();
             missile->owner = parent;
+            missile->owner_id = parent->getMultiplayerId();
             missile->setFactionId(parent->getFactionId());
             missile->target_id = parent->target_id;
             missile->setPosition(fireLocation);
@@ -139,6 +141,7 @@ void WeaponTube::spawnProjectile(float target_angle)
         {
             P<Mine> missile = new Mine();
             missile->owner = parent;
+            missile->owner_id = parent->getMultiplayerId();
             missile->setFactionId(parent->getFactionId());
             missile->setPosition(fireLocation);
             missile->setRotation(parent->getRotation() + direction);
@@ -149,6 +152,7 @@ void WeaponTube::spawnProjectile(float target_angle)
         {
             P<HVLI> missile = new HVLI();
             missile->owner = parent;
+            missile->owner_id = parent->getMultiplayerId();
             missile->setFactionId(parent->getFactionId());
             missile->setPosition(fireLocation);
             missile->setRotation(parent->getRotation() + direction);
@@ -160,6 +164,7 @@ void WeaponTube::spawnProjectile(float target_angle)
         {
             P<EMPMissile> missile = new EMPMissile();
             missile->owner = parent;
+            missile->owner_id = parent->getMultiplayerId();
             missile->setFactionId(parent->getFactionId());
             missile->target_id = parent->target_id;
             missile->setPosition(fireLocation);

--- a/src/spaceObjects/spaceshipParts/weaponTube.cpp
+++ b/src/spaceObjects/spaceshipParts/weaponTube.cpp
@@ -115,7 +115,6 @@ void WeaponTube::spawnProjectile(float target_angle)
         {
             P<HomingMissile> missile = new HomingMissile();
             missile->owner = parent;
-            missile->owner_id = parent->getMultiplayerId();
             missile->setFactionId(parent->getFactionId());
             missile->target_id = parent->target_id;
             missile->setPosition(fireLocation);
@@ -128,7 +127,6 @@ void WeaponTube::spawnProjectile(float target_angle)
         {
             P<Nuke> missile = new Nuke();
             missile->owner = parent;
-            missile->owner_id = parent->getMultiplayerId();
             missile->setFactionId(parent->getFactionId());
             missile->target_id = parent->target_id;
             missile->setPosition(fireLocation);
@@ -141,7 +139,6 @@ void WeaponTube::spawnProjectile(float target_angle)
         {
             P<Mine> missile = new Mine();
             missile->owner = parent;
-            missile->owner_id = parent->getMultiplayerId();
             missile->setFactionId(parent->getFactionId());
             missile->setPosition(fireLocation);
             missile->setRotation(parent->getRotation() + direction);
@@ -152,7 +149,6 @@ void WeaponTube::spawnProjectile(float target_angle)
         {
             P<HVLI> missile = new HVLI();
             missile->owner = parent;
-            missile->owner_id = parent->getMultiplayerId();
             missile->setFactionId(parent->getFactionId());
             missile->setPosition(fireLocation);
             missile->setRotation(parent->getRotation() + direction);
@@ -164,7 +160,6 @@ void WeaponTube::spawnProjectile(float target_angle)
         {
             P<EMPMissile> missile = new EMPMissile();
             missile->owner = parent;
-            missile->owner_id = parent->getMultiplayerId();
             missile->setFactionId(parent->getFactionId());
             missile->target_id = parent->target_id;
             missile->setPosition(fireLocation);


### PR DESCRIPTION
- Add `getOwner()` to MissileWeapon and Mine objects
- Report MissileWeapon and Mine details (including ownership, homing target, missile lifetime, and faction) via `getGMInfo()`