### PR TITLE
Fixed not showing buttons for Defend a Waypoint in comms_ships.lua

### DIFF
--- a/scripts/comms_ship.lua
+++ b/scripts/comms_ship.lua
@@ -51,7 +51,8 @@ function commsShipFriendly(comms_source, comms_target)
                     addCommsReply(
                         string.format(_("commsShipAssist", "Defend %s"), formatWaypoint(n)),
                         function(comms_source, comms_target)
-                            comms_target:orderDefendLocation(comms_source:getWaypoint(n))
+                            x, y = comms_source:getWaypoint(n)
+                            comms_target:orderDefendLocation(x, y)
                             setCommsMessage(string.format(_("commsShipAssist", "We are heading to assist at %s."), formatWaypoint(n)))
                             addCommsReply(_("button", "Back"), commsShipMainMenu)
                         end


### PR DESCRIPTION
Tracked down and fixed problem that prevented players to send allied ships to defend player-defined waypoints in scenarios that uses comms_ships.lua. Fixes #1399 but this might be more of a symptom of some other bug in EE engine, since it breaks on sf::Vector2f that needs to be explicitly expanded. 