### PR TITLE
#825 Configurable energy consumption rates

### DIFF
--- a/src/gameStateLogger.cpp
+++ b/src/gameStateLogger.cpp
@@ -389,7 +389,7 @@ void GameStateLogger::writeShipEntry(JSONGenerator& json, P<SpaceShip> ship)
                 system.write("power_rate_per_second", ship->systems[n].power_rate_per_second);
                 system.write("power_request", ship->systems[n].power_request);
                 system.write("heat", ship->systems[n].heat_level);
-                system.write("heatup_rate_per_second", ship->systems[n].heatup_rate_per_second);
+                system.write("heat_rate_per_second", ship->systems[n].heat_rate_per_second);
                 system.write("coolant_level", ship->systems[n].coolant_level);
                 system.write("coolant_rate_per_second", ship->systems[n].coolant_rate_per_second);
                 system.write("coolant_request", ship->systems[n].coolant_request);

--- a/src/gameStateLogger.cpp
+++ b/src/gameStateLogger.cpp
@@ -386,9 +386,12 @@ void GameStateLogger::writeShipEntry(JSONGenerator& json, P<SpaceShip> ship)
                 JSONGenerator system = systems.createDict(getSystemName(ESystem(n)).c_str());
                 system.write("health", ship->systems[n].health);
                 system.write("power_level", ship->systems[n].power_level);
+                system.write("power_rate_per_second", ship->systems[n].power_rate_per_second);
                 system.write("power_request", ship->systems[n].power_request);
                 system.write("heat", ship->systems[n].heat_level);
+                system.write("heatup_rate_per_second", ship->systems[n].heatup_rate_per_second);
                 system.write("coolant_level", ship->systems[n].coolant_level);
+                system.write("coolant_rate_per_second", ship->systems[n].coolant_rate_per_second);
                 system.write("coolant_request", ship->systems[n].coolant_request);
                 system.write("power_factor", ship->systems[n].power_factor);
             }

--- a/src/screens/gm/tweak.cpp
+++ b/src/screens/gm/tweak.cpp
@@ -972,6 +972,48 @@ GuiShipTweakPlayer2::GuiShipTweakPlayer2(GuiContainer* owner)
     });
     scan_probes_slider->addOverlay()->setSize(GuiElement::GuiSizeMax, 40);
 
+    energy_warp_per_second = new GuiLabel(left_col, "", "", 30);
+    energy_warp_per_second->setSize(GuiElement::GuiSizeMax, 50);
+    desired_energy_warp_per_second = new GuiTextEntry(left_col, "", "");
+    desired_energy_warp_per_second->setSize(GuiElement::GuiSizeMax, 30);
+    desired_energy_warp_per_second->enterCallback([this](const string& text)
+        {
+            // Perform safe conversion (typos can happen).
+            char* end = nullptr;
+            auto converted = strtof(text.c_str(), &end);
+            if (converted == 0.f && end == text.c_str())
+            {
+                // failed - reset text to current value.
+                desired_energy_warp_per_second->setText(string(this->target->getEnergyWarpPerSecond(), 2));
+            }
+            else
+            {
+                // apply!
+                this->target->setEnergyWarpPerSecond(converted);
+            }
+        });
+
+    energy_shield_per_second = new GuiLabel(left_col, "", "", 30);
+    energy_shield_per_second->setSize(GuiElement::GuiSizeMax, 50);
+    desired_energy_shield_per_second = new GuiTextEntry(left_col, "", "");
+    desired_energy_shield_per_second->setSize(GuiElement::GuiSizeMax, 30);
+    desired_energy_shield_per_second->enterCallback([this](const string& text)
+        {
+            // Perform safe conversion (typos can happen).
+            char* end = nullptr;
+            auto converted = strtof(text.c_str(), &end);
+            if (converted == 0.f && end == text.c_str())
+            {
+                // failed - reset text to current value.
+                desired_energy_shield_per_second->setText(string(this->target->getEnergyShieldUsePerSecond(), 2));
+            }
+            else
+            {
+                // apply!
+                this->target->setEnergyShieldUsePerSecond(converted);
+            }
+        });
+
     // Right column
     // Can scan bool
     can_scan = new GuiToggleButton(right_col, "", tr("button", "Can scan"), [this](bool value) {
@@ -1033,6 +1075,15 @@ void GuiShipTweakPlayer2::onDraw(sf::RenderTarget& window)
     can_launch_probe->setValue(target->getCanLaunchProbe());
     auto_coolant_enabled->setValue(target->auto_coolant_enabled);
     auto_repair_enabled->setValue(target->auto_repair_enabled);
+    
+    energy_warp_per_second->setText(tr("player_tweak", "Warp (E/s): {energy_per_second}").format({ {"energy_per_second", string(target->getEnergyWarpPerSecond())} }));
+    energy_shield_per_second->setText(tr("player_tweak", "Shields (E/s): {energy_per_second}").format({ {"energy_per_second", string(target->getEnergyShieldUsePerSecond())} }));
+
+    energy_warp_per_second->setVisible(target->hasWarpDrive());
+    desired_energy_warp_per_second->setVisible(energy_warp_per_second->isVisible());
+
+    energy_shield_per_second->setVisible(target->hasShield());
+    desired_energy_shield_per_second->setVisible(energy_shield_per_second->isVisible());
 }
 
 void GuiShipTweakPlayer2::open(P<SpaceObject> target)

--- a/src/screens/gm/tweak.h
+++ b/src/screens/gm/tweak.h
@@ -207,6 +207,30 @@ public:
     void onDraw(sf::RenderTarget& window) override;
 };
 
+class GuiShipTweakSystemRates : public GuiTweakPage
+{
+public:
+    enum class Type
+    {
+        Power = 0,
+        Heat,
+        Coolant
+    };
+
+    GuiShipTweakSystemRates(GuiContainer* owner, Type type);
+
+    void open(P<SpaceObject> target) override;
+    void onDraw(sf::RenderTarget& window) override;
+private:
+    float getRateValue(ESystem system, Type type) const;
+    void setRateValue(ESystem system, Type type, float value);
+    std::array<GuiLabel*, SYS_COUNT> current_rates;
+    std::array<GuiTextEntry*, SYS_COUNT> desired_rates;
+
+    P<SpaceShip> target;
+    Type type;
+};
+
 class GuiShipTweakPlayer : public GuiTweakPage
 {
 private:

--- a/src/screens/gm/tweak.h
+++ b/src/screens/gm/tweak.h
@@ -268,6 +268,12 @@ private:
     GuiToggleButton* can_launch_probe;
     GuiToggleButton* auto_coolant_enabled;
     GuiToggleButton* auto_repair_enabled;
+
+    GuiLabel* energy_warp_per_second{};
+    GuiTextEntry* desired_energy_warp_per_second{};
+
+    GuiLabel* energy_shield_per_second{};
+    GuiTextEntry* desired_energy_shield_per_second{};
 public:
     GuiShipTweakPlayer2(GuiContainer* owner);
 

--- a/src/spaceObjects/playerSpaceship.cpp
+++ b/src/spaceObjects/playerSpaceship.cpp
@@ -2143,6 +2143,21 @@ string PlayerSpaceship::getExportLine()
             {
                 result += ":setSystemPowerFactor(" + string(system) + ", " + string(current_factor, 1) + ")";
             }
+
+            if (std::fabs(getSystemCoolantRate(system) - ShipSystem::default_coolant_rate_per_second) > std::numeric_limits<float>::epsilon())
+            {
+                result += ":setSystemCoolantRate(" + string(system) + ", " + string(getSystemCoolantRate(system), 2) + ")";
+            }
+
+            if (std::fabs(getSystemHeatRate(system) - ShipSystem::default_heatup_rate_per_second) > std::numeric_limits<float>::epsilon())
+            {
+                result += ":setSystemHeatRate(" + string(system) + ", " + string(getSystemHeatRate(system), 2) + ")";
+            }
+
+            if (std::fabs(getSystemPowerRate(system) - ShipSystem::default_power_rate_per_second) > std::numeric_limits<float>::epsilon())
+            {
+                result += ":setSystemPowerRate(" + string(system) + ", " + string(getSystemPowerRate(system), 2) + ")";
+            }
         }
     }
     return result;

--- a/src/spaceObjects/playerSpaceship.cpp
+++ b/src/spaceObjects/playerSpaceship.cpp
@@ -2160,6 +2160,16 @@ string PlayerSpaceship::getExportLine()
             }
         }
     }
+
+    if (std::fabs(getEnergyShieldUsePerSecond() - default_energy_shield_use_per_second) > std::numeric_limits<float>::epsilon())
+    {
+        result += ":setEnergyShieldUsePerSecond(" + string(getEnergyShieldUsePerSecond(), 2) + ")";
+    }
+
+    if (std::fabs(getEnergyWarpPerSecond() - default_energy_warp_per_second) > std::numeric_limits<float>::epsilon())
+    {
+        result += ":setEnergyWarpPerSecond(" + string(getEnergyWarpPerSecond(), 2) + ")";
+    }
     return result;
 }
 

--- a/src/spaceObjects/playerSpaceship.cpp
+++ b/src/spaceObjects/playerSpaceship.cpp
@@ -400,7 +400,7 @@ PlayerSpaceship::PlayerSpaceship()
         systems[n].coolant_level = 0.0f;
         systems[n].coolant_rate_per_second = ShipSystem::default_coolant_rate_per_second;
         systems[n].heat_level = 0.0f;
-        systems[n].heatup_rate_per_second = ShipSystem::default_heatup_rate_per_second;
+        systems[n].heat_rate_per_second = ShipSystem::default_heat_rate_per_second;
         systems[n].power_factor = default_system_power_factors[n];
 
         registerMemberReplication(&systems[n].power_level);
@@ -410,7 +410,7 @@ PlayerSpaceship::PlayerSpaceship()
         registerMemberReplication(&systems[n].coolant_rate_per_second, .5f);
         registerMemberReplication(&systems[n].coolant_request);
         registerMemberReplication(&systems[n].heat_level, 1.0);
-        registerMemberReplication(&systems[n].heatup_rate_per_second, .5f);
+        registerMemberReplication(&systems[n].heat_rate_per_second, .5f);
         registerMemberReplication(&systems[n].power_factor);
     }
 
@@ -596,7 +596,7 @@ void PlayerSpaceship::update(float delta)
             }
 
             // Add heat to overpowered subsystems.
-            addHeat(ESystem(n), delta * systems[n].getHeatingDelta() * systems[n].heatup_rate_per_second);
+            addHeat(ESystem(n), delta * systems[n].getHeatingDelta() * systems[n].heat_rate_per_second);
         }
 
         // If reactor health is worse than -90% and overheating, it explodes,
@@ -883,7 +883,7 @@ void PlayerSpaceship::addHeat(ESystem system, float amount)
             // Heat damage is specified as damage per second while overheating.
             // Calculate the amount of overheat back to a time, and use that to
             // calculate the actual damage taken.
-            systems[system].health -= overheat / systems[system].heatup_rate_per_second * damage_per_second_on_overheat;
+            systems[system].health -= overheat / systems[system].heat_rate_per_second * damage_per_second_on_overheat;
 
             if (systems[system].health < -1.0)
                 systems[system].health = -1.0;
@@ -2149,7 +2149,7 @@ string PlayerSpaceship::getExportLine()
                 result += ":setSystemCoolantRate(" + string(system) + ", " + string(getSystemCoolantRate(system), 2) + ")";
             }
 
-            if (std::fabs(getSystemHeatRate(system) - ShipSystem::default_heatup_rate_per_second) > std::numeric_limits<float>::epsilon())
+            if (std::fabs(getSystemHeatRate(system) - ShipSystem::default_heat_rate_per_second) > std::numeric_limits<float>::epsilon())
             {
                 result += ":setSystemHeatRate(" + string(system) + ", " + string(getSystemHeatRate(system), 2) + ")";
             }

--- a/src/spaceObjects/playerSpaceship.h
+++ b/src/spaceObjects/playerSpaceship.h
@@ -35,12 +35,8 @@ class PlayerSpaceship : public SpaceShip
 {
 public:
     // Power consumption and generation base rates
-    constexpr static float energy_shield_use_per_second = 1.5f;
-    constexpr static float energy_warp_per_second = 1.0f;
-    constexpr static float system_heatup_per_second = 0.05f;
-    constexpr static float system_power_level_change_per_second = 0.3;
-    // Coolant change rate
-    constexpr static float system_coolant_level_change_per_second = 1.2;
+    constexpr static float default_energy_shield_use_per_second = 1.5f;
+    constexpr static float default_energy_warp_per_second = 1.0f;
     // Total coolant
     constexpr static float max_coolant_per_system = 10.0f;
     float max_coolant;
@@ -115,6 +111,8 @@ private:
     CommsScriptInterface comms_script_interface; // Server only
     // Ship's log container
     std::vector<ShipLogEntry> ships_log;
+    float energy_shield_use_per_second = default_energy_shield_use_per_second;
+    float energy_warp_per_second = default_energy_warp_per_second;
 public:
     std::vector<CustomShipFunction> custom_functions;
 
@@ -301,6 +299,12 @@ public:
     int getRepairCrewCount();
     void setRepairCrewCount(int amount);
     EAlertLevel getAlertLevel() { return alert_level; }
+
+    // Flow rate controls.
+    float getEnergyShieldUsePerSecond() const { return energy_shield_use_per_second; }
+    void setEnergyShieldUsePerSecond(float rate) { energy_shield_use_per_second = rate; }
+    float getEnergyWarpPerSecond() const { return energy_warp_per_second; }
+    void setEnergyWarpPerSecond(float rate) { energy_warp_per_second = rate; }
 
     // Ship update functions
     virtual void update(float delta) override;

--- a/src/spaceObjects/spaceship.cpp
+++ b/src/spaceObjects/spaceship.cpp
@@ -48,12 +48,18 @@ REGISTER_SCRIPT_SUBCLASS_NO_CREATE(SpaceShip, ShipTemplateBasedObject)
     REGISTER_SCRIPT_CLASS_FUNCTION(SpaceShip, setSystemHealthMax);
     REGISTER_SCRIPT_CLASS_FUNCTION(SpaceShip, getSystemHeat);
     REGISTER_SCRIPT_CLASS_FUNCTION(SpaceShip, setSystemHeat);
+    REGISTER_SCRIPT_CLASS_FUNCTION(SpaceShip, getSystemHeatRate);
+    REGISTER_SCRIPT_CLASS_FUNCTION(SpaceShip, setSystemHeatRate);
     REGISTER_SCRIPT_CLASS_FUNCTION(SpaceShip, getSystemPower);
     REGISTER_SCRIPT_CLASS_FUNCTION(SpaceShip, setSystemPower);
+    REGISTER_SCRIPT_CLASS_FUNCTION(SpaceShip, getSystemPowerRate);
+    REGISTER_SCRIPT_CLASS_FUNCTION(SpaceShip, setSystemPowerRate);
     REGISTER_SCRIPT_CLASS_FUNCTION(SpaceShip, getSystemPowerFactor);
     REGISTER_SCRIPT_CLASS_FUNCTION(SpaceShip, setSystemPowerFactor);
     REGISTER_SCRIPT_CLASS_FUNCTION(SpaceShip, getSystemCoolant);
     REGISTER_SCRIPT_CLASS_FUNCTION(SpaceShip, setSystemCoolant);
+    REGISTER_SCRIPT_CLASS_FUNCTION(SpaceShip, getSystemCoolantRate);
+    REGISTER_SCRIPT_CLASS_FUNCTION(SpaceShip, setSystemCoolantRate);
     REGISTER_SCRIPT_CLASS_FUNCTION(SpaceShip, getImpulseMaxSpeed);
     REGISTER_SCRIPT_CLASS_FUNCTION(SpaceShip, setImpulseMaxSpeed);
     REGISTER_SCRIPT_CLASS_FUNCTION(SpaceShip, getRotationMaxSpeed);
@@ -219,10 +225,13 @@ SpaceShip::SpaceShip(string multiplayerClassName, float multiplayer_significant_
         systems[n].health = 1.0f;
         systems[n].health_max = 1.0f;
         systems[n].power_level = 1.0f;
+        systems[n].power_rate_per_second = ShipSystem::default_power_rate_per_second;
         systems[n].power_request = 1.0f;
         systems[n].coolant_level = 0.0f;
+        systems[n].coolant_rate_per_second = ShipSystem::default_coolant_rate_per_second;
         systems[n].coolant_request = 0.0f;
         systems[n].heat_level = 0.0f;
+        systems[n].heatup_rate_per_second = ShipSystem::default_heatup_rate_per_second;
         systems[n].hacked_level = 0.0f;
         systems[n].power_factor = default_system_power_factors[n];
 

--- a/src/spaceObjects/spaceship.cpp
+++ b/src/spaceObjects/spaceship.cpp
@@ -231,7 +231,7 @@ SpaceShip::SpaceShip(string multiplayerClassName, float multiplayer_significant_
         systems[n].coolant_rate_per_second = ShipSystem::default_coolant_rate_per_second;
         systems[n].coolant_request = 0.0f;
         systems[n].heat_level = 0.0f;
-        systems[n].heatup_rate_per_second = ShipSystem::default_heatup_rate_per_second;
+        systems[n].heat_rate_per_second = ShipSystem::default_heat_rate_per_second;
         systems[n].hacked_level = 0.0f;
         systems[n].power_factor = default_system_power_factors[n];
 

--- a/src/spaceObjects/spaceship.h
+++ b/src/spaceObjects/spaceship.h
@@ -39,6 +39,9 @@ class ShipSystem
 {
 public:
     static constexpr float power_factor_rate = 0.08f;
+    static constexpr float default_heatup_rate_per_second = 0.05f;
+    static constexpr float default_power_rate_per_second = 0.3f;
+    static constexpr float default_coolant_rate_per_second = 1.2f;
     float health; //1.0-0.0, where 0.0 is fully broken.
     float health_max; //1.0-0.0, where 0.0 is fully broken.
     float power_level; //0.0-3.0, default 1.0
@@ -48,6 +51,9 @@ public:
     float coolant_request;
     float hacked_level; //0.0-1.0
     float power_factor;
+    float coolant_rate_per_second{};
+    float heatup_rate_per_second{};
+    float power_rate_per_second{};
 
     float getHeatingDelta() const
     {
@@ -330,14 +336,20 @@ public:
     void setSystemHealthMax(ESystem system, float health_max) { if (system >= SYS_COUNT) return; if (system <= SYS_None) return; systems[system].health_max = std::min(1.0f, std::max(-1.0f, health_max)); }
     float getSystemHeat(ESystem system) { if (system >= SYS_COUNT) return 0.0; if (system <= SYS_None) return 0.0; return systems[system].heat_level; }
     void setSystemHeat(ESystem system, float heat) { if (system >= SYS_COUNT) return; if (system <= SYS_None) return; systems[system].heat_level = std::min(1.0f, std::max(0.0f, heat)); }
+    float getSystemHeatRate(ESystem system) const { if (system >= SYS_COUNT) return 0.f; if (system <= SYS_None) return 0.f; return systems[system].heatup_rate_per_second; }
+    void setSystemHeatRate(ESystem system, float rate) { if (system >= SYS_COUNT) return; if (system <= SYS_None) return; systems[system].heatup_rate_per_second = rate; }
+
     float getSystemPower(ESystem system) { if (system >= SYS_COUNT) return 0.0; if (system <= SYS_None) return 0.0; return systems[system].power_level; }
     void setSystemPower(ESystem system, float power) { if (system >= SYS_COUNT) return; if (system <= SYS_None) return; systems[system].power_level = std::min(3.0f, std::max(0.0f, power)); }
+    float getSystemPowerRate(ESystem system) const { if (system >= SYS_COUNT) return 0.f; if (system <= SYS_None) return 0.f; return systems[system].power_rate_per_second; }
+    void setSystemPowerRate(ESystem system, float rate) { if (system >= SYS_COUNT) return; if (system <= SYS_None) return; systems[system].power_rate_per_second = rate; }
     float getSystemPowerUserFactor(ESystem system) { if (system >= SYS_COUNT) return 0.f; if (system <= SYS_None) return 0.f; return systems[system].getPowerUserFactor(); }
     float getSystemPowerFactor(ESystem system) { if (system >= SYS_COUNT) return 0.f; if (system <= SYS_None) return 0.f; return systems[system].power_factor; }
     void setSystemPowerFactor(ESystem system, float factor) { if (system >= SYS_COUNT) return; if (system <= SYS_None) return; systems[system].power_factor = factor; }
     float getSystemCoolant(ESystem system) { if (system >= SYS_COUNT) return 0.0; if (system <= SYS_None) return 0.0; return systems[system].coolant_level; }
     void setSystemCoolant(ESystem system, float coolant) { if (system >= SYS_COUNT) return; if (system <= SYS_None) return; systems[system].coolant_level = std::min(1.0f, std::max(0.0f, coolant)); }
-    
+    float getSystemCoolantRate(ESystem system) const { if (system >= SYS_COUNT) return 0.f; if (system <= SYS_None) return 0.f; return systems[system].coolant_rate_per_second; }
+    void setSystemCoolantRate(ESystem system, float rate) { if (system >= SYS_COUNT) return; if (system <= SYS_None) return; systems[system].coolant_rate_per_second = rate; }
     float getImpulseMaxSpeed() { return impulse_max_speed; }
     void setImpulseMaxSpeed(float speed) { impulse_max_speed = speed; }
     float getRotationMaxSpeed() { return turn_speed; }

--- a/src/spaceObjects/spaceship.h
+++ b/src/spaceObjects/spaceship.h
@@ -39,7 +39,7 @@ class ShipSystem
 {
 public:
     static constexpr float power_factor_rate = 0.08f;
-    static constexpr float default_heatup_rate_per_second = 0.05f;
+    static constexpr float default_heat_rate_per_second = 0.05f;
     static constexpr float default_power_rate_per_second = 0.3f;
     static constexpr float default_coolant_rate_per_second = 1.2f;
     float health; //1.0-0.0, where 0.0 is fully broken.
@@ -52,7 +52,7 @@ public:
     float hacked_level; //0.0-1.0
     float power_factor;
     float coolant_rate_per_second{};
-    float heatup_rate_per_second{};
+    float heat_rate_per_second{};
     float power_rate_per_second{};
 
     float getHeatingDelta() const
@@ -336,8 +336,8 @@ public:
     void setSystemHealthMax(ESystem system, float health_max) { if (system >= SYS_COUNT) return; if (system <= SYS_None) return; systems[system].health_max = std::min(1.0f, std::max(-1.0f, health_max)); }
     float getSystemHeat(ESystem system) { if (system >= SYS_COUNT) return 0.0; if (system <= SYS_None) return 0.0; return systems[system].heat_level; }
     void setSystemHeat(ESystem system, float heat) { if (system >= SYS_COUNT) return; if (system <= SYS_None) return; systems[system].heat_level = std::min(1.0f, std::max(0.0f, heat)); }
-    float getSystemHeatRate(ESystem system) const { if (system >= SYS_COUNT) return 0.f; if (system <= SYS_None) return 0.f; return systems[system].heatup_rate_per_second; }
-    void setSystemHeatRate(ESystem system, float rate) { if (system >= SYS_COUNT) return; if (system <= SYS_None) return; systems[system].heatup_rate_per_second = rate; }
+    float getSystemHeatRate(ESystem system) const { if (system >= SYS_COUNT) return 0.f; if (system <= SYS_None) return 0.f; return systems[system].heat_rate_per_second; }
+    void setSystemHeatRate(ESystem system, float rate) { if (system >= SYS_COUNT) return; if (system <= SYS_None) return; systems[system].heat_rate_per_second = rate; }
 
     float getSystemPower(ESystem system) { if (system >= SYS_COUNT) return 0.0; if (system <= SYS_None) return 0.0; return systems[system].power_level; }
     void setSystemPower(ESystem system, float power) { if (system >= SYS_COUNT) return; if (system <= SYS_None) return; systems[system].power_level = std::min(3.0f, std::max(0.0f, power)); }


### PR DESCRIPTION
This fixes #825 by providing customizable energy consumption rates per type per subsystem per ship.

This means that heat, coolant, and power consumption can be configured at will on a ship:
![image](https://user-images.githubusercontent.com/53709079/119039957-d841a580-b982-11eb-9e62-6ef1ea42f4df.png)


And ditto for shields an warp drive:
![image](https://user-images.githubusercontent.com/53709079/119040003-e55e9480-b982-11eb-8228-9c140c191720.png)

(bonus: the fields will hide themselves if the ship has no warp or shield).

Everything is exposed to lua scripts and values are uncapped for maximum ~wreckage~ tweakability.

So yes, if you were wondering, you can have systems that produces energy, a warp drive can be set to recharge the ship, coolant can heat and heat can cool.

Note that all values are viewed from the _consumer_ perspective: a positive value will drain energy ("gives to" the consumer, "takes from" the producer), a negative value will produce energy ("takes from" the consumer, "gives to" the producer).