### PR TITLE
cicd: windows build fix up

### DIFF
--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -96,8 +96,8 @@ jobs:
           cmake ../EmptyEpsilon
           -G "Visual Studio 16 2019" -A Win32
           -DCMAKE_BUILD_TYPE=${{ matrix.build_type }}
-          -DSFML_ROOT="${{github.workspace}}/externals/SFML-2.5.1"
-          -DSERIOUS_PROTON_DIR=../SeriousProton
+          -DSFML_ROOT="../externals/SFML-2.5.1"
+          -DSERIOUS_PROTON_DIR="../SeriousProton"
       - name: Build
         working-directory: ${{github.workspace}}/build
-        run: cmake --build . --config ${{ matrix.build_type }}      
+        run: cmake --build . --config ${{ matrix.build_type }} --target package 


### PR DESCRIPTION
Trying some release automation on my branch, I noticed the windows build actually never built EE... only some of SP.

That's because of the underlying shell (powershell) which apparently really needs quotes for argument passing 🙄 

Additionnally, made the windows build the package target as well.