### PR TITLE
Options for mainscreen display flags

### DIFF
--- a/src/preferenceManager.cpp
+++ b/src/preferenceManager.cpp
@@ -61,7 +61,7 @@ void PreferencesManager::save(string filename)
         fprintf(f, "# Empty Epsilon Settings\n# This file will be overwritten by EE.\n\n");
         fprintf(f, "# Include the following line to enable an experimental http server:\n# httpserver=8080\n\n");
         fprintf(f, "# For possible hotkey values check: http://www.sfml-dev.org/documentation/2.3.1/classsf_1_1Keyboard.php#acb4cacd7cc5802dec45724cf3314a142\n\n");
-        fprintf(f, "# Values for ship_window_flags are: spacedust:1, headings:2, callsigns:4 \n# Add them for any combination. Example: ship_window_flags=7 for all three\n\n");
+        fprintf(f, "# Values for ship_window_flags and main_screen_flags are: spacedust:1, headings:2, callsigns:4 \n# Add them for any combination. Example: ship_window_flags=7 for all three\n\n");
         std::vector<string> keys;
         for(std::unordered_map<string, string>::iterator i = preference.begin(); i != preference.end(); i++)
         {

--- a/src/screenComponents/viewportMainScreen.cpp
+++ b/src/screenComponents/viewportMainScreen.cpp
@@ -6,7 +6,14 @@
 GuiViewportMainScreen::GuiViewportMainScreen(GuiContainer* owner, string id)
 : GuiViewport3D(owner, id)
 {
-    showCallsigns()->showHeadings()->showSpacedust();
+    uint8_t flags = PreferencesManager::get("main_screen_flags","7").toInt();
+
+    if (flags & flag_callsigns)
+      showCallsigns();
+    if (flags & flag_headings)
+      showHeadings();
+    if (flags & flag_spacedust)
+      showSpacedust();
 
     first_person = PreferencesManager::get("first_person") == "1";
 }

--- a/src/screenComponents/viewportMainScreen.h
+++ b/src/screenComponents/viewportMainScreen.h
@@ -11,6 +11,10 @@ public:
     virtual void onDraw(sf::RenderTarget& window);
 
     bool first_person = false;
+
+    constexpr static uint8_t flag_callsigns = 0x04;
+    constexpr static uint8_t flag_headings  = 0x02;
+    constexpr static uint8_t flag_spacedust = 0x01;
 };
 
 #endif//VIEWPORT_MAIN_SCREEN_H


### PR DESCRIPTION
This is complementary to #695, as there were some requests for a mainscreen without labels, and a 0° window screen won't accomplish quite the same.
Note that this only affects the standalone mainscreen, not the one embedded in stations, at least for now. So we can decide later if we want to add another option or let this one affect all kinds of mainscreen.