### PR TITLE
Add callbacks when a probe is linked to or unlinked from Science

### DIFF
--- a/src/screens/crew6/relayScreen.cpp
+++ b/src/screens/crew6/relayScreen.cpp
@@ -116,9 +116,13 @@ RelayScreen::RelayScreen(GuiContainer* owner, bool allow_comms)
     // Link probe to science button.
     link_to_science_button = new GuiToggleButton(option_buttons, "LINK_TO_SCIENCE", tr("Link to Science"), [this](bool value){
         if (value)
-            my_spaceship->commandSetScienceLink(targets.get()->getMultiplayerId());
+        {
+            my_spaceship->commandSetScienceLink(targets.get());
+        }
         else
-            my_spaceship->commandSetScienceLink(-1);
+        {
+            my_spaceship->commandClearScienceLink();
+        }
     });
     link_to_science_button->setSize(GuiElement::GuiSizeMax, 50)->setVisible(my_spaceship && my_spaceship->getCanLaunchProbe());
 

--- a/src/spaceObjects/playerSpaceship.cpp
+++ b/src/spaceObjects/playerSpaceship.cpp
@@ -2042,8 +2042,9 @@ void PlayerSpaceship::commandSetScienceLink(P<ScanProbe> probe)
 void PlayerSpaceship::commandClearScienceLink()
 {
     sf::Packet packet;
+
     packet << CMD_SET_SCIENCE_LINK;
-    packet << -1;
+    packet << int32_t(-1);
     sendClientCommand(packet);
 }
 

--- a/src/spaceObjects/playerSpaceship.cpp
+++ b/src/spaceObjects/playerSpaceship.cpp
@@ -151,11 +151,13 @@ REGISTER_SCRIPT_SUBCLASS(PlayerSpaceship, SpaceShip)
     ///     print("Probe " .. probe:getCallSign() .. " linked to Science on ship " .. player:getCallSign())
     /// end)
     REGISTER_SCRIPT_CLASS_FUNCTION(PlayerSpaceship, onProbeLink);
-    /// Callback when this ship unlinks a probe from the Science screen.
-    /// Passes the PlayerShip.
+    /// Callback when this ship unlinks a probe on the Science screen.
+    /// Passes the PlayerShip and previously linked ScanProbe.
+    /// Does _not_ fire when the probe is destroyed or expires;
+    /// see ScanProbe:onDestruction() and ScanProbe:onExpiration().
     /// Example:
-    /// player:onProbeUnlink(function (player)
-    ///     print("Probe unlinked from Science on ship " .. player:getCallSign())
+    /// player:onProbeUnlink(function (player, probe)
+    ///     print("Probe " .. probe:getCallSign() .. " unlinked from Science on ship " .. player:getCallSign())
     /// end)
     REGISTER_SCRIPT_CLASS_FUNCTION(PlayerSpaceship, onProbeUnlink);
     REGISTER_SCRIPT_CLASS_FUNCTION(PlayerSpaceship, getLongRangeRadarRange);

--- a/src/spaceObjects/playerSpaceship.cpp
+++ b/src/spaceObjects/playerSpaceship.cpp
@@ -1,6 +1,5 @@
 #include "playerSpaceship.h"
 #include "gui/colorConfig.h"
-#include "scanProbe.h"
 #include "repairCrew.h"
 #include "explosionEffect.h"
 #include "gameGlobalInfo.h"
@@ -113,7 +112,16 @@ REGISTER_SCRIPT_SUBCLASS(PlayerSpaceship, SpaceShip)
     REGISTER_SCRIPT_CLASS_FUNCTION(PlayerSpaceship, commandConfirmDestructCode);
     REGISTER_SCRIPT_CLASS_FUNCTION(PlayerSpaceship, commandCombatManeuverBoost);
     REGISTER_SCRIPT_CLASS_FUNCTION(PlayerSpaceship, commandLaunchProbe);
+    /// Command the science screen to link to the given ScanProbe object.
+    /// This is equivalent of selecting a probe on Relay and clicking
+    /// "Link to Science".
+    /// Example: player:commandSetScienceLink(probeObject)
     REGISTER_SCRIPT_CLASS_FUNCTION(PlayerSpaceship, commandSetScienceLink);
+    /// Command the science screen to clear its link to any ScanProbe object.
+    /// This is equivalent to clicking "Link to Science" on Relay when a link
+    /// is already active.
+    /// Example: player:commandClearScienceLink()
+    REGISTER_SCRIPT_CLASS_FUNCTION(PlayerSpaceship, commandClearScienceLink);
     REGISTER_SCRIPT_CLASS_FUNCTION(PlayerSpaceship, commandSetAlertLevel);
 
     /// Return the number of Engineering repair crews on the ship.
@@ -133,21 +141,21 @@ REGISTER_SCRIPT_SUBCLASS(PlayerSpaceship, SpaceShip)
     /// Passes the launching PlayerSpaceship and launched ScanProbe.
     /// Example:
     /// player:onProbeLaunch(function (player, probe)
-    ///     print(probe:getCallSign() .. " launched from " .. player:getCallSign())
+    ///     print("Probe " .. probe:getCallSign() .. " launched from ship " .. player:getCallSign())
     /// end)
     REGISTER_SCRIPT_CLASS_FUNCTION(PlayerSpaceship, onProbeLaunch);
-    /// Callback when this ship links a probe to the science screen.
+    /// Callback when this ship links a probe to the Science screen.
     /// Passes the PlayerShip and linked ScanProbe.
     /// Example:
     /// player:onProbeLink(function (player, probe)
-    ///     print(probe:getCallSign() .. " linked to science on " .. player:getCallSign())
+    ///     print("Probe " .. probe:getCallSign() .. " linked to Science on ship " .. player:getCallSign())
     /// end)
     REGISTER_SCRIPT_CLASS_FUNCTION(PlayerSpaceship, onProbeLink);
-    /// Callback when this ship unlinks a probe from the science screen.
+    /// Callback when this ship unlinks a probe from the Science screen.
     /// Passes the PlayerShip.
     /// Example:
     /// player:onProbeUnlink(function (player)
-    ///     print("probe unlinked from science on " .. player:getCallSign())
+    ///     print("Probe unlinked from Science on ship " .. player:getCallSign())
     /// end)
     REGISTER_SCRIPT_CLASS_FUNCTION(PlayerSpaceship, onProbeUnlink);
     REGISTER_SCRIPT_CLASS_FUNCTION(PlayerSpaceship, getLongRangeRadarRange);
@@ -2003,10 +2011,19 @@ void PlayerSpaceship::commandCustomFunction(string name)
     sendClientCommand(packet);
 }
 
-void PlayerSpaceship::commandSetScienceLink(int32_t id)
+void PlayerSpaceship::commandSetScienceLink(P<ScanProbe> probe)
 {
     sf::Packet packet;
-    packet << CMD_SET_SCIENCE_LINK << id;
+    packet << CMD_SET_SCIENCE_LINK;
+    packet << probe->getMultiplayerId();
+    sendClientCommand(packet);
+}
+
+void PlayerSpaceship::commandClearScienceLink()
+{
+    sf::Packet packet;
+    packet << CMD_SET_SCIENCE_LINK;
+    packet << -1;
     sendClientCommand(packet);
 }
 

--- a/src/spaceObjects/playerSpaceship.cpp
+++ b/src/spaceObjects/playerSpaceship.cpp
@@ -2025,7 +2025,18 @@ void PlayerSpaceship::commandSetScienceLink(P<ScanProbe> probe)
 {
     sf::Packet packet;
     packet << CMD_SET_SCIENCE_LINK;
-    packet << probe->getMultiplayerId();
+
+    // Pass the probe's multiplayer ID if the probe isn't nullptr.
+    if (probe)
+    {
+        packet << probe->getMultiplayerId();
+    }
+    // Otherwise, pass -1 to unlink it, same as commandClearScienceLink().
+    else
+    {
+        LOG(WARNING) << "Attempted to unlink a ScanProbe from Science, but the ScanProbe wasn't valid.";
+        packet << -1;
+    }
     sendClientCommand(packet);
 }
 

--- a/src/spaceObjects/playerSpaceship.cpp
+++ b/src/spaceObjects/playerSpaceship.cpp
@@ -2024,20 +2024,19 @@ void PlayerSpaceship::commandCustomFunction(string name)
 void PlayerSpaceship::commandSetScienceLink(P<ScanProbe> probe)
 {
     sf::Packet packet;
-    packet << CMD_SET_SCIENCE_LINK;
 
     // Pass the probe's multiplayer ID if the probe isn't nullptr.
     if (probe)
     {
+        packet << CMD_SET_SCIENCE_LINK;
         packet << probe->getMultiplayerId();
+        sendClientCommand(packet);
     }
-    // Otherwise, pass -1 to unlink it, same as commandClearScienceLink().
+    // Otherwise, it's invalid. Warn and do nothing.
     else
     {
-        LOG(WARNING) << "Attempted to unlink a ScanProbe from Science, but the ScanProbe wasn't valid.";
-        packet << -1;
+        LOG(WARNING) << "commandSetScienceLink received a null or invalid ScanProbe, so no command was sent.";
     }
-    sendClientCommand(packet);
 }
 
 void PlayerSpaceship::commandClearScienceLink()

--- a/src/spaceObjects/playerSpaceship.cpp
+++ b/src/spaceObjects/playerSpaceship.cpp
@@ -1644,20 +1644,28 @@ void PlayerSpaceship::onReceiveClientCommand(int32_t client_id, sf::Packet& pack
         break;
     case CMD_SET_SCIENCE_LINK:
         {
+            // Capture previously linked probe, if there is one.
+            P<ScanProbe> old_linked_probe;
+
+            if (linked_science_probe_id != -1)
+            {
+                old_linked_probe = game_server->getObjectById(linked_science_probe_id);
+            }
+
             packet >> linked_science_probe_id;
 
             if (linked_science_probe_id != -1 && on_probe_link.isSet())
             {
-                P<ScanProbe> p = game_server->getObjectById(linked_science_probe_id);
+                P<ScanProbe> new_linked_probe = game_server->getObjectById(linked_science_probe_id);
 
-                if (p)
+                if (new_linked_probe)
                 {
-                    on_probe_link.call(P<PlayerSpaceship>(this), P<ScanProbe>(p));
+                    on_probe_link.call(P<PlayerSpaceship>(this), P<ScanProbe>(new_linked_probe));
                 }
             }
             else if (linked_science_probe_id == -1 && on_probe_unlink.isSet())
             {
-                on_probe_unlink.call(P<PlayerSpaceship>(this));
+                on_probe_unlink.call(P<PlayerSpaceship>(this), P<ScanProbe>(old_linked_probe));
             }
         }
         break;

--- a/src/spaceObjects/playerSpaceship.h
+++ b/src/spaceObjects/playerSpaceship.h
@@ -2,9 +2,12 @@
 #define PLAYER_SPACESHIP_H
 
 #include "spaceship.h"
+#include "scanProbe.h"
 #include "commsScriptInterface.h"
 #include "playerInfo.h"
 #include <iostream>
+
+class ScanProbe;
 
 enum ECommsState
 {
@@ -247,7 +250,8 @@ public:
     void commandWarp(int8_t target);
     void commandJump(float distance);
     void commandSetTarget(P<SpaceObject> target);
-    void commandSetScienceLink(int32_t id);
+    void commandSetScienceLink(P<ScanProbe> probe);
+    void commandClearScienceLink();
     void commandLoadTube(int8_t tubeNumber, EMissileWeapons missileType);
     void commandUnloadTube(int8_t tubeNumber);
     void commandFireTube(int8_t tubeNumber, float missile_target_angle);

--- a/src/spaceObjects/playerSpaceship.h
+++ b/src/spaceObjects/playerSpaceship.h
@@ -157,6 +157,8 @@ public:
     int scan_probe_stock;
     float scan_probe_recharge = 0.0;
     ScriptSimpleCallback on_probe_launch;
+    ScriptSimpleCallback on_probe_link;
+    ScriptSimpleCallback on_probe_unlink;
 
     // Main screen content
     EMainScreenSetting main_screen_setting;
@@ -226,6 +228,8 @@ public:
     int getMaxScanProbeCount() { return max_scan_probes; }
 
     void onProbeLaunch(ScriptSimpleCallback callback);
+    void onProbeLink(ScriptSimpleCallback callback);
+    void onProbeUnlink(ScriptSimpleCallback callback);
 
     void addCustomButton(ECrewPosition position, string name, string caption, ScriptSimpleCallback callback);
     void addCustomInfo(ECrewPosition position, string name, string caption);


### PR DESCRIPTION
- Add `PlayerSpaceship:onProbeLink(PlayerSpaceship, ScanProbe)` callback, fired when a scan probe is linked to Science.
- Add `PlayerSpaceship:onProbeUnlink(PlayerSpaceship)` callback, fired when a scan probe is unlinked from Science.
- Modify `PlayerSpaceship:commandSetScienceLink(int32_t)` to take a ScanProbe object as an argument instead of a multiplayer ID, which scripts can't easily get.
- Add `PlayerSpaceship:commandClearScienceLink()` to unlink whatever probe is linked to Science, equivalent to what `commandSetScienceLink(-1)` did previously.
- Document `commandSetScienceLink()` as well as the new callback functions.

**This is a breaking change for any scripts that use `commandSetScienceLink()`**. No scenarios bundled with EE use it, I couldn't find any after a quick search of GitHub and GitLab, and the function was undocumented for scripting until this PR.

Example code that automatically launches a probe toward coordinates 1U,1U, then links it to Science upon arrival, then unlinks it:

```lua
function probeLaunched(player, probe)
    print("Probe " .. probe:getCallSign() .. " launched from ship " .. player:getCallSign())
    probe:onArrival(function(probe)
        -- This is for demonstration purposes only.
        -- It's possible that the probe owner no longer exists by the time the probe arrives!
        print("Probe " .. probe:getCallSign() .. " from ship " .. probe:getOwner():getCallSign() .. " arrived at target coordinates")
        probe:getOwner():commandSetScienceLink(probe)
        probe:getOwner():commandClearScienceLink()
    end)
end

function probeLinked(player, probe)
    print("Probe " .. probe:getCallSign() .. " linked to Science on ship " .. player:getCallSign())
end

function probeUnlinked(player, probe)
    print("Probe " .. probe:getCallSign() .. " unlinked from Science on ship " .. player:getCallSign())
end

function init()
    player = PlayerSpaceship():setFaction("Human Navy"):setTemplate("Atlantis")

    player:onProbeLaunch(probeLaunched)
    player:onProbeLink(probeLinked)
    player:onProbeUnlink(probeUnlinked)

    player:commandLaunchProbe(1000, 1000)
end
```

Results in:

```
Probe 313P launched from ship PL309
Probe 313P from ship PL309 arrived at target coordinates
Probe 313P linked to Science on ship PL309
Probe 313P unlinked from Science on ship PL309
```

Fixes #942.