### PR TITLE
Artifact collision callbacks

### DIFF
--- a/src/spaceObjects/artifact.cpp
+++ b/src/spaceObjects/artifact.cpp
@@ -18,9 +18,27 @@ REGISTER_SCRIPT_SUBCLASS(Artifact, SpaceObject)
     REGISTER_SCRIPT_CLASS_FUNCTION(Artifact, explode);
     /// Set if this artifact can be picked up or not. When it is picked up, this artifact will be destroyed.
     REGISTER_SCRIPT_CLASS_FUNCTION(Artifact, allowPickup);
-    /// Set a function that will be called if a player picks up the artifact.
-    /// First argument given to the function will be the artifact, the second the player.
+    /// Set a function that will be called every tick when a SpaceObject is
+    /// colliding with the artifact.
+    /// Passes the artifact and colliding SpaceObject.
+    /// Example:
+    /// artifact:onCollision(function(artifact, collider) print("Collision occurred") end)
+    REGISTER_SCRIPT_CLASS_FUNCTION(Artifact, onCollision);
+    /// Set a function that will be called every tick when a PlayerSpaceship is
+    /// colliding with the artifact.
+    /// Passes the artifact and colliding PlayerSpaceship.
+    /// Example:
+    /// artifact:onCollision(function(artifact, player) print("Collision occurred") end)
+    REGISTER_SCRIPT_CLASS_FUNCTION(Artifact, onPlayerCollision);
+    /// Set a function that will be called once when a PlayerSpaceship collides
+    /// with the artifact while allowPickup is enabled. The artifact is
+    /// subsequently destroyed.
+    /// Passes the artifact and colliding PlayerSpaceship.
+    /// Example:
+    /// artifact:onPickUp(function(artifact, player) print("Artifact retrieved") end)
     REGISTER_SCRIPT_CLASS_FUNCTION(Artifact, onPickUp);
+    /// Alias of onPickUp.
+    REGISTER_SCRIPT_CLASS_FUNCTION(Artifact, onPickup);
     /// Let the artifact rotate. For reference, normal asteroids in the game have spins between 0.1 and 0.8.
     REGISTER_SCRIPT_CLASS_FUNCTION(Artifact, setSpin);
     /// Set the icon to be used for this artifact on the radar.
@@ -102,17 +120,43 @@ void Artifact::drawOnRadar(sf::RenderTarget& window, sf::Vector2f position, floa
 
 void Artifact::collide(Collisionable* target, float force)
 {
-    if (!isServer() || !allow_pickup)
+    // Handle collisions on the server only.
+    if (!isServer())
+    {
         return;
+    }
+
+    // Fire collision callbacks.
     P<SpaceObject> hit_object = P<Collisionable>(target);
     P<PlayerSpaceship> player = hit_object;
+
+    // Player-specific callback handling.
     if (player)
     {
-        if (on_pickup_callback.isSet())
+        if (allow_pickup)
         {
-            on_pickup_callback.call(P<Artifact>(this), player);
+            // If the artifact is collectible, pick it up.
+            if (on_pickup_callback.isSet())
+            {
+                on_pickup_callback.call(P<Artifact>(this), player);
+            }
+
+            destroy();
         }
-        destroy();
+        else
+        {
+            // If the artifact isn't collectible, fire the collision callback.
+            if (on_player_collision_callback.isSet())
+            {
+                on_player_collision_callback.call(P<Artifact>(this), player);
+            }
+        }
+    }
+
+    // Fire the SpaceObject collision callback, if set.
+    if (hit_object && on_collision_callback.isSet())
+    {
+        on_collision_callback.call(P<Artifact>(this), hit_object);
     }
 }
 
@@ -153,6 +197,16 @@ void Artifact::onPickUp(ScriptSimpleCallback callback)
 {
     this->allow_pickup = 1;
     this->on_pickup_callback = callback;
+}
+
+void Artifact::onCollision(ScriptSimpleCallback callback)
+{
+    this->on_collision_callback = callback;
+}
+
+void Artifact::onPlayerCollision(ScriptSimpleCallback callback)
+{
+    this->on_player_collision_callback = callback;
 }
 
 string Artifact::getExportLine()

--- a/src/spaceObjects/artifact.cpp
+++ b/src/spaceObjects/artifact.cpp
@@ -36,21 +36,23 @@ REGISTER_SCRIPT_SUBCLASS(Artifact, SpaceObject)
 
 REGISTER_MULTIPLAYER_CLASS(Artifact, "Artifact");
 Artifact::Artifact()
-: SpaceObject(120, "Artifact")
+: SpaceObject(120, "Artifact"),
+  current_model_data_name("artifact" + string(irandom(1, 8))),
+  model_data_name(current_model_data_name),
+  artifact_spin(0.0f),
+  allow_pickup(false),
+  radar_trace_icon("RadarBlip.png"),
+  radar_trace_scale(0),
+  radar_trace_color(sf::Color(255, 255, 255))
 {
+    setRotation(random(0, 360));
+    model_info.setData(current_model_data_name);
+
     registerMemberReplication(&model_data_name);
     registerMemberReplication(&artifact_spin);
     registerMemberReplication(&radar_trace_icon);
     registerMemberReplication(&radar_trace_scale);
     registerMemberReplication(&radar_trace_color);
-
-    setRotation(random(0, 360));
-
-    current_model_data_name = "artifact" + string(irandom(1, 8));
-    model_data_name = current_model_data_name;
-    model_info.setData(current_model_data_name);
-
-    allow_pickup = false;
 }
 
 void Artifact::update(float delta)

--- a/src/spaceObjects/artifact.h
+++ b/src/spaceObjects/artifact.h
@@ -8,13 +8,13 @@ class Artifact : public SpaceObject, public Updatable
 private:
     string current_model_data_name;
     string model_data_name;
-    float artifact_spin=0.0;
+    float artifact_spin;
     bool allow_pickup;
     ScriptSimpleCallback on_pickup_callback;
 
-    string radar_trace_icon="RadarBlip.png";
-    float radar_trace_scale=0;
-    sf::Color radar_trace_color = sf::Color(255, 255, 255);
+    string radar_trace_icon;
+    float radar_trace_scale;
+    sf::Color radar_trace_color;
 
 public:
     Artifact();

--- a/src/spaceObjects/artifact.h
+++ b/src/spaceObjects/artifact.h
@@ -10,12 +10,12 @@ private:
     string model_data_name;
     float artifact_spin;
     bool allow_pickup;
+    ScriptSimpleCallback on_collision_callback;
     ScriptSimpleCallback on_pickup_callback;
 
     string radar_trace_icon;
     float radar_trace_scale;
     sf::Color radar_trace_color;
-
 public:
     Artifact();
 
@@ -36,8 +36,13 @@ public:
     void setRadarTraceScale(float scale);
     void setRadarTraceColor(int r, int g, int b) { radar_trace_color = sf::Color(r, g, b); }
 
-    virtual string getExportLine() override;
     void onPickUp(ScriptSimpleCallback callback);
+    // Consistent naming workaround
+    void onPickup(ScriptSimpleCallback callback) { onPickUp(callback); }
+    void onCollision(ScriptSimpleCallback callback);
+    void onPlayerCollision(ScriptSimpleCallback callback);
+
+    virtual string getExportLine() override;
 };
 
 #endif//ARTIFACT_H

--- a/src/spaceObjects/artifact.h
+++ b/src/spaceObjects/artifact.h
@@ -10,8 +10,9 @@ private:
     string model_data_name;
     float artifact_spin;
     bool allow_pickup;
-    ScriptSimpleCallback on_collision_callback;
     ScriptSimpleCallback on_pickup_callback;
+    ScriptSimpleCallback on_collision_callback;
+    ScriptSimpleCallback on_player_collision_callback;
 
     string radar_trace_icon;
     float radar_trace_scale;


### PR DESCRIPTION
Adds `onCollision(artifact, obj)` and `onPlayerCollision(artifact, player)` callbacks that fire during collisions with SpaceObjects and PlayerSpaceships, respectively. Unlike `onPickUp`, these do not destroy the object; however, they fire every tick as long as objects are colliding.