### PR TITLE
Fix blackhole blend function

### DIFF
--- a/src/spaceObjects/blackHole.cpp
+++ b/src/spaceObjects/blackHole.cpp
@@ -74,6 +74,7 @@ void BlackHole::draw3DTransparent()
 
     std::initializer_list<uint8_t> indices = { 0, 2, 1, 0, 3, 2 };
     glDrawElements(GL_TRIANGLES, 6, GL_UNSIGNED_BYTE, std::begin(indices));
+    glBlendFunc(GL_ONE, GL_ONE);
 }
 #endif
 


### PR DESCRIPTION
BlackHole was changing the active blend function without restoring the default one. This lead to issues in some circumstances.