### PR TITLE
Index property for custom functions

### DIFF
--- a/src/screenComponents/customShipFunctions.cpp
+++ b/src/screenComponents/customShipFunctions.cpp
@@ -69,6 +69,7 @@ void GuiCustomShipFunctions::createEntries()
             e.element->destroy();
     }
     entries.clear();
+    std::sort(my_spaceship->custom_functions.begin(), my_spaceship->custom_functions.end());
     for(PlayerSpaceship::CustomShipFunction& csf : my_spaceship->custom_functions)
     {
         entries.emplace_back();

--- a/src/spaceObjects/playerSpaceship.cpp
+++ b/src/spaceObjects/playerSpaceship.cpp
@@ -68,9 +68,9 @@ REGISTER_SCRIPT_SUBCLASS(PlayerSpaceship, SpaceShip)
     REGISTER_SCRIPT_CLASS_FUNCTION(PlayerSpaceship, setMaxScanProbeCount);
     REGISTER_SCRIPT_CLASS_FUNCTION(PlayerSpaceship, getMaxScanProbeCount);
 
-    /// add a custom Button to the according station. Use Index to sort (shared with custom info).
+    /// add a custom Button to the according station. Use order to sort (shared with custom info).
     REGISTER_SCRIPT_CLASS_FUNCTION(PlayerSpaceship, addCustomButton);
-    /// add a custom Info Label to the according station. Use Index to sort (shared with custom button).
+    /// add a custom Info Label to the according station. Use order to sort (shared with custom button).
     REGISTER_SCRIPT_CLASS_FUNCTION(PlayerSpaceship, addCustomInfo);
     REGISTER_SCRIPT_CLASS_FUNCTION(PlayerSpaceship, addCustomMessage);
     REGISTER_SCRIPT_CLASS_FUNCTION(PlayerSpaceship, addCustomMessageWithCallback);
@@ -1056,7 +1056,7 @@ bool PlayerSpaceship::hasPlayerAtPosition(ECrewPosition position)
     return false;
 }
 
-void PlayerSpaceship::addCustomButton(ECrewPosition position, string name, string caption, ScriptSimpleCallback callback, std::optional<int> index)
+void PlayerSpaceship::addCustomButton(ECrewPosition position, string name, string caption, ScriptSimpleCallback callback, std::optional<int> order)
 {
     removeCustom(name);
     custom_functions.emplace_back();
@@ -1066,10 +1066,10 @@ void PlayerSpaceship::addCustomButton(ECrewPosition position, string name, strin
     csf.crew_position = position;
     csf.caption = caption;
     csf.callback = callback;
-    csf.index = index.value_or(0);
+    csf.order = order.value_or(0);
 }
 
-void PlayerSpaceship::addCustomInfo(ECrewPosition position, string name, string caption, std::optional<int> index)
+void PlayerSpaceship::addCustomInfo(ECrewPosition position, string name, string caption, std::optional<int> order)
 {
     removeCustom(name);
     custom_functions.emplace_back();
@@ -1078,7 +1078,7 @@ void PlayerSpaceship::addCustomInfo(ECrewPosition position, string name, string 
     csf.name = name;
     csf.crew_position = position;
     csf.caption = caption;
-    csf.index = index.value_or(0);
+    csf.order = order.value_or(0);
 }
 
 void PlayerSpaceship::addCustomMessage(ECrewPosition position, string name, string caption)

--- a/src/spaceObjects/playerSpaceship.cpp
+++ b/src/spaceObjects/playerSpaceship.cpp
@@ -68,7 +68,9 @@ REGISTER_SCRIPT_SUBCLASS(PlayerSpaceship, SpaceShip)
     REGISTER_SCRIPT_CLASS_FUNCTION(PlayerSpaceship, setMaxScanProbeCount);
     REGISTER_SCRIPT_CLASS_FUNCTION(PlayerSpaceship, getMaxScanProbeCount);
 
+    /// add a custom Button to the according station. Use Index to sort (shared with custom info).
     REGISTER_SCRIPT_CLASS_FUNCTION(PlayerSpaceship, addCustomButton);
+    /// add a custom Info Label to the according station. Use Index to sort (shared with custom button).
     REGISTER_SCRIPT_CLASS_FUNCTION(PlayerSpaceship, addCustomInfo);
     REGISTER_SCRIPT_CLASS_FUNCTION(PlayerSpaceship, addCustomMessage);
     REGISTER_SCRIPT_CLASS_FUNCTION(PlayerSpaceship, addCustomMessageWithCallback);
@@ -1054,7 +1056,7 @@ bool PlayerSpaceship::hasPlayerAtPosition(ECrewPosition position)
     return false;
 }
 
-void PlayerSpaceship::addCustomButton(ECrewPosition position, string name, string caption, ScriptSimpleCallback callback)
+void PlayerSpaceship::addCustomButton(ECrewPosition position, string name, string caption, ScriptSimpleCallback callback, std::optional<int> index)
 {
     removeCustom(name);
     custom_functions.emplace_back();
@@ -1064,9 +1066,10 @@ void PlayerSpaceship::addCustomButton(ECrewPosition position, string name, strin
     csf.crew_position = position;
     csf.caption = caption;
     csf.callback = callback;
+    csf.index = index.value_or(0);
 }
 
-void PlayerSpaceship::addCustomInfo(ECrewPosition position, string name, string caption)
+void PlayerSpaceship::addCustomInfo(ECrewPosition position, string name, string caption, std::optional<int> index)
 {
     removeCustom(name);
     custom_functions.emplace_back();
@@ -1075,6 +1078,7 @@ void PlayerSpaceship::addCustomInfo(ECrewPosition position, string name, string 
     csf.name = name;
     csf.crew_position = position;
     csf.caption = caption;
+    csf.index = index.value_or(0);
 }
 
 void PlayerSpaceship::addCustomMessage(ECrewPosition position, string name, string caption)

--- a/src/spaceObjects/playerSpaceship.h
+++ b/src/spaceObjects/playerSpaceship.h
@@ -81,7 +81,7 @@ public:
         string caption;
         ECrewPosition crew_position;
         ScriptSimpleCallback callback;
-        int index;
+        int order;
 
         bool operator!=(const CustomShipFunction& csf) { return type != csf.type || name != csf.name || caption != csf.caption || crew_position != csf.crew_position; }
     };
@@ -230,8 +230,8 @@ public:
     void onProbeLink(ScriptSimpleCallback callback);
     void onProbeUnlink(ScriptSimpleCallback callback);
 
-    void addCustomButton(ECrewPosition position, string name, string caption, ScriptSimpleCallback callback, std::optional<int> index);
-    void addCustomInfo(ECrewPosition position, string name, string caption, std::optional<int> index);
+    void addCustomButton(ECrewPosition position, string name, string caption, ScriptSimpleCallback callback, std::optional<int> order);
+    void addCustomInfo(ECrewPosition position, string name, string caption, std::optional<int> order);
     void addCustomMessage(ECrewPosition position, string name, string caption);
     void addCustomMessageWithCallback(ECrewPosition position, string name, string caption, ScriptSimpleCallback callback);
     void removeCustom(string name);
@@ -355,5 +355,5 @@ static inline sp::io::DataBuffer& operator >> (sp::io::DataBuffer& packet, Playe
 string alertLevelToString(EAlertLevel level);
 string alertLevelToLocaleString(EAlertLevel level);
 
-static inline bool operator < (const PlayerSpaceship::CustomShipFunction& a, const PlayerSpaceship::CustomShipFunction& b) {return (a.index < b.index);}
+static inline bool operator < (const PlayerSpaceship::CustomShipFunction& a, const PlayerSpaceship::CustomShipFunction& b) {return (a.order < b.order);}
 #endif//PLAYER_SPACESHIP_H

--- a/src/spaceObjects/playerSpaceship.h
+++ b/src/spaceObjects/playerSpaceship.h
@@ -81,6 +81,7 @@ public:
         string caption;
         ECrewPosition crew_position;
         ScriptSimpleCallback callback;
+        int index;
 
         bool operator!=(const CustomShipFunction& csf) { return type != csf.type || name != csf.name || caption != csf.caption || crew_position != csf.crew_position; }
     };
@@ -229,8 +230,8 @@ public:
     void onProbeLink(ScriptSimpleCallback callback);
     void onProbeUnlink(ScriptSimpleCallback callback);
 
-    void addCustomButton(ECrewPosition position, string name, string caption, ScriptSimpleCallback callback);
-    void addCustomInfo(ECrewPosition position, string name, string caption);
+    void addCustomButton(ECrewPosition position, string name, string caption, ScriptSimpleCallback callback, std::optional<int> index);
+    void addCustomInfo(ECrewPosition position, string name, string caption, std::optional<int> index);
     void addCustomMessage(ECrewPosition position, string name, string caption);
     void addCustomMessageWithCallback(ECrewPosition position, string name, string caption, ScriptSimpleCallback callback);
     void removeCustom(string name);
@@ -354,4 +355,5 @@ static inline sp::io::DataBuffer& operator >> (sp::io::DataBuffer& packet, Playe
 string alertLevelToString(EAlertLevel level);
 string alertLevelToLocaleString(EAlertLevel level);
 
+static inline bool operator < (const PlayerSpaceship::CustomShipFunction& a, const PlayerSpaceship::CustomShipFunction& b) {return (a.index < b.index);}
 #endif//PLAYER_SPACESHIP_H


### PR DESCRIPTION
The new index argument for the add functions is optional, if empty, the index property will be set to zero.
As the entries are sorted by index, this is now a way to have better control over the display order  of custom functions.
This is especially useful if you want to update information, so you can avoid the last updated element jumping to the bottom.