### PR TITLE
Fix bad glFrustum on resize

### DIFF
--- a/src/screenComponents/viewport3d.cpp
+++ b/src/screenComponents/viewport3d.cpp
@@ -162,6 +162,17 @@ GuiViewport3D::GuiViewport3D(GuiContainer* owner, string id)
 void GuiViewport3D::onDraw(sf::RenderTarget& window)
 {
 #if FEATURE_3D_RENDERING
+    if (rect.width == 0.f)
+    {
+        // The GUI ticks before Updatables.
+        // When the 3D screen is on the side of a station,
+        // and the window is resized in a way that will hide the main screen,
+        // this leaves a *one frame* gap where the 3D gui element is 'visible' but will try to render
+        // with a computed 0-width rect.
+        // Since some gl calls don't really like an empty viewport, just ignore the draw.
+        return;
+    }
+        
     if (my_spaceship)
         soundManager->setListenerPosition(my_spaceship->getPosition(), my_spaceship->getRotation());
     else


### PR DESCRIPTION
When the 3D screen is displayed as a side screen, and the user resizes in a way that will hide it, there's one frame where the viewport will try to render in a 0-width viewport.

This leads to a bad gl state (`glFrustum` namely complains), so we just skip the draw when hitting that case.

Thanks to @StarryWisdom for the find!