### PR TITLE
Full name for crew, in tweak view

### DIFF
--- a/src/screens/gm/tweak.cpp
+++ b/src/screens/gm/tweak.cpp
@@ -789,9 +789,18 @@ void GuiShipTweakPlayer::onDraw(sf::RenderTarget& window)
         string position_name = getCrewPositionName(ECrewPosition(n));
         string position_state = "-";
 
+        std::vector<string> players;
+         foreach(PlayerInfo, i, player_info_list)
+         {
+            if (i->ship_id == target->getMultiplayerId() && i->crew_position[n])
+            {
+                players.push_back(i->name);
+            }
+        }
+
         if (target->hasPlayerAtPosition(ECrewPosition(n)))
         {
-            position_state = tr("position", "Occupied");
+            position_state = tr("position", string(", ").join(players));
             position_counter += 1;
         }
 


### PR DESCRIPTION
Instead of showing "occupied", show player actual names as entered in EE title screen.