### PR TITLE
Remove misuse of gl_Color

### DIFF
--- a/resources/shaders/objectShaderB.frag
+++ b/resources/shaders/objectShaderB.frag
@@ -14,7 +14,7 @@ void main()
 	vec3 lightDir = normalize(vec3(light_position) - position);
 	float intensity = max(0.1, dot(lightDir, normalize(normal)));
 	
-	vec3 base = texture2D(baseMap, gl_TexCoord[0].st).rgb;
+	vec4 base = texture2D(baseMap, gl_TexCoord[0].st);
 	
-	gl_FragColor = vec4((base * intensity), gl_Color.a);
+	gl_FragColor = (base * intensity);
 }

--- a/resources/shaders/objectShaderB.vert
+++ b/resources/shaders/objectShaderB.vert
@@ -10,6 +10,4 @@ void main()
 	
 	gl_TexCoord[0] = gl_MultiTexCoord0;
 	gl_Position = gl_ModelViewProjectionMatrix * gl_Vertex;
-	gl_FrontColor = gl_Color;
-	gl_BackColor = gl_Color;
 }

--- a/resources/shaders/objectShaderBI.frag
+++ b/resources/shaders/objectShaderBI.frag
@@ -14,8 +14,8 @@ void main()
 	vec3 n = normalize(normal);
 	float intensity = max(0.1, dot(lightDir, n));
 	
-	vec3 base = texture2D(baseMap, gl_TexCoord[0].st).rgb;
-	vec3 illumination = texture2D(illuminationMap, gl_TexCoord[0].st).rgb;
+	vec4 base = texture2D(baseMap, gl_TexCoord[0].st);
+	vec4 illumination = texture2D(illuminationMap, gl_TexCoord[0].st);
 	
-	gl_FragColor = vec4(((base - illumination) * intensity) + illumination, gl_Color.a);
+	gl_FragColor = (base - illumination) * intensity) + illumination;
 }

--- a/resources/shaders/objectShaderBI.frag
+++ b/resources/shaders/objectShaderBI.frag
@@ -17,5 +17,5 @@ void main()
 	vec4 base = texture2D(baseMap, gl_TexCoord[0].st);
 	vec4 illumination = texture2D(illuminationMap, gl_TexCoord[0].st);
 	
-	gl_FragColor = (base - illumination) * intensity) + illumination;
+	gl_FragColor = (base - illumination) * intensity + illumination;
 }

--- a/resources/shaders/objectShaderBI.vert
+++ b/resources/shaders/objectShaderBI.vert
@@ -10,6 +10,4 @@ void main()
 	
 	gl_TexCoord[0] = gl_MultiTexCoord0;
 	gl_Position = gl_ModelViewProjectionMatrix * gl_Vertex;
-	gl_FrontColor = gl_Color;
-	gl_BackColor = gl_Color;
 }

--- a/resources/shaders/objectShaderBS.frag
+++ b/resources/shaders/objectShaderBS.frag
@@ -17,8 +17,8 @@ void main()
 	float intensity = max(0.1, dot(lightDir, n));
 	float specularIntensity = min(1.0, pow(max(0.0, dot(lightDir2, n)) * 1.2, 20.0));
 	
-	vec3 base = texture2D(baseMap, gl_TexCoord[0].st).rgb;
-	vec3 specular = texture2D(specularMap, gl_TexCoord[0].st).rgb;
+	vec4 base = texture2D(baseMap, gl_TexCoord[0].st);
+	vec4 specular = texture2D(specularMap, gl_TexCoord[0].st);
 	
-	gl_FragColor = vec4(((base) * intensity) + (specular * specularIntensity), gl_Color.a);
+	gl_FragColor = (base * intensity) + (specular * specularIntensity);
 }

--- a/resources/shaders/objectShaderBS.vert
+++ b/resources/shaders/objectShaderBS.vert
@@ -10,6 +10,4 @@ void main()
 	
 	gl_TexCoord[0] = gl_MultiTexCoord0;
 	gl_Position = gl_ModelViewProjectionMatrix * gl_Vertex;
-	gl_FrontColor = gl_Color;
-	gl_BackColor = gl_Color;
 }

--- a/resources/shaders/objectShaderBSI.frag
+++ b/resources/shaders/objectShaderBSI.frag
@@ -18,11 +18,9 @@ void main()
 	float intensity = max(0.1, dot(lightDir, n));
 	float specularIntensity = min(1.0, pow(max(0.0, dot(lightDir2, n)) * 1.2, 20.0));
 	
-	vec3 base = texture2D(baseMap, gl_TexCoord[0].st).rgb;
-	vec3 illumination = texture2D(illuminationMap, gl_TexCoord[0].st).rgb;
-	vec3 specular = texture2D(specularMap, gl_TexCoord[0].st).rgb;
+	vec4 base = texture2D(baseMap, gl_TexCoord[0].st);
+	vec4 illumination = texture2D(illuminationMap, gl_TexCoord[0].st);
+	vec4 specular = texture2D(specularMap, gl_TexCoord[0].st);
 	
-	gl_FragColor = vec4(((base - illumination) * intensity) + (specular * specularIntensity) + illumination, gl_Color.a);
-	//gl_FragColor = vec4(base, gl_Color.a);
-	//gl_FragColor = vec4(specular * specularIntensity, gl_Color.a);
+	gl_FragColor = ((base - illumination) * intensity) + (specular * specularIntensity) + illumination;
 }

--- a/resources/shaders/objectShaderBSI.vert
+++ b/resources/shaders/objectShaderBSI.vert
@@ -10,6 +10,4 @@ void main()
 	
 	gl_TexCoord[0] = gl_MultiTexCoord0;
 	gl_Position = gl_ModelViewProjectionMatrix * gl_Vertex;
-	gl_FrontColor = gl_Color;
-	gl_BackColor = gl_Color;
 }

--- a/src/mesh.cpp
+++ b/src/mesh.cpp
@@ -66,6 +66,7 @@ void Mesh::render()
         glDisableClientState(GL_VERTEX_ARRAY);
         glDisableClientState(GL_NORMAL_ARRAY);
         glDisableClientState(GL_TEXTURE_COORD_ARRAY);
+        glEnableClientState(GL_COLOR_ARRAY);
         glBindBuffer(GL_ARRAY_BUFFER, 0);
     }else{
         glEnableClientState(GL_VERTEX_ARRAY);
@@ -79,6 +80,7 @@ void Mesh::render()
         glDisableClientState(GL_VERTEX_ARRAY);
         glDisableClientState(GL_NORMAL_ARRAY);
         glDisableClientState(GL_TEXTURE_COORD_ARRAY);
+        glEnableClientState(GL_COLOR_ARRAY);
     }
 #endif//FEATURE_3D_RENDERING
 }


### PR DESCRIPTION
`mesh.render()` explicitely disables the color array, yet it is referenced in the shaders.

I noticed this while trying to fix the warp offset issue - I was lucky enough to get a visual glitch on my machine, and noticing that particular variable was actually never set from code.

Also restored proper symmetry by re-enabling the color array once done with the render.