### PR TITLE
Add missing header

### DIFF
--- a/src/glObjects.h
+++ b/src/glObjects.h
@@ -5,6 +5,7 @@
 
 #if FEATURE_3D_RENDERING
 #include <array>
+#include <cstddef>
 #include <cstdint>
 
 namespace gl


### PR DESCRIPTION
Debian based systems don't seem to need this, but Fedora does need it.