### PR TITLE
Hotkeys for warp increase and decrease

### DIFF
--- a/src/gui/hotkeyConfig.cpp
+++ b/src/gui/hotkeyConfig.cpp
@@ -55,6 +55,8 @@ HotkeyConfig::HotkeyConfig()
     newKey("WARP_2", std::make_tuple("Warp 2", "Num8"));
     newKey("WARP_3", std::make_tuple("Warp 3", "Num9"));
     newKey("WARP_4", std::make_tuple("Warp 4", "Num0"));
+    newKey("INC_WARP", std::make_tuple("Increase Warp", ""));
+    newKey("DEC_WARP", std::make_tuple("Decrease Warp", ""));
     newKey("DOCK_ACTION", std::make_tuple("Dock request/abort/undock", "D"));
     newKey("DOCK_REQUEST", std::make_tuple("Initiate docking", ""));
     newKey("DOCK_ABORT", std::make_tuple("Abort docking", ""));

--- a/src/screenComponents/warpControls.cpp
+++ b/src/screenComponents/warpControls.cpp
@@ -84,5 +84,19 @@ void GuiWarpControls::onHotkey(const HotkeyResult& key)
             my_spaceship->commandWarp(4);
             slider->setValue(4);
         }
+        else if (key.hotkey == "INC_WARP")
+        {
+            if (my_spaceship->warp_request < 4) {
+                my_spaceship->commandWarp(my_spaceship->warp_request+1);
+                slider->setValue(my_spaceship->warp_request+1);
+            }
+        }
+        else if (key.hotkey == "DEC_WARP")
+        {
+            if (my_spaceship->warp_request > 0) {
+                my_spaceship->commandWarp(my_spaceship->warp_request-1);
+                slider->setValue(my_spaceship->warp_request-1);
+            }
+        }
     }
 }


### PR DESCRIPTION
This adds two additional hotkeys to increase/decrease the warp level. Useful e.g. for joystick setups and to enable a control style similar to the jump hotkeys.