### PR TITLE
Fixed mistyped variable in CZ translation.

### DIFF
--- a/resources/locale/cz.po
+++ b/resources/locale/cz.po
@@ -3383,7 +3383,7 @@ msgstr "Zacilit system:"
 #: src/screenComponents/hackingDialog.cpp:115
 msgctxt "hacking"
 msgid "Hacking in Progress: {percent}%"
-msgstr "Hackovani probiha: {procent}%"
+msgstr "Hackovani probiha: {percent}%"
 
 #: src/screenComponents/hackingDialog.cpp:124
 msgctxt "hacking"


### PR DESCRIPTION
gcask has notified me on Discord, that I have error in one variable of CZ translation. And he was correct, so this PR is fixing this errorneous line. 