### PR TITLE
#1319 Removing fixed pipeline for spacedust

### DIFF
--- a/resources/locale/de.po
+++ b/resources/locale/de.po
@@ -95,7 +95,7 @@ msgid ""
 "long."
 msgstr ""
 "Anders als sein Vorgaenger macht der Starhammer II seinem Namen alle Ehre. "
-"Die Probleme der Energie und Hitzemanagement des Ursprungsmodells wurden "
+"Die Probleme von Energie und Hitzemanagement des Ursprungsmodells wurden "
 "geloest, und so stellt das neue Modell ein ausgezeichnetes Angriffsschiff "
 "dar. Seine geringe Geschwindigkeit erschwert es, in Position zu kommen, aber "
 "sobald er sich zur richtigen Zeit am richtigen Ort befindet, koennen selbst "
@@ -435,7 +435,7 @@ msgstr "Szenario starten"
 #: src/menus/serverCreationScreen.cpp:235
 msgctxt "variation"
 msgid "None"
-msgstr "Keine"
+msgstr ""
 
 msgid "No variation."
 msgstr "Keine Variante."
@@ -680,7 +680,7 @@ msgstr "{system} : Zustand"
 
 #: src/screens/gm/tweak.cpp:595
 msgid "{system} heat"
-msgstr "{system}: Hitze"
+msgstr "{system}: Waerme"
 
 #: src/screenComponents/aimLock.cpp:11
 msgctxt "missile"
@@ -3360,7 +3360,7 @@ msgstr ""
 
 #: src/menus/shipSelectionScreen.cpp:84
 msgid "Ship window"
-msgstr ""
+msgstr "Schiffsfenster"
 
 msgid "0 degrees"
 msgstr ""
@@ -3375,7 +3375,7 @@ msgstr ""
 
 #: src/menus/shipSelectionScreen.cpp:118
 msgid "Spectate (view all)"
-msgstr ""
+msgstr "Zuschauer (alles sichtbar)"
 
 #: src/menus/shipSelectionScreen.cpp:127
 msgid "Enter the GM control code:"
@@ -3383,7 +3383,7 @@ msgstr "SL-Kontrollcode eingeben :"
 
 #: src/menus/shipSelectionScreen.cpp:143
 msgid "Select ship"
-msgstr ""
+msgstr "Waehle Schiff"
 
 #: src/menus/shipSelectionScreen.cpp:144
 msgid "Waiting for server to spawn a ship"
@@ -3479,7 +3479,7 @@ msgstr "Kuehlm."
 #: src/screens/extra/powerManagement.cpp:42
 msgctxt "button"
 msgid "Heat"
-msgstr ""
+msgstr "Waerme"
 
 #: src/screens/gm/objectCreationView.cpp:51
 msgctxt "create"
@@ -3665,7 +3665,7 @@ msgstr ""
 
 #: src/screenComponents/shipDestroyedPopup.cpp:18
 msgid "SHIP DESTROYED!"
-msgstr ""
+msgstr "Schiff zerstoert!"
 
 #: src/screenComponents/shipDestroyedPopup.cpp:19
 msgctxt "shipdestroyed"
@@ -3678,7 +3678,7 @@ msgstr ""
 
 #: src/screenComponents/commsOverlay.cpp:39
 msgid "Answer"
-msgstr ""
+msgstr "Antworten"
 
 #: src/screenComponents/commsOverlay.cpp:45
 msgid "Ignore"
@@ -4181,7 +4181,7 @@ msgstr "HGBI"
 
 #: scripts/science_db.lua:63
 msgid "Burst"
-msgstr ""
+msgstr "Einzelgeschosse"
 
 #: scripts/shipTemplates_Frigates.lua:371
 msgid "Jump/Turret version of Flavia Falcon"
@@ -4202,12 +4202,12 @@ msgstr ""
 #: src/menus/shipSelectionScreen.cpp:93
 msgctxt "shipwindow"
 msgid "{angle} degrees"
-msgstr ""
+msgstr "{angle} Grad"
 
 #: src/menus/shipSelectionScreen.cpp:96
 msgctxt "shipwindow"
 msgid "0 degrees"
-msgstr ""
+msgstr "0 Grad"
 
 #: src/screens/gm/objectCreationView.cpp:35
 msgctxt "create"

--- a/resources/shaders/spacedust.vert
+++ b/resources/shaders/spacedust.vert
@@ -1,70 +1,15 @@
 #version 120
 
-// Shader constants
-const vec2 distance_limits = vec2(100., 500.);
-const float two_pi = 2. * radians(180.);
-const float max_input_seed = 32767.;
-
-// Utility functions
-// https://gist.github.com/patriciogonzalezvivo/670c22f3966e662d2f83
-vec2 rand(const vec2 v)
-{
-    return fract(sin(v) * 43758.5453123);
-}
-
-float getRadius(const float value)
-{
-    return distance_limits.x + (distance_limits.y - distance_limits.x) * value;
-}
-
 // Program inputs.
 uniform mat4 projection;
 uniform mat4 model_view;
-
 uniform vec2 velocity;
-uniform vec2 center;
-uniform float time;
 
 // Per-vertex inputs
-attribute float vertex_hash; // Passed in as a signed byte, [-32767,32767], non-zero
+attribute vec3 position;
+attribute float sign_value;
 
 void main()
-{
-    // Two points of the same line
-    // Share the same absolute seed.
-    float seed = abs(vertex_hash);
-
-    // From the seed, we derive an offset.
-    // It places each point at a different base position on a sphere around the spaceship.
-    
-    // Infer spherical coordinates from the seed.
-    float theta = mod(seed, 256.); // [0,255]
-    float phi = floor(seed / 256.); // [0,127]
-    vec2 theta_phi = two_pi * rand(vec2(theta, phi));
-
-    // Now we can put our particle offset on the sphere.
-    // We use a minimum radius to avoid having useless particles inside the ship.
-    vec4 sincos = vec4(sin(theta_phi), cos(theta_phi));
-
-    // Standard spherical to cartesian:
-    // x = sin(theta) * cos(phi)
-    // y = sin(theta) * sin(phi)
-    // z = cos(theta)
-    float radius = getRadius(seed / max_input_seed); 
-    vec3 offset = radius * vec3(sincos.x * sincos.wy, sincos.z);
-
-    
-    // Give the illusion of movement by offset further alongside the velocity vector.
-    // Use the seed to have particules at different offsets, with different frequencies.
-    float speed = length(velocity);
-    float particle_frequency =  radius;
-    offset.xy -= mod(time * speed + seed, particle_frequency) * normalize(velocity);
-    
-    // Center the box around the ship's axis of movement.
-    offset.xy += particle_frequency / 2. * normalize(velocity);
-
-    // We use the alternating vertex sign to determine either end of the line.
-    vec2 line_end = -sign(vertex_hash) * velocity / 100.;
-    
-    gl_Position = projection * model_view * vec4(center + line_end + offset.xy, offset.z, 1.);
+{    
+    gl_Position = projection * model_view * vec4(position.xy + sign_value * velocity, position.z, 1.);
 }

--- a/src/screenComponents/viewport3d.h
+++ b/src/screenComponents/viewport3d.h
@@ -40,12 +40,15 @@ class GuiViewport3D : public GuiElement
     enum class VertexAttributes : uint8_t
     {
         Position = 0,
-        Count
+        StarboxCount,
+
+        Sign = StarboxCount,
+        SpacedustCount
     };
 
     // Starbox
     std::array<uint32_t, static_cast<size_t>(Uniforms::StarboxCount)> starbox_uniforms;
-    std::array<uint32_t, static_cast<size_t>(VertexAttributes::Count)> starbox_vertex_attributes;
+    std::array<uint32_t, static_cast<size_t>(VertexAttributes::StarboxCount)> starbox_vertex_attributes;
     gl::Textures<1> starbox_texture;
     gl::Buffers<static_cast<size_t>(Buffers::StarboxCount)> starbox_buffers;
     sf::Shader* starbox_shader = nullptr;
@@ -53,7 +56,7 @@ class GuiViewport3D : public GuiElement
     // Spacedust
     static constexpr size_t spacedust_particle_count = 1024;
     std::array<uint32_t, static_cast<size_t>(Uniforms::SpacedustCount)> spacedust_uniforms;
-    uint32_t spacedust_vertex_hash_attribute = 0;
+    std::array<uint32_t, static_cast<size_t>(VertexAttributes::SpacedustCount)> spacedust_vertex_attributes;
     gl::Buffers<static_cast<size_t>(Buffers::SpacedustCount)> spacedust_buffer;
     sf::Shader* spacedust_shader = nullptr;
 


### PR DESCRIPTION
#1319 - removing fixed pipeline for spacedust.

This is the "safe" version which is a 1:1 equivalent of current code - only without fixed functions (and a single draw call instead of a thousand).

Technically uses more memory, but it adds up to less than an additional 64KiB, hopefully that's ok :) (twice the existing amount on the CPU + a fixed-size GPU buffer).