### PR TITLE
Shader-based spacedust

### DIFF
--- a/resources/shaders/spacedust.frag
+++ b/resources/shaders/spacedust.frag
@@ -1,0 +1,9 @@
+#version 120
+
+// Shader constants
+const vec4 color = vec4(0.7, 0.5, 0.35, 0.07);
+
+void main()
+{
+    gl_FragColor = color;
+}

--- a/resources/shaders/spacedust.vert
+++ b/resources/shaders/spacedust.vert
@@ -1,0 +1,70 @@
+#version 120
+
+// Shader constants
+const vec2 distance_limits = vec2(100., 500.);
+const float two_pi = 2. * radians(180.);
+const float max_input_seed = 32767.;
+
+// Utility functions
+// https://gist.github.com/patriciogonzalezvivo/670c22f3966e662d2f83
+vec2 rand(const vec2 v)
+{
+    return fract(sin(v) * 43758.5453123);
+}
+
+float getRadius(const float value)
+{
+    return distance_limits.x + (distance_limits.y - distance_limits.x) * value;
+}
+
+// Program inputs.
+uniform mat4 projection;
+uniform mat4 model_view;
+
+uniform vec2 velocity;
+uniform vec2 center;
+uniform float time;
+
+// Per-vertex inputs
+attribute float vertex_hash; // Passed in as a signed byte, [-32767,32767], non-zero
+
+void main()
+{
+    // Two points of the same line
+    // Share the same absolute seed.
+    float seed = abs(vertex_hash);
+
+    // From the seed, we derive an offset.
+    // It places each point at a different base position on a sphere around the spaceship.
+    
+    // Infer spherical coordinates from the seed.
+    float theta = mod(seed, 256.); // [0,255]
+    float phi = floor(seed / 256.); // [0,127]
+    vec2 theta_phi = two_pi * rand(vec2(theta, phi));
+
+    // Now we can put our particle offset on the sphere.
+    // We use a minimum radius to avoid having useless particles inside the ship.
+    vec4 sincos = vec4(sin(theta_phi), cos(theta_phi));
+
+    // Standard spherical to cartesian:
+    // x = sin(theta) * cos(phi)
+    // y = sin(theta) * sin(phi)
+    // z = cos(theta)
+    float radius = getRadius(seed / max_input_seed); 
+    vec3 offset = radius * vec3(sincos.x * sincos.wy, sincos.z);
+
+    
+    // Give the illusion of movement by offset further alongside the velocity vector.
+    // Use the seed to have particules at different offsets, with different frequencies.
+    float speed = length(velocity);
+    float particle_frequency =  radius;
+    offset.xy -= mod(time * speed + seed, particle_frequency) * normalize(velocity);
+    
+    // Center the box around the ship's axis of movement.
+    offset.xy += particle_frequency / 2. * normalize(velocity);
+
+    // We use the alternating vertex sign to determine either end of the line.
+    vec2 line_end = -sign(vertex_hash) * velocity / 100.;
+    
+    gl_Position = projection * model_view * vec4(center + line_end + offset.xy, offset.z, 1.);
+}

--- a/src/screenComponents/viewport3d.h
+++ b/src/screenComponents/viewport3d.h
@@ -20,15 +20,21 @@ class GuiViewport3D : public GuiElement
         Projection = 0,
         ModelView,
 
-        Count
+        StarboxCount,
+
+        Rotation = StarboxCount,
+
+        SpacedustCount
     };
 
     enum class Buffers : uint8_t
     {
         Vertex = 0,
-        Element,
 
-        Count
+        SpacedustCount,
+
+        Element = SpacedustCount,
+        StarboxCount
     };
 
     enum class VertexAttributes : uint8_t
@@ -37,11 +43,20 @@ class GuiViewport3D : public GuiElement
         Count
     };
 
-    std::array<uint32_t, static_cast<size_t>(Uniforms::Count)> starbox_uniforms;
-    std::array<uint32_t, static_cast<size_t>(Uniforms::Count)> starbox_vertex_attributes;
+    // Starbox
+    std::array<uint32_t, static_cast<size_t>(Uniforms::StarboxCount)> starbox_uniforms;
+    std::array<uint32_t, static_cast<size_t>(VertexAttributes::Count)> starbox_vertex_attributes;
     gl::Textures<1> starbox_texture;
-    gl::Buffers<static_cast<size_t>(Buffers::Count)> starbox_buffers;
+    gl::Buffers<static_cast<size_t>(Buffers::StarboxCount)> starbox_buffers;
     sf::Shader* starbox_shader = nullptr;
+
+    // Spacedust
+    static constexpr size_t spacedust_particle_count = 1024;
+    std::array<uint32_t, static_cast<size_t>(Uniforms::SpacedustCount)> spacedust_uniforms;
+    uint32_t spacedust_vertex_hash_attribute = 0;
+    gl::Buffers<static_cast<size_t>(Buffers::SpacedustCount)> spacedust_buffer;
+    sf::Shader* spacedust_shader = nullptr;
+
     
 #endif
 public:


### PR DESCRIPTION
#1319 - Shader-based spacedust.

It's pretty close to where I would like it to be, but still have a few shortcomings (full disclosure, I _suck_ at maths).

It mimicks the existing system by putting points on a sphere around the ship, and passing that ship through it.

Currently it has the following limitations:
  * The pattern is fixed - that's easy to overcome by adding a "generation" factor based on time to increase the illusion of randomness.
  * There is a slight bias towards the center (clustering around the ship). Probably want a non-linear scale for the radius (logarithmic falloff maybe)?
  * Currently, because I'm using the velocity to compute the offset, the look and feel isn't too great during velocity changes (esp. large ones, like coming out warp).
 
 I believe what I want is actually to have a "rolling" sphere center that the ship passes through along its current direction.
My issue is mirroring the existing code where that sphere has a fixed point in worldspace and the ship passes through it (and when the ship goes too far out, it just rolls back in front of it).
Maybe that's something that would be more easily computed on the code side.

Any help welcome :)


As for performance, this cuts down on ~2k draw calls (now it's just one for all particles), as many push/pop matrices, random generation (we just need it to "look good")