### PR TITLE
Rolling back to 120

### DIFF
--- a/resources/shaders/starbox.frag
+++ b/resources/shaders/starbox.frag
@@ -1,6 +1,4 @@
-#version 100
-
-precision mediump float;
+#version 120
 
 // Program inputs
 uniform samplerCube starbox;

--- a/resources/shaders/starbox.vert
+++ b/resources/shaders/starbox.vert
@@ -1,4 +1,4 @@
-#version 100
+#version 120
 
 // Program inputs
 uniform mat4 projection;


### PR DESCRIPTION
Fixing up shader version to 120 for compability with some (*cough*macos*cough*) desktop systems which can't deal with es2 shaders.