### PR TITLE
#1162: Display reputation and clock in comms window header

### DIFF
--- a/scripts/comms_station.lua
+++ b/scripts/comms_station.lua
@@ -83,14 +83,12 @@ end
 -- @tparam SpaceStation comms_target
 function commsStationDocked(comms_source, comms_target)
     local message
-
     if comms_source:isFriendly(comms_target) then
         message = string.format(_("commsStation", "Good day, officer! Welcome to %s.\nWhat can we do for you today?"), comms_target:getCallSign())
     else
         message = string.format(_("commsStation", "Welcome to our lovely station %s."), comms_target:getCallSign())
     end
-
-    setCommsMessage(string.format(_("commsStation", "%s\n\nReputation: %d"), message, comms_source:getReputationPoints()))
+    setCommsMessage(message)
 
     local reply_messages = {
         ["Homing"] = _("commsStation", "Do you have spare homing missiles for us?"),
@@ -170,14 +168,12 @@ end
 -- @tparam SpaceStation comms_target
 function commsStationUndocked(comms_source, comms_target)
     local message
-
     if comms_source:isFriendly(comms_target) then
         message = string.format(_("commsStation", "This is %s. Good day, officer.\nIf you need supplies, please dock with us first."), comms_target:getCallSign())
     else
         message = string.format(_("commsStation", "This is %s. Greetings.\nIf you want to do business, please dock with us first."), comms_target:getCallSign())
     end
-
-    setCommsMessage(string.format(_("commsStation", "%s\n\nReputation: %d"), message, comms_source:getReputationPoints()))
+    setCommsMessage(message)
 
     -- supply drop
     if isAllowedTo(comms_source, comms_target, comms_target.comms_data.services.supplydrop) then

--- a/src/screenComponents/commsOverlay.h
+++ b/src/screenComponents/commsOverlay.h
@@ -10,6 +10,7 @@ class GuiLabel;
 class GuiScrollText;
 class GuiListbox;
 class GuiTextEntry;
+class GuiKeyValueDisplay;
 
 class GuiCommsOverlay : public GuiElement
 {
@@ -34,6 +35,8 @@ private:
     GuiButton* chat_comms_close_button;
 
     GuiPanel* script_comms_box;
+    GuiKeyValueDisplay* script_comms_box_reputation{};
+    GuiKeyValueDisplay* script_comms_box_clock{};
     GuiScrollText* script_comms_text;
     GuiListbox* script_comms_options;
     GuiButton* script_comms_close;


### PR DESCRIPTION
Result:
![image](https://user-images.githubusercontent.com/53709079/118909116-88b29980-b8f0-11eb-9c2b-21848b415ae5.png)

This fixes #1162 by ensuring the information is always on-screen.

Note that I also rolled back the workaround from #1217, which only worked for the standard comms window.
