### PR TITLE
Colorize output when ninja is used

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -50,7 +50,7 @@ endif()
 message(STATUS "EmptyEpsilon Version = ${PROJECT_VERSION}")
 
 # Enable colored output with Ninja
-if(CMAKE_GENERATOR MATCHES "Ninja")
+if((CMAKE_GENERATOR MATCHES "Ninja") AND (CMAKE_CXX_COMPILER_ID MATCHES "GNU"))
     add_compile_options (-fdiagnostics-color)
 endif()
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -49,6 +49,11 @@ endif()
 
 message(STATUS "EmptyEpsilon Version = ${PROJECT_VERSION}")
 
+# Enable colored output with Ninja
+if(CMAKE_GENERATOR MATCHES "Ninja")
+    add_compile_options (-fdiagnostics-color)
+endif()
+
 # Dependencies
 
 # Setup OpenGl


### PR DESCRIPTION
While ninja is faster than make, the output is not colorized per default, that can make reading error messages more difficult.
This commit incorporates the workaround mentioned in the FAQ:
https://github.com/ninja-build/ninja/wiki/FAQ