### PR TITLE
fix: Hotkey menu deleted joystick button mapping.

### DIFF
--- a/src/menus/hotkeyMenu.cpp
+++ b/src/menus/hotkeyMenu.cpp
@@ -1,6 +1,7 @@
 #include <i18n.h>
 #include "engine.h"
 #include "hotkeyMenu.h"
+#include <regex>
 
 #include "gui/hotkeyBinder.h"
 #include "gui/gui2_autolayout.h"
@@ -204,14 +205,15 @@ void HotkeyMenu::saveHotkeys()
     }
 
     // Read in all TextEntry values and update hotkeys
+    std::regex buttonIdExpression ("(\\[J([0-7])\\])?\\[B([0-9]|[12][0-9]|3[0-1])\\]"); // matches [J0] - [J7] (optional) and  [B0] - [B31]
     for (std::pair<string,string> item : hotkey_list)
     {
         text = text_entries[i]->getText();
         hotkey_exists = HotkeyConfig::get().setHotkey(category, item, text);
-
-        if (!hotkey_exists)
+        std::smatch matches;
+        if (!hotkey_exists && !std::regex_match(text, matches, buttonIdExpression))
         {
-            // Keys without equivalent SFML codes can't be accepted.
+            // Keys without equivalent SFML codes or joystick button code can't be accepted.
             // Blank the corresponding key entry field.
             text_entries[i]->setText("");
 

--- a/src/menus/hotkeyMenu.cpp
+++ b/src/menus/hotkeyMenu.cpp
@@ -205,7 +205,7 @@ void HotkeyMenu::saveHotkeys()
     }
 
     // Read in all TextEntry values and update hotkeys
-    std::regex buttonIdExpression ("(\\[J([0-7])\\])?\\[B([0-9]|[12][0-9]|3[0-1])\\]"); // matches [J0] - [J7] (optional) and  [B0] - [B31]
+    std::regex buttonIdExpression(R"((\[[JB][0-9]+\])+)"); // matches Joystick and keyboard button codes (loosely)
     for (std::pair<string,string> item : hotkey_list)
     {
         text = text_entries[i]->getText();


### PR DESCRIPTION
As the (very cool) new hotkey menu is not aware of joystick mappings, joystick button codes added in options.ini got deleted in the mapping menu, as it assumed a wrong keycode.

This PR fixes the issue by checking for joystick button codes in addition to sfml key codes..

This is just a bugfix, joystick button mappings still have to be added manually in options.ini