### PR TITLE
Line up rotating model view with 3D viewport

### DIFF
--- a/src/screenComponents/rotatingModelView.cpp
+++ b/src/screenComponents/rotatingModelView.cpp
@@ -34,7 +34,7 @@ void GuiRotatingModelView::onDraw(sf::RenderTarget& window)
     if (rect.width <= 0) return;
     if (!model) return;
 
-    window.popGLStates();
+    window.setActive();
 
     float camera_fov = 60.0f;
     float sx = window.getSize().x * window.getView().getViewport().width / window.getView().getSize().x;
@@ -139,6 +139,7 @@ void GuiRotatingModelView::onDraw(sf::RenderTarget& window)
     }
     glDisable(GL_DEPTH_TEST);
 
-    window.pushGLStates();
+    window.resetGLStates();
+    window.setActive(false);
 #endif//FEATURE_3D_RENDERING
 }


### PR DESCRIPTION
Window activation, state reset (and not push/pop).

While I'm still unable to get an actual error, I do see the GL warning about a potential underflow.

Making the rotating view more in line with what was done for the 3D screen eliminates the warning.