### PR TITLE
Use radar ranges instead of hardcoded values for AI targeting and firing

### DIFF
--- a/src/ai/ai.cpp
+++ b/src/ai/ai.cpp
@@ -236,6 +236,9 @@ void ShipAI::updateTarget()
     EAIOrder orders = owner->getOrder();
     sf::Vector2f order_target_location = owner->getOrderTargetLocation();
     P<SpaceObject> order_target = owner->getOrderTarget();
+    // Update ranges before calculating
+    short_range = owner->getShortRangeRadarRange();
+    long_range = owner->getLongRangeRadarRange();
 
     // Check if we lost our target because it entered a nebula.
     if (target && target->canHideInNebula() && Nebula::blockedByNebula(position, target->getPosition()))
@@ -355,6 +358,10 @@ void ShipAI::updateTarget()
 
 void ShipAI::runOrders()
 {
+    // Update ranges before calculating
+    long_range = owner->getLongRangeRadarRange();
+    relay_range = long_range * 2.0f;
+
     //When we are not attacking a target, follow orders
     switch(owner->getOrder())
     {
@@ -722,6 +729,9 @@ bool ShipAI::betterTarget(P<SpaceObject> new_target, P<SpaceObject> current_targ
 
 float ShipAI::calculateFiringSolution(P<SpaceObject> target, int tube_index)
 {
+    // Update ranges before calculating
+    short_range = owner->getShortRangeRadarRange();
+
     // Never fire missiles at scan probes.
     if (P<ScanProbe>(target))
     {

--- a/src/ai/ai.h
+++ b/src/ai/ai.h
@@ -21,6 +21,10 @@ protected:
     bool has_missiles;
     bool has_beams;
     float beam_weapon_range;
+    float short_range;
+    float long_range;
+    float relay_range;
+
     enum class EWeaponDirection
     {
         Front,


### PR DESCRIPTION
Use `getShort` and `getLongRangeRadarRange()` values when calculating AI actions, instead of hardcoded values. Some values are now modified based on those ranges by a fixed amount (ie. short-range + 3U instead of 8U). 

Assuming a ship's defaults aren't modified from 5U short/25U long, only these ranges behaviors should change:

- Roaming will now seek the best targets within long-range radar range, rather than 8U.
- New roaming destinations will be generated from a radius equal to the long-range radar range, rather than 30U.
- Default AI missile attacks will consider a radius equal to short-range radar range, rather than 4.5U.