### PR TITLE
Use deferred translation for GMInfo.

### DIFF
--- a/resources/locale/en.po
+++ b/resources/locale/en.po
@@ -3745,3 +3745,64 @@ msgstr ""
 msgctxt "subclass"
 msgid "High Punch"
 msgstr ""
+
+#: src/screens/gm/gameMasterScreen.cpp:324
+msgctxt "gm_info"
+msgid "Position"
+msgstr ""
+
+#: src/screens/gm/gameMasterScreen.cpp:336
+msgid "gm_info"
+msgstr ""
+
+#: src/spaceObjects/missiles/missileWeapon.cpp:192
+#: src/spaceObjects/mine.cpp:160
+msgctxt "gm_info"
+msgid "Owner"
+msgstr ""
+
+#: src/spaceObjects/missiles/missileWeapon.cpp:199
+msgctxt "gm_info"
+msgid "Target"
+msgstr ""
+
+#: src/spaceObjects/missiles/missileWeapon.cpp:202
+#: src/spaceObjects/mine.cpp:163
+msgctxt "gm_info"
+msgid "Faction"
+msgstr ""
+
+#: src/spaceObjects/missiles/missileWeapon.cpp:203
+msgctxt "gm_info"
+msgid "Lifetime"
+msgstr ""
+
+#: src/spaceObjects/missiles/missileWeapon.cpp:204
+msgctxt "gm_info"
+msgid "Size"
+msgstr ""
+
+#: src/spaceObjects/cpuShip.cpp:306
+msgctxt "gm_info"
+msgid "Orders"
+msgstr ""
+
+#: src/spaceObjects/shipTemplateBasedObject.cpp:271
+msgctxt "gm_info"
+msgid "CallSign"
+msgstr ""
+
+#: src/spaceObjects/shipTemplateBasedObject.cpp:272
+msgctxt "gm_info"
+msgid "Type"
+msgstr ""
+
+#: src/spaceObjects/shipTemplateBasedObject.cpp:273
+msgctxt "gm_info"
+msgid "Hull"
+msgstr ""
+
+#: src/spaceObjects/shipTemplateBasedObject.cpp:278
+msgctxt "gm_info"
+msgid "Shield"
+msgstr ""

--- a/src/screens/gm/gameMasterScreen.cpp
+++ b/src/screens/gm/gameMasterScreen.cpp
@@ -321,7 +321,7 @@ void GameMasterScreen::update(float delta)
 
     if (targets.getTargets().size() == 1)
     {
-        selection_info["Position"] = string(targets.getTargets()[0]->getPosition().x, 0) + "," + string(targets.getTargets()[0]->getPosition().y, 0);
+        selection_info[trMark("gm_info", "Position")] = string(targets.getTargets()[0]->getPosition().x, 0) + "," + string(targets.getTargets()[0]->getPosition().y, 0);
     }
 
     unsigned int cnt = 0;
@@ -333,7 +333,7 @@ void GameMasterScreen::update(float delta)
             info_items[cnt]->setSize(GuiElement::GuiSizeMax, 30);
         }else{
             info_items[cnt]->show();
-            info_items[cnt]->setKey(i->first)->setValue(i->second);
+            info_items[cnt]->setKey(tr("gm_info", i->first))->setValue(i->second);
         }
         cnt++;
     }

--- a/src/spaceObjects/cpuShip.cpp
+++ b/src/spaceObjects/cpuShip.cpp
@@ -303,7 +303,7 @@ void CpuShip::drawOnGMRadar(sf::RenderTarget& window, sf::Vector2f position, flo
 std::unordered_map<string, string> CpuShip::getGMInfo()
 {
     std::unordered_map<string, string> ret = SpaceShip::getGMInfo();
-    ret["Orders"] = getAIOrderString(orders);
+    ret[trMark("gm_info", "Orders")] = getAIOrderString(orders);
     return ret;
 }
 

--- a/src/spaceObjects/mine.cpp
+++ b/src/spaceObjects/mine.cpp
@@ -7,6 +7,8 @@
 
 #include "scriptInterface.h"
 
+#include "i18n.h"
+
 /// A mine object. Simple, effective, deadly.
 REGISTER_SCRIPT_SUBCLASS(Mine, SpaceObject)
 {
@@ -155,10 +157,10 @@ std::unordered_map<string, string> Mine::getGMInfo()
 
     if (owner)
     {
-        ret["Owner"] = owner->getCallSign();
+        ret[trMark("gm_info", "Owner")] = owner->getCallSign();
     }
 
-    ret["Faction"] = getLocaleFaction();
+    ret[trMark("gm_info", "Faction")] = getLocaleFaction();
 
     return ret;
 }

--- a/src/spaceObjects/missiles/missileWeapon.cpp
+++ b/src/spaceObjects/missiles/missileWeapon.cpp
@@ -2,6 +2,8 @@
 #include "particleEffect.h"
 #include "spaceObjects/explosionEffect.h"
 
+#include "i18n.h"
+
 
 /// Base class for every missile (mines are not missiles)
 /// You cannot create a missile in script with this class, use derived classes
@@ -187,19 +189,19 @@ std::unordered_map<string, string> MissileWeapon::getGMInfo()
 
     if (owner)
     {
-        ret["Owner"] = owner->getCallSign();
+        ret[trMark("gm_info", "Owner")] = owner->getCallSign();
     }
 
     P<SpaceObject> target = game_server->getObjectById(target_id);
 
     if (target)
     {
-        ret["Target"] = target->getCallSign();
+        ret[trMark("gm_info", "Target")] = target->getCallSign();
     }
 
-    ret["Faction"] = getLocaleFaction();
-    ret["Lifetime"] = lifetime;
-    ret["Size"] = getMissileSize();
+    ret[trMark("gm_info", "Faction")] = getLocaleFaction();
+    ret[trMark("gm_info", "Lifetime")] = lifetime;
+    ret[trMark("gm_info", "Size")] = getMissileSize();
 
     return ret;
 }

--- a/src/spaceObjects/shipTemplateBasedObject.cpp
+++ b/src/spaceObjects/shipTemplateBasedObject.cpp
@@ -1,6 +1,9 @@
 #include "shipTemplateBasedObject.h"
 
 #include "scriptInterface.h"
+
+#include "i18n.h"
+
 REGISTER_SCRIPT_SUBCLASS_NO_CREATE(ShipTemplateBasedObject, SpaceObject)
 {
     /// Set the template to be used for this ship or station. Templates define hull/shields/looks etc.
@@ -265,12 +268,14 @@ void ShipTemplateBasedObject::update(float delta)
 std::unordered_map<string, string> ShipTemplateBasedObject::getGMInfo()
 {
     std::unordered_map<string, string> ret;
-    ret["CallSign"] = callsign;
-    ret["Type"] = type_name;
-    ret["Hull"] = string(hull_strength) + "/" + string(hull_max);
+    ret[trMark("gm_info", "CallSign")] = callsign;
+    ret[trMark("gm_info", "Type")] = type_name;
+    ret[trMark("gm_info", "Hull")] = string(hull_strength) + "/" + string(hull_max);
     for(int n=0; n<shield_count; n++)
     {
-        ret["Shield" + string(n + 1)] = string(shield_level[n]) + "/" + string(shield_max[n]);
+        // Note, translators: this is a compromise.
+        // Because of the deferred translation the variable parameter can't be forwarded, so it'll always be a suffix.
+        ret[trMark("gm_info", "Shield") + string(n + 1)] = string(shield_level[n]) + "/" + string(shield_max[n]);
     }
     return ret;
 }


### PR DESCRIPTION
Use deferred translation for the GMInfo map.

Using deferred translation allow the map to still rely on the english keywords, while providng translators a way to translate them.

The translation is only done at the last minute, on the Key/Value display.

fixes #1417 .