### PR TITLE
Settable radar ranges for all ShipTemplateBasedObjects

### DIFF
--- a/src/screenComponents/radarView.cpp
+++ b/src/screenComponents/radarView.cpp
@@ -240,9 +240,11 @@ void GuiRadarView::drawNoneFriendlyBlockedAreas(sf::RenderTarget& window)
 
         foreach(SpaceObject, obj, space_object_list)
         {
-            if (P<ShipTemplateBasedObject>(obj) && obj->isFriendly(my_spaceship))
+            P<ShipTemplateBasedObject> stb_obj = obj;
+
+            if (stb_obj && obj->isFriendly(my_spaceship))
             {
-                r = P<ShipTemplateBasedObject>(obj)->getShortRangeRadarRange() * scale;
+                r = stb_obj->getShortRangeRadarRange() * scale;
                 sf::CircleShape circle(r, 50);
                 circle.setOrigin(r, r);
                 circle.setFillColor(sf::Color(255, 255, 255, 255));
@@ -611,16 +613,19 @@ void GuiRadarView::drawObjects(sf::RenderTarget& window_normal, sf::RenderTarget
             if (!obj->canHideInNebula())
                 visible_objects.insert(*obj);
 
-            if (!P<ShipTemplateBasedObject>(obj) || !obj->isFriendly(my_spaceship))
+            P<ShipTemplateBasedObject> stb_obj = obj;
+
+            if (!stb_obj || !obj->isFriendly(my_spaceship))
             {
                 P<ScanProbe> sp = obj;
+
                 if (!sp || sp->owner_id != my_spaceship->getMultiplayerId())
                 {
                     continue;
                 }
             }
 
-            float r = ((P<ShipTemplateBasedObject>(obj)) && obj->isFriendly(my_spaceship)) ? P<ShipTemplateBasedObject>(obj)->getShortRangeRadarRange() : 5000.0f;
+            float r = (stb_obj && obj->isFriendly(my_spaceship)) ? stb_obj->getShortRangeRadarRange() : 5000.0f;
 
             sf::Vector2f position = obj->getPosition();
             PVector<Collisionable> obj_list = CollisionManager::queryArea(position - sf::Vector2f(r, r), position + sf::Vector2f(r, r));

--- a/src/screenComponents/radarView.cpp
+++ b/src/screenComponents/radarView.cpp
@@ -606,14 +606,30 @@ void GuiRadarView::drawObjects(sf::RenderTarget& window_normal, sf::RenderTarget
         }
         break;
     case FriendlysShortRangeFogOfWar:
-        if (!my_spaceship)
-            return;
+        // Reveal objects if they are within short-range radar range (or 5U) of
+        // a friendly ship, station, or scan probe.
 
+        // Continue only if the player's ship exists.
+        if (!my_spaceship)
+        {
+            return;
+        }
+
+        // For each SpaceObject on the map...
         foreach(SpaceObject, obj, space_object_list)
         {
+            // If the object can't hide in a nebula, it's considered visible.
             if (!obj->canHideInNebula())
+            {
                 visible_objects.insert(*obj);
+            }
 
+            // Consider the object only if it is:
+            // - Any ShipTemplateBasedObject (ship or station)
+            // - A SpaceObject belonging to a friendly faction
+            // - The player's ship
+            // - A scan probe owned by the player's ship
+            // This check is duplicated in RelayScreen::onDraw.
             P<ShipTemplateBasedObject> stb_obj = obj;
 
             if (!stb_obj
@@ -627,20 +643,27 @@ void GuiRadarView::drawObjects(sf::RenderTarget& window_normal, sf::RenderTarget
                 }
             }
 
-            float r = (stb_obj && obj->isFriendly(my_spaceship)) ? stb_obj->getShortRangeRadarRange() : 5000.0f;
+            // Set the radius to reveal as getShortRangeRadarRange() if the
+            // object's a ShipTemplateBasedObject. Otherwise, default to 5U.
+            float r = stb_obj ? stb_obj->getShortRangeRadarRange() : 5000.0f;
 
+            // Query for objects within short-range radar/5U of this object.
             sf::Vector2f position = obj->getPosition();
             PVector<Collisionable> obj_list = CollisionManager::queryArea(position - sf::Vector2f(r, r), position + sf::Vector2f(r, r));
 
+            // For each of those objects, check if it is at least partially
+            // inside the revealed radius. If so, reveal the object on the map.
             foreach(Collisionable, c_obj, obj_list)
             {
                 P<SpaceObject> obj2 = c_obj;
+
                 if (obj2 && (obj->getPosition() - obj2->getPosition()) < r + obj2->getRadius())
                 {
                     visible_objects.insert(*obj2);
                 }
             }
         }
+
         break;
     case NebulaFogOfWar:
         foreach(SpaceObject, obj, space_object_list)

--- a/src/screens/crew6/relayScreen.cpp
+++ b/src/screens/crew6/relayScreen.cpp
@@ -218,15 +218,19 @@ void RelayScreen::onDraw(sf::RenderTarget& window)
         bool near_friendly = false;
         foreach(SpaceObject, obj, space_object_list)
         {
-            if ((!P<ShipTemplateBasedObject>(obj)) || !obj->isFriendly(my_spaceship))
+            P<ShipTemplateBasedObject> stb_obj = obj;
+
+            if (!stb_obj || !obj->isFriendly(my_spaceship))
             {
                 P<ScanProbe> sp = obj;
+
                 if (!sp || sp->owner_id != my_spaceship->getMultiplayerId())
                 {
                     continue;
                 }
             }
-            if (obj->getPosition() - target->getPosition() < P<ShipTemplateBasedObject>(obj)->getShortRangeRadarRange())
+
+            if (obj->getPosition() - target->getPosition() < stb_obj->getShortRangeRadarRange())
             {
                 near_friendly = true;
                 break;

--- a/src/screens/crew6/relayScreen.cpp
+++ b/src/screens/crew6/relayScreen.cpp
@@ -218,7 +218,7 @@ void RelayScreen::onDraw(sf::RenderTarget& window)
         bool near_friendly = false;
         foreach(SpaceObject, obj, space_object_list)
         {
-            if ((!P<SpaceShip>(obj) && !P<SpaceStation>(obj)) || !obj->isFriendly(my_spaceship))
+            if ((!P<ShipTemplateBasedObject>(obj)) || !obj->isFriendly(my_spaceship))
             {
                 P<ScanProbe> sp = obj;
                 if (!sp || sp->owner_id != my_spaceship->getMultiplayerId())
@@ -226,7 +226,7 @@ void RelayScreen::onDraw(sf::RenderTarget& window)
                     continue;
                 }
             }
-            if (obj->getPosition() - target->getPosition() < 5000.0f)
+            if (obj->getPosition() - target->getPosition() < P<ShipTemplateBasedObject>(obj)->getShortRangeRadarRange())
             {
                 near_friendly = true;
                 break;

--- a/src/screens/gm/tweak.cpp
+++ b/src/screens/gm/tweak.cpp
@@ -118,6 +118,15 @@ GuiTweakShip::GuiTweakShip(GuiContainer* owner)
     right_col->setPosition(-25, 25, ATopRight)->setSize(300, GuiElement::GuiSizeMax);
 
     // Left column
+    // Set type name. Does not change ship type.
+    (new GuiLabel(left_col, "", tr("Type name:"), 30))->setSize(GuiElement::GuiSizeMax, 50);
+
+    type_name = new GuiTextEntry(left_col, "", "");
+    type_name->setSize(GuiElement::GuiSizeMax, 50);
+    type_name->callback([this](string text) {
+        target->setTypeName(text);
+    });
+
     (new GuiLabel(left_col, "", tr("Impulse speed:"), 30))->setSize(GuiElement::GuiSizeMax, 50);
     impulse_speed_slider = new GuiSlider(left_col, "", 0.0, 250, 0.0, [this](float value) {
         target->impulse_max_speed = value;
@@ -149,15 +158,6 @@ GuiTweakShip::GuiTweakShip(GuiContainer* owner)
     jump_charge_slider->addOverlay()->setSize(GuiElement::GuiSizeMax, 40);
 
     // Right column
-    // Set type name. Does not change ship type.
-    (new GuiLabel(right_col, "", tr("Type name:"), 30))->setSize(GuiElement::GuiSizeMax, 50);
-
-    type_name = new GuiTextEntry(right_col, "", "");
-    type_name->setSize(GuiElement::GuiSizeMax, 50);
-    type_name->callback([this](string text) {
-        target->setTypeName(text);
-    });
-
     // Hull max and state sliders
     (new GuiLabel(right_col, "", tr("Hull max:"), 30))->setSize(GuiElement::GuiSizeMax, 50);
     hull_max_slider = new GuiSlider(right_col, "", 0.0, 500, 0.0, [this](float value) {
@@ -172,11 +172,11 @@ GuiTweakShip::GuiTweakShip(GuiContainer* owner)
     });
     hull_slider->addOverlay()->setSize(GuiElement::GuiSizeMax, 40);
 
-   // Can be destroyed bool
-   can_be_destroyed_toggle = new GuiToggleButton(right_col, "", tr("Could be destroyed"), [this](bool value) {
-       target->setCanBeDestroyed(value);
-   });
-   can_be_destroyed_toggle->setSize(GuiElement::GuiSizeMax, 40);
+    // Can be destroyed bool
+    can_be_destroyed_toggle = new GuiToggleButton(right_col, "", tr("Could be destroyed"), [this](bool value) {
+        target->setCanBeDestroyed(value);
+    });
+    can_be_destroyed_toggle->setSize(GuiElement::GuiSizeMax, 40);
 
     // Warp and jump drive toggles
     (new GuiLabel(right_col, "", "Special drives:", 30))->setSize(GuiElement::GuiSizeMax, 50);
@@ -189,6 +189,19 @@ GuiTweakShip::GuiTweakShip(GuiContainer* owner)
         target->setJumpDrive(value);
     });
     jump_toggle->setSize(GuiElement::GuiSizeMax, 40);
+
+    // Radar ranges
+    (new GuiLabel(right_col, "", tr("Short-range radar range:"), 30))->setSize(GuiElement::GuiSizeMax, 50);
+    short_range_radar_slider = new GuiSlider(right_col, "", 100.0, 20000.0, 0.0, [this](float value) {
+        target->setShortRangeRadarRange(value);
+    });
+    short_range_radar_slider->addOverlay()->setSize(GuiElement::GuiSizeMax, 40);
+
+    (new GuiLabel(right_col, "", tr("Long-range radar range:"), 30))->setSize(GuiElement::GuiSizeMax, 50);
+    long_range_radar_slider = new GuiSlider(right_col, "", 100.0, 100000.0, 0.0, [this](float value) {
+        target->setLongRangeRadarRange(value);
+    });
+    long_range_radar_slider->addOverlay()->setSize(GuiElement::GuiSizeMax, 40);
 }
 
 void GuiTweakShip::onDraw(sf::RenderTarget& window)
@@ -204,6 +217,8 @@ void GuiTweakShip::onDraw(sf::RenderTarget& window)
     turn_speed_slider->setValue(target->turn_speed);
     hull_max_slider->setValue(target->hull_max);
     can_be_destroyed_toggle->setValue(target->getCanBeDestroyed());
+    short_range_radar_slider->setValue(target->getShortRangeRadarRange());
+    long_range_radar_slider->setValue(target->getLongRangeRadarRange());
 }
 
 void GuiTweakShip::open(P<SpaceObject> target)
@@ -832,18 +847,6 @@ GuiShipTweakPlayer2::GuiShipTweakPlayer2(GuiContainer* owner)
     });
     coolant_slider->addSnapValue(10,1)->addOverlay()->setSize(GuiElement::GuiSizeMax, 40);
 
-    (new GuiLabel(left_col, "", tr("Short range radar:"), 30))->setSize(GuiElement::GuiSizeMax, 50);
-    short_range_radar_slider = new GuiSlider(left_col, "", 100.0, 20000.0, 0.0, [this](float value) {
-        target->setShortRangeRadarRange(value);
-    });
-    short_range_radar_slider->addOverlay()->setSize(GuiElement::GuiSizeMax, 40);
-
-    (new GuiLabel(left_col, "", tr("Long range radar:"), 30))->setSize(GuiElement::GuiSizeMax, 50);
-    long_range_radar_slider = new GuiSlider(left_col, "", 100.0, 100000.0, 0.0, [this](float value) {
-        target->setLongRangeRadarRange(value);
-    });
-    long_range_radar_slider->addOverlay()->setSize(GuiElement::GuiSizeMax, 40);
-
     (new GuiLabel(left_col, "", tr("Max Scan Probes:"), 30))->setSize(GuiElement::GuiSizeMax, 50);
     max_scan_probes_slider = new GuiSlider(left_col, "", 0, 20, 0.0, [this](float value) {
         target->setMaxScanProbeCount(value);
@@ -907,8 +910,6 @@ GuiShipTweakPlayer2::GuiShipTweakPlayer2(GuiContainer* owner)
 void GuiShipTweakPlayer2::onDraw(sf::RenderTarget& window)
 {
     coolant_slider->setValue(target->max_coolant);
-    short_range_radar_slider->setValue(target->getShortRangeRadarRange());
-    long_range_radar_slider->setValue(target->getLongRangeRadarRange());
     max_scan_probes_slider->setValue(target->getMaxScanProbeCount());
     scan_probes_slider->setValue(target->getScanProbeCount());
     can_scan->setValue(target->getCanScan());

--- a/src/screens/gm/tweak.h
+++ b/src/screens/gm/tweak.h
@@ -64,6 +64,8 @@ private:
     GuiSlider* jump_min_distance_slider;
     GuiSlider* jump_max_distance_slider;
     GuiToggleButton* can_be_destroyed_toggle;
+    GuiSlider* short_range_radar_slider;
+    GuiSlider* long_range_radar_slider;
 public:
     GuiTweakShip(GuiContainer* owner);
 
@@ -232,8 +234,6 @@ private:
     P<PlayerSpaceship> target;
 
     GuiSlider* coolant_slider;
-    GuiSlider* short_range_radar_slider;
-    GuiSlider* long_range_radar_slider;
     GuiSlider* max_scan_probes_slider;
     GuiSlider* scan_probes_slider;
     GuiToggleButton* can_scan;

--- a/src/shipTemplate.cpp
+++ b/src/shipTemplate.cpp
@@ -152,6 +152,8 @@ ShipTemplate::ShipTemplate()
     has_cloaking = false;
     for(int n=0; n<MW_Count; n++)
         weapon_storage[n] = 0;
+    long_range_radar_range = 30000.0f;
+    short_range_radar_range = 5000.0f;
     radar_trace = "RadarArrow.png";
     impulse_sound_file = "sfx/engine.wav";
     default_ai_name = "default";

--- a/src/shipTemplate.h
+++ b/src/shipTemplate.h
@@ -119,8 +119,8 @@ public:
     int weapon_storage[MW_Count];
 
     string radar_trace;
-    float long_range_radar_range = 30000.0f;
-    float short_range_radar_range = 5000.0f;
+    float long_range_radar_range;
+    float short_range_radar_range;
     string impulse_sound_file;
 
     std::vector<ShipRoomTemplate> rooms;

--- a/src/spaceObjects/cpuShip.cpp
+++ b/src/spaceObjects/cpuShip.cpp
@@ -310,6 +310,17 @@ std::unordered_map<string, string> CpuShip::getGMInfo()
 string CpuShip::getExportLine()
 {
     string ret = "CpuShip():setFaction(\"" + getFaction() + "\"):setTemplate(\"" + template_name + "\"):setCallSign(\"" + getCallSign() + "\"):setPosition(" + string(getPosition().x, 0) + ", " + string(getPosition().y, 0) + ")";
+
+    if (getShortRangeRadarRange() != ship_template->short_range_radar_range)
+    {
+        ret += ":setShortRangeRadarRange(" + string(getShortRangeRadarRange(), 0) + ")";
+    }
+
+    if (getLongRangeRadarRange() != ship_template->long_range_radar_range)
+    {
+        ret += ":setLongRangeRadarRange(" + string(getLongRangeRadarRange(), 0) + ")";
+    }
+
     switch(orders)
     {
     case AI_Idle: break;

--- a/src/spaceObjects/playerSpaceship.cpp
+++ b/src/spaceObjects/playerSpaceship.cpp
@@ -133,10 +133,6 @@ REGISTER_SCRIPT_SUBCLASS(PlayerSpaceship, SpaceShip)
     /// Returns the launching PlayerSpaceship and launched ScanProbe.
     /// Example: player:onProbeLaunch(trackProbe)
     REGISTER_SCRIPT_CLASS_FUNCTION(PlayerSpaceship, onProbeLaunch);
-    REGISTER_SCRIPT_CLASS_FUNCTION(PlayerSpaceship, getLongRangeRadarRange);
-    REGISTER_SCRIPT_CLASS_FUNCTION(PlayerSpaceship, getShortRangeRadarRange);
-    REGISTER_SCRIPT_CLASS_FUNCTION(PlayerSpaceship, setLongRangeRadarRange);
-    REGISTER_SCRIPT_CLASS_FUNCTION(PlayerSpaceship, setShortRangeRadarRange);
     /// Set whether the object can scan other objects.
     /// Requires a Boolean value.
     /// Example: ship:setCanScan(true)
@@ -339,8 +335,6 @@ PlayerSpaceship::PlayerSpaceship()
     registerMemberReplication(&alert_level);
     registerMemberReplication(&linked_science_probe_id);
     registerMemberReplication(&control_code);
-    registerMemberReplication(&long_range_radar_range);
-    registerMemberReplication(&short_range_radar_range);
     registerMemberReplication(&custom_functions);
 
     // Determine which stations must provide self-destruct confirmation codes.
@@ -711,10 +705,6 @@ void PlayerSpaceship::applyTemplateValues()
     // Set the ship's number of repair crews in Engineering from the ship's
     // template.
     setRepairCrewCount(ship_template->repair_crew_count);
-
-    // Set the ship's radar ranges.
-    long_range_radar_range = ship_template->long_range_radar_range;
-    short_range_radar_range = ship_template->short_range_radar_range;
 
     // Set the ship's capabilities.
     can_scan = ship_template->can_scan;
@@ -2004,16 +1994,16 @@ void PlayerSpaceship::drawOnGMRadar(sf::RenderTarget& window, sf::Vector2f posit
     SpaceShip::drawOnGMRadar(window, position, scale, rotation, long_range);
     if (long_range)
     {
-        sf::CircleShape radar_radius(long_range_radar_range * scale);
-        radar_radius.setOrigin(long_range_radar_range * scale, long_range_radar_range * scale);
+        sf::CircleShape radar_radius(getShortRangeRadarRange() * scale);
+        radar_radius.setOrigin(getShortRangeRadarRange() * scale, getShortRangeRadarRange() * scale);
         radar_radius.setPosition(position);
         radar_radius.setFillColor(sf::Color::Transparent);
         radar_radius.setOutlineColor(sf::Color(255, 255, 255, 64));
         radar_radius.setOutlineThickness(3.0);
         window.draw(radar_radius);
 
-        sf::CircleShape short_radar_radius(short_range_radar_range * scale);
-        short_radar_radius.setOrigin(short_range_radar_range * scale, short_range_radar_range * scale);
+        sf::CircleShape short_radar_radius(getShortRangeRadarRange() * scale);
+        short_radar_radius.setOrigin(getShortRangeRadarRange() * scale, getShortRangeRadarRange() * scale);
         short_radar_radius.setPosition(position);
         short_radar_radius.setFillColor(sf::Color::Transparent);
         short_radar_radius.setOutlineColor(sf::Color(255, 255, 255, 64));
@@ -2022,37 +2012,13 @@ void PlayerSpaceship::drawOnGMRadar(sf::RenderTarget& window, sf::Vector2f posit
     }
 }
 
-float PlayerSpaceship::getLongRangeRadarRange()
-{
-    return long_range_radar_range;
-}
-
-float PlayerSpaceship::getShortRangeRadarRange()
-{
-    return short_range_radar_range;
-}
-
-void PlayerSpaceship::setLongRangeRadarRange(float range)
-{
-    range = std::max(range, 100.0f);
-    long_range_radar_range = range;
-    short_range_radar_range = std::min(short_range_radar_range, range);
-}
-
-void PlayerSpaceship::setShortRangeRadarRange(float range)
-{
-    range = std::max(range, 100.0f);
-    short_range_radar_range = range;
-    long_range_radar_range = std::max(long_range_radar_range, range);
-}
-
 string PlayerSpaceship::getExportLine()
 {
     string result = "PlayerSpaceship():setTemplate(\"" + template_name + "\"):setPosition(" + string(getPosition().x, 0) + ", " + string(getPosition().y, 0) + ")" + getScriptExportModificationsOnTemplate();
-    if (short_range_radar_range != ship_template->short_range_radar_range)
-        result += ":setShortRangeRadarRange(" + string(short_range_radar_range, 0) + ")";
-    if (long_range_radar_range != ship_template->long_range_radar_range)
-        result += ":setLongRangeRadarRange(" + string(long_range_radar_range, 0) + ")";
+    if (getShortRangeRadarRange() != ship_template->short_range_radar_range)
+        result += ":setShortRangeRadarRange(" + string(getShortRangeRadarRange(), 0) + ")";
+    if (getLongRangeRadarRange() != ship_template->long_range_radar_range)
+        result += ":setLongRangeRadarRange(" + string(getLongRangeRadarRange(), 0) + ")";
     if (can_scan != ship_template->can_scan)
         result += ":setCanScan(" + string(can_scan, true) + ")";
     if (can_hack != ship_template->can_hack)

--- a/src/spaceObjects/playerSpaceship.cpp
+++ b/src/spaceObjects/playerSpaceship.cpp
@@ -160,10 +160,10 @@ REGISTER_SCRIPT_SUBCLASS(PlayerSpaceship, SpaceShip)
     ///     print("Probe " .. probe:getCallSign() .. " unlinked from Science on ship " .. player:getCallSign())
     /// end)
     REGISTER_SCRIPT_CLASS_FUNCTION(PlayerSpaceship, onProbeUnlink);
-    REGISTER_SCRIPT_CLASS_FUNCTION(PlayerSpaceship, getLongRangeRadarRange);
-    REGISTER_SCRIPT_CLASS_FUNCTION(PlayerSpaceship, getShortRangeRadarRange);
-    REGISTER_SCRIPT_CLASS_FUNCTION(PlayerSpaceship, setLongRangeRadarRange);
-    REGISTER_SCRIPT_CLASS_FUNCTION(PlayerSpaceship, setShortRangeRadarRange);
+    REGISTER_SCRIPT_CLASS_FUNCTION(ShipTemplateBasedObject, getLongRangeRadarRange);
+    REGISTER_SCRIPT_CLASS_FUNCTION(ShipTemplateBasedObject, getShortRangeRadarRange);
+    REGISTER_SCRIPT_CLASS_FUNCTION(ShipTemplateBasedObject, setLongRangeRadarRange);
+    REGISTER_SCRIPT_CLASS_FUNCTION(ShipTemplateBasedObject, setShortRangeRadarRange);
     /// Set whether the object can scan other objects.
     /// Requires a Boolean value.
     /// Example: ship:setCanScan(true)

--- a/src/spaceObjects/playerSpaceship.cpp
+++ b/src/spaceObjects/playerSpaceship.cpp
@@ -1992,18 +1992,24 @@ void PlayerSpaceship::onReceiveServerCommand(sf::Packet& packet)
 void PlayerSpaceship::drawOnGMRadar(sf::RenderTarget& window, sf::Vector2f position, float scale, float rotation, bool long_range)
 {
     SpaceShip::drawOnGMRadar(window, position, scale, rotation, long_range);
+
     if (long_range)
     {
-        sf::CircleShape radar_radius(getShortRangeRadarRange() * scale);
-        radar_radius.setOrigin(getShortRangeRadarRange() * scale, getShortRangeRadarRange() * scale);
+        float long_radar_indicator_radius = getLongRangeRadarRange() * scale;
+        float short_radar_indicator_radius = getShortRangeRadarRange() * scale;
+
+        // Draw long-range radar radius indicator
+        sf::CircleShape radar_radius(long_radar_indicator_radius);
+        radar_radius.setOrigin(long_radar_indicator_radius, long_radar_indicator_radius);
         radar_radius.setPosition(position);
         radar_radius.setFillColor(sf::Color::Transparent);
         radar_radius.setOutlineColor(sf::Color(255, 255, 255, 64));
         radar_radius.setOutlineThickness(3.0);
         window.draw(radar_radius);
 
-        sf::CircleShape short_radar_radius(getShortRangeRadarRange() * scale);
-        short_radar_radius.setOrigin(getShortRangeRadarRange() * scale, getShortRangeRadarRange() * scale);
+        // Draw short-range radar radius indicator
+        sf::CircleShape short_radar_radius(short_radar_indicator_radius);
+        short_radar_radius.setOrigin(short_radar_indicator_radius, short_radar_indicator_radius);
         short_radar_radius.setPosition(position);
         short_radar_radius.setFillColor(sf::Color::Transparent);
         short_radar_radius.setOutlineColor(sf::Color(255, 255, 255, 64));

--- a/src/spaceObjects/playerSpaceship.h
+++ b/src/spaceObjects/playerSpaceship.h
@@ -112,9 +112,6 @@ private:
     CommsScriptInterface comms_script_interface; // Server only
     // Ship's log container
     std::vector<ShipLogEntry> ships_log;
-
-    float long_range_radar_range = 50000.0f;
-    float short_range_radar_range = 5000.0f;
 public:
     std::vector<CustomShipFunction> custom_functions;
 
@@ -330,12 +327,6 @@ public:
 
     // Radar function
     virtual void drawOnGMRadar(sf::RenderTarget& window, sf::Vector2f position, float scale, float rotation, bool long_range) override;
-
-    // Radar range
-    float getLongRangeRadarRange();
-    float getShortRangeRadarRange();
-    void setLongRangeRadarRange(float range);
-    void setShortRangeRadarRange(float range);
 
     // Script export function
     virtual string getExportLine() override;

--- a/src/spaceObjects/shipTemplateBasedObject.cpp
+++ b/src/spaceObjects/shipTemplateBasedObject.cpp
@@ -71,6 +71,11 @@ REGISTER_SCRIPT_SUBCLASS_NO_CREATE(ShipTemplateBasedObject, SpaceObject)
     REGISTER_SCRIPT_CLASS_FUNCTION(ShipTemplateBasedObject, getRestocksMissilesDocked);
     REGISTER_SCRIPT_CLASS_FUNCTION(ShipTemplateBasedObject, setRestocksMissilesDocked);
 
+    REGISTER_SCRIPT_CLASS_FUNCTION(ShipTemplateBasedObject, getLongRangeRadarRange);
+    REGISTER_SCRIPT_CLASS_FUNCTION(ShipTemplateBasedObject, getShortRangeRadarRange);
+    REGISTER_SCRIPT_CLASS_FUNCTION(ShipTemplateBasedObject, setLongRangeRadarRange);
+    REGISTER_SCRIPT_CLASS_FUNCTION(ShipTemplateBasedObject, setShortRangeRadarRange);
+
     /// [Depricated]
     REGISTER_SCRIPT_CLASS_FUNCTION(ShipTemplateBasedObject, getFrontShield);
     /// [Depricated]
@@ -109,6 +114,9 @@ ShipTemplateBasedObject::ShipTemplateBasedObject(float collision_range, string m
     }
     hull_strength = hull_max = 100.0;
 
+    long_range_radar_range = 30000.0f;
+    short_range_radar_range = 5000.0f;
+
     registerMemberReplication(&template_name);
     registerMemberReplication(&type_name);
     registerMemberReplication(&shield_count);
@@ -122,6 +130,8 @@ ShipTemplateBasedObject::ShipTemplateBasedObject(float collision_range, string m
     registerMemberReplication(&impulse_sound_file);
     registerMemberReplication(&hull_strength, 0.5);
     registerMemberReplication(&hull_max);
+    registerMemberReplication(&long_range_radar_range, 0.5);
+    registerMemberReplication(&short_range_radar_range, 0.5);
 
     callsign = "[" + string(getMultiplayerId()) + "]";
 
@@ -364,6 +374,10 @@ void ShipTemplateBasedObject::setTemplate(string template_name)
     shield_count = ship_template->shield_count;
     for(int n=0; n<shield_count; n++)
         shield_level[n] = shield_max[n] = ship_template->shield_level[n];
+
+    // Set the ship's radar ranges.
+    long_range_radar_range = ship_template->long_range_radar_range;
+    short_range_radar_range = ship_template->short_range_radar_range;
 
     radar_trace = ship_template->radar_trace;
     impulse_sound_file = ship_template->impulse_sound_file;

--- a/src/spaceObjects/shipTemplateBasedObject.h
+++ b/src/spaceObjects/shipTemplateBasedObject.h
@@ -14,6 +14,9 @@
 */
 class ShipTemplateBasedObject : public SpaceObject, public Updatable
 {
+private:
+    float long_range_radar_range;
+    float short_range_radar_range;
 public:
     string template_name;
     string type_name;
@@ -90,6 +93,12 @@ public:
     float getRearShieldMax() { return shield_max[1]; }
     void setRearShield(float amount) { if (amount < 0) return; shield_level[1] = amount; }
     void setRearShieldMax(float amount) { if (amount < 0) return; shield_max[1] = amount; shield_level[1] = std::min(shield_level[1], shield_max[1]); }
+
+    // Radar range
+    float getLongRangeRadarRange() { return long_range_radar_range; }
+    float getShortRangeRadarRange() { return short_range_radar_range; }
+    void setLongRangeRadarRange(float range) { range = std::max(range, 100.0f); long_range_radar_range = range; short_range_radar_range = std::min(short_range_radar_range, range); }
+    void setShortRangeRadarRange(float range) { range = std::max(range, 100.0f); short_range_radar_range = range; long_range_radar_range = std::max(long_range_radar_range, range); }
 
     void setRadarTrace(string trace) { radar_trace = trace; }
     void setImpulseSoundFile(string sound) { impulse_sound_file = sound; }

--- a/src/spaceObjects/spaceStation.cpp
+++ b/src/spaceObjects/spaceStation.cpp
@@ -97,5 +97,22 @@ bool SpaceStation::canBeDockedBy(P<SpaceObject> obj)
 
 string SpaceStation::getExportLine()
 {
-    return "SpaceStation():setTemplate(\"" + template_name + "\"):setFaction(\"" + getFaction() + "\"):setCallSign(\"" + getCallSign() + "\"):setPosition(" + string(getPosition().x, 0) + ", " + string(getPosition().y, 0) + ")";
+    string ret = "SpaceStation()";
+    ret += ":setTemplate(\"" + template_name + "\")";
+
+    if (getShortRangeRadarRange() != ship_template->short_range_radar_range)
+    {
+        ret += ":setShortRangeRadarRange(" + string(getShortRangeRadarRange(), 0) + ")";
+    }
+
+    if (getLongRangeRadarRange() != ship_template->long_range_radar_range)
+    {
+        ret += ":setLongRangeRadarRange(" + string(getLongRangeRadarRange(), 0) + ")";
+    }
+
+    ret += ":setFaction(\"" + getFaction() + "\")";
+    ret += ":setCallSign(\"" + getCallSign() + "\")";
+    ret += ":setPosition(" + string(getPosition().x, 0) + ", " + string(getPosition().y, 0) + ")";
+
+    return ret;
 }


### PR DESCRIPTION
- Move short- and long-range radar range values, getter, and setter from PlayerSpaceship to ShipTemplateBasedObject.
- Update export lines to add radar range modifications.
- Move GM radar range tweaks from Player2 tab to Ship tab.
- Use short-range radar range for friendly shared radar reveals on Relay.

Example scenario:

```
CpuShip():setTemplate("Atlantis X23"):setFaction("Human Navy"):setPosition(10000, 0):setShortRangeRadarRange(10000)
SpaceStation():setTemplate("Huge Station"):setFaction("Human Navy"):setPosition(-10000, 0):setShortRangeRadarRange(20000)
PlayerSpaceship():setTemplate("Atlantis"):setFaction("Human Navy"):setPosition(0, 0):setLongRangeRadarRange(30000)
```

- The CpuShip has a short-range radar range of 10U, shared with the Player on Relay.
- The SpaceStation has a short-range radar range of 20U, shared with the Player on Relay.
- The PlayerSpaceship has a long-range radar range of 30U, visible from its Science screen.
