### PR TITLE
Expose probe functions to scripting and add onArrival callback

### DIFF
--- a/src/spaceObjects/playerSpaceship.cpp
+++ b/src/spaceObjects/playerSpaceship.cpp
@@ -112,6 +112,7 @@ REGISTER_SCRIPT_SUBCLASS(PlayerSpaceship, SpaceShip)
     REGISTER_SCRIPT_CLASS_FUNCTION(PlayerSpaceship, commandCancelSelfDestruct);
     REGISTER_SCRIPT_CLASS_FUNCTION(PlayerSpaceship, commandConfirmDestructCode);
     REGISTER_SCRIPT_CLASS_FUNCTION(PlayerSpaceship, commandCombatManeuverBoost);
+    REGISTER_SCRIPT_CLASS_FUNCTION(PlayerSpaceship, commandLaunchProbe);
     REGISTER_SCRIPT_CLASS_FUNCTION(PlayerSpaceship, commandSetScienceLink);
     REGISTER_SCRIPT_CLASS_FUNCTION(PlayerSpaceship, commandSetAlertLevel);
 

--- a/src/spaceObjects/scanProbe.cpp
+++ b/src/spaceObjects/scanProbe.cpp
@@ -70,7 +70,7 @@ ScanProbe::~ScanProbe()
 
 void ScanProbe::setLifetime(float lifetime)
 {
-    this->lifetime = lifetime;
+    this->lifetime = lifetime > 0.0f ? lifetime : 0.0f;
 }
 
 float ScanProbe::getLifetime()

--- a/src/spaceObjects/scanProbe.h
+++ b/src/spaceObjects/scanProbe.h
@@ -12,10 +12,12 @@ private:
     float lifetime;
     // Probe target coordinates.
     sf::Vector2f target_position;
+    // Whether the probe has arrived to the target_position.
+    bool has_arrived;
 public:
     int owner_id;
 
-    ScriptSimpleCallback on_creation;
+    ScriptSimpleCallback on_arrival;
     ScriptSimpleCallback on_expiration;
     ScriptSimpleCallback on_destruction;
 
@@ -31,11 +33,13 @@ public:
     virtual void drawOnRadar(sf::RenderTarget& window, sf::Vector2f position, float scale, float rotation, bool long_range) override;
     virtual void drawOnGMRadar(sf::RenderTarget& window, sf::Vector2f position, float scale, float rotation, bool long_range) override;
 
+    bool hasArrived() { return has_arrived; }
     void setTarget(sf::Vector2f target) { target_position = target; }
     sf::Vector2f getTarget() { return target_position; }
+    P<SpaceObject> getOwner() { return game_server->getObjectById(owner_id); }
     void setOwner(P<SpaceObject> owner);
 
-    void onCreation(ScriptSimpleCallback callback);
+    void onArrival(ScriptSimpleCallback callback);
     void onExpiration(ScriptSimpleCallback callback);
     void onDestruction(ScriptSimpleCallback callback);
 };

--- a/src/spaceObjects/scanProbe.h
+++ b/src/spaceObjects/scanProbe.h
@@ -6,13 +6,16 @@
 class ScanProbe : public SpaceObject, public Updatable
 {
 private:
+    // Probe flight speed; 1U/sec.
     constexpr static float probe_speed = 1000.0f;
-    // remaining lifetime in seconds
+    // Remaining lifetime in seconds.
     float lifetime;
+    // Probe target coordinates.
     sf::Vector2f target_position;
 public:
     int owner_id;
 
+    ScriptSimpleCallback on_creation;
     ScriptSimpleCallback on_expiration;
     ScriptSimpleCallback on_destruction;
 
@@ -32,6 +35,7 @@ public:
     sf::Vector2f getTarget() { return target_position; }
     void setOwner(P<SpaceObject> owner);
 
+    void onCreation(ScriptSimpleCallback callback);
     void onExpiration(ScriptSimpleCallback callback);
     void onDestruction(ScriptSimpleCallback callback);
 };


### PR DESCRIPTION
- Expose `PlayerSpaceship:commandLaunchProbe(Vector2f)` to scripting.
- Expose `ScanProbe:setTarget(Vector2f)` and `::getTarget()` to scripting.
- Add `ScanProbe:getOwner()` and expose it to scripting.
- Add `ScanProbe:onArrival(probe, target_x, target_y)` callback and expose it
  to scripting.
- Disallow negative `ScanProbe:setLifetime(float)` values.
- Align probe's heading value to its travel vector.

`onArrival` will fire once when a ScanProbe reaches its target coordinates.
If its target coordinates change after arrival, it will fire again upon
reaching the new coordinates.

Example code:

```lua
player = PlayerSpaceship():setTemplate("Atlantis")

player:onProbeLaunch(function (owner, probe)
    print(probe:getCallSign() .. " launched by " .. owner:getCallSign())
    probe:onArrival(function (probe, x, y)
        print(probe:getCallSign() .. " arrived to " .. x .. ", " .. y .. " on heading " .. probe:getHeading())
        print("Moving probe to " .. -x .. ", " .. -y)
        probe:setTarget(-x, -y)
    end)
end)

player:commandLaunchProbe(5000, 5000)
```

Results in:

```
310P launched by PL306
310P arrived to 4934.3452148438, 4934.3452148438 on heading 135.0
Moving probe to -4934.3452148438, -4934.3452148438
310P arrived to -4867.4545898438, -4867.4545898438 on heading 315.0
Moving probe to 4867.4545898438, 4867.4545898438
310P arrived to 4797.6079101562, 4797.6079101562 on heading 135.0
Moving probe to -4797.6079101562, -4797.6079101562
310P arrived to -4738.4682617188, -4738.4682617188 on heading 315.0
Moving probe to 4738.4682617188, 4738.4682617188
310P arrived to 4669.9921875, 4669.9921875 on heading 135.0
Moving probe to -4669.9921875, -4669.9921875
```

(Note that the values approach zero over time, since arrival is based on the
probe's radius reaching the target coordinates, rather than the probe's center.)