### PR TITLE
Allow mod name without slash

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -151,6 +151,8 @@ int main(int argc, char** argv)
     if (PreferencesManager::get("mod") != "")
     {
         string mod = PreferencesManager::get("mod");
+        if (mod.back() != '/')
+            mod += "/";
         if (getenv("HOME"))
         {
             new DirectoryResourceProvider(string(getenv("HOME")) + "/.emptyepsilon/resources/mods/" + mod);


### PR DESCRIPTION
As adding a "/" at the end of the modfolder name isn't obvious, this adds an alternative syntax for the mod option. So you just have to enter `mod=modname` instead of `mod=modname/` in options.ini

Similar to f5cc8a5a2260cb1f797cbc66509373d95cc1c273 from #620, but backwards compatible, so the old syntax is still valid.