### PR TITLE
#1305 : Detect overall GL availability

### DIFF
--- a/src/glObjects.cpp
+++ b/src/glObjects.cpp
@@ -33,6 +33,12 @@ namespace gl
         if (attrib != -1)
             glDisableVertexAttribArray(attrib);
     }
+
+    bool isAvailable()
+    {
+        // Works in "greater or equal than" fashion..
+        return GLEW_VERSION_2_0;
+    }
 } // namespace gl
 
 #endif // FEATURE_3D_RENDERING

--- a/src/glObjects.h
+++ b/src/glObjects.h
@@ -48,6 +48,8 @@ namespace gl
     private:
         int32_t attrib = -1;
     };
+
+    bool isAvailable();
 }
 #endif // FEATURE_3D_RENDERING
 #endif // EMPTYEPSILON_GLOBJECTS_H

--- a/src/spaceObjects/beamEffect.cpp
+++ b/src/spaceObjects/beamEffect.cpp
@@ -57,7 +57,7 @@ BeamEffect::BeamEffect()
     registerMemberReplication(&beam_fire_sound_power);
     registerMemberReplication(&fire_ring);
 #if FEATURE_3D_RENDERING
-    if (!shader)
+    if (!shader && gl::isAvailable())
     {
         shader = ShaderManager::getShader("shaders/basic");
         shaderPositionAttribute = glGetAttribLocation(shader->getNativeHandle(), "position");

--- a/src/spaceObjects/explosionEffect.cpp
+++ b/src/spaceObjects/explosionEffect.cpp
@@ -43,7 +43,7 @@ ExplosionEffect::ExplosionEffect()
     registerMemberReplication(&size);
     registerMemberReplication(&on_radar);
 #if FEATURE_3D_RENDERING
-    if (!basicShader)
+    if (!basicShader && gl::isAvailable())
     {
         basicShader = ShaderManager::getShader("shaders/basic");
         basicShaderPositionAttribute = glGetAttribLocation(basicShader->getNativeHandle(), "position");


### PR DESCRIPTION
For #1305 : Skip shader initialization if OpenGL is not available.

Detecting this via glew variables, since using sf::Shader::isAvailable() would force GL initialization, something we probably want to try and avoid in headless contexts.