### PR TITLE
Disabling sliders in GM Tweak Shields menu dependent on shield_count

### DIFF
--- a/src/screens/gm/tweak.cpp
+++ b/src/screens/gm/tweak.cpp
@@ -471,6 +471,16 @@ void GuiShipTweakShields::onDraw(sf::RenderTarget& window)
     {
         shield_slider[n]->setValue(target->shield_level[n]);
         shield_max_slider[n]->setValue(target->shield_max[n]);
+
+        // Set range to 0 on all unused shields, since values set there by GM are not reflected by the game anyways.
+        if(target->shield_count>n) {
+            shield_slider[n]->setRange(0.0, 500);
+            shield_max_slider[n]->setRange(0.0, 500);
+        }
+        else{
+            shield_slider[n]->setRange(0.0, 0);
+            shield_max_slider[n]->setRange(0.0, 0);
+        }
     }
 }
 


### PR DESCRIPTION
Shield Count for every ShipTemplateBasedObject is set upon object creation (loaded from ship template) and after that there are no methods to safely change this value. 

This PR simply disables any "Current shield" and "Max shield" for shields above this value, so when GM changes those values it will not give him a false impression that number of shields is changed. Instead it is more obvious that if some of those shields are set to 0, ship in question will simply have a hole in its defences. 