### PR TITLE
Save config android

### DIFF
--- a/src/preferenceManager.cpp
+++ b/src/preferenceManager.cpp
@@ -23,7 +23,7 @@ void PreferencesManager::load(string filename)
 {
 #if defined(ANDROID)
     ANativeActivity *nactivity {sf::getNativeActivity()};
-    filename = string(nactivity->internalDataPath) + "/" + filename;
+    filename = string(nactivity->internalDataPath) + "/" + filename.substr(filename.rfind("/")+1);
 #endif
     FILE* f = fopen(filename.c_str(), "r");
     if (f)
@@ -49,8 +49,11 @@ void PreferencesManager::load(string filename)
 void PreferencesManager::save(string filename)
 {
 #if defined(ANDROID)
+    //I guess nobody wants to set something like options.ini and then some_directory/options.ini
+    //so here the directory hierarchy is not keept.
+    //On Android you have to write your user files to a specific directory.
     ANativeActivity *nactivity {sf::getNativeActivity()};
-    filename = string(nactivity->internalDataPath) + "/" + filename;
+    filename = string(nactivity->internalDataPath) + "/" + filename.substr(filename.rfind("/")+1);
 #endif
     FILE* f = fopen(filename.c_str(), "w");
     if (f)

--- a/src/preferenceManager.cpp
+++ b/src/preferenceManager.cpp
@@ -1,5 +1,10 @@
 #include "preferenceManager.h"
 
+#if defined(ANDROID)
+#include <SFML/System/NativeActivity.hpp>
+#include <android/native_activity.h>
+#endif
+
 std::unordered_map<string, string> PreferencesManager::preference;
 
 void PreferencesManager::set(string key, string value)
@@ -16,6 +21,10 @@ string PreferencesManager::get(string key, string default_value)
 
 void PreferencesManager::load(string filename)
 {
+#if defined(ANDROID)
+    ANativeActivity *nactivity {sf::getNativeActivity()};
+    filename = string(nactivity->internalDataPath) + "/" + filename;
+#endif
     FILE* f = fopen(filename.c_str(), "r");
     if (f)
     {
@@ -39,6 +48,10 @@ void PreferencesManager::load(string filename)
 
 void PreferencesManager::save(string filename)
 {
+#if defined(ANDROID)
+    ANativeActivity *nactivity {sf::getNativeActivity()};
+    filename = string(nactivity->internalDataPath) + "/" + filename;
+#endif
     FILE* f = fopen(filename.c_str(), "w");
     if (f)
     {

--- a/src/preferenceManager.cpp
+++ b/src/preferenceManager.cpp
@@ -50,7 +50,7 @@ void PreferencesManager::save(string filename)
 {
 #if defined(ANDROID)
     //I guess nobody wants to set something like options.ini and then some_directory/options.ini
-    //so here the directory hierarchy is not keept.
+    //so here the directory hierarchy is not kept.
     //On Android you have to write your user files to a specific directory.
     ANativeActivity *nactivity {sf::getNativeActivity()};
     filename = string(nactivity->internalDataPath) + "/" + filename.substr(filename.rfind("/")+1);


### PR DESCRIPTION
Preferences can be saved on android.
For android, every preference file is writted to the root of user data directory.

Implementation details : this limitation of not keeping dir is solely for purpose of maximising not modifying code everywhere with not so readable imbricated ifdefs + avoiding extremely long directory names (android has home folder so we would append every home subdirectories) over usefulness.
