### PR TITLE
Update light computation

### DIFF
--- a/resources/shaders/objectShader.shader
+++ b/resources/shaders/objectShader.shader
@@ -13,14 +13,12 @@ attribute vec2 texcoords;
 
 // Per-vertex outputs
 varying vec3 fragnormal;
-varying vec3 viewspace_position;
 varying vec2 fragtexcoords;
 
 void main()
 {
 	fragnormal = normalize((model * vec4(normal, 0.)).xyz);
 	vec4 modelview_position = view * model * vec4(position, 1.);
-	viewspace_position = vec3(modelview_position);
 	
 	fragtexcoords = texcoords;
 	gl_Position = projection * modelview_position;
@@ -29,12 +27,12 @@ void main()
 [fragment]
 //Simple per-pixel light shader.
 
-const vec4 light0_position = vec4(20000., 20000., 20000., 1.0);
-const vec4 light1_position = vec4(0., 0., 0., 1.);
-
 // Program inputs
+uniform vec3 ambientLightDirection;
+
 uniform sampler2D baseMap;
 #ifdef SPECULAR
+uniform vec3 specularLightDirection;
 uniform sampler2D specularMap;
 #endif
 #ifdef ILLUMINATION
@@ -43,17 +41,13 @@ uniform sampler2D illuminationMap;
 
 // Per-fragment inputs
 varying vec3 fragnormal;
-varying vec3 viewspace_position;
 varying vec2 fragtexcoords;
 
 
 void main()
 {
-	vec3 lightDir = normalize(vec3(light0_position) - viewspace_position);
-	vec3 lightDir2 = normalize(vec3(light1_position) - viewspace_position);
 	vec3 n = fragnormal;
-	float intensity = max(0.1, dot(lightDir, n));
-	float specularIntensity = min(1.0, pow(max(0.0, dot(lightDir2, n)) * 1.2, 20.0));
+	float intensity = max(0.1, dot(ambientLightDirection, n));
 	
 	vec4 base = texture2D(baseMap, fragtexcoords.st);
 #ifdef ILLUMINATION
@@ -62,10 +56,11 @@ void main()
     vec4 illumination = vec4(0.0, 0.0, 0.0, 0.0);
 #endif
 #ifdef SPECULAR
-	vec4 specular = texture2D(specularMap, fragtexcoords.st);
+	float specularIntensity = min(1.0, pow(max(0.0, dot(specularLightDirection, n)) * 1.2, 20.0));
+	vec4 specular = specularIntensity * texture2D(specularMap, fragtexcoords.st);
 #else
 	vec4 specular = vec4(0.0, 0.0, 0.0, 0.0);
 #endif
 	
-	gl_FragColor = ((base - illumination) * intensity) + (specular * specularIntensity) + illumination;
+	gl_FragColor = ((base - illumination) * intensity) + specular + illumination;
 }

--- a/resources/shaders/planet.shader
+++ b/resources/shaders/planet.shader
@@ -11,14 +11,12 @@ attribute vec2 texcoords;
 
 // Per-vertex outputs
 varying vec3 fragnormal;
-varying vec3 viewspace_position;
 varying vec2 fragtexcoords;
 
 void main()
 {
 	fragnormal = normalize((model * vec4(normal, 0.)).xyz);
 	vec4 modelview_position = view * model * vec4(position, 1.);
-	viewspace_position = vec3(modelview_position);
 	
 	fragtexcoords = texcoords;
 	gl_Position = projection * modelview_position;
@@ -30,19 +28,18 @@ const vec4 light0_position = vec4(20000., 20000., 20000., 1.0);
 const vec4 light1_position = vec4(0., 0., 0., 1.);
 
 // Program inputs
+uniform vec3 ambientLightDirection;
 uniform sampler2D baseMap;
 uniform vec4 color;
 uniform vec4 atmosphereColor;
 
 // Per-fragment inputs
 varying vec3 fragnormal;
-varying vec3 viewspace_position;
 varying vec2 fragtexcoords;
 
 void main()
 {
-	vec3 lightDir = normalize(vec3(light1_position) - viewspace_position);
-	float intensity = max(0.0, dot(lightDir, fragnormal));
+	float intensity = max(0.0, dot(ambientLightDirection, fragnormal));
 	
 	vec3 base = texture2D(baseMap, fragtexcoords.st).rgb;
 	

--- a/src/modelData.cpp
+++ b/src/modelData.cpp
@@ -213,8 +213,12 @@ void ModelData::render(const glm::mat4& model_view)
     model_matrix = glm::translate(model_matrix, mesh_offset);
 
     ShaderRegistry::ScopedShader shader(shader_id);
-    glUniformMatrix4fv(shader.get().get()->getUniformLocation("view"), 1, GL_FALSE, glm::value_ptr(model_view));
-    glUniformMatrix4fv(shader.get().get()->getUniformLocation("model"), 1, GL_FALSE, glm::value_ptr(model_matrix));
+    glUniformMatrix4fv(shader.get().uniform(ShaderRegistry::Uniforms::View), 1, GL_FALSE, glm::value_ptr(model_view));
+    glUniformMatrix4fv(shader.get().uniform(ShaderRegistry::Uniforms::Model), 1, GL_FALSE, glm::value_ptr(model_matrix));
+
+
+    // Lights setup.
+    ShaderRegistry::setupLights(shader.get(), model_view, model_matrix);
 
     // Textures
     texture->bind();
@@ -235,6 +239,8 @@ void ModelData::render(const glm::mat4& model_view)
     gl::ScopedVertexAttribArray positions(shader.get().attribute(ShaderRegistry::Attributes::Position));
     gl::ScopedVertexAttribArray texcoords(shader.get().attribute(ShaderRegistry::Attributes::Texcoords));
     gl::ScopedVertexAttribArray normals(shader.get().attribute(ShaderRegistry::Attributes::Normal));
+
+    
     mesh->render(positions.get(), texcoords.get(), normals.get());
 
     if (specular_texture || illumination_texture)

--- a/src/shaderRegistry.cpp
+++ b/src/shaderRegistry.cpp
@@ -4,6 +4,8 @@
 #include <tuple>
 
 #include <graphics/opengl.h>
+#include <glm/glm.hpp>
+#include <glm/gtc/type_ptr.hpp>
 
 #include "logging.h"
 #include "shaderManager.h"
@@ -32,6 +34,8 @@ namespace ShaderRegistry
 			"color",
 			"model_view_projection",
 			"projection",
+			"model",
+			"view",
 			"model_view",
 			"camera_position",
 			"atmosphereColor",
@@ -39,7 +43,10 @@ namespace ShaderRegistry
 			"textureMap",
 			"baseMap",
 			"specularMap",
-			"illuminationMap"
+			"illuminationMap",
+
+			"ambientLightDirection",
+			"specularLightDirection"
 		};
 
 		std::array<const char*, Attributes_t(Attributes::Count)> attribute_names{
@@ -95,6 +102,19 @@ namespace ShaderRegistry
 	const Shader& get(Shaders shader)
 	{
 		return shaders[Shaders_t(shader)];
+	}
+
+	void setupLights(const Shader& shader, const glm::vec3& target_viewspace)
+	{
+		if (auto ambient = shader.uniform(ShaderRegistry::Uniforms::AmbientLightDirection); ambient != -1)
+		{
+			glUniform3fv(ambient, 1, glm::value_ptr(glm::normalize(ambientLightPosition - target_viewspace)));
+		}
+
+		if (auto specular = shader.uniform(ShaderRegistry::Uniforms::AmbientLightDirection); specular != -1)
+		{
+			glUniform3fv(specular, 1, glm::value_ptr(glm::normalize(specularLightPosition - target_viewspace)));
+		}
 	}
 
 	ScopedShader::ScopedShader(Shaders id) noexcept

--- a/src/shaderRegistry.h
+++ b/src/shaderRegistry.h
@@ -7,6 +7,10 @@
 
 #include <type_traits>
 
+#include <glm/vec3.hpp>
+#include <glm/vec4.hpp>
+#include <glm/mat4x4.hpp>
+
 namespace sp
 {
 	class Shader;
@@ -14,6 +18,9 @@ namespace sp
 
 namespace ShaderRegistry
 {
+	constexpr glm::vec3 ambientLightPosition{ 20000.f, 20000.f, 20000.f };
+	constexpr glm::vec3 specularLightPosition{ 0.f, 0.f, 0.f };
+
 	enum class Shaders
 	{
 		Basic = 0,
@@ -35,6 +42,8 @@ namespace ShaderRegistry
 		Color = 0,
 		ModelViewProjection,
 		Projection,
+		Model,
+		View,
 		ModelView,
 		CameraPosition,
 		AtmosphereColor,
@@ -43,6 +52,9 @@ namespace ShaderRegistry
 		BaseMap,
 		SpecularMap,
 		IlluminationMap,
+
+		AmbientLightDirection,
+		SpecularLightDirection,
 
 		Count
 	};
@@ -82,7 +94,16 @@ namespace ShaderRegistry
 		std::array<int32_t, Uniforms_t(Attributes::Count)> attributes;
 	};
 
+	
+
 	const Shader& get(Shaders id);
+	void setupLights(const Shader& shader, const glm::vec3& target_viewspace);
+	inline void setupLights(const Shader& shader, const glm::mat4& view, const glm::mat4& model)
+	{
+		// Target center of model.
+		setupLights(shader, view * model * glm::vec4{ glm::vec3{0.f}, 1.f });
+	}
+	
 
 	class ScopedShader final
 	{

--- a/src/spaceObjects/asteroid.cpp
+++ b/src/spaceObjects/asteroid.cpp
@@ -51,8 +51,8 @@ void Asteroid::draw3D(const glm::mat4& object_view_matrix)
 
     ShaderRegistry::ScopedShader shader(ShaderRegistry::Shaders::ObjectSpecular);
 
-    glUniformMatrix4fv(shader.get().get()->getUniformLocation("view"), 1, GL_FALSE, glm::value_ptr(object_view_matrix));
-    glUniformMatrix4fv(shader.get().get()->getUniformLocation("model"), 1, GL_FALSE, glm::value_ptr(model_matrix));
+    glUniformMatrix4fv(shader.get().uniform(ShaderRegistry::Uniforms::View), 1, GL_FALSE, glm::value_ptr(object_view_matrix));
+    glUniformMatrix4fv(shader.get().uniform(ShaderRegistry::Uniforms::Model), 1, GL_FALSE, glm::value_ptr(model_matrix));
 
     textureManager.getTexture("Astroid_" + string(model_number) + "_d.png")->bind();
 
@@ -65,6 +65,7 @@ void Asteroid::draw3D(const glm::mat4& object_view_matrix)
     gl::ScopedVertexAttribArray texcoords(shader.get().attribute(ShaderRegistry::Attributes::Texcoords));
     gl::ScopedVertexAttribArray normals(shader.get().attribute(ShaderRegistry::Attributes::Normal));
 
+    ShaderRegistry::setupLights(shader.get(), object_view_matrix, model_matrix);
     m->render(positions.get(), texcoords.get(), normals.get());
 
 
@@ -158,8 +159,8 @@ void VisualAsteroid::draw3D(const glm::mat4& object_view_matrix)
 
     ShaderRegistry::ScopedShader shader(ShaderRegistry::Shaders::ObjectSpecular);
 
-    glUniformMatrix4fv(shader.get().get()->getUniformLocation("view"), 1, GL_FALSE, glm::value_ptr(object_view_matrix));
-    glUniformMatrix4fv(shader.get().get()->getUniformLocation("model"), 1, GL_FALSE, glm::value_ptr(model_matrix));
+    glUniformMatrix4fv(shader.get().uniform(ShaderRegistry::Uniforms::View), 1, GL_FALSE, glm::value_ptr(object_view_matrix));
+    glUniformMatrix4fv(shader.get().uniform(ShaderRegistry::Uniforms::Model), 1, GL_FALSE, glm::value_ptr(model_matrix));
 
     textureManager.getTexture("Astroid_" + string(model_number) + "_d.png")->bind();
 
@@ -171,6 +172,8 @@ void VisualAsteroid::draw3D(const glm::mat4& object_view_matrix)
     gl::ScopedVertexAttribArray positions(shader.get().attribute(ShaderRegistry::Attributes::Position));
     gl::ScopedVertexAttribArray texcoords(shader.get().attribute(ShaderRegistry::Attributes::Texcoords));
     gl::ScopedVertexAttribArray normals(shader.get().attribute(ShaderRegistry::Attributes::Normal));
+
+    ShaderRegistry::setupLights(shader.get(), object_view_matrix, model_matrix);
     m->render(positions.get(), texcoords.get(), normals.get());
 
     glActiveTexture(GL_TEXTURE0);

--- a/src/spaceObjects/planet.cpp
+++ b/src/spaceObjects/planet.cpp
@@ -268,10 +268,12 @@ void Planet::draw3D(const glm::mat4& object_view_matrix)
 
         ShaderRegistry::ScopedShader shader(ShaderRegistry::Shaders::Planet);
 
-        glUniformMatrix4fv(shader.get().get()->getUniformLocation("view"), 1, GL_FALSE, glm::value_ptr(object_view_matrix));
-        glUniformMatrix4fv(shader.get().get()->getUniformLocation("model"), 1, GL_FALSE, glm::value_ptr(model_matrix));
+        glUniformMatrix4fv(shader.get().uniform(ShaderRegistry::Uniforms::View), 1, GL_FALSE, glm::value_ptr(object_view_matrix));
+        glUniformMatrix4fv(shader.get().uniform(ShaderRegistry::Uniforms::Model), 1, GL_FALSE, glm::value_ptr(model_matrix));
         glUniform4f(shader.get().uniform(ShaderRegistry::Uniforms::Color), 1.f, 1.f, 1.f, 1.f);
         glUniform4fv(shader.get().uniform(ShaderRegistry::Uniforms::AtmosphereColor), 1, glm::value_ptr(glm::vec4(atmosphere_color.r, atmosphere_color.g, atmosphere_color.b, atmosphere_color.a) / 255.f));
+
+        ShaderRegistry::setupLights(shader.get(), object_view_matrix, model_matrix);
 
         textureManager.getTexture(planet_texture)->bind();
         {
@@ -310,10 +312,12 @@ void Planet::draw3DTransparent(const glm::mat4& object_view_matrix)
 
         ShaderRegistry::ScopedShader shader(ShaderRegistry::Shaders::Planet);
 
-        glUniformMatrix4fv(shader.get().get()->getUniformLocation("view"), 1, GL_FALSE, glm::value_ptr(object_view_matrix));
-        glUniformMatrix4fv(shader.get().get()->getUniformLocation("model"), 1, GL_FALSE, glm::value_ptr(cloud_model_matrix));
+        glUniformMatrix4fv(shader.get().uniform(ShaderRegistry::Uniforms::View), 1, GL_FALSE, glm::value_ptr(object_view_matrix));
+        glUniformMatrix4fv(shader.get().uniform(ShaderRegistry::Uniforms::Model), 1, GL_FALSE, glm::value_ptr(cloud_model_matrix));
         glUniform4f(shader.get().uniform(ShaderRegistry::Uniforms::Color), 1.f, 1.f, 1.f, 1.f);
         glUniform4fv(shader.get().uniform(ShaderRegistry::Uniforms::AtmosphereColor), 1, glm::value_ptr(glm::vec4(0.f)));
+
+        ShaderRegistry::setupLights(shader.get(), object_view_matrix, cloud_model_matrix);
 
         textureManager.getTexture(cloud_texture)->bind();
         {
@@ -337,7 +341,7 @@ void Planet::draw3DTransparent(const glm::mat4& object_view_matrix)
 
         textureManager.getTexture(atmosphere_texture)->bind();
         glm::vec4 color(glm::vec3(atmosphere_color.r, atmosphere_color.g, atmosphere_color.b) / 255.f, atmosphere_size * 2.0f);
-        glUniformMatrix4fv(shader.get().get()->getUniformLocation("view"), 1, GL_FALSE, glm::value_ptr(object_view_matrix * model_matrix));
+        glUniformMatrix4fv(shader.get().uniform(ShaderRegistry::Uniforms::View), 1, GL_FALSE, glm::value_ptr(object_view_matrix * model_matrix));
         glUniform4fv(shader.get().uniform(ShaderRegistry::Uniforms::Color), 1, glm::value_ptr(color));
         gl::ScopedVertexAttribArray positions(shader.get().attribute(ShaderRegistry::Attributes::Position));
         gl::ScopedVertexAttribArray texcoords(shader.get().attribute(ShaderRegistry::Attributes::Texcoords));


### PR DESCRIPTION
Moving light computation on the cpu side: now computed as directional lights, only the direction gets passed to the shaders as uniforms (for those accepting it).

Opens the door to more complex lighting setup as well.

+ Added Model/View named uniforms to the registry.