### PR TITLE
Document CpuShip AI-related scripting functions

### DIFF
--- a/src/spaceObjects/cpuShip.cpp
+++ b/src/spaceObjects/cpuShip.cpp
@@ -16,36 +16,80 @@
 /// Example: CpuShip():setTemplate("Fighter"):setPosition(random(-10000, 10000), random(0, 3000)):setFaction("Human Navy"):orderRoaming():setScanned(true)
 REGISTER_SCRIPT_SUBCLASS(CpuShip, SpaceShip)
 {
-    /// Switch the AI to a different type. AI can be set per ship, or left per default which will be taken from the shipTemplate then.
+    /// Switch the AI to a different state. AI state can be set per ship,
+    /// defined in the shipTemplate, or left to "default". AI state is distinct
+    /// from orders, and determines the AI's tactics and responses in combat.
+    /// Valid values are "default", "missileVolley", "fighter", and "evasion".
+    /// "missileVolley" prefers lining up missile attacks from long range.
+    /// "fighter" prefers attacking at close range with strafing maneuvers.
+    /// "evasion" maintains distance from enemy weapons and evades attacks.
+    /// Example: enemy:setAI("fighter")
     REGISTER_SCRIPT_CLASS_FUNCTION(CpuShip, setAI);
-
-    /// Order this ship to stand still and do nothing.
+    /// Order this ship to hold the current position. Do nothing; don't attack.
+    /// Orders are distinct from AI state, and determines what the ship's
+    /// current objectives.
+    /// Example: enemy:orderIdle()
     REGISTER_SCRIPT_CLASS_FUNCTION(CpuShip, orderIdle);
-    /// Order this ship to roam around the world and attack targets
+    /// Order this ship to roam and engage at will, without a specific target.
+    /// Example: enemy:orderRoaming()
     REGISTER_SCRIPT_CLASS_FUNCTION(CpuShip, orderRoaming);
-    /// Order this ship to stand still, but still target and try to hit nearby enemies
-    REGISTER_SCRIPT_CLASS_FUNCTION(CpuShip, orderStandGround);
-    /// Order this ship to defend a specific location. It will attack enemies near this target.
-    REGISTER_SCRIPT_CLASS_FUNCTION(CpuShip, orderDefendLocation);
-    /// Order this ship to defend a specific object. It will attack enemies near this object.
-    REGISTER_SCRIPT_CLASS_FUNCTION(CpuShip, orderDefendTarget);
-    /// Order this ship to fly in formation with another ship. It will attack nearby enemies.
-    REGISTER_SCRIPT_CLASS_FUNCTION(CpuShip, orderFlyFormation);
-    /// Order this ship to fly to a location, attacking everything alogn the way.
-    REGISTER_SCRIPT_CLASS_FUNCTION(CpuShip, orderFlyTowards);
-    /// Order this ship to fly to a location, without attacking anything
-    REGISTER_SCRIPT_CLASS_FUNCTION(CpuShip, orderFlyTowardsBlind);
-    /// Order this ship to attack a specific target. If the target is destroyed it will fall back to roaming orders.
-    REGISTER_SCRIPT_CLASS_FUNCTION(CpuShip, orderAttack);
-    /// Order this ship to dock at a specific object (station or otherwise)
-    REGISTER_SCRIPT_CLASS_FUNCTION(CpuShip, orderDock);
-    /// Order this ship to restock missiles at a specific station or finds a close station
+    /// Order this ship to dock at [order_target] to re-stock missiles and
+    /// repair its hull. If neccessary, roam to locate a dockable target.
+    /// Continue roaming after repairs and re-stocking, or if no dockable
+    /// target is found.
+    /// Requires a target ShipTemplateBasedObject that supports docking.
+    /// Example: enemy:orderRetreat(spaceStation)
     REGISTER_SCRIPT_CLASS_FUNCTION(CpuShip, orderRetreat);
-    /// Get the order this ship is executing
+    /// Order this ship to hold the current position. Do not retreat, and
+    /// attack nearby targets.
+    /// Example: enemy:orderStandGround()
+    REGISTER_SCRIPT_CLASS_FUNCTION(CpuShip, orderStandGround);
+    /// Order this ship to defend [order_target_location] against enemies that
+    /// get too close.
+    /// Requires x,y coordinates to defend.
+    /// Example: enemy:orderDefendLocation(500, 1000)
+    REGISTER_SCRIPT_CLASS_FUNCTION(CpuShip, orderDefendLocation);
+    /// Order this ship to defend [order_target] against enemies that get too
+    /// close. Default to AI_Roaming if the defense target is destroyed.
+    /// Requires a SpaceObject to defend.
+    /// Example: enemy:orderDefendTarget(enemy2)
+    REGISTER_SCRIPT_CLASS_FUNCTION(CpuShip, orderDefendTarget);
+    /// Order this ship to follow [order_target] from a specified distance, and
+    /// to use [order_target]'s target if one is selected.
+    /// Requires a SpaceObject to serve as the formation's flight leader, and a
+    /// float value for the offset distance to maintain.
+    /// Example: enemy:orderFlyFormation(enemy2, 500)
+    REGISTER_SCRIPT_CLASS_FUNCTION(CpuShip, orderFlyFormation);
+    /// Order this ship to move towards [order_target_location] and attack
+    /// enemies that get too close during transit. Disengage from combat and
+    /// continue towards the destination if enemies are too distant.
+    /// Requires x,y coordinates to move towards.
+    /// Example: enemy:orderFlyTowards(500, 1000)
+    REGISTER_SCRIPT_CLASS_FUNCTION(CpuShip, orderFlyTowards);
+    /// Order this ship to move towards [order_target_location] while ignoring
+    /// all enemies. Don't attack.
+    /// Requires x,y coordinates to move towards.
+    /// Example: enemy:orderFlyTowardsBlind(500, 1000)
+    REGISTER_SCRIPT_CLASS_FUNCTION(CpuShip, orderFlyTowardsBlind);
+    /// Order this ship to attack the specified [order_target].
+    /// Requires a SpaceObject to attack.
+    /// Example: enemy:orderAttack(player)
+    REGISTER_SCRIPT_CLASS_FUNCTION(CpuShip, orderAttack);
+    /// Order this ship to dock with the specified target, if possible.
+    /// Requires a dockable SpaceObject to dock with.
+    /// Example: enemy:orderDock(spaceStation)
+    REGISTER_SCRIPT_CLASS_FUNCTION(CpuShip, orderDock);
+    /// Get this ship's current orders.
+    /// Returns a string representation of the ship's current EAIOrder value.
+    /// Example: local ship_orders = enemy:getOrder()
     REGISTER_SCRIPT_CLASS_FUNCTION(CpuShip, getOrder);
-    /// Get the target location of the currently executed order
+    /// Get the target location of this ship's current orders.
+    /// Returns the targeted x,y coordinates, or 0,0 if not defined.
+    /// Example: local x, y = enemy:getOrderTargetLocation()
     REGISTER_SCRIPT_CLASS_FUNCTION(CpuShip, getOrderTargetLocation);
-    /// Get the target SpaceObject of the currently executed order
+    /// Get the target SpaceObject of this ship's current orders.
+    /// Returns the targeted SpaceObject.
+    /// Example: local target = enemy:getOrderTarget()
     REGISTER_SCRIPT_CLASS_FUNCTION(CpuShip, getOrderTarget);
 }
 


### PR DESCRIPTION
Expand documentation of CpuShip AI-related scripting functions with examples, requirements, and for `setAI` valid AI state value strings.