### PR TITLE
Smaller font for IPs on server creation screen

### DIFF
--- a/src/gui/gui2_selector.cpp
+++ b/src/gui/gui2_selector.cpp
@@ -80,6 +80,7 @@ void GuiSelector::onMouseUp(sf::Vector2f position)
                     callback();
                 }));
                 popup_buttons[n]->setSize(GuiElement::GuiSizeMax, 50);
+                popup_buttons[n]->setTextSize(text_size);
             }else{
                 popup_buttons[n]->setText(entries[n].name);
             }

--- a/src/menus/serverCreationScreen.cpp
+++ b/src/menus/serverCreationScreen.cpp
@@ -75,6 +75,7 @@ ServerCreationScreen::ServerCreationScreen()
     (new GuiLabel(row, "IP_LABEL", tr("Server IPs: "), 30))->setAlignment(ACenterRight)->setSize(250, GuiElement::GuiSizeMax);
     auto ips = new GuiSelector(row, "IP", [](int index, string value){});
     ips->setSize(GuiElement::GuiSizeMax, GuiElement::GuiSizeMax);
+    ips->setTextSize(20);
     for(auto addr_str : sp::io::network::Address::getLocalAddress().getHumanReadable())
     {
         if (addr_str == "::1" || addr_str == "127.0.0.1") continue;


### PR DESCRIPTION
So IPv6 adresses will fit in.
This also includes a small fix for the selector, so the selector font size will also apply to the popup list that appears when clicked on the center rather than the arrows.