### PR TITLE
Removed glBegin/End on Beam effects and explosions

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -118,6 +118,7 @@ set(SOURCES
 	src/GMMessage.cpp
 	src/tutorialGame.cpp
 	src/scriptDataStorage.cpp
+	src/glObjects.cpp
 	src/menus/joinServerMenu.cpp
 	src/menus/serverBrowseMenu.cpp
 	src/menus/mainMenus.cpp

--- a/resources/shaders/basic.frag
+++ b/resources/shaders/basic.frag
@@ -1,0 +1,9 @@
+#version 120
+uniform vec4 color;
+uniform sampler2D textureMap;
+varying vec2 fragtexcoords;
+void main()
+{
+	gl_FragColor = texture2D(textureMap, fragtexcoords.st) * color;
+	gl_FragColor.rgb *= color.a;
+}

--- a/resources/shaders/basic.frag
+++ b/resources/shaders/basic.frag
@@ -1,7 +1,10 @@
 #version 120
+
 uniform vec4 color;
 uniform sampler2D textureMap;
+
 varying vec2 fragtexcoords;
+
 void main()
 {
 	gl_FragColor = texture2D(textureMap, fragtexcoords.st) * color;

--- a/resources/shaders/basic.frag
+++ b/resources/shaders/basic.frag
@@ -7,6 +7,6 @@ varying vec2 fragtexcoords;
 
 void main()
 {
-	gl_FragColor = texture2D(textureMap, fragtexcoords.st) * color;
-	gl_FragColor.rgb *= color.a;
+    gl_FragColor = texture2D(textureMap, fragtexcoords.st) * color;
+    gl_FragColor.rgb *= color.a;
 }

--- a/resources/shaders/basic.vert
+++ b/resources/shaders/basic.vert
@@ -1,0 +1,11 @@
+#version 120
+uniform vec4 color;
+uniform mat4 modelViewProj;
+attribute vec3 position;
+attribute vec2 texcoords;
+varying vec2 fragtexcoords;
+void main()
+{
+	fragtexcoords = texcoords;
+	gl_Position = gl_ModelViewProjectionMatrix * vec4(position, 1.0);
+}

--- a/resources/shaders/basic.vert
+++ b/resources/shaders/basic.vert
@@ -10,6 +10,6 @@ varying vec2 fragtexcoords;
 
 void main()
 {
-	fragtexcoords = texcoords;
-	gl_Position = gl_ModelViewProjectionMatrix * vec4(position, 1.0);
+    fragtexcoords = texcoords;
+    gl_Position = gl_ModelViewProjectionMatrix * vec4(position, 1.0);
 }

--- a/resources/shaders/basic.vert
+++ b/resources/shaders/basic.vert
@@ -1,9 +1,13 @@
 #version 120
+
 uniform vec4 color;
 uniform mat4 modelViewProj;
+
 attribute vec3 position;
 attribute vec2 texcoords;
+
 varying vec2 fragtexcoords;
+
 void main()
 {
 	fragtexcoords = texcoords;

--- a/resources/shaders/billboard.frag
+++ b/resources/shaders/billboard.frag
@@ -1,8 +1,11 @@
 #version 120
+
 uniform sampler2D textureMap;
+
 varying vec4 fragcolor;
 varying vec2 fragtexcoords;
+
 void main()
 {
-	gl_FragColor = texture2D(textureMap, fragtexcoords.st) * fragcolor;
+    gl_FragColor = texture2D(textureMap, fragtexcoords.st) * fragcolor;
 }

--- a/resources/shaders/billboard.frag
+++ b/resources/shaders/billboard.frag
@@ -1,0 +1,8 @@
+#version 120
+uniform sampler2D textureMap;
+varying vec4 fragcolor;
+varying vec2 fragtexcoords;
+void main()
+{
+	gl_FragColor = texture2D(textureMap, fragtexcoords.st) * fragcolor;
+}

--- a/resources/shaders/billboard.vert
+++ b/resources/shaders/billboard.vert
@@ -10,7 +10,7 @@ varying vec4 fragcolor;
 
 void main()
 {
-	fragtexcoords = texcoords;
-	gl_Position = gl_ProjectionMatrix * ((gl_ModelViewMatrix * vec4(position, 1.0)) + vec4((texcoords.x - 0.5) * color.a, (texcoords.y - 0.5) * color.a, 0.0, 0.0));
-	fragcolor = vec4(color.rgb, 1.0);
+    fragtexcoords = texcoords;
+    gl_Position = gl_ProjectionMatrix * ((gl_ModelViewMatrix * vec4(position, 1.0)) + vec4((texcoords.x - 0.5) * color.a, (texcoords.y - 0.5) * color.a, 0.0, 0.0));
+    fragcolor = vec4(color.rgb, 1.0);
 }

--- a/resources/shaders/billboard.vert
+++ b/resources/shaders/billboard.vert
@@ -1,9 +1,13 @@
 #version 120
+
 uniform vec4 color;
+
 attribute vec3 position;
 attribute vec2 texcoords;
+
 varying vec2 fragtexcoords;
 varying vec4 fragcolor;
+
 void main()
 {
 	fragtexcoords = texcoords;

--- a/resources/shaders/billboard.vert
+++ b/resources/shaders/billboard.vert
@@ -1,0 +1,12 @@
+#version 120
+uniform vec4 color;
+attribute vec3 position;
+attribute vec2 texcoords;
+varying vec2 fragtexcoords;
+varying vec4 fragcolor;
+void main()
+{
+	fragtexcoords = texcoords;
+	gl_Position = gl_ProjectionMatrix * ((gl_ModelViewMatrix * vec4(position, 1.0)) + vec4((texcoords.x - 0.5) * color.a, (texcoords.y - 0.5) * color.a, 0.0, 0.0));
+	fragcolor = vec4(color.rgb, 1.0);
+}

--- a/resources/shaders/explosionParticle.vert
+++ b/resources/shaders/explosionParticle.vert
@@ -1,0 +1,17 @@
+#version 120
+
+uniform vec4 color;
+uniform float size;
+uniform float scale;
+
+attribute vec3 position;
+attribute vec2 texcoords;
+
+varying vec4 fragcolor;
+
+void main()
+{
+	fragtexcoords = texcoords;
+	gl_Position = gl_ProjectionMatrix * ((gl_ModelViewMatrix * vec4(position, 1.0)) + vec4((texcoords.x - 0.5) * color.a, (texcoords.y - 0.5) * color.a, 0.0, 0.0));
+	fragcolor = vec4(color.rgb, 1.0);
+}

--- a/src/glObjects.cpp
+++ b/src/glObjects.cpp
@@ -1,0 +1,33 @@
+#include "glObjects.h"
+#if FEATURE_3D_RENDERING
+#include <GL/glew.h>
+#include <type_traits>
+static_assert(std::is_same<uint32_t, GLuint>::value, "GLuint and uint32_t are *NOT* the same: troubles!");
+namespace gl
+{
+	namespace details
+	{
+		void createBuffers(size_t count, uint32_t* buffers)
+		{
+			glGenBuffers(count, buffers);
+		}
+		void deleteBuffers(size_t count, const uint32_t* buffers)
+		{
+			glDeleteBuffers(count, buffers);
+		}
+	}
+
+	ScopedVertexAttribArray::ScopedVertexAttribArray(int32_t attrib)
+		:attrib{ attrib }
+	{
+		if (attrib != -1)
+			glEnableVertexAttribArray(attrib);
+	}
+	ScopedVertexAttribArray::~ScopedVertexAttribArray()
+	{
+		if (attrib != -1)
+			glDisableVertexAttribArray(attrib);
+	}
+} // namespace gl
+#endif // FEATURE_3D_RENDERING
+

--- a/src/glObjects.cpp
+++ b/src/glObjects.cpp
@@ -9,30 +9,30 @@ static_assert(std::is_same<uint32_t, GLuint>::value, "GLuint and uint32_t are *N
 
 namespace gl
 {
-	namespace details
-	{
-		void createBuffers(size_t count, uint32_t* buffers)
-		{
-			glGenBuffers(count, buffers);
-		}
-		void deleteBuffers(size_t count, const uint32_t* buffers)
-		{
-			glDeleteBuffers(count, buffers);
-		}
-	}
+    namespace details
+    {
+        void createBuffers(size_t count, uint32_t* buffers)
+        {
+            glGenBuffers(count, buffers);
+        }
+        void deleteBuffers(size_t count, const uint32_t* buffers)
+        {
+            glDeleteBuffers(count, buffers);
+        }
+    }
 
-	ScopedVertexAttribArray::ScopedVertexAttribArray(int32_t attrib)
-		:attrib{ attrib }
-	{
-		if (attrib != -1)
-			glEnableVertexAttribArray(attrib);
-	}
+    ScopedVertexAttribArray::ScopedVertexAttribArray(int32_t attrib)
+        :attrib{ attrib }
+    {
+        if (attrib != -1)
+            glEnableVertexAttribArray(attrib);
+    }
 
-	ScopedVertexAttribArray::~ScopedVertexAttribArray()
-	{
-		if (attrib != -1)
-			glDisableVertexAttribArray(attrib);
-	}
+    ScopedVertexAttribArray::~ScopedVertexAttribArray()
+    {
+        if (attrib != -1)
+            glDisableVertexAttribArray(attrib);
+    }
 } // namespace gl
 
 #endif // FEATURE_3D_RENDERING

--- a/src/glObjects.cpp
+++ b/src/glObjects.cpp
@@ -1,8 +1,12 @@
 #include "glObjects.h"
+
 #if FEATURE_3D_RENDERING
+
 #include <GL/glew.h>
 #include <type_traits>
+
 static_assert(std::is_same<uint32_t, GLuint>::value, "GLuint and uint32_t are *NOT* the same: troubles!");
+
 namespace gl
 {
 	namespace details
@@ -23,11 +27,13 @@ namespace gl
 		if (attrib != -1)
 			glEnableVertexAttribArray(attrib);
 	}
+
 	ScopedVertexAttribArray::~ScopedVertexAttribArray()
 	{
 		if (attrib != -1)
 			glDisableVertexAttribArray(attrib);
 	}
 } // namespace gl
+
 #endif // FEATURE_3D_RENDERING
 

--- a/src/glObjects.h
+++ b/src/glObjects.h
@@ -1,0 +1,49 @@
+#ifndef EMPTYEPSILON_GLOBJECTS_H
+#define EMPTYEPSILON_GLOBJECTS_H
+#include "featureDefs.h"
+#if FEATURE_3D_RENDERING
+#include <array>
+#include <cstdint>
+namespace gl
+{
+	// Because sfml and glew clashes, we cannot have any
+	// OpenGL functions here (or rather, any 'modern' ones).
+	// So add thin wrappers.
+	namespace details
+	{
+		void createBuffers(size_t count, uint32_t* dst);
+		void deleteBuffers(size_t count, const uint32_t* src);
+	}
+	// RAII object to hold multiple buffers (vbo, ebo etc).
+	template<size_t Count>
+	class Buffers final
+	{
+	public:
+		Buffers()
+		{
+			details::createBuffers(buffers.size(), buffers.data());
+		}
+		~Buffers()
+		{
+			details::deleteBuffers(buffers.size(), buffers.data());
+		}
+		constexpr uint32_t operator[](size_t index)
+		{
+			return buffers[index];
+		}
+	private:
+		std::array<uint32_t, Count> buffers;
+	};
+
+	class ScopedVertexAttribArray final
+	{
+	public:
+		explicit ScopedVertexAttribArray(int32_t attrib);
+		~ScopedVertexAttribArray();
+		int32_t get() const { return attrib; }
+	private:
+		int32_t attrib = -1;
+	};
+}
+#endif // FEATURE_3D_RENDERING
+#endif // EMPTYEPSILON_GLOBJECTS_H

--- a/src/glObjects.h
+++ b/src/glObjects.h
@@ -9,45 +9,45 @@
 
 namespace gl
 {
-	// Because sfml and glew clashes, we cannot have any
-	// OpenGL functions here (or rather, any 'modern' ones).
-	// So add thin wrappers.
-	namespace details
-	{
-		void createBuffers(size_t count, uint32_t* dst);
-		void deleteBuffers(size_t count, const uint32_t* src);
-	}
+    // Because sfml and glew clashes, we cannot have any
+    // OpenGL functions here (or rather, any 'modern' ones).
+    // So add thin wrappers.
+    namespace details
+    {
+        void createBuffers(size_t count, uint32_t* dst);
+        void deleteBuffers(size_t count, const uint32_t* src);
+    }
 
-	// RAII object to hold multiple buffers (vbo, ebo etc).
-	template<size_t Count>
-	class Buffers final
-	{
-	public:
-		Buffers()
-		{
-			details::createBuffers(buffers.size(), buffers.data());
-		}
-		~Buffers()
-		{
-			details::deleteBuffers(buffers.size(), buffers.data());
-		}
-		constexpr uint32_t operator[](size_t index)
-		{
-			return buffers[index];
-		}
-	private:
-		std::array<uint32_t, Count> buffers;
-	};
+    // RAII object to hold multiple buffers (vbo, ebo etc).
+    template<size_t Count>
+    class Buffers final
+    {
+    public:
+        Buffers()
+        {
+            details::createBuffers(buffers.size(), buffers.data());
+        }
+        ~Buffers()
+        {
+            details::deleteBuffers(buffers.size(), buffers.data());
+        }
+        constexpr uint32_t operator[](size_t index)
+        {
+            return buffers[index];
+        }
+    private:
+        std::array<uint32_t, Count> buffers;
+    };
 
-	class ScopedVertexAttribArray final
-	{
-	public:
-		explicit ScopedVertexAttribArray(int32_t attrib);
-		~ScopedVertexAttribArray();
-		int32_t get() const { return attrib; }
-	private:
-		int32_t attrib = -1;
-	};
+    class ScopedVertexAttribArray final
+    {
+    public:
+        explicit ScopedVertexAttribArray(int32_t attrib);
+        ~ScopedVertexAttribArray();
+        int32_t get() const { return attrib; }
+    private:
+        int32_t attrib = -1;
+    };
 }
 #endif // FEATURE_3D_RENDERING
 #endif // EMPTYEPSILON_GLOBJECTS_H

--- a/src/glObjects.h
+++ b/src/glObjects.h
@@ -1,9 +1,12 @@
 #ifndef EMPTYEPSILON_GLOBJECTS_H
 #define EMPTYEPSILON_GLOBJECTS_H
+
 #include "featureDefs.h"
+
 #if FEATURE_3D_RENDERING
 #include <array>
 #include <cstdint>
+
 namespace gl
 {
 	// Because sfml and glew clashes, we cannot have any
@@ -14,6 +17,7 @@ namespace gl
 		void createBuffers(size_t count, uint32_t* dst);
 		void deleteBuffers(size_t count, const uint32_t* src);
 	}
+
 	// RAII object to hold multiple buffers (vbo, ebo etc).
 	template<size_t Count>
 	class Buffers final

--- a/src/spaceObjects/beamEffect.h
+++ b/src/spaceObjects/beamEffect.h
@@ -2,6 +2,7 @@
 #define BEAM_EFFECT_H
 
 #include "spaceObject.h"
+#include "glObjects.h"
 
 class BeamEffect : public SpaceObject, public Updatable
 {
@@ -12,6 +13,11 @@ class BeamEffect : public SpaceObject, public Updatable
     sf::Vector3f targetOffset;
     sf::Vector2f targetLocation;
     sf::Vector3f hitNormal;
+#if FEATURE_3D_RENDERING
+    static sf::Shader* shader;
+    static uint32_t shaderPositionAttribute;
+    static uint32_t shaderTexCoordsAttribute;
+#endif
 public:
     bool fire_ring;
     string beam_texture;

--- a/src/spaceObjects/explosionEffect.cpp
+++ b/src/spaceObjects/explosionEffect.cpp
@@ -1,6 +1,24 @@
+#include <GL/glew.h>
 #include <SFML/OpenGL.hpp>
 #include "main.h"
 #include "explosionEffect.h"
+#include "glObjects.h"
+
+#if FEATURE_3D_RENDERING
+sf::Shader* ExplosionEffect::basicShader = nullptr;
+uint32_t ExplosionEffect::basicShaderPositionAttribute = 0;
+uint32_t ExplosionEffect::basicShaderTexCoordsAttribute = 0;
+
+sf::Shader* ExplosionEffect::particlesShader = nullptr;
+uint32_t ExplosionEffect::particlesShaderPositionAttribute = 0;
+uint32_t ExplosionEffect::particlesShaderTexCoordsAttribute = 0;
+
+struct VertexAndTexCoords
+{
+    sf::Vector3f vertex;
+    sf::Vector2f texcoords;
+};
+#endif
 
 /// ExplosionEffect is a visible explosion, like from nukes, missiles, ship destruction, etc
 /// Example: ExplosionEffect():setPosition(500,5000):setSize(20)
@@ -24,6 +42,18 @@ ExplosionEffect::ExplosionEffect()
 
     registerMemberReplication(&size);
     registerMemberReplication(&on_radar);
+#if FEATURE_3D_RENDERING
+    if (!basicShader)
+    {
+        basicShader = ShaderManager::getShader("shaders/basic");
+        basicShaderPositionAttribute = glGetAttribLocation(basicShader->getNativeHandle(), "position");
+        basicShaderTexCoordsAttribute = glGetAttribLocation(basicShader->getNativeHandle(), "texcoords");
+
+        particlesShader = ShaderManager::getShader("shaders/billboard");
+        particlesShaderPositionAttribute = glGetAttribLocation(particlesShader->getNativeHandle(), "position");
+        particlesShaderTexCoordsAttribute = glGetAttribLocation(particlesShader->getNativeHandle(), "texcoords");
+    }
+#endif
 }
 
 //due to a suspected compiler bug this deconstructor needs to be explicitly defined
@@ -59,43 +89,66 @@ void ExplosionEffect::draw3DTransparent()
     Mesh* m = Mesh::getMesh("sphere.obj");
     m->render();
 
-    ShaderManager::getShader("basicShader")->setUniform("textureMap", *textureManager.getTexture("fire_ring.png"));
-    sf::Shader::bind(ShaderManager::getShader("basicShader"));
+    basicShader->setUniform("textureMap", *textureManager.getTexture("fire_ring.png"));
+    basicShader->setUniform("color", sf::Glsl::Vec4(alpha, alpha, alpha, 1.f));
+    sf::Shader::bind(basicShader);
     glScalef(1.5, 1.5, 1.5);
-    glBegin(GL_QUADS);
-    glTexCoord2f(0, 0);
-    glVertex3f(v1.x, v1.y, v1.z);
-    glTexCoord2f(1, 0);
-    glVertex3f(v2.x, v2.y, v2.z);
-    glTexCoord2f(1, 1);
-    glVertex3f(v3.x, v3.y, v3.z);
-    glTexCoord2f(0, 1);
-    glVertex3f(v4.x, v4.y, v4.z);
-    glEnd();
+
+    constexpr size_t quad_count = 10;
+    std::array<VertexAndTexCoords, 4*quad_count> quads;
+    // Initialize texcoords per quad.
+    for (auto i = 0; i < quads.size(); i += 4)
+    {
+        quads[i + 0].texcoords = { 0.f, 0.f };
+        quads[i + 1].texcoords = { 1.f, 0.f };
+        quads[i + 2].texcoords = { 1.f, 1.f };
+        quads[i + 3].texcoords = { 0.f, 1.f };
+    }
+    // Draw
+    {
+        quads[0].vertex = v1;
+        quads[1].vertex = v2;
+        quads[2].vertex = v3;
+        quads[3].vertex = v4;
+        gl::ScopedVertexAttribArray positions(basicShaderPositionAttribute);
+        gl::ScopedVertexAttribArray texcoords(basicShaderTexCoordsAttribute);
+        glVertexAttribPointer(positions.get(), 3, GL_FLOAT, GL_FALSE, sizeof(VertexAndTexCoords), (GLvoid*)quads.data());
+        glVertexAttribPointer(texcoords.get(), 2, GL_FLOAT, GL_FALSE, sizeof(VertexAndTexCoords), (GLvoid*)((char*)quads.data() + sizeof(sf::Vector3f)));
+        glDrawArrays(GL_QUADS, 0, 4);
+    }
     glPopMatrix();
 
 
-    ShaderManager::getShader("billboardShader")->setUniform("textureMap", *textureManager.getTexture("particle.png"));
-    sf::Shader::bind(ShaderManager::getShader("billboardShader"));
+    particlesShader->setUniform("textureMap", *textureManager.getTexture("particle.png"));
+    
+    sf::Shader::bind(particlesShader);
     scale = Tween<float>::easeInCubic(f, 0.0, 1.0, 0.3f, 5.0f);
     float r = Tween<float>::easeInQuad(f, 0.0, 1.0, 1.0f, 0.0f);
     float g = Tween<float>::easeOutQuad(f, 0.0, 1.0, 1.0f, 0.0f);
     float b = Tween<float>::easeOutQuad(f, 0.0, 1.0, 1.0f, 0.0f);
-    glColor4f(r, g, b, size / 32.0f);
-    glBegin(GL_QUADS);
-    for(int n=0; n<particleCount; n++)
+    particlesShader->setUniform("color", sf::Glsl::Vec4(r, g, b, size / 32.0f));
+    gl::ScopedVertexAttribArray positions(particlesShaderPositionAttribute);
+    gl::ScopedVertexAttribArray texcoords(particlesShaderTexCoordsAttribute);
+
+    // We're drawing particles `quad_count` at a time.
+    for(size_t n = 0; n<particleCount;)
     {
-        sf::Vector3f v = particleDirections[n] * scale * size;
-        glTexCoord2f(0, 0);
-        glVertex3f(v.x, v.y, v.z);
-        glTexCoord2f(1, 0);
-        glVertex3f(v.x, v.y, v.z);
-        glTexCoord2f(1, 1);
-        glVertex3f(v.x, v.y, v.z);
-        glTexCoord2f(0, 1);
-        glVertex3f(v.x, v.y, v.z);
-    }
-    glEnd();
+        auto active_quads = std::min(quad_count, particleCount - n);
+        // setup quads
+        for (auto p = 0; p < active_quads; ++p)
+        {
+            sf::Vector3f v = particleDirections[n + p] * scale * size;
+            quads[4 * p + 0].vertex = v;
+            quads[4 * p + 1].vertex = v;
+            quads[4 * p + 2].vertex = v;
+            quads[4 * p + 3].vertex = v;
+        }
+       
+        glVertexAttribPointer(positions.get(), 3, GL_FLOAT, GL_FALSE, sizeof(VertexAndTexCoords), (GLvoid*)quads.data());
+        glVertexAttribPointer(texcoords.get(), 2, GL_FLOAT, GL_FALSE, sizeof(VertexAndTexCoords), (GLvoid*)((char*)quads.data() + sizeof(sf::Vector3f)));
+        glDrawArrays(GL_QUADS, 0, 4 * active_quads);
+        n += active_quads;
+    }    
 }
 #endif//FEATURE_3D_RENDERING
 

--- a/src/spaceObjects/explosionEffect.h
+++ b/src/spaceObjects/explosionEffect.h
@@ -13,6 +13,15 @@ class ExplosionEffect : public SpaceObject, public Updatable
     string explosion_sound;
     sf::Vector3f particleDirections[particleCount];
     bool on_radar;
+#if FEATURE_3D_RENDERING
+    static sf::Shader* basicShader;
+    static uint32_t basicShaderPositionAttribute;
+    static uint32_t basicShaderTexCoordsAttribute;
+
+    static sf::Shader* particlesShader;
+    static uint32_t particlesShaderPositionAttribute;
+    static uint32_t particlesShaderTexCoordsAttribute;
+#endif
 public:
     ExplosionEffect();
     virtual ~ExplosionEffect();


### PR DESCRIPTION
Removing fixed functions - starting with glBegin/glEnd in the beam fx.

Keeping in mind that the end game is to remove the fixed pipeline entirely, that means a lot of the `gl_*` variables used in the shaders won't be available.
To that end, added versioned shaders (`gl_ModelViewProjectionMatrix` is not a thing in es2 shaders, but it is in gl2), as to not conflict with existing ones.
And started a few utilities

Moved over to the shader pipeline in the simplest way possible.