### PR TITLE
Spacedust could use unitialized data

### DIFF
--- a/src/screenComponents/viewport3d.cpp
+++ b/src/screenComponents/viewport3d.cpp
@@ -128,25 +128,30 @@ GuiViewport3D::GuiViewport3D(GuiContainer* owner, string id)
         // Reserve our GPU buffer.
         // Each dust particle consist of:
         // - a worldpace position (Vector3f)
-        // - a sign value (single byte).
+        // - a sign value (single byte, passed as float).
         // Both "arrays" are maintained separate:
         // the signs are stable (they just tell us which "end" of the line we're on)
         // The positions will get updated more frequently.
-        // It means each particle occupies 2*13B (assuming tight packing)
+        // It means each particle occupies 2*16B (assuming tight packing)
         glBindBuffer(GL_ARRAY_BUFFER, spacedust_buffer[0]);
-        glBufferData(GL_ARRAY_BUFFER, 2 * spacedust_particle_count * (sizeof(sf::Vector3f) + sizeof(int8_t)), nullptr, GL_DYNAMIC_DRAW);
+        glBufferData(GL_ARRAY_BUFFER, 2 * spacedust_particle_count * (sizeof(sf::Vector3f) + sizeof(float)), nullptr, GL_DYNAMIC_DRAW);
 
         // Generate and update the alternating vertices signs.
-        std::array<int8_t, 2 * spacedust_particle_count> signs;
+        std::array<float, 2 * spacedust_particle_count> signs;
         
         for (auto n = 0; n < signs.size(); n += 2)
         {
-            signs[n] = -1;
-            signs[n + 1] = 1;
+            signs[n] = -1.f;
+            signs[n + 1] = 1.f;
         }
 
         // Update sign parts.
-        glBufferSubData(GL_ARRAY_BUFFER, 2 * spacedust_particle_count * sizeof(sf::Vector3f), signs.size() * sizeof(int8_t), signs.data());
+        glBufferSubData(GL_ARRAY_BUFFER, 2 * spacedust_particle_count * sizeof(sf::Vector3f), signs.size() * sizeof(float), signs.data());
+        {
+            // zero out positions.
+            const std::vector<sf::Vector3f> zeroed_positions(2 * spacedust_particle_count);
+            glBufferSubData(GL_ARRAY_BUFFER, 0, 2 * spacedust_particle_count * sizeof(sf::Vector3f), zeroed_positions.data());
+        }
         glBindBuffer(GL_ARRAY_BUFFER, GL_NONE);
         
     }
@@ -365,7 +370,7 @@ void GuiViewport3D::onDraw(sf::RenderTarget& window)
                 glBufferSubData(GL_ARRAY_BUFFER, 0, space_dust.size() * sizeof(sf::Vector3f), space_dust.data());
             }
             glVertexAttribPointer(positions.get(), 3, GL_FLOAT, GL_FALSE, sizeof(sf::Vector3f), (GLvoid*)0);
-            glVertexAttribPointer(signs.get(), 1, GL_BYTE, GL_FALSE, 0, (GLvoid*)(2 * spacedust_particle_count * sizeof(sf::Vector3f)));
+            glVertexAttribPointer(signs.get(), 1, GL_FLOAT, GL_FALSE, 0, (GLvoid*)(2 * spacedust_particle_count * sizeof(sf::Vector3f)));
             
             glDrawArrays(GL_LINES, 0, 2 * spacedust_particle_count);
             glBindBuffer(GL_ARRAY_BUFFER, GL_NONE);


### PR DESCRIPTION
Happens when the ship is initially at full-stop *and* the ship is around the (0, 0) world position - the positions in the buffer have not been initialized and will remain so until the ship moves enough.

Moreover, ensuring the data type sent from cpu to the shaders lines up for the signs.