### PR TITLE
Static waypoint labels

### DIFF
--- a/src/screenComponents/radarView.cpp
+++ b/src/screenComponents/radarView.cpp
@@ -425,7 +425,7 @@ void GuiRadarView::drawWaypoints(sf::RenderTarget& window)
         object_sprite.setPosition(screen_position - sf::Vector2f(0, 10));
         object_sprite.setScale(0.8, 0.8);
         window.draw(object_sprite);
-        drawText(window, sf::FloatRect(screen_position.x, screen_position.y - 10, 0, 0), string(n + 1), ACenter, 18, bold_font, colorConfig.ship_waypoint_text);
+        drawText(window, sf::FloatRect(screen_position.x, screen_position.y - 10, 0, 0), string(my_spaceship->waypoint_labels[n]), ACenter, 18, bold_font, colorConfig.ship_waypoint_text);
 
         if (style != Rectangular && sf::length(screen_position - radar_screen_center) > std::min(rect.width, rect.height) * 0.5f)
         {
@@ -435,7 +435,7 @@ void GuiRadarView::drawWaypoints(sf::RenderTarget& window)
             object_sprite.setRotation(sf::vector2ToAngle(screen_position - radar_screen_center) - 90);
             window.draw(object_sprite);
 
-            drawText(window, sf::FloatRect(screen_position.x, screen_position.y, 0, 0), string(n + 1), ACenter, 18, bold_font, colorConfig.ship_waypoint_text);
+            drawText(window, sf::FloatRect(screen_position.x, screen_position.y, 0, 0), string(my_spaceship->waypoint_labels[n]), ACenter, 18, bold_font, colorConfig.ship_waypoint_text);
         }
     }
 }

--- a/src/screenComponents/radarView.cpp
+++ b/src/screenComponents/radarView.cpp
@@ -417,7 +417,7 @@ void GuiRadarView::drawWaypoints(sf::RenderTarget& window)
 
     for(unsigned int n=0; n<my_spaceship->waypoints.size(); n++)
     {
-        sf::Vector2f screen_position = worldToScreen(my_spaceship->waypoints[n]);
+        sf::Vector2f screen_position = worldToScreen(my_spaceship->waypoints[n].first);
 
         sf::Sprite object_sprite;
         textureManager.setTexture(object_sprite, "waypoint");
@@ -425,7 +425,7 @@ void GuiRadarView::drawWaypoints(sf::RenderTarget& window)
         object_sprite.setPosition(screen_position - sf::Vector2f(0, 10));
         object_sprite.setScale(0.8, 0.8);
         window.draw(object_sprite);
-        drawText(window, sf::FloatRect(screen_position.x, screen_position.y - 10, 0, 0), string(my_spaceship->waypoint_labels[n]), ACenter, 18, bold_font, colorConfig.ship_waypoint_text);
+        drawText(window, sf::FloatRect(screen_position.x, screen_position.y - 10, 0, 0), string(my_spaceship->waypoints[n].second), ACenter, 18, bold_font, colorConfig.ship_waypoint_text);
 
         if (style != Rectangular && sf::length(screen_position - radar_screen_center) > std::min(rect.width, rect.height) * 0.5f)
         {
@@ -435,7 +435,7 @@ void GuiRadarView::drawWaypoints(sf::RenderTarget& window)
             object_sprite.setRotation(sf::vector2ToAngle(screen_position - radar_screen_center) - 90);
             window.draw(object_sprite);
 
-            drawText(window, sf::FloatRect(screen_position.x, screen_position.y, 0, 0), string(my_spaceship->waypoint_labels[n]), ACenter, 18, bold_font, colorConfig.ship_waypoint_text);
+            drawText(window, sf::FloatRect(screen_position.x, screen_position.y, 0, 0), string(my_spaceship->waypoints[n].second), ACenter, 18, bold_font, colorConfig.ship_waypoint_text);
         }
     }
 }
@@ -736,7 +736,7 @@ void GuiRadarView::drawTargets(sf::RenderTarget& window)
 
     if (my_spaceship && targets->getWaypointIndex() > -1 && targets->getWaypointIndex() < my_spaceship->getWaypointCount())
     {
-        sf::Vector2f object_position_on_screen = worldToScreen(my_spaceship->waypoints[targets->getWaypointIndex()]);
+        sf::Vector2f object_position_on_screen = worldToScreen(my_spaceship->waypoints[targets->getWaypointIndex()].first);
 
         target_sprite.setPosition(object_position_on_screen - sf::Vector2f(0, 10));
         window.draw(target_sprite);

--- a/src/screenComponents/targetsContainer.cpp
+++ b/src/screenComponents/targetsContainer.cpp
@@ -76,13 +76,13 @@ void TargetsContainer::setToClosestTo(sf::Vector2f position, float max_range, ES
     {
         for(int n=0; n<my_spaceship->getWaypointCount(); n++)
         {
-            if ((my_spaceship->waypoints[n] - position) < max_range)
+            if ((my_spaceship->waypoints[n].first - position) < max_range)
             {
-                if (!target || sf::length(position - my_spaceship->waypoints[n]) < sf::length(position - target->getPosition()))
+                if (!target || sf::length(position - my_spaceship->waypoints[n].first) < sf::length(position - target->getPosition()))
                 {
                     clear();
                     waypoint_selection_index = n;
-                    waypoint_selection_position = my_spaceship->waypoints[n];
+                    waypoint_selection_position = my_spaceship->waypoints[n].first;
                     return;
                 }
             }
@@ -97,7 +97,7 @@ int TargetsContainer::getWaypointIndex()
         waypoint_selection_index = -1;
     else if (waypoint_selection_index >= my_spaceship->getWaypointCount())
         waypoint_selection_index = -1;
-    else if (my_spaceship->waypoints[waypoint_selection_index] != waypoint_selection_position)
+    else if (my_spaceship->waypoints[waypoint_selection_index].first != waypoint_selection_position)
         waypoint_selection_index = -1;
     return waypoint_selection_index;
 }
@@ -106,5 +106,5 @@ void TargetsContainer::setWaypointIndex(int index)
 {
     waypoint_selection_index = index;
     if (my_spaceship && index >= 0 && index < (int)my_spaceship->waypoints.size())
-        waypoint_selection_position = my_spaceship->waypoints[index];
+        waypoint_selection_position = my_spaceship->waypoints[index].first;
 }

--- a/src/screens/crew4/operationsScreen.cpp
+++ b/src/screens/crew4/operationsScreen.cpp
@@ -31,7 +31,7 @@ OperationScreen::OperationScreen(GuiContainer* owner)
             {
                 // ... and we select something near a waypoint, switch to move
                 // waypoint mode.
-                if (sf::length(my_spaceship->waypoints[science->targets.getWaypointIndex()] - position) < 1000.0)
+                if (sf::length(my_spaceship->waypoints[science->targets.getWaypointIndex()].first - position) < 1000.0)
                 {
                     mode = MoveWaypoint;
                     drag_waypoint_index = science->targets.getWaypointIndex();

--- a/src/screens/crew6/relayScreen.cpp
+++ b/src/screens/crew6/relayScreen.cpp
@@ -32,7 +32,7 @@ RelayScreen::RelayScreen(GuiContainer* owner, bool allow_comms)
         [this](sf::Vector2f position) { //down
             if (mode == TargetSelection && targets.getWaypointIndex() > -1 && my_spaceship)
             {
-                if (sf::length(my_spaceship->waypoints[targets.getWaypointIndex()] - position) < 1000.0)
+                if (sf::length(my_spaceship->waypoints[targets.getWaypointIndex()].first - position) < 1000.0)
                 {
                     mode = MoveWaypoint;
                     drag_waypoint_index = targets.getWaypointIndex();

--- a/src/screens/crew6/scienceScreen.cpp
+++ b/src/screens/crew6/scienceScreen.cpp
@@ -430,7 +430,7 @@ void ScienceScreen::onDraw(sf::RenderTarget& window)
     else if (targets.getWaypointIndex() >= 0)
     {
         sidebar_pager->hide();
-        sf::Vector2f position_diff = my_spaceship->waypoints[targets.getWaypointIndex()] - my_spaceship->getPosition();
+        sf::Vector2f position_diff = my_spaceship->waypoints[targets.getWaypointIndex()].first - my_spaceship->getPosition();
         float distance = sf::length(position_diff);
         float heading = sf::vector2ToAngle(position_diff) - 270;
 

--- a/src/spaceObjects/playerSpaceship.cpp
+++ b/src/spaceObjects/playerSpaceship.cpp
@@ -1540,8 +1540,8 @@ void PlayerSpaceship::onReceiveClientCommand(int32_t client_id, sf::Packet& pack
             sf::Vector2f position;
             packet >> position;
             if (waypoints.size() < 9) {
-                waypoints.push_back(position);
-                waypoint_labels.push_back(waypoint_free_label_pool.front());
+                std::pair<sf::Vector2f,uint8_t> wp_pair(position, waypoint_free_label_pool.front());
+                waypoints.push_back(wp_pair);
                 waypoint_free_label_pool.erase(waypoint_free_label_pool.begin());
             }
         }
@@ -1551,9 +1551,8 @@ void PlayerSpaceship::onReceiveClientCommand(int32_t client_id, sf::Packet& pack
             int32_t index;
             packet >> index;
             if (index >= 0 && index < int(waypoints.size())) {
+                waypoint_free_label_pool.push_back(waypoints.at(index).second);
                 waypoints.erase(waypoints.begin() + index);
-                waypoint_free_label_pool.push_back(waypoint_labels.at(index));
-                waypoint_labels.erase(waypoint_labels.begin() + index);
                 std::sort(waypoint_free_label_pool.begin(), waypoint_free_label_pool.end());
             }
         }
@@ -1564,7 +1563,7 @@ void PlayerSpaceship::onReceiveClientCommand(int32_t client_id, sf::Packet& pack
             sf::Vector2f position;
             packet >> index >> position;
             if (index >= 0 && index < int(waypoints.size()))
-                waypoints[index] = position;
+                waypoints[index].first = position;
         }
         break;
     case CMD_ACTIVATE_SELF_DESTRUCT:

--- a/src/spaceObjects/playerSpaceship.cpp
+++ b/src/spaceObjects/playerSpaceship.cpp
@@ -1539,16 +1539,23 @@ void PlayerSpaceship::onReceiveClientCommand(int32_t client_id, sf::Packet& pack
         {
             sf::Vector2f position;
             packet >> position;
-            if (waypoints.size() < 9)
+            if (waypoints.size() < 9) {
                 waypoints.push_back(position);
+                waypoint_labels.push_back(waypoint_free_label_pool.front());
+                waypoint_free_label_pool.erase(waypoint_free_label_pool.begin());
+            }
         }
         break;
     case CMD_REMOVE_WAYPOINT:
         {
             int32_t index;
             packet >> index;
-            if (index >= 0 && index < int(waypoints.size()))
+            if (index >= 0 && index < int(waypoints.size())) {
                 waypoints.erase(waypoints.begin() + index);
+                waypoint_free_label_pool.push_back(waypoint_labels.at(index));
+                waypoint_labels.erase(waypoint_labels.begin() + index);
+                std::sort(waypoint_free_label_pool.begin(), waypoint_free_label_pool.end());
+            }
         }
         break;
     case CMD_MOVE_WAYPOINT:

--- a/src/spaceObjects/playerSpaceship.cpp
+++ b/src/spaceObjects/playerSpaceship.cpp
@@ -1540,9 +1540,22 @@ void PlayerSpaceship::onReceiveClientCommand(int32_t client_id, sf::Packet& pack
             sf::Vector2f position;
             packet >> position;
             if (waypoints.size() < 9) {
-                std::pair<sf::Vector2f,uint8_t> wp_pair(position, waypoint_free_label_pool.front());
+                std::bitset<9> taken_labels;
+                uint8_t label = 0;
+                
+                for(int n=0; n<waypoints.size(); n++) {
+                    taken_labels[waypoints[n].second-1] = true;
+                }
+
+                for(int n=0; n<9; n++) {
+                    if(taken_labels[n] != true) {
+                        label = n+1;
+                        break;
+                    }
+                }
+
+                std::pair<sf::Vector2f,uint8_t> wp_pair(position, label);
                 waypoints.push_back(wp_pair);
-                waypoint_free_label_pool.erase(waypoint_free_label_pool.begin());
             }
         }
         break;
@@ -1550,11 +1563,8 @@ void PlayerSpaceship::onReceiveClientCommand(int32_t client_id, sf::Packet& pack
         {
             int32_t index;
             packet >> index;
-            if (index >= 0 && index < int(waypoints.size())) {
-                waypoint_free_label_pool.push_back(waypoints.at(index).second);
+            if (index >= 0 && index < int(waypoints.size()))
                 waypoints.erase(waypoints.begin() + index);
-                std::sort(waypoint_free_label_pool.begin(), waypoint_free_label_pool.end());
-            }
         }
         break;
     case CMD_MOVE_WAYPOINT:

--- a/src/spaceObjects/playerSpaceship.cpp
+++ b/src/spaceObjects/playerSpaceship.cpp
@@ -1539,23 +1539,22 @@ void PlayerSpaceship::onReceiveClientCommand(int32_t client_id, sf::Packet& pack
         {
             sf::Vector2f position;
             packet >> position;
-            if (waypoints.size() < 9) {
-                std::bitset<9> taken_labels;
-                uint8_t label = 0;
+            if (waypoints.size() < max_waypoints) {
+                std::bitset<max_waypoints> taken_labels;
                 
-                for(int n=0; n<waypoints.size(); n++) {
-                    taken_labels[waypoints[n].second-1] = true;
+                for(const auto& waypoint: waypoints) {
+                    taken_labels[waypoint.second-1] = true;
                 }
 
-                for(int n=0; n<9; n++) {
+                uint8_t label = 0;
+                for(int n=0; n<max_waypoints; n++) {
                     if(taken_labels[n] != true) {
                         label = n+1;
                         break;
                     }
                 }
 
-                std::pair<sf::Vector2f,uint8_t> wp_pair(position, label);
-                waypoints.push_back(wp_pair);
+                waypoints.emplace_back(position, label);
             }
         }
         break;

--- a/src/spaceObjects/playerSpaceship.h
+++ b/src/spaceObjects/playerSpaceship.h
@@ -6,7 +6,7 @@
 #include "commsScriptInterface.h"
 #include "playerInfo.h"
 #include <iostream>
-#include <algorithm>
+#include <bitset>
 
 class ScanProbe;
 
@@ -117,8 +117,6 @@ private:
     // Ship's log container
     std::vector<ShipLogEntry> ships_log;
 
-    //waypoint variables
-    std::vector<uint8_t> waypoint_free_label_pool{1, 2, 3, 4, 5, 6, 7, 8, 9};
 public:
     std::vector<CustomShipFunction> custom_functions;
 

--- a/src/spaceObjects/playerSpaceship.h
+++ b/src/spaceObjects/playerSpaceship.h
@@ -55,6 +55,9 @@ public:
     // Maximum number of self-destruction confirmation codes
     constexpr static int max_self_destruct_codes = 3;
 
+    // Maximum number of waypoints
+    constexpr static size_t max_waypoints = 9;
+
     constexpr static int16_t CMD_PLAY_CLIENT_SOUND = 0x0001;
 
     // Content of a line in the ship's log

--- a/src/spaceObjects/playerSpaceship.h
+++ b/src/spaceObjects/playerSpaceship.h
@@ -122,8 +122,7 @@ private:
 public:
     std::vector<CustomShipFunction> custom_functions;
 
-    std::vector<sf::Vector2f> waypoints;
-    std::vector<uint8_t> waypoint_labels;
+    std::vector<std::pair<sf::Vector2f,uint8_t>> waypoints;
 
     // Ship functionality
     // Capable of scanning a target
@@ -333,7 +332,7 @@ public:
 
     // Waypoint functions
     int getWaypointCount() { return waypoints.size(); }
-    sf::Vector2f getWaypoint(int index) { if (index > 0 && index <= int(waypoints.size())) return waypoints[index - 1]; return sf::Vector2f(0, 0); }
+    sf::Vector2f getWaypoint(int index) { if (index > 0 && index <= int(waypoints.size())) return waypoints[index - 1].first; return sf::Vector2f(0, 0); }
 
     // Ship control code/password setter
     void setControlCode(string code) { control_code = code.upper(); }

--- a/src/spaceObjects/playerSpaceship.h
+++ b/src/spaceObjects/playerSpaceship.h
@@ -6,6 +6,7 @@
 #include "commsScriptInterface.h"
 #include "playerInfo.h"
 #include <iostream>
+#include <algorithm>
 
 class ScanProbe;
 
@@ -115,10 +116,14 @@ private:
     CommsScriptInterface comms_script_interface; // Server only
     // Ship's log container
     std::vector<ShipLogEntry> ships_log;
+
+    //waypoint variables
+    std::vector<uint8_t> waypoint_free_label_pool{1, 2, 3, 4, 5, 6, 7, 8, 9};
 public:
     std::vector<CustomShipFunction> custom_functions;
 
     std::vector<sf::Vector2f> waypoints;
+    std::vector<uint8_t> waypoint_labels;
 
     // Ship functionality
     // Capable of scanning a target


### PR DESCRIPTION
Waypoint labels are now static. After waypoint removal, the rest of the waypoints retains their number. When adding waypoint, first free number is used as label of the waypoint. 

I recommend squashing commits into one during merge. 