### PR TITLE
Limit main screen to gl2

### DIFF
--- a/src/menus/shipSelectionScreen.cpp
+++ b/src/menus/shipSelectionScreen.cpp
@@ -1,4 +1,8 @@
 #include "shipSelectionScreen.h"
+
+#include "featureDefs.h"
+#include "glObjects.h"
+
 #include "serverCreationScreen.h"
 #include "epsilonServer.h"
 #include "main.h"
@@ -421,6 +425,18 @@ void ShipSelectionScreen::update(float delta)
     //Sync our configured user name with the server
     if (my_player_info->name != PreferencesManager::get("username"))
         my_player_info->commandSetName(PreferencesManager::get("username"));
+}
+
+bool ShipSelectionScreen::canDoMainScreen() const
+{
+    if constexpr (FEATURE_3D_RENDERING)
+    {
+        return PostProcessor::isEnabled() && sf::Shader::isAvailable() && gl::isAvailable();
+    }
+    else
+    {
+        return false;
+    }
 }
 
 void ShipSelectionScreen::updateReadyButton()

--- a/src/menus/shipSelectionScreen.h
+++ b/src/menus/shipSelectionScreen.h
@@ -55,7 +55,7 @@ private:
      * \brief check if this console can be mainscreen.
      * Being a main screen requires a bit more than the normal GUI, so we need to do some checks.
      */
-    bool canDoMainScreen() { return PostProcessor::isEnabled() && sf::Shader::isAvailable(); }
+    bool canDoMainScreen() const;
 
     void updateReadyButton();
     void updateCrewTypeOptions();


### PR DESCRIPTION
From user reports, it looks like some gl 1.4 with the right flavor of extensions will have shader available but still lack the necessary systems (namely buffers) that are used for 3D.

Added extra sanity checks to ensure the main menu entry remains unavailable without at least 2.0 and the 3D rendering enabled.