### PR TITLE
#1162 :  align reputation and clock a little more to the left on the relay screen

### DIFF
--- a/scripts/comms_station.lua
+++ b/scripts/comms_station.lua
@@ -83,14 +83,12 @@ end
 -- @tparam SpaceStation comms_target
 function commsStationDocked(comms_source, comms_target)
     local message
-
     if comms_source:isFriendly(comms_target) then
         message = string.format(_("commsStation", "Good day, officer! Welcome to %s.\nWhat can we do for you today?"), comms_target:getCallSign())
     else
         message = string.format(_("commsStation", "Welcome to our lovely station %s."), comms_target:getCallSign())
     end
-
-    setCommsMessage(string.format(_("commsStation", "%s\n\nReputation: %d"), message, comms_source:getReputationPoints()))
+    setCommsMessage(message)
 
     local reply_messages = {
         ["Homing"] = _("commsStation", "Do you have spare homing missiles for us?"),
@@ -170,14 +168,12 @@ end
 -- @tparam SpaceStation comms_target
 function commsStationUndocked(comms_source, comms_target)
     local message
-
     if comms_source:isFriendly(comms_target) then
         message = string.format(_("commsStation", "This is %s. Good day, officer.\nIf you need supplies, please dock with us first."), comms_target:getCallSign())
     else
         message = string.format(_("commsStation", "This is %s. Greetings.\nIf you want to do business, please dock with us first."), comms_target:getCallSign())
     end
-
-    setCommsMessage(string.format(_("commsStation", "%s\n\nReputation: %d"), message, comms_source:getReputationPoints()))
+    setCommsMessage(message)
 
     -- supply drop
     if isAllowedTo(comms_source, comms_target, comms_target.comms_data.services.supplydrop) then

--- a/src/screens/crew6/relayScreen.cpp
+++ b/src/screens/crew6/relayScreen.cpp
@@ -148,11 +148,11 @@ RelayScreen::RelayScreen(GuiContainer* owner, bool allow_comms)
     launch_probe_button->setSize(GuiElement::GuiSizeMax, 50)->setVisible(my_spaceship && my_spaceship->getCanLaunchProbe());
 
     // Reputation display.
-    info_reputation = new GuiKeyValueDisplay(option_buttons, "INFO_REPUTATION", 0.7, tr("Reputation") + ":", "");
+    info_reputation = new GuiKeyValueDisplay(option_buttons, "INFO_REPUTATION", 0.4f, tr("Reputation") + ":", "");
     info_reputation->setSize(GuiElement::GuiSizeMax, 40);
 
     // Scenario clock display.
-    info_clock = new GuiKeyValueDisplay(option_buttons, "INFO_CLOCK", 0.7, tr("Clock") + ":", "");
+    info_clock = new GuiKeyValueDisplay(option_buttons, "INFO_CLOCK", 0.4f, tr("Clock") + ":", "");
     info_clock->setSize(GuiElement::GuiSizeMax, 40);
 
     // Bottom layout.


### PR DESCRIPTION
This prevents them from being obscured by the comms window, without requiring further changes.

![image](https://user-images.githubusercontent.com/53709079/118973589-d60a2780-b93f-11eb-8cb7-414a88b4f671.png)


fixes #1162 