### PR TITLE
Expose ScienDatabase::setModelDataName to script

### DIFF
--- a/src/scienceDatabase.cpp
+++ b/src/scienceDatabase.cpp
@@ -34,6 +34,8 @@ REGISTER_SCRIPT_CLASS(ScienceDatabase)
     REGISTER_SCRIPT_CLASS_FUNCTION(ScienceDatabase, getLongDescription);
     REGISTER_SCRIPT_CLASS_FUNCTION(ScienceDatabase, setImage);
     REGISTER_SCRIPT_CLASS_FUNCTION(ScienceDatabase, getImage);
+
+    REGISTER_SCRIPT_CLASS_FUNCTION(ScienceDatabase, setModelDataName);
 }
 
 PVector<ScienceDatabase> ScienceDatabase::science_databases;


### PR DESCRIPTION
Allowing scripts to customize the model displayed with a science DB entry (pass an empty string to clear any model set).

fixes #1152