### PR TITLE
lua functions to customize artifact radar traces

### DIFF
--- a/src/spaceObjects/artifact.h
+++ b/src/spaceObjects/artifact.h
@@ -11,6 +11,11 @@ private:
     float artifact_spin=0.0;
     bool allow_pickup;
     ScriptSimpleCallback on_pickup_callback;
+
+    string radar_trace_icon="RadarBlip.png";
+    float radar_trace_scale=0;
+    sf::Color radar_trace_color = sf::Color(255, 255, 255);
+
 public:
     Artifact();
 
@@ -26,6 +31,10 @@ public:
     void setSpin(float spin=0.0);
     void explode();
     void allowPickup(bool allow);
+
+    void setRadarTraceIcon(string icon);
+    void setRadarTraceScale(float scale);
+    void setRadarTraceColor(int r, int g, int b) { radar_trace_color = sf::Color(r, g, b); }
 
     virtual string getExportLine() override;
     void onPickUp(ScriptSimpleCallback callback);


### PR DESCRIPTION
This adds 3 functions for artifacts:

setRadarTraceIcon()
setRadarTraceScale()
setRadarTraceColor()

Originally made with asteroid mining in mind, so you could make artifacts that look like asteroids, but are either big "motherlodes" that should not explode on contact, or small chunks that could be cut from the bigger ones, and then be collected (maybe for the latter, one might still want to make it look slightly different from normal asteroids). 
But there would also be a lot of other applications for that.
![artifacts](https://user-images.githubusercontent.com/25465934/106396923-3023c300-640b-11eb-87c0-8349a8f2e28c.jpg)
