### PR TITLE
Line up directory prefixes between package/source-tree install

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -9,6 +9,8 @@ cmake_minimum_required(VERSION 3.8 FATAL_ERROR)
 
 set(CMAKE_MODULE_PATH "${CMAKE_SOURCE_DIR}/cmake" ${CMAKE_MODULE_PATH})
 
+include(GNUInstallDirs)
+
 # Set a default version.
 # For historical reason, we first honor CPack variables if they are set.
 if(DEFINED CPACK_PACKAGE_VERSION_MAJOR)
@@ -324,9 +326,9 @@ target_compile_definitions(seriousproton_deps
         VERSION_NUMBER=${PROJECT_VERSION_MAJOR}${PROJECT_VERSION_MINOR}${PROJECT_VERSION_PATCH}
 
         # Set RESOURCE_BASE_DIR on Unix so the built binary is able to find resources
-        $<$<BOOL:${UNIX}>:RESOURCE_BASE_DIR="${CMAKE_INSTALL_PREFIX}/share/emptyepsilon/">
+        $<$<BOOL:${UNIX}>:RESOURCE_BASE_DIR="${CMAKE_INSTALL_FULL_DATADIR}/emptyepsilon/">
         $<$<BOOL:${CONFIG_DIR}>:CONFIG_DIR="${CONFIG_DIR}">
-        $<$<NOT:$<BOOL:${CONFIG_DIR}>>:CONFIG_DIR="${CMAKE_INSTALL_PREFIX}/share/emptyepsilon/">
+        $<$<NOT:$<BOOL:${CONFIG_DIR}>>:CONFIG_DIR="${CMAKE_INSTALL_FULL_DATADIR}/emptyepsilon/">
 )
 
 target_compile_definitions(${PROJECT_NAME} PUBLIC WITH_DISCORD=$<BOOL:${WITH_DISCORD}>)
@@ -380,7 +382,6 @@ elseif(APPLE)
 elseif(ANDROID)
   android_apk(EmptyEpsilon)
 else()
-    include(GNUInstallDirs)
     install(TARGETS ${PROJECT_NAME} RUNTIME DESTINATION "${CMAKE_INSTALL_BINDIR}")
     install(DIRECTORY ${EE_RESOURCES} DESTINATION "${CMAKE_INSTALL_DATADIR}/emptyepsilon")
 endif()
@@ -458,6 +459,10 @@ if(NOT DEFINED CPACK_GENERATOR)
     set(CPACK_DEBIAN_PACKAGE_DEPENDS "libsfml-dev")
   endif()
 endif()
+
+# Allows injection of per-generator logic.
+configure_file("${CMAKE_CURRENT_SOURCE_DIR}/cmake/CPackProjectConfig.cmake.in" "${PROJECT_BINARY_DIR}/CPackProjectConfig.cmake" @ONLY)
+set(CPACK_PROJECT_CONFIG_FILE "${PROJECT_BINARY_DIR}/CPackProjectConfig.cmake")
 
 if(APPLE)
   if("DragNDrop" IN_LIST CPACK_GENERATOR)

--- a/cmake/CPackProjectConfig.cmake.in
+++ b/cmake/CPackProjectConfig.cmake.in
@@ -1,0 +1,6 @@
+if(CPACK_GENERATOR MATCHES "DEB")
+    # On UNIX, the CMAKE_INSTALL_PREFIX will default to /usr/local.
+    # But the debian *package* will default to put everything under /usr.
+    # Since the resource path are hardcoded inside EE, make sure they line up.
+    set(CPACK_PACKAGING_INSTALL_PREFIX "@CMAKE_INSTALL_PREFIX@")
+endif()


### PR DESCRIPTION
Because EE burns absolute path on compilation, we need to take some care ensuring they all line up during packaging.

This comes after noticing that leaving an empty install prefix would try to load from `/usr/local/...` while the package would be installed under `/usr/...`.

This comes from CMake having different logic handling between install-from-build-tree and install-from-package.

It also lines up the hardcoded defines with the GNU Install dirs, one less assumption.

This aims at ensuring all the root paths line up, and limit surprises.