### PR TITLE
change missile pitch depending on size

### DIFF
--- a/src/spaceObjects/missiles/missileWeapon.cpp
+++ b/src/spaceObjects/missiles/missileWeapon.cpp
@@ -63,7 +63,7 @@ void MissileWeapon::update(float delta)
 
     if (!launch_sound_played)
     {
-        soundManager->playSound(data.fire_sound, getPosition(), 400.0, 60.0, 1.0f + random(-0.2f, 0.2f));
+        soundManager->playSound(data.fire_sound, getPosition(), 400.0, 60.0, (1.0f + random(-0.2f, 0.2f)) * size_speed_modifier);
         launch_sound_played = true;
     }
 


### PR DESCRIPTION
So smaller missiles have a higher pitch than large ones. 
setPitch() changes the playing speed of a file as well, but I think this is no issue here. On the contrary, a longer playing time for larger missiles fits pretty well here IMHO.