### PR TITLE
Remove constexpr on array with tuples

### DIFF
--- a/src/screenComponents/viewport3d.cpp
+++ b/src/screenComponents/viewport3d.cpp
@@ -42,7 +42,7 @@ GuiViewport3D::GuiViewport3D(GuiContainer* owner, string id)
 
         // Load up the cube texture.
         // Face setup
-        constexpr std::array<std::tuple<const char*, uint32_t>, 6> faces{
+        std::array<std::tuple<const char*, uint32_t>, 6> faces{
             std::make_tuple("StarsRight.png", GL_TEXTURE_CUBE_MAP_POSITIVE_X),
             std::make_tuple("StarsLeft.png", GL_TEXTURE_CUBE_MAP_NEGATIVE_X),
             std::make_tuple("StarsTop.png", GL_TEXTURE_CUBE_MAP_POSITIVE_Y),


### PR DESCRIPTION
Removing constexpr on the array with tuples (tuples/pairs have constexpr ctor starting at cpp14).