### PR TITLE
Relay tutorial: Removed comms capability of dummy ships, modified short range radar presentation.

### DIFF
--- a/scripts/tutorial_06_relay.lua
+++ b/scripts/tutorial_06_relay.lua
@@ -151,13 +151,13 @@ addToSequence(relayTutorial, function() tutorial:setMessageToBottomPosition() en
 addToSequence(relayTutorial, function() prev_object:destroy() end)
 addToSequence(relayTutorial, _([[Depending on the scenario, you might have different options when communicating with stations.
 They might inform you about new objectives and your mission progress, ask for backup, or resupply your weapons. This is all part of your responsibilities as relay officer.]]))
-addToSequence(relayTutorial, function() prev_object = CpuShip():setFaction("Human Navy"):setTemplate("Phobos T3"):setPosition(20000, -20000):orderIdle():setCallSign("DMY-01"):setScanned(true) end)
-addToSequence(relayTutorial, function() prev_object2 = CpuShip():setFaction("Human Navy"):setTemplate("Phobos T3"):setPosition(-24000, 2500):orderIdle():setScanned(true) end)
-addToSequence(relayTutorial, function() prev_object3 = CpuShip():setFaction("Human Navy"):setTemplate("Phobos T3"):setPosition(-17000, -7500):orderIdle():setScanned(true) end)
-addToSequence(relayTutorial, function() prev_object4 = CpuShip():setFaction("Human Navy"):setTemplate("Phobos T3"):setPosition(5400, 7500):orderIdle():setScanned(false) end)
+addToSequence(relayTutorial, function() prev_object = CpuShip():setFaction("Human Navy"):setTemplate("Phobos T3"):setPosition(20000, -20000):orderIdle():setCallSign("DMY-01"):setScanned(true):setCommsScript("") end)
+addToSequence(relayTutorial, function() prev_object2 = CpuShip():setFaction("Human Navy"):setTemplate("Phobos T3"):setPosition(-24000, 2500):orderIdle():setScanned(true):setCommsScript(""):setShortRangeRadarRange(10000) end)
+addToSequence(relayTutorial, function() prev_object3 = CpuShip():setFaction("Human Navy"):setTemplate("Phobos T3"):setPosition(-17000, -7500):orderIdle():setScanned(true):setCommsScript("") end)
+addToSequence(relayTutorial, function() prev_object4 = CpuShip():setFaction("Human Navy"):setTemplate("Phobos T3"):setPosition(5400, 7500):orderIdle():setScanned(false):setCommsScript("") end)
 addToSequence(relayTutorial, _([[Your station also includes this radar map.
 
-On this map, you can detect objects within 5u of all allied ships and stations. Everything else is invisible to you. This gives you a different view from the science officer, because you can scan the contents of nebulae.]]))
+On this map, you can detect objects within short-range radar range of all allied ships and stations. Everything else is invisible to you. This gives you a different view from the science officer, because you can scan the contents of nebulae.]]))
 addToSequence(relayTutorial, _([[Finally, you control your ship's probes. Probes can expand your radar view. Launch a probe to the top right, toward the ship designated DMY-01.]]), function()
     for _, obj in ipairs(getObjectsInRadius(20000, -20000, 5000)) do
         if obj.typeName == "ScanProbe" then


### PR DESCRIPTION
* Comms window could not be closed because tutorial window was over the comms's cancel button if user hailed dummy ship instead of sending a probe.
* Removed 5U sensor range in tutorial text (since now it can be different per ship) and changed short range of one ship to demonstrate different sensor ranges.