### PR TITLE
Roam near position if no target position is set

### DIFF
--- a/src/ai/ai.cpp
+++ b/src/ai/ai.cpp
@@ -332,7 +332,7 @@ void ShipAI::runOrders()
             // 30U of this ship's current position.
             else
             {
-                roamToNewRandomLocation(30000.0f);
+                roamToNewRandomLocation(owner->getPosition(), 30000.0f);
             }
         }
         // - Retreat to a station, or roam to find a station, if out of
@@ -352,7 +352,7 @@ void ShipAI::runOrders()
             // 30U of this ship's current position.
             else
             {
-                roamToNewRandomLocation(30000.0f);
+                roamToNewRandomLocation(owner->getPosition(), 30000.0f);
             }
         }
         // - Hold ground if unarmed.
@@ -800,15 +800,16 @@ P<SpaceObject> ShipAI::findBestMissileRestockTarget(sf::Vector2f position, float
     return target;
 }
 
-void ShipAI::roamToNewRandomLocation(float radius = 30000.0f)
+void ShipAI::roamToNewRandomLocation(sf::Vector2f position, float radius)
 {
-    sf::Vector2f position = owner->getPosition();
+    sf::Vector2f owner_position = owner->getPosition();
     sf::Vector2f target_location = owner->getOrderTargetLocation();
-    sf::Vector2f diff = target_location - position;
+    sf::Vector2f diff = target_location - owner_position;
 
     // If we're within 1U of the point we're roaming toward, or our
     // target coordinates are the default 0,0, roam toward a new
-    // random point within a 30U radius of our current position.
+    // random point within a 30U radius of the roaming origin
+    // (ship's position at initial start of roaming).
     if (diff < 1000.0f || target_location == sf::Vector2f(0.0f, 0.0f))
     {
         owner->orderRoamingAt(sf::Vector2f(random(position.x - radius, position.y + radius), random(position.x - radius, position.y + radius)));

--- a/src/ai/ai.h
+++ b/src/ai/ai.h
@@ -61,7 +61,7 @@ protected:
     virtual void runAttack(P<SpaceObject> target);
     virtual void flyTowards(sf::Vector2f target, float keep_distance = 100.0);
     virtual void flyFormation(P<SpaceObject> target, sf::Vector2f offset);
-    virtual void roamToNewRandomLocation(float radius);
+    virtual void roamToNewRandomLocation(sf::Vector2f position, float radius);
 
     P<SpaceObject> findBestTarget(sf::Vector2f position, float radius);
     float targetScore(P<SpaceObject> target);

--- a/src/ai/ai.h
+++ b/src/ai/ai.h
@@ -61,6 +61,7 @@ protected:
     virtual void runAttack(P<SpaceObject> target);
     virtual void flyTowards(sf::Vector2f target, float keep_distance = 100.0);
     virtual void flyFormation(P<SpaceObject> target, sf::Vector2f offset);
+    virtual void roamToNewRandomLocation(float radius);
 
     P<SpaceObject> findBestTarget(sf::Vector2f position, float radius);
     float targetScore(P<SpaceObject> target);


### PR DESCRIPTION
If no order_target_position is set, a ship's orders are set to AI_Roaming, and
no targets are within 50U, ships following roaming orders will move towards 0,0
because that's the default value if no target position is unassigned.

When getting orders to roam, instead get the ship's current position at that time,
and then continuously move to random points within a 30U radius of that position.

This significantly changes the behavior of roaming ships more than 50U away from an
enemy, which will no longer fly to coordinates 0,0. Scenarios that rely on this behavior might be affected. To reproduce an equivalent to the old behavior, order
`flyTowards(0,0)` before roaming.

Fixes #355.