### PR TITLE
Ubuntu 18.04 / SFML 2.4 compatibility

### DIFF
--- a/src/gui/gui2_element.cpp
+++ b/src/gui/gui2_element.cpp
@@ -272,12 +272,14 @@ void GuiElement::updateRect(sf::FloatRect parent_rect)
 [[nodiscard]]
 bool GuiElement::adjustRenderTexture(sf::RenderTexture& texture)
 {
-#ifdef SFML_SYSTEM_ANDROID
+#if defined(SFML_SYSTEM_ANDROID) || SFML_VERSION_MINOR < 5
     /* On GL ES systems, SFML runs on assumptions regarding
     the available GL extensions, for instance considering packed depth/stencil is never available.[1]
     Because of that unreliability, just forego render textures on those systems.
 
       [1]: https://github.com/SFML/SFML/blob/2f11710abc5aa478503a7ff3f9e654bd2078ebab/src/SFML/Graphics/GLExtensions.hpp#L128
+
+    For SFML 2.4, the texture creation process simply does not allow to request a stencil.
     */
     return false;
 #else

--- a/src/screenComponents/radarView.cpp
+++ b/src/screenComponents/radarView.cpp
@@ -8,6 +8,7 @@
 #include "radarView.h"
 #include "missileTubeControls.h"
 #include "targetsContainer.h"
+#include "sfmlCompatibility.h"
 
 namespace
 {
@@ -137,7 +138,7 @@ void GuiRadarView::onDraw(sf::RenderTarget& window)
     // Each SFML call may reset the binding,
     // so we have to keep re-activating the target window all the time.
     // We're relying on stencil buffer to draw the radar:
-    radar_target.setActive(true);
+    activateRenderTarget(radar_target, true);
 
     // Stencil setup.
     glEnable(GL_STENCIL_TEST);
@@ -173,7 +174,7 @@ void GuiRadarView::onDraw(sf::RenderTarget& window)
         radar_target.draw(circle);
     }
 
-    radar_target.setActive(true);
+    activateRenderTarget(radar_target, true);
     if (fog_style == NebulaFogOfWar)
     {
         // Draw the *blocked* areas.
@@ -191,7 +192,7 @@ void GuiRadarView::onDraw(sf::RenderTarget& window)
     }
 
     // Stencil is setup!
-    radar_target.setActive(true);
+    activateRenderTarget(radar_target, true);
     glStencilMask(as_mask(RadarStencil::None)); // disable writes.
     glStencilOp(GL_KEEP, GL_KEEP, GL_KEEP); // Back to defaults.
 
@@ -217,7 +218,7 @@ void GuiRadarView::onDraw(sf::RenderTarget& window)
     drawObjects(radar_target);
 
     // Post masking
-    radar_target.setActive(true);
+    activateRenderTarget(radar_target, true);
     glStencilFunc(GL_EQUAL, as_mask(RadarStencil::RadarBounds), as_mask(RadarStencil::RadarBounds));
     if (show_game_master_data)
         drawObjectsGM(radar_target);
@@ -244,10 +245,10 @@ void GuiRadarView::onDraw(sf::RenderTarget& window)
         }
     }
     // Done with the stencil.
-    radar_target.setActive(true);
+    activateRenderTarget(radar_target, true);
     glDepthMask(GL_TRUE);
     glDisable(GL_STENCIL_TEST);
-    radar_target.setActive(false);
+    activateRenderTarget(radar_target, false);
 
     if (use_rendertexture)
     {
@@ -736,7 +737,7 @@ void GuiRadarView::drawObjects(sf::RenderTarget& window)
     };
 
     // First draw all objects that are maybe hidden.
-    window.setActive(true);
+    activateRenderTarget(window, true);
     glStencilFunc(GL_EQUAL, as_mask(RadarStencil::InBoundsAndVisible), as_mask(RadarStencil::InBoundsAndVisible));
     for (auto obj : visible_objects)
     {
@@ -747,7 +748,7 @@ void GuiRadarView::drawObjects(sf::RenderTarget& window)
     }
 
     // Second, draw all objects that can't hide.
-    window.setActive(true);
+    activateRenderTarget(window, true);
     glStencilFunc(GL_EQUAL, as_mask(RadarStencil::RadarBounds), as_mask(RadarStencil::RadarBounds));
     for(SpaceObject* obj : visible_objects)
     {

--- a/src/screenComponents/radarView.cpp
+++ b/src/screenComponents/radarView.cpp
@@ -110,6 +110,21 @@ void GuiRadarView::onDraw(sf::RenderTarget& window)
     auto use_rendertexture = adjustRenderTexture(background_texture);
     auto& radar_target = use_rendertexture ? background_texture : window;
 
+    if (!use_rendertexture)
+    {
+        // When we are not using a render texture, we must take some care to not overstep our bounds,
+        // quite literally.
+        // We use scissoring to define a 'box' in which all draw operations can happen.
+        // This allows the side main screen to work correctly even when falling back in the non-render texture path.
+        auto origin = radar_target.mapCoordsToPixel(sf::Vector2f{ rect.left, rect.top });
+        auto extents = radar_target.mapCoordsToPixel(sf::Vector2f{ rect.width, rect.height });
+        
+        activateRenderTarget(radar_target, true);
+        
+        glEnable(GL_SCISSOR_TEST);
+        glScissor(origin.x, origin.y, extents.x, extents.y);
+    }
+
     // Draw the initial background 'clear' color.
     if (use_rendertexture || style == Rectangular)
     {
@@ -248,6 +263,10 @@ void GuiRadarView::onDraw(sf::RenderTarget& window)
     activateRenderTarget(radar_target, true);
     glDepthMask(GL_TRUE);
     glDisable(GL_STENCIL_TEST);
+    if (!use_rendertexture)
+    {
+        glDisable(GL_SCISSOR_TEST);
+    }
     activateRenderTarget(radar_target, false);
 
     if (use_rendertexture)

--- a/src/screenComponents/viewport3d.cpp
+++ b/src/screenComponents/viewport3d.cpp
@@ -8,6 +8,7 @@
 
 #include "particleEffect.h"
 #include "glObjects.h"
+#include "sfmlCompatibility.h"
 
 #if FEATURE_3D_RENDERING
 static void _glPerspective(double fovY, double aspect, double zNear, double zFar )
@@ -174,7 +175,7 @@ void GuiViewport3D::onDraw(sf::RenderTarget& window)
     // SFML docs warn that any library calls (into SFML that is) may
     // freely change the active binding, so change with caution
     // (the window.get*() below and shader/texture binding are 'fine').
-    window.setActive();
+    activateRenderTarget(window);
     ShaderManager::getShader("shaders/billboardShader")->setUniform("camera_position", camera_position);
 
     float camera_fov = 60.0f;
@@ -498,7 +499,7 @@ void GuiViewport3D::onDraw(sf::RenderTarget& window)
 #endif
     sf::Shader::bind(nullptr);
     window.resetGLStates();
-    window.setActive(false);
+    activateRenderTarget(window, false);
 
     if (show_callsigns && render_lists.size() > 0)
     {

--- a/src/sfmlCompatibility.h
+++ b/src/sfmlCompatibility.h
@@ -1,0 +1,34 @@
+#ifndef EE_SFML_COMPATIBILITY_H
+#define EE_SFML_COMPATIBILITY_H
+
+#include <SFML/Config.hpp>
+
+#if SFML_VERSION_MAJOR != 2
+#error unhandled sfml version.
+#endif
+
+#include <SFML/Graphics/RenderTarget.hpp>
+
+#if SFML_VERSION_MAJOR < 5
+#include <SFML/Graphics/RenderTexture.hpp>
+#include <SFML/Graphics/RenderWindow.hpp>
+#endif
+
+inline void activateRenderTarget(sf::RenderTarget& target, bool active = true)
+{
+#if SFML_VERSION_MAJOR > 4
+    target.setActive(active);
+#else
+    // SFML 2.4 has setActive on both render texture and window,
+    // but it's not on their common ancestor (that change is from 2.5)
+    if (auto* as_window = dynamic_cast<sf::RenderWindow *>(&target))
+    {
+        as_window->setActive(active);
+    }
+    else if (auto* as_texture = dynamic_cast<sf::RenderTexture *>(&target))
+    {
+        as_texture->setActive(active);
+    }
+#endif // SFML_VERSION_MAJOR > 4
+}
+#endif // EE_SFML_COMPATIBLITY_H


### PR DESCRIPTION
It has come to my attention that the build is broken on Ubuntu 18.04 (LTS).

This PR fixes the build, as well as the stencil-based radar on SFML 2.4 (since this version does not support creating stencil-backed render texture).

Note that since it means handling desktop, and desktop means 3D screen, there are the proper fixes there to handle the wide screen 3D viewport on the side of the radar.