### PR TITLE
Only create the 3D viewport if requested

### DIFF
--- a/src/playerInfo.cpp
+++ b/src/playerInfo.cpp
@@ -144,11 +144,10 @@ void PlayerInfo::spawnUI()
     if (my_player_info->isOnlyMainScreen())
     {
         new ScreenMainScreen();
-    }else{
+    }
+    else {
 
-        CrewStationScreen* screen = new CrewStationScreen();
-        if (main_screen)
-            screen->enableMainScreen();
+        CrewStationScreen* screen = new CrewStationScreen{ main_screen };
         auto container = screen->getTabContainer();
 
         //Crew 6/5

--- a/src/screens/crewStationScreen.cpp
+++ b/src/screens/crewStationScreen.cpp
@@ -17,13 +17,16 @@
 #include "gui/gui2_scrolltext.h"
 #include "gui/joystickConfig.h"
 
-CrewStationScreen::CrewStationScreen()
+CrewStationScreen::CrewStationScreen(bool with_main_screen)
 {
-    // Create a 3D viewport behind everything, to serve as the right-side panel
-    viewport = new GuiViewportMainScreen(this, "3D_VIEW");
-    viewport->showCallsigns()->showHeadings()->showSpacedust();
-    viewport->setPosition(1200, 0, ATopLeft)->setSize(GuiElement::GuiSizeMax, GuiElement::GuiSizeMax);
-    viewport->hide();
+    if (with_main_screen)
+    {
+        // Create a 3D viewport behind everything, to serve as the right-side panel
+        viewport = new GuiViewportMainScreen(this, "3D_VIEW");
+        viewport->showCallsigns()->showHeadings()->showSpacedust();
+        viewport->setPosition(1200, 0, ATopLeft)->setSize(GuiElement::GuiSizeMax, GuiElement::GuiSizeMax);
+        viewport->hide();
+    }
 
     main_panel = new GuiElement(this, "MAIN");
     main_panel->setSize(1200, GuiElement::GuiSizeMax);
@@ -162,15 +165,24 @@ void CrewStationScreen::update(float delta)
         return;
     }
 
-    // Responsively show/hide the 3D viewport.
-    if (!main_screen_enabled || viewport->getRect().width < viewport->getRect().height / 3.0f)
+    if (viewport)
     {
-        viewport->hide();
-        main_panel->setSize(GuiElement::GuiSizeMax, GuiElement::GuiSizeMax);
-    } else {
-        viewport->show();
-        tileViewport();
+        // Responsively show/hide the 3D viewport.
+        if (viewport->getRect().width < viewport->getRect().height / 3.0f)
+        {
+            viewport->hide();
+            main_panel->setSize(GuiElement::GuiSizeMax, GuiElement::GuiSizeMax);
+        }
+        else {
+            viewport->show();
+            tileViewport();
+        }
     }
+    else
+    {
+        main_panel->setSize(GuiElement::GuiSizeMax, GuiElement::GuiSizeMax);
+    }
+    
 
     if (my_spaceship)
     {
@@ -347,6 +359,9 @@ string CrewStationScreen::listHotkeysLimited(string station)
 
 void CrewStationScreen::tileViewport()
 {
+    if (!viewport)
+        return;
+
     if (current_position == singlePilot)
     {
         main_panel->setSize(1000, GuiElement::GuiSizeMax);

--- a/src/screens/crewStationScreen.h
+++ b/src/screens/crewStationScreen.h
@@ -22,12 +22,11 @@ class CrewStationScreen : public GuiCanvas, public Updatable
 {
     P<ThreatLevelEstimate> threat_estimate;
 public:
-    CrewStationScreen();
+    explicit CrewStationScreen(bool with_main_screen);
     virtual void destroy() override;
 
     GuiContainer* getTabContainer();
     void addStationTab(GuiElement* element, ECrewPosition position, string name, string icon);
-    void enableMainScreen() { main_screen_enabled = true; }
     void finishCreation();
 
     virtual void update(float delta) override;
@@ -36,7 +35,7 @@ public:
 
 private:
     GuiElement* main_panel;
-    GuiViewport3D* viewport;
+    GuiViewport3D* viewport{ nullptr };
     GuiButton* select_station_button;
     GuiPanel* button_strip;
     GuiHelpOverlay* keyboard_help;
@@ -44,7 +43,6 @@ private:
     GuiScrollText* message_text;
     GuiButton* message_close_button;
     std::unique_ptr<ImpulseSound> impulse_sound;
-    bool main_screen_enabled = false;
 
     struct CrewTabInfo {
         GuiToggleButton* button;


### PR DESCRIPTION
This helps maintain compatibility with GL 1.4, ensuring stations don't create a 3D viewport.

cc @aBlueShadow 