### PR TITLE
Android build fix

### DIFF
--- a/src/menus/shipSelectionScreen.cpp
+++ b/src/menus/shipSelectionScreen.cpp
@@ -432,6 +432,7 @@ bool ShipSelectionScreen::canDoMainScreen() const
 #if FEATURE_3D_RENDERING
     return PostProcessor::isEnabled() && sf::Shader::isAvailable() && gl::isAvailable();
 #else
+    // Don't bother checking anything without 3D rendering feature on.
     return false;
 #endif
 }

--- a/src/menus/shipSelectionScreen.cpp
+++ b/src/menus/shipSelectionScreen.cpp
@@ -429,14 +429,11 @@ void ShipSelectionScreen::update(float delta)
 
 bool ShipSelectionScreen::canDoMainScreen() const
 {
-    if constexpr (FEATURE_3D_RENDERING)
-    {
-        return PostProcessor::isEnabled() && sf::Shader::isAvailable() && gl::isAvailable();
-    }
-    else
-    {
-        return false;
-    }
+#if FEATURE_3D_RENDERING
+    return PostProcessor::isEnabled() && sf::Shader::isAvailable() && gl::isAvailable();
+#else
+    return false;
+#endif
 }
 
 void ShipSelectionScreen::updateReadyButton()


### PR DESCRIPTION
Use good old preprocessor macro for the feature 3d rendering switch in `ShipSelectionScreen::canDoMainScreen()`.