### PR TITLE
Fix Relay when the player belongs to a faction that is hostile to itself

### DIFF
--- a/src/screenComponents/radarView.cpp
+++ b/src/screenComponents/radarView.cpp
@@ -243,7 +243,8 @@ void GuiRadarView::drawNoneFriendlyBlockedAreas(sf::RenderTarget& window)
 
         foreach(SpaceObject, obj, space_object_list)
         {
-            if ((P<SpaceShip>(obj) || P<SpaceStation>(obj)) && obj->isFriendly(my_spaceship))
+            if ((P<SpaceShip>(obj) || P<SpaceStation>(obj))
+                && (obj->isFriendly(my_spaceship) || obj == my_spaceship))
             {
                 circle.setPosition(worldToScreen(obj->getPosition()));
                 window.draw(circle);
@@ -604,7 +605,8 @@ void GuiRadarView::drawObjects(sf::RenderTarget& window_normal, sf::RenderTarget
             if (!obj->canHideInNebula())
                 visible_objects.insert(*obj);
 
-            if ((!P<SpaceShip>(obj) && !P<SpaceStation>(obj)) || !obj->isFriendly(my_spaceship))
+            if ((!P<SpaceShip>(obj) && !P<SpaceStation>(obj))
+                || (!obj->isFriendly(my_spaceship) && obj != my_spaceship))
             {
                 P<ScanProbe> sp = obj;
                 if (!sp || sp->owner_id != my_spaceship->getMultiplayerId())

--- a/src/screens/crew6/relayScreen.cpp
+++ b/src/screens/crew6/relayScreen.cpp
@@ -218,7 +218,8 @@ void RelayScreen::onDraw(sf::RenderTarget& window)
         bool near_friendly = false;
         foreach(SpaceObject, obj, space_object_list)
         {
-            if ((!P<SpaceShip>(obj) && !P<SpaceStation>(obj)) || !obj->isFriendly(my_spaceship))
+            if ((!P<SpaceShip>(obj) && !P<SpaceStation>(obj))
+                || (!obj->isFriendly(my_spaceship) && obj != my_spaceship))
             {
                 P<ScanProbe> sp = obj;
                 if (!sp || sp->owner_id != my_spaceship->getMultiplayerId())


### PR DESCRIPTION
If a player ship belongs to a faction that is hostile to itself, the short-range radar view around the player ship on Relay breaks because the player ship is not in a faction friendly to itself.

Catch this edge case and render the player ship's own radar range on Relay.

Example faction:

```
pirates = FactionInfo()
pirates:setName("Pirates"):setLocaleName(_("Pirates"))
pirates:setGMColor(255, 255, 0)
pirates:setEnemy(pirates)
```

Example scenario:

```
PlayerSpaceship():setTemplate("Atlantis"):setFaction("Pirates"):setPosition(0, 0)
CpuShip():setTemplate("Atlantis"):setFaction("Pirates"):setPosition(-4000, 0)
```

Expected behavior:

- The PlayerSpaceship's Relay screen can see and select objects within its short-range radar range.
- The CpuShip is in the same faction but is not considered Friendly for the purposes of Relay and does not share its short-range radar.