### PR TITLE
Particles Compatibility

### DIFF
--- a/resources/shaders/particles.vert
+++ b/resources/shaders/particles.vert
@@ -1,54 +1,28 @@
 #version 120
 
 // Constants
-// ES2 does not support constant arrays
-// this is a way around (since vectors can be indexed)
-const vec4 texcoord_s = vec4(0., 1., 1., 0.);
-const vec4 texcoord_t = vec4(0., 0., 1., 1.);
-
-const int max_instance_count = 60; // ! Sync up with code !
-// Computing the instance limit:
-// GLSL 1.00: Appendix A: Limitations for ES 2.0111 7 Counting of Varyings and Uniforms
-// Spec says *minimum* of 128 rows x 4 columns for uniforms ()
-// As uniform inputs, we have our two matrices - 4 rows each.
-// That leaves us with (128 - 8 = ) 120 rows.
-// we need two rows per instance, hence 60 instances.
-
 
 // Program inputs
 uniform mat4 projection;
 uniform mat4 model_view;
 
-uniform vec3 centers[max_instance_count];
-uniform vec4 color_and_sizes[max_instance_count]; // RGB color, alpha channel = size.
-
-
 // Per-vertex inputs
-attribute float vertex_id; // actually a uint8 (must be float in ES2)
+attribute vec3 center;
+attribute vec2 texcoords;
+attribute vec3 color;
+attribute float size;
 
 // Per-vertex outputs
 varying vec3 fragcolor;
 varying vec2 fragtexcoords;
 
-
-vec2 resolve_texcoords(int vertex_id)
-{
-    return vec2(texcoord_s[vertex_id], texcoord_t[vertex_id]);
-}
-
 void main()
 {
-    int instance_id = int(floor(vertex_id / 4.));
-    int relative_vertex_id = int(mod(vertex_id, 4.));
-    vec3 center = centers[instance_id];
-    vec4 color_and_size = color_and_sizes[instance_id];
-    vec2 texcoords = resolve_texcoords(relative_vertex_id);
-
     vec4 viewspace_center = model_view * vec4(center, 1.0);
-    vec4 viewspace_halfextents = vec4(texcoords.x - .5, texcoords.y - .5, 0., 0.) * color_and_size.w;
+    vec4 viewspace_halfextents = vec4(texcoords.x - .5, texcoords.y - .5, 0., 0.) * size;
 
     // Outputs to fragment shader
     gl_Position = projection * (viewspace_center + viewspace_halfextents);
     fragtexcoords = texcoords;
-    fragcolor = color_and_size.rgb;
+    fragcolor = color;
 }

--- a/src/particleEffect.h
+++ b/src/particleEffect.h
@@ -8,12 +8,11 @@
 
 #include "glObjects.h"
 
-class ParticleData
+struct ParticleData
 {
-public:
-    sf::Vector3f position;
-    sf::Vector3f color;
-    float size;
+    sf::Vector3f position{};
+    sf::Vector3f color{};
+    float size{};
 };
 class Particle
 {
@@ -31,14 +30,12 @@ class ParticleEngine : public Updatable
 #if FEATURE_3D_RENDERING
     static constexpr size_t vertices_per_instance = 4; // a quad...
     static constexpr size_t elements_per_instance = 6; // ... made of two triangles (ES2 has no support for GL_QUADS)
-    static constexpr size_t instances_per_draw = 60; // Number of particles that a single draw can handle. ! Sync up with the shader !
+    static constexpr size_t instances_per_draw = (std::numeric_limits<uint8_t>::max() + 1) / vertices_per_instance; // Number of particles that a single draw can handle.
     static constexpr size_t max_vertex_count = instances_per_draw * vertices_per_instance; // Maximum number of vertices per draw call.
 
     enum class Uniforms : uint8_t
     {
-        Centers = 0,
-        ColorAndSizes,
-        Projection,
+        Projection = 0,
         ModelView,
 
         Count
@@ -48,6 +45,16 @@ class ParticleEngine : public Updatable
     {
         Element = 0,
         Vertex,
+
+        Count
+    };
+
+    enum class Attributes : uint8_t
+    {
+        Center = 0,
+        TexCoords,
+        Color,
+        Size,
 
         Count
     };
@@ -66,13 +73,13 @@ private:
     void doSpawn(sf::Vector3f position, sf::Vector3f end_position, sf::Vector3f color, sf::Vector3f end_color, float size, float end_size, float life_time);
 
     std::array<uint32_t, static_cast<size_t>(Uniforms::Count)> uniforms;
+    std::array<uint32_t, static_cast<size_t>(Attributes::Count)> attributes{};
     gl::Buffers<static_cast<size_t>(Buffers::Count)> buffers{ gl::Unitialized{} };
 
     std::vector<Particle> particles;
     std::vector<Particle>::iterator first_expired;
     
     sf::Shader* shader = nullptr;
-    uint32_t shaderVertexIDAttribute = 0;
 #endif
 };
 


### PR DESCRIPTION
Given issues on some graphics device, using a more straightforward approach for particles: they're drawn through standard vertex attributes (got rid of the instancing 'trick').

It is now using the same approach as the explosions.

It still retains a decent chunk of optimization (same number of draw calls per particle count) but it does cost a little more memory (now a whopping 9KiB. Crazy I know).