### PR TITLE
Coherent winding order

### DIFF
--- a/packs/pack_gen.py
+++ b/packs/pack_gen.py
@@ -29,10 +29,10 @@ def convertObj(filename):
 		for i in xrange(2, len(face)):
 			for n in [0, i, i-1]:
 				v = vertices[face[n][0] - 1]
-				vt = uvs[face[n][2] - 1]
-				vn = normals[face[n][1] - 1]
+				vt = uvs[face[n][1] - 1]
+				vn = normals[face[n][2] - 1]
 				cnt += 1
-				data += struct.pack('@ffffffff', v[0], v[2], v[1], vn[0], vn[2], vn[1], vt[0], 1.0 - vt[1])
+				data += struct.pack('@ffffffff', v[0], v[1], v[2], vn[0], vn[1], vn[2], vt[0], 1.0 - vt[1])
 	data = struct.pack('>i', cnt) + data
 	return data, os.path.splitext(filename)[0] + '.model'
 

--- a/packs/pack_gen.py
+++ b/packs/pack_gen.py
@@ -29,10 +29,10 @@ def convertObj(filename):
 		for i in xrange(2, len(face)):
 			for n in [0, i, i-1]:
 				v = vertices[face[n][0] - 1]
-				vt = uvs[face[n][1] - 1]
-				vn = normals[face[n][2] - 1]
+				vt = uvs[face[n][2] - 1]
+				vn = normals[face[n][1] - 1]
 				cnt += 1
-				data += struct.pack('@ffffffff', -v[0], v[2], v[1], -vn[0], vn[2], vn[1], vt[0], 1.0 - vt[1])
+				data += struct.pack('@ffffffff', v[0], v[2], v[1], vn[0], vn[2], vn[1], vt[0], 1.0 - vt[1])
 	data = struct.pack('>i', cnt) + data
 	return data, os.path.splitext(filename)[0] + '.model'
 

--- a/src/mesh.cpp
+++ b/src/mesh.cpp
@@ -89,7 +89,6 @@ sf::Vector3f Mesh::randomPoint()
 {
     //int idx = irandom(0, vertexCount-1);
     //return sf::Vector3f(vertices[idx].position[0], vertices[idx].position[1], vertices[idx].position[2]);
-    int idx = irandom(0, vertexCount / 3) * 3;
     sf::Vector3f v0 = sf::Vector3f(vertices[idx].position[0], vertices[idx].position[1], vertices[idx].position[2]);
     sf::Vector3f v1 = sf::Vector3f(vertices[idx+1].position[0], vertices[idx+1].position[1], vertices[idx+1].position[2]);
     sf::Vector3f v2 = sf::Vector3f(vertices[idx+2].position[0], vertices[idx+2].position[1], vertices[idx+2].position[2]);
@@ -158,16 +157,16 @@ Mesh* Mesh::getMesh(string filename)
 
                         IndexInfo info;
                         info.v = p0[0].toInt() - 1;
-                        info.t = p0[1].toInt() - 1;
-                        info.n = p0[2].toInt() - 1;
+                        info.t = p0[2].toInt() - 1;
+                        info.n = p0[1].toInt() - 1;
                         indices.push_back(info);
                         info.v = p1[0].toInt() - 1;
-                        info.t = p1[1].toInt() - 1;
-                        info.n = p1[2].toInt() - 1;
+                        info.t = p1[2].toInt() - 1;
+                        info.n = p1[1].toInt() - 1;
                         indices.push_back(info);
                         info.v = p2[0].toInt() - 1;
-                        info.t = p2[1].toInt() - 1;
-                        info.n = p2[2].toInt() - 1;
+                        info.t = p2[2].toInt() - 1;
+                        info.n = p2[1].toInt() - 1;
                         indices.push_back(info);
                     }
                 }else{
@@ -179,14 +178,14 @@ Mesh* Mesh::getMesh(string filename)
         ret->vertices = new MeshVertex[indices.size()];
         for(unsigned int n=0; n<indices.size(); n++)
         {
-            ret->vertices[n].position[0] = -vertices[indices[n].v].x;
+            ret->vertices[n].position[0] = vertices[indices[n].v].x;
             ret->vertices[n].position[1] = vertices[indices[n].v].z;
             ret->vertices[n].position[2] = vertices[indices[n].v].y;
-            ret->vertices[n].normal[0] = -normals[indices[n].n].x;
+            ret->vertices[n].normal[0] = normals[indices[n].n].x;
             ret->vertices[n].normal[1] = normals[indices[n].n].z;
             ret->vertices[n].normal[2] = normals[indices[n].n].y;
             ret->vertices[n].uv[0] = texCoords[indices[n].t].x;
-            ret->vertices[n].uv[1] = 1.0 - texCoords[indices[n].t].y;
+            ret->vertices[n].uv[1] = 1.f - texCoords[indices[n].t].y;
         }
     }else if (filename.endswith(".model"))
     {

--- a/src/mesh.cpp
+++ b/src/mesh.cpp
@@ -157,16 +157,16 @@ Mesh* Mesh::getMesh(string filename)
 
                         IndexInfo info;
                         info.v = p0[0].toInt() - 1;
-                        info.t = p0[2].toInt() - 1;
-                        info.n = p0[1].toInt() - 1;
-                        indices.push_back(info);
-                        info.v = p1[0].toInt() - 1;
-                        info.t = p1[2].toInt() - 1;
-                        info.n = p1[1].toInt() - 1;
+                        info.t = p0[1].toInt() - 1;
+                        info.n = p0[2].toInt() - 1;
                         indices.push_back(info);
                         info.v = p2[0].toInt() - 1;
-                        info.t = p2[2].toInt() - 1;
-                        info.n = p2[1].toInt() - 1;
+                        info.t = p2[1].toInt() - 1;
+                        info.n = p2[2].toInt() - 1;
+                        indices.push_back(info);
+                        info.v = p1[0].toInt() - 1;
+                        info.t = p1[1].toInt() - 1;
+                        info.n = p1[2].toInt() - 1;
                         indices.push_back(info);
                     }
                 }else{

--- a/src/mesh.cpp
+++ b/src/mesh.cpp
@@ -89,6 +89,7 @@ sf::Vector3f Mesh::randomPoint()
 {
     //int idx = irandom(0, vertexCount-1);
     //return sf::Vector3f(vertices[idx].position[0], vertices[idx].position[1], vertices[idx].position[2]);
+    int idx = irandom(0, vertexCount / 3) * 3;
     sf::Vector3f v0 = sf::Vector3f(vertices[idx].position[0], vertices[idx].position[1], vertices[idx].position[2]);
     sf::Vector3f v1 = sf::Vector3f(vertices[idx+1].position[0], vertices[idx+1].position[1], vertices[idx+1].position[2]);
     sf::Vector3f v2 = sf::Vector3f(vertices[idx+2].position[0], vertices[idx+2].position[1], vertices[idx+2].position[2]);

--- a/src/modelData.cpp
+++ b/src/modelData.cpp
@@ -202,7 +202,9 @@ void ModelData::render()
         return;
 
     glPushMatrix();
-
+    // EE's coordinate flips to a Z-up left hand.
+    // To account for that, flip the model around 180deg.
+    glRotatef(180.f, 0.f, 0.f, 1.f);
     glScalef(scale, scale, scale);
     glTranslatef(mesh_offset.x, mesh_offset.y, mesh_offset.z);
     shader->setUniform("baseMap", *texture);

--- a/src/particleEffect.cpp
+++ b/src/particleEffect.cpp
@@ -94,10 +94,11 @@ ParticleEngine::ParticleEngine()
             elements[base_element + 5] = base_vertex + 1;
 
             // Setup texcoords.
-            texcoords[base_vertex + 0] = { 0.f, 0.f };
-            texcoords[base_vertex + 1] = { 1.f, 0.f };
-            texcoords[base_vertex + 2] = { 1.f, 1.f };
-            texcoords[base_vertex + 3] = { 0.f, 1.f };
+            // OpenGL origin is bottom left.
+            texcoords[base_vertex + 0] = { 0.f, 1.f };
+            texcoords[base_vertex + 1] = { 1.f, 1.f };
+            texcoords[base_vertex + 2] = { 1.f, 0.f };
+            texcoords[base_vertex + 3] = { 0.f, 0.f };
         }
 
         // Hand off to the GPU.

--- a/src/screenComponents/viewport3d.cpp
+++ b/src/screenComponents/viewport3d.cpp
@@ -215,11 +215,11 @@ void GuiViewport3D::onDraw(sf::RenderTarget& window)
     glMatrixMode(GL_MODELVIEW);
     glLoadIdentity();
 
-    // OpenGL standard: X across (left-to-right), Y up, Z "into".
-    glRotatef(90, 1, 0, 0); // -> X across (l-t-r), Y "into", Z down 
-    glScalef(1,1,-1);  // -> X across (l-t-r), Y "into", Z up
+    // OpenGL standard: X across (left-to-right), Y up, Z "towards".
+    glRotatef(90, 1, 0, 0); // -> X across (l-t-r), Y "towards", Z down 
+    glScalef(1,1,-1);  // -> X across (l-t-r), Y "towards", Z up
     glRotatef(-camera_pitch, 1, 0, 0);
-    glRotatef(-camera_yaw - 90, 0, 0, 1);
+    glRotatef(-(camera_yaw + 90), 0, 0, 1);
 
     glGetDoublev(GL_PROJECTION_MATRIX, projection_matrix);
     glGetDoublev(GL_MODELVIEW_MATRIX, model_matrix);
@@ -515,6 +515,7 @@ void GuiViewport3D::onDraw(sf::RenderTarget& window)
 
         for(int angle = 0; angle < 360; angle += 30)
         {
+            sf::Vector2f world_pos = my_spaceship->getPosition() + sf::vector2FromAngle(angle - 90.f) * distance;
             sf::Vector3f screen_pos = worldToScreen(window, sf::Vector3f(world_pos.x, world_pos.y, 0.0f));
             if (screen_pos.z > 0.0f)
                 drawText(window, sf::FloatRect(screen_pos.x, screen_pos.y, 0, 0), string(angle), ACenter, 30, bold_font, sf::Color(255, 255, 255, 128));

--- a/src/screenComponents/viewport3d.cpp
+++ b/src/screenComponents/viewport3d.cpp
@@ -281,7 +281,11 @@ void GuiViewport3D::onDraw(sf::RenderTarget& window)
     std::vector<std::vector<RenderInfo>> render_lists;
 
     sf::Vector2f viewVector = sf::vector2FromAngle(camera_yaw);
+    float depth_cutoff_back = camera_position.z * -tanf((90+camera_pitch + camera_fov/2.f) / 180.f * M_PI);
+    float depth_cutoff_front = camera_position.z * -tanf((90+camera_pitch - camera_fov/2.f) / 180.f * M_PI);
+    if (camera_pitch - camera_fov/2.f <= 0.f)
         depth_cutoff_front = std::numeric_limits<float>::infinity();
+    if (camera_pitch + camera_fov/2.f >= 180.f)
         depth_cutoff_back = -std::numeric_limits<float>::infinity();
     foreach(SpaceObject, obj, space_object_list)
     {

--- a/src/spaceObjects/blackHole.cpp
+++ b/src/spaceObjects/blackHole.cpp
@@ -55,10 +55,10 @@ void BlackHole::update(float delta)
 void BlackHole::draw3DTransparent()
 {
     static std::array<VertexAndTexCoords, 4> quad{
-        sf::Vector3f(), {0.f, 0.f},
-        sf::Vector3f(), {1.f, 0.f},
+        sf::Vector3f(), {0.f, 1.f},
         sf::Vector3f(), {1.f, 1.f},
-        sf::Vector3f(), {0.f, 1.f}
+        sf::Vector3f(), {1.f, 0.f},
+        sf::Vector3f(), {0.f, 0.f}
     };
 
     gl::ScopedVertexAttribArray positions(shaderPositionAttribute);
@@ -72,9 +72,8 @@ void BlackHole::draw3DTransparent()
     glVertexAttribPointer(positions.get(), 3, GL_FLOAT, GL_FALSE, sizeof(VertexAndTexCoords), (GLvoid*)quad.data());
     glVertexAttribPointer(texcoords.get(), 2, GL_FLOAT, GL_FALSE, sizeof(VertexAndTexCoords), (GLvoid*)((char*)quad.data() + sizeof(sf::Vector3f)));
 
-    std::initializer_list<uint8_t> indices = { 0, 1, 2, 2, 3, 0 };
+    std::initializer_list<uint8_t> indices = { 0, 2, 1, 0, 3, 2 };
     glDrawElements(GL_TRIANGLES, 6, GL_UNSIGNED_BYTE, std::begin(indices));
-    glBlendFunc(GL_ONE, GL_ONE);
 }
 #endif
 

--- a/src/spaceObjects/electricExplosionEffect.cpp
+++ b/src/spaceObjects/electricExplosionEffect.cpp
@@ -59,17 +59,17 @@ ElectricExplosionEffect::ElectricExplosionEffect()
         for (auto i = 0; i < max_quad_count; ++i)
         {
             auto quad_offset = 4 * i;
-            texcoords[quad_offset + 0] = { 0.f, 0.f };
-            texcoords[quad_offset + 1] = { 1.f, 0.f };
-            texcoords[quad_offset + 2] = { 1.f, 1.f };
-            texcoords[quad_offset + 3] = { 0.f, 1.f };
+            texcoords[quad_offset + 0] = { 0.f, 1.f };
+            texcoords[quad_offset + 1] = { 1.f, 1.f };
+            texcoords[quad_offset + 2] = { 1.f, 0.f };
+            texcoords[quad_offset + 3] = { 0.f, 0.f };
 
             indices[6 * i + 0] = quad_offset + 0;
-            indices[6 * i + 1] = quad_offset + 1;
-            indices[6 * i + 2] = quad_offset + 2;
-            indices[6 * i + 3] = quad_offset + 2;
+            indices[6 * i + 1] = quad_offset + 2;
+            indices[6 * i + 2] = quad_offset + 1;
+            indices[6 * i + 3] = quad_offset + 0;
             indices[6 * i + 4] = quad_offset + 3;
-            indices[6 * i + 5] = quad_offset + 0;
+            indices[6 * i + 5] = quad_offset + 2;
         }
 
         // Update texcoords

--- a/src/spaceObjects/explosionEffect.cpp
+++ b/src/spaceObjects/explosionEffect.cpp
@@ -65,17 +65,17 @@ ExplosionEffect::ExplosionEffect()
         for (auto i = 0; i < max_quad_count; ++i)
         {
             auto quad_offset = 4 * i;
-            texcoords[quad_offset + 0] = { 0.f, 0.f };
-            texcoords[quad_offset + 1] = { 1.f, 0.f };
-            texcoords[quad_offset + 2] = { 1.f, 1.f };
-            texcoords[quad_offset + 3] = { 0.f, 1.f };
+            texcoords[quad_offset + 0] = { 0.f, 1.f };
+            texcoords[quad_offset + 1] = { 1.f, 1.f };
+            texcoords[quad_offset + 2] = { 1.f, 0.f };
+            texcoords[quad_offset + 3] = { 0.f, 0.f };
 
             indices[6 * i + 0] = quad_offset + 0;
-            indices[6 * i + 1] = quad_offset + 1;
-            indices[6 * i + 2] = quad_offset + 2;
-            indices[6 * i + 3] = quad_offset + 2;
+            indices[6 * i + 1] = quad_offset + 2;
+            indices[6 * i + 2] = quad_offset + 1;
+            indices[6 * i + 3] = quad_offset + 0;
             indices[6 * i + 4] = quad_offset + 3;
-            indices[6 * i + 5] = quad_offset + 0;
+            indices[6 * i + 5] = quad_offset + 2;
         }
 
         // Update texcoords

--- a/src/spaceObjects/nebula.cpp
+++ b/src/spaceObjects/nebula.cpp
@@ -66,14 +66,13 @@ Nebula::Nebula()
 #if FEATURE_3D_RENDERING
 void Nebula::draw3DTransparent()
 {
-    glRotatef(getRotation(), 0, 0, -1);
     glTranslatef(-getPosition().x, -getPosition().y, 0);
 
     std::array<VertexAndTexCoords, 4> quad{
-        sf::Vector3f(), {0.f, 0.f},
-        sf::Vector3f(), {1.f, 0.f},
+        sf::Vector3f(), {0.f, 1.f},
         sf::Vector3f(), {1.f, 1.f},
-        sf::Vector3f(), {0.f, 1.f}
+        sf::Vector3f(), {1.f, 0.f},
+        sf::Vector3f(), {0.f, 0.f}
     };
 
     gl::ScopedVertexAttribArray positions(shaderPositionAttribute);
@@ -105,7 +104,7 @@ void Nebula::draw3DTransparent()
 
         glVertexAttribPointer(positions.get(), 3, GL_FLOAT, GL_FALSE, sizeof(VertexAndTexCoords), (GLvoid*)quad.data());
         glVertexAttribPointer(texcoords.get(), 2, GL_FLOAT, GL_FALSE, sizeof(VertexAndTexCoords), (GLvoid*)((char*)quad.data() + sizeof(sf::Vector3f)));
-        std::initializer_list<uint8_t> indices = { 0, 1, 2, 2, 3, 0 };
+        std::initializer_list<uint8_t> indices = { 0, 3, 2, 0, 2, 1 };
         glDrawElements(GL_TRIANGLES, 6, GL_UNSIGNED_BYTE, std::begin(indices));
     }
 }

--- a/src/spaceObjects/planet.cpp
+++ b/src/spaceObjects/planet.cpp
@@ -322,10 +322,10 @@ void Planet::draw3DTransparent()
     if (atmosphere_texture != "" && atmosphere_size > 0)
     {
         static std::array<VertexAndTexCoords, 4> quad{
-        sf::Vector3f(), {0.f, 0.f},
-        sf::Vector3f(), {1.f, 0.f},
+        sf::Vector3f(), {0.f, 1.f},
         sf::Vector3f(), {1.f, 1.f},
-        sf::Vector3f(), {0.f, 1.f}
+        sf::Vector3f(), {1.f, 0.f},
+        sf::Vector3f(), {0.f, 0.f}
         };
 
         gl::ScopedVertexAttribArray positions(billboardShaderPositionAttribute);
@@ -338,7 +338,7 @@ void Planet::draw3DTransparent()
         glVertexAttribPointer(positions.get(), 3, GL_FLOAT, GL_FALSE, sizeof(VertexAndTexCoords), (GLvoid*)quad.data());
         glVertexAttribPointer(texcoords.get(), 2, GL_FLOAT, GL_FALSE, sizeof(VertexAndTexCoords), (GLvoid*)((char*)quad.data() + sizeof(sf::Vector3f)));
 
-        std::initializer_list<uint8_t> indices = { 0, 1, 2, 2, 3, 0 };
+        std::initializer_list<uint8_t> indices = { 0, 2, 1, 0, 3, 2 };
         glDrawElements(GL_TRIANGLES, 6, GL_UNSIGNED_BYTE, std::begin(indices));
     }
 }

--- a/src/spaceObjects/wormHole.cpp
+++ b/src/spaceObjects/wormHole.cpp
@@ -73,14 +73,13 @@ WormHole::WormHole()
 #if FEATURE_3D_RENDERING
 void WormHole::draw3DTransparent()
 {
-    glRotatef(getRotation(), 0, 0, -1);
     glTranslatef(-getPosition().x, -getPosition().y, 0);
 
     std::array<VertexAndTexCoords, 4> quad{
-        sf::Vector3f(), {0.f, 0.f},
-        sf::Vector3f(), {1.f, 0.f},
+        sf::Vector3f(), {0.f, 1.f},
         sf::Vector3f(), {1.f, 1.f},
-        sf::Vector3f(), {0.f, 1.f}
+        sf::Vector3f(), {1.f, 0.f},
+        sf::Vector3f(), {0.f, 0.f}
     };
 
     gl::ScopedVertexAttribArray positions(shaderPositionAttribute);
@@ -105,7 +104,7 @@ void WormHole::draw3DTransparent()
 
         glVertexAttribPointer(positions.get(), 3, GL_FLOAT, GL_FALSE, sizeof(VertexAndTexCoords), (GLvoid*)quad.data());
         glVertexAttribPointer(texcoords.get(), 2, GL_FLOAT, GL_FALSE, sizeof(VertexAndTexCoords), (GLvoid*)((char*)quad.data() + sizeof(sf::Vector3f)));
-        std::initializer_list<uint8_t> indices = { 0, 1, 2, 2, 3, 0 };
+        std::initializer_list<uint8_t> indices = { 0, 2, 1, 0, 3, 2 };
         glDrawElements(GL_TRIANGLES, 6, GL_UNSIGNED_BYTE, std::begin(indices));
     }
 }


### PR DESCRIPTION
This harmonizes the winding order to be counter-clockwise across the board (I checked the nebulas, wormholes, beams, engine trails, particles, asteroids, stations, black holes, planets, stars... all render OK).

Meshes do need to be rotated around the Z axis because of how EE massages the matrices around for the 3D pass (and how the entire world appears slanted 90 degrees overall, but that is a story for another time maybe :) )

fixes #294.

