### PR TITLE
Prevent Nukes and EMPs detonating twice on clients

### DIFF
--- a/src/spaceObjects/missiles/missileWeapon.cpp
+++ b/src/spaceObjects/missiles/missileWeapon.cpp
@@ -71,7 +71,7 @@ void MissileWeapon::update(float delta)
 
     // Since we do want the range to remain the same, ensure that slow missiles don't die down as fast.
     lifetime -= delta * size_speed_modifier;
-    if (lifetime < 0)
+    if (lifetime < 0 && isServer())
     {
         lifeEnded();
         destroy();


### PR DESCRIPTION
This was observed causing different clients to disagree on if a ship
was destroyed due to it having taken damage twice.