### PR TITLE
Display disconnect reason in server browser

### DIFF
--- a/src/menus/joinServerMenu.cpp
+++ b/src/menus/joinServerMenu.cpp
@@ -61,6 +61,7 @@ void JoinServerScreen::update(float delta)
         auto reason = game_client->getDisconnectReason();
         destroy();
         disconnectFromServer();
+        
         new ServerBrowserMenu(this->source, reason);
     }
         

--- a/src/menus/joinServerMenu.cpp
+++ b/src/menus/joinServerMenu.cpp
@@ -57,9 +57,13 @@ void JoinServerScreen::update(float delta)
         }
         break;
     case GameClient::Disconnected:
+    {
+        auto reason = game_client->getDisconnectReason();
         destroy();
         disconnectFromServer();
-        new ServerBrowserMenu(this->source);
+        new ServerBrowserMenu(this->source, reason);
+    }
+        
         break;
     case GameClient::Connected:
         PreferencesManager::set("last_server", this->ip.toString());

--- a/src/menus/serverBrowseMenu.cpp
+++ b/src/menus/serverBrowseMenu.cpp
@@ -35,7 +35,7 @@ namespace
     }
 }
 
-ServerBrowserMenu::ServerBrowserMenu(SearchSource source, std::optional<GameClient::DisconnectReason> last_attempt)
+ServerBrowserMenu::ServerBrowserMenu(SearchSource source, std::optional<GameClient::DisconnectReason> last_attempt /* = {} */)
 {
     scanner = new ServerScanner(VERSION_NUMBER);
 

--- a/src/menus/serverBrowseMenu.cpp
+++ b/src/menus/serverBrowseMenu.cpp
@@ -8,9 +8,34 @@
 #include "gui/gui2_button.h"
 #include "gui/gui2_selector.h"
 #include "gui/gui2_textentry.h"
+#include "gui/gui2_label.h"
 #include "gui/gui2_listbox.h"
 
-ServerBrowserMenu::ServerBrowserMenu(SearchSource source)
+namespace
+{
+    const string& disconnectErrorMessage(GameClient::DisconnectReason reason)
+    {
+        switch (reason)
+        {
+        case GameClient::DisconnectReason::None:
+            return tr("game_client_disconnect_reason", "still connected");
+        case GameClient::DisconnectReason::BadCredentials:
+            return tr("game_client_disconnect_reason", "bad credentials");
+        case GameClient::DisconnectReason::ClosedByServer:
+            return tr("game_client_disconnect_reason", "closed by server");
+        case GameClient::DisconnectReason::TimedOut:
+            return tr("game_client_disconnect_reason", "timed out");
+        case GameClient::DisconnectReason::Unknown:
+            return tr("game_client_disconnect_reason", "unknown");
+        case GameClient::DisconnectReason::VersionMismatch:
+            return tr("game_client_disconnect_reason", "version mismatch");
+        default:
+            return tr("game_client_disconnect_reason", "unspecified error {error}").format({ {"error", string{static_cast<int>(reason)}} });
+        }
+    }
+}
+
+ServerBrowserMenu::ServerBrowserMenu(SearchSource source, std::optional<GameClient::DisconnectReason> last_attempt)
 {
     scanner = new ServerScanner(VERSION_NUMBER);
 
@@ -26,6 +51,13 @@ ServerBrowserMenu::ServerBrowserMenu(SearchSource source)
         destroy();
         returnToMainMenu();
     }))->setPosition(50, -50, ABottomLeft)->setSize(300, 50);
+
+    if (last_attempt)
+    {
+        auto error_message = tr("Connection error: {message}").format({ {"message", disconnectErrorMessage(*last_attempt)} });
+        auto error_info = new GuiLabel(this, "LAST_ATTEMPT_ERROR_MESSAGE", error_message, 30);
+        error_info->setPosition(0, 25, ATopCenter);
+    }
 
     lan_internet_selector = new GuiSelector(this, "LAN_INTERNET_SELECT", [this](int index, string value) {
         if (index == 0)

--- a/src/menus/serverBrowseMenu.h
+++ b/src/menus/serverBrowseMenu.h
@@ -3,6 +3,8 @@
 
 #include "gui/gui2_canvas.h"
 
+#include <optional>
+
 class GuiTextEntry;
 class GuiButton;
 class GuiListbox;
@@ -24,7 +26,7 @@ private:
 
     P<ServerScanner> scanner;
 public:
-    ServerBrowserMenu(SearchSource source);
+    ServerBrowserMenu(SearchSource source, std::optional<GameClient::DisconnectReason> last_attempt = {});
     virtual ~ServerBrowserMenu();
 };
 


### PR DESCRIPTION
In the server browser, when the player fails to connect, display a reason on screen.

![image](https://user-images.githubusercontent.com/53709079/118575289-215fe280-b754-11eb-9ab2-fc45c6196f4a.png)


This is currently most useful to quickly spot version mismatch error (one that seems common).

requires daid/SeriousProton#111

fixes #940