### PR TITLE
resize tweak menu

### DIFF
--- a/src/screens/gm/tweak.cpp
+++ b/src/screens/gm/tweak.cpp
@@ -16,7 +16,7 @@ GuiObjectTweak::GuiObjectTweak(GuiContainer* owner, ETweakType tweak_type)
 : GuiPanel(owner, "GM_TWEAK_DIALOG")
 {
     setPosition(0, -100, ABottomCenter);
-    setSize(1000, 600);
+    setSize(1000, 700);
 
     GuiListbox* list = new GuiListbox(this, "", [this](int index, string value)
     {
@@ -85,7 +85,7 @@ GuiObjectTweak::GuiObjectTweak(GuiContainer* owner, ETweakType tweak_type)
 
     for(GuiTweakPage* page : pages)
     {
-        page->setSize(700, 600)->setPosition(0, 0, ABottomRight)->hide();
+        page->setSize(700, 700)->setPosition(0, 0, ABottomRight)->hide();
     }
 
     pages[0]->show();


### PR DESCRIPTION
So the last row in the ship tab (for CPU ships) won't overflow