### PR TITLE
Use resetGLStates

### DIFF
--- a/src/screenComponents/viewport3d.cpp
+++ b/src/screenComponents/viewport3d.cpp
@@ -165,7 +165,6 @@ void GuiViewport3D::onDraw(sf::RenderTarget& window)
         soundManager->setListenerPosition(my_spaceship->getPosition(), my_spaceship->getRotation());
     else
         soundManager->setListenerPosition(sf::Vector2f(camera_position.x, camera_position.y), camera_yaw);
-    window.popGLStates();
     // Depending on the extensions,
     // SFML may rely on FBOs.
     // calling setActive() ensures the *correct* one is bound,
@@ -498,8 +497,8 @@ void GuiViewport3D::onDraw(sf::RenderTarget& window)
     }
 #endif
     sf::Shader::bind(nullptr);
+    window.resetGLStates();
     window.setActive(false);
-    window.pushGLStates();
 
     if (show_callsigns && render_lists.size() > 0)
     {


### PR DESCRIPTION
The current pop/push generate warnings (because they're backwards), as well as issues on some graphics hardware (older gen GeForce among other).

We have been checking this with @StarryWisdom & friends - no issues reported.

It actually fixed a few glitches on some graphics card.

Note that a clever mind actually [suggested exactly this a while back](https://github.com/daid/EmptyEpsilon/commit/3f4524bc389be38fc03c35e8e3b64377db4e414e#commitcomment-34589720)...