### PR TITLE
Sceince frequency graphs reflecting lack of beams/shields

### DIFF
--- a/src/screenComponents/frequencyCurve.cpp
+++ b/src/screenComponents/frequencyCurve.cpp
@@ -15,52 +15,62 @@ void GuiFrequencyCurve::onDraw(sf::RenderTarget& window)
 
     if (frequency >= 0 && frequency <= SpaceShip::max_frequency)
     {
-        float w = (rect.width - 40) / (SpaceShip::max_frequency + 1);
-        for(int n=0; n<=SpaceShip::max_frequency; n++)
-        {
-            float x = rect.left + 20 + w * n;
-            float f;
-            if (frequency_is_beam)
-                f = frequencyVsFrequencyDamageFactor(frequency, n);
-            else
-                f = frequencyVsFrequencyDamageFactor(n, frequency);
-            f = Tween<float>::linear(f, 0.5, 1.5, 0.1, 1.0);
-            float h = (rect.height - 50) * f;
-            sf::RectangleShape bar(sf::Vector2f(w * 0.8, h));
-            bar.setPosition(x, rect.top + rect.height - 10 - h);
-            if (more_damage_is_positive)
-                bar.setFillColor(sf::Color(255 * (1.0 - f), 255 * f, 0));
-            else
-                bar.setFillColor(sf::Color(255 * f, 255 * (1.0 - f), 0));
-            window.draw(bar);
-
-            if (my_spaceship && ((frequency_is_beam && n == my_spaceship->getShieldsFrequency()) || (!frequency_is_beam && n == my_spaceship->beam_frequency)))
-            {
-                sf::Sprite image;
-                textureManager.setTexture(image, "gui/SelectorArrow");
-                image.setPosition(x + w / 2.0, rect.top + rect.height - 20 - h);
-                image.setRotation(-90);
-                image.setScale(0.2, 0.2);
-                window.draw(image);
+        if (enemy_without_equipment) {
+            if (frequency_is_beam) {
+                drawText(window, rect, tr("scienceGraph", "No enemy beams"), ACenter, 35);
+            }
+            else {
+                drawText(window, rect, tr("scienceGraph", "No enemy shields"), ACenter, 35);
             }
         }
+        else {
+            float w = (rect.width - 40) / (SpaceShip::max_frequency + 1);
+            for(int n=0; n<=SpaceShip::max_frequency; n++)
+            {
+                float x = rect.left + 20 + w * n;
+                float f;
+                if (frequency_is_beam)
+                    f = frequencyVsFrequencyDamageFactor(frequency, n);
+                else
+                    f = frequencyVsFrequencyDamageFactor(n, frequency);
+                f = Tween<float>::linear(f, 0.5, 1.5, 0.1, 1.0);
+                float h = (rect.height - 50) * f;
+                sf::RectangleShape bar(sf::Vector2f(w * 0.8, h));
+                bar.setPosition(x, rect.top + rect.height - 10 - h);
+                if (more_damage_is_positive)
+                    bar.setFillColor(sf::Color(255 * (1.0 - f), 255 * f, 0));
+                else
+                    bar.setFillColor(sf::Color(255 * f, 255 * (1.0 - f), 0));
+                window.draw(bar);
 
-        int mouse_freq_nr = int((InputHandler::getMousePos().x - rect.left - 20) / w);
+                if (my_spaceship && ((frequency_is_beam && n == my_spaceship->getShieldsFrequency()) || (!frequency_is_beam && n == my_spaceship->beam_frequency)))
+                {
+                    sf::Sprite image;
+                    textureManager.setTexture(image, "gui/SelectorArrow");
+                    image.setPosition(x + w / 2.0, rect.top + rect.height - 20 - h);
+                    image.setRotation(-90);
+                    image.setScale(0.2, 0.2);
+                    window.draw(image);
+                }
+            }
 
-        string text = "";
-        if (rect.contains(InputHandler::getMousePos()) && mouse_freq_nr >= 0 && mouse_freq_nr <= SpaceShip::max_frequency)
-        {
-            if (frequency_is_beam)
-                text = frequencyToString(mouse_freq_nr) + " " + string(int(frequencyVsFrequencyDamageFactor(frequency, mouse_freq_nr) * 100)) + "% dmg";
-            else
-                text = frequencyToString(mouse_freq_nr) + " " + string(int(frequencyVsFrequencyDamageFactor(mouse_freq_nr, frequency) * 100)) + "% dmg";
-        }else{
-            if (more_damage_is_positive)
-                text = tr("Damage with your beams");
-            else
-                text = tr("Damage on your shields");
-        }
-        drawText(window, sf::FloatRect(rect.left, rect.top, rect.width, 40), text, ACenter, 20);
+            int mouse_freq_nr = int((InputHandler::getMousePos().x - rect.left - 20) / w);
+
+            string text = "";
+            if (rect.contains(InputHandler::getMousePos()) && mouse_freq_nr >= 0 && mouse_freq_nr <= SpaceShip::max_frequency)
+            {
+                if (frequency_is_beam)
+                    text = frequencyToString(mouse_freq_nr) + " " + string(int(frequencyVsFrequencyDamageFactor(frequency, mouse_freq_nr) * 100)) + "% dmg";
+                else
+                    text = frequencyToString(mouse_freq_nr) + " " + string(int(frequencyVsFrequencyDamageFactor(mouse_freq_nr, frequency) * 100)) + "% dmg";
+            }else{
+                if (more_damage_is_positive)
+                    text = tr("Damage with your beams");
+                else
+                    text = tr("Damage on your shields");
+            }
+            drawText(window, sf::FloatRect(rect.left, rect.top, rect.width, 40), text, ACenter, 20);
+        } // end else enemy_without_equipment
     }else{
         drawText(window, rect, "No data", ACenter, 35);
     }

--- a/src/screenComponents/frequencyCurve.cpp
+++ b/src/screenComponents/frequencyCurve.cpp
@@ -15,15 +15,7 @@ void GuiFrequencyCurve::onDraw(sf::RenderTarget& window)
 
     if (frequency >= 0 && frequency <= SpaceShip::max_frequency)
     {
-        if (enemy_without_equipment) {
-            if (frequency_is_beam) {
-                drawText(window, rect, tr("scienceGraph", "No enemy beams"), ACenter, 35);
-            }
-            else {
-                drawText(window, rect, tr("scienceGraph", "No enemy shields"), ACenter, 35);
-            }
-        }
-        else {
+        if (enemy_has_equipment) {
             float w = (rect.width - 40) / (SpaceShip::max_frequency + 1);
             for(int n=0; n<=SpaceShip::max_frequency; n++)
             {
@@ -70,7 +62,13 @@ void GuiFrequencyCurve::onDraw(sf::RenderTarget& window)
                     text = tr("Damage on your shields");
             }
             drawText(window, sf::FloatRect(rect.left, rect.top, rect.width, 40), text, ACenter, 20);
-        } // end else enemy_without_equipment
+        } // end if enemy_has_equipment
+        else {
+            if (frequency_is_beam)
+                drawText(window, rect, tr("scienceFrequencyGraph", "No enemy beams"), ACenter, 35);
+            else
+                drawText(window, rect, tr("scienceFrequencyGraph", "No enemy shields"), ACenter, 35);
+        }
     }else{
         drawText(window, rect, "No data", ACenter, 35);
     }

--- a/src/screenComponents/frequencyCurve.h
+++ b/src/screenComponents/frequencyCurve.h
@@ -7,7 +7,7 @@ class GuiFrequencyCurve : public GuiPanel
 {
     bool frequency_is_beam;
     bool more_damage_is_positive;
-    bool enemy_without_equipment;   /*< If target ship have beams/shields (depending on frequency_is_beam) */
+    bool enemy_has_equipment;   /*< True if target ship have beams/shields (which of those depends on frequency_is_beam) */
 
     int frequency;
 public:
@@ -17,7 +17,7 @@ public:
 
     GuiFrequencyCurve* setFrequency(int frequency) { this->frequency = frequency; return this; }
 
-    void setEnemyWithoutEquipment(bool state) { this->enemy_without_equipment = state; }
+    void setEnemyHasEquipment(bool state) { this->enemy_has_equipment = state; }
 };
 
 #endif//FREQUENCY_CURVE_H

--- a/src/screenComponents/frequencyCurve.h
+++ b/src/screenComponents/frequencyCurve.h
@@ -7,6 +7,7 @@ class GuiFrequencyCurve : public GuiPanel
 {
     bool frequency_is_beam;
     bool more_damage_is_positive;
+    bool enemy_without_equipment;   /*< If target ship have beams/shields (depending on frequency_is_beam) */
 
     int frequency;
 public:
@@ -15,6 +16,8 @@ public:
     virtual void onDraw(sf::RenderTarget& window);
 
     GuiFrequencyCurve* setFrequency(int frequency) { this->frequency = frequency; return this; }
+
+    void setEnemyWithoutEquipment(bool state) { this->enemy_without_equipment = state; }
 };
 
 #endif//FREQUENCY_CURVE_H

--- a/src/screens/crew6/scienceScreen.cpp
+++ b/src/screens/crew6/scienceScreen.cpp
@@ -398,6 +398,11 @@ void ScienceScreen::onDraw(sf::RenderTarget& window)
                 {
                     info_shield_frequency->setFrequency(ship->shield_frequency);
                     info_beam_frequency->setFrequency(ship->beam_frequency);
+
+                    // Target ship has no shields - inform science operator. 
+                    info_shield_frequency->setEnemyWithoutEquipment(ship->getShieldDataString().size() == 0);
+
+                    info_beam_frequency->setEnemyWithoutEquipment(false);   // Not implemented yet. 
                 }
 
                 // Show the status of each subsystem.

--- a/src/screens/crew6/scienceScreen.cpp
+++ b/src/screens/crew6/scienceScreen.cpp
@@ -4,6 +4,7 @@
 #include "scienceDatabase.h"
 #include "spaceObjects/nebula.h"
 #include "preferenceManager.h"
+#include "shipTemplate.h"
 
 #include "screenComponents/radarView.h"
 #include "screenComponents/rawScannerDataRadarOverlay.h"
@@ -399,10 +400,19 @@ void ScienceScreen::onDraw(sf::RenderTarget& window)
                     info_shield_frequency->setFrequency(ship->shield_frequency);
                     info_beam_frequency->setFrequency(ship->beam_frequency);
 
-                    // Target ship has no shields - inform science operator. 
-                    info_shield_frequency->setEnemyWithoutEquipment(ship->getShieldDataString().size() == 0);
+                    // Show on graph information that target has no shields instead of frequencies. 
+                    info_shield_frequency->setEnemyHasEquipment(ship->getShieldCount() > 0);
 
-                    info_beam_frequency->setEnemyWithoutEquipment(false);   // Not implemented yet. 
+                    // Show on graph information that target has no beams instad of frequencies. 
+                    bool has_beams = false;
+                    for(int n = 0; n < max_beam_weapons; n++)
+                    {
+                        if (ship->beam_weapons[n].getRange() > 0.0) {
+                            has_beams = true;
+                            break;
+                        }
+                    }
+                    info_beam_frequency->setEnemyHasEquipment(has_beams);
                 }
 
                 // Show the status of each subsystem.


### PR DESCRIPTION
Related issue #1449. 

Science graphs now shows "No enemy beams" instead of frequencies in graph "damage on your shields" when selected enemy ship has no beams (all beams have 0 range). 

Also it shows "No enemy shields" instead of frequencies in graph "Damage with your beams" when ship's shield count is 0. 

Known issue: 
Some ship templates (for example Player ship Atlantis) have beam 3 with 0.1 range - so even though GM disables the "obvious" beams (1 and 2), beam number 3 still counts as a valid beam - so the graph WILL be shown. But I think this should be solved in LUA ship templates code, not in C++ code. 