### PR TITLE
Allow scripts to create ScanProbes

### DIFF
--- a/src/spaceObjects/scanProbe.cpp
+++ b/src/spaceObjects/scanProbe.cpp
@@ -21,6 +21,10 @@ REGISTER_SCRIPT_SUBCLASS_NO_CREATE(ScanProbe, SpaceObject)
     /// Get the probe's target coordinates.
     /// Example: local targetX, targetY = probe:getTarget()
     REGISTER_SCRIPT_CLASS_FUNCTION(ScanProbe, getTarget);
+    /// Set the probe's owner SpaceObject.
+    /// Requires a SpaceObject.
+    /// Example: probe:setOwner(owner_ship)
+    REGISTER_SCRIPT_CLASS_FUNCTION(ScanProbe, setOwner);
     /// Get the probe's owner SpaceObject.
     /// Example: local owner_ship = probe:getOwner()
     REGISTER_SCRIPT_CLASS_FUNCTION(ScanProbe, getOwner);

--- a/src/spaceObjects/scanProbe.cpp
+++ b/src/spaceObjects/scanProbe.cpp
@@ -6,7 +6,7 @@
 #include "scriptInterface.h"
 
 /// A scan probe.
-REGISTER_SCRIPT_SUBCLASS_NO_CREATE(ScanProbe, SpaceObject)
+REGISTER_SCRIPT_SUBCLASS(ScanProbe, SpaceObject)
 {
     /// Set the probe's remaining lifetime, in seconds.
     /// The default initial lifetime is 10 minutes.


### PR DESCRIPTION
Remove `NO_CREATE` from ScanProbes script registration and expose `setOwner()` to scripting, so scripts can create new probes and assign them to a ship.

Example code:

```lua
ScanProbe():setOwner(getPlayerShip(-1)):setPosition(getPlayerShip(-1):getPosition()):setTarget(10000,10000)
```

creates a new ScanProbe owned by the first PlayerSpaceship at the ship's location, then moves it to coordinates 10000,10000.