### PR TITLE
ensure lighting intensity sticks within reasonable bounds

### DIFF
--- a/resources/shaders/objectShader.shader
+++ b/resources/shaders/objectShader.shader
@@ -52,7 +52,7 @@ void main()
 	vec3 lightDir = normalize(vec3(light0_position) - viewspace_position);
 	vec3 lightDir2 = normalize(vec3(light1_position) - viewspace_position);
 	vec3 n = fragnormal;
-	float intensity = max(0.1, dot(lightDir, n));
+	float intensity = clamp(dot(lightDir, n), 0.1, 1.0);
 	float specularIntensity = min(1.0, pow(max(0.0, dot(lightDir2, n)) * 1.2, 20.0));
 	
 	vec4 base = texture2D(baseMap, fragtexcoords.st);

--- a/resources/shaders/planet.shader
+++ b/resources/shaders/planet.shader
@@ -42,7 +42,7 @@ varying vec2 fragtexcoords;
 void main()
 {
 	vec3 lightDir = normalize(vec3(light1_position) - viewspace_position);
-	float intensity = max(0.0, dot(lightDir, fragnormal));
+	float intensity = clamp(dot(lightDir, fragnormal), 0.0, 1.0);
 	
 	vec3 base = texture2D(baseMap, fragtexcoords.st).rgb;
 	


### PR DESCRIPTION
On some systems (ie, my freaking phone), the lighting would go out the window because on numerical stability.
Clamping the value so it sticks within the 0-1 bounds.