### PR TITLE
Use u16 for elements indices

### DIFF
--- a/src/particleEffect.cpp
+++ b/src/particleEffect.cpp
@@ -64,17 +64,16 @@ ParticleEngine::ParticleEngine()
     attributes[as_index(Attributes::Color)] = shader->getAttributeLocation("color");
     attributes[as_index(Attributes::Size)] = shader->getAttributeLocation("size");
 
-    std::array<uint8_t, instances_per_draw * elements_per_instance> elements;
+    std::array<uint16_t, instances_per_draw * elements_per_instance> elements;
 
     std::array<glm::vec2, max_vertex_count> texcoords{};
 
-    // Hitting this means either needing to lower the number of instances / vertices per instance,
-    // Or switch the element index to a uint16_t.
-    static_assert((texcoords.size() - 1) <= std::numeric_limits<uint8_t>::max(), "Too many elements! Indices overflow.");
+    // Hitting this means needing to lower the number of instances / vertices per instance.
+    static_assert((texcoords.size() - 1) <= std::numeric_limits<uint16_t>::max(), "Too many elements! Indices overflow.");
 
     for (auto quad = 0U; quad < instances_per_draw; ++quad)
     {
-        auto base_vertex = static_cast<uint8_t>(vertices_per_instance * quad);
+        auto base_vertex = static_cast<uint16_t>(vertices_per_instance * quad);
         auto base_element = elements_per_instance * quad;
 
         // Each quad is two triangles
@@ -97,7 +96,7 @@ ParticleEngine::ParticleEngine()
     gl::ScopedBufferBinding element_buffer(GL_ELEMENT_ARRAY_BUFFER, buffers[as_index(Buffers::Element)]);
     gl::ScopedBufferBinding vertex_buffer(GL_ARRAY_BUFFER, buffers[as_index(Buffers::Vertex)]);
 
-    glBufferData(GL_ELEMENT_ARRAY_BUFFER, elements.size() * sizeof(uint8_t), elements.data(), GL_STATIC_DRAW);
+    glBufferData(GL_ELEMENT_ARRAY_BUFFER, elements.size() * sizeof(uint16_t), elements.data(), GL_STATIC_DRAW);
     glBufferData(GL_ARRAY_BUFFER, max_vertex_count * (sizeof(ParticleData) + sizeof(glm::vec2)), nullptr, GL_DYNAMIC_DRAW);
     {
         // Ensure zero-initialization of the particle data.
@@ -165,7 +164,7 @@ void ParticleEngine::doRender(const glm::mat4& projection, const glm::mat4& view
             glBufferSubData(GL_ARRAY_BUFFER, 0, instance_count * vertices_per_instance * sizeof(ParticleData), particle_data.data());
         
             // Draw our instances
-            glDrawElements(GL_TRIANGLES, static_cast<GLsizei>(elements_per_instance * instance_count), GL_UNSIGNED_BYTE, nullptr);
+            glDrawElements(GL_TRIANGLES, static_cast<GLsizei>(elements_per_instance * instance_count), GL_UNSIGNED_SHORT, nullptr);
             
             n += instance_count;
         }

--- a/src/screenComponents/viewport3d.cpp
+++ b/src/screenComponents/viewport3d.cpp
@@ -97,7 +97,7 @@ GuiViewport3D::GuiViewport3D(GuiContainer* owner, string id)
         glm::vec3{1.f, 1.f, 1.f},    // 7
     };
 
-    constexpr std::array<uint8_t, 6 * 6> elements{
+    constexpr std::array<uint16_t, 6 * 6> elements{
         2, 6, 4, 4, 0, 2, // Back
         3, 2, 0, 0, 1, 3, // Left
         6, 7, 5, 5, 4, 6, // Right
@@ -111,7 +111,7 @@ GuiViewport3D::GuiViewport3D(GuiContainer* owner, string id)
     glBindBuffer(GL_ELEMENT_ARRAY_BUFFER, starbox_buffers[static_cast<size_t>(Buffers::Element)]);
 
     glBufferData(GL_ARRAY_BUFFER, positions.size() * sizeof(glm::vec3), positions.data(), GL_STATIC_DRAW);
-    glBufferData(GL_ELEMENT_ARRAY_BUFFER, elements.size() * sizeof(uint8_t), elements.data(), GL_STATIC_DRAW);
+    glBufferData(GL_ELEMENT_ARRAY_BUFFER, elements.size() * sizeof(uint16_t), elements.data(), GL_STATIC_DRAW);
     glBindBuffer(GL_ELEMENT_ARRAY_BUFFER, GL_NONE);
     // Setup spacedust
     spacedust_shader = ShaderManager::getShader("shaders/spacedust");
@@ -226,7 +226,7 @@ void GuiViewport3D::onDraw(sp::RenderTarget& renderer)
             // Vertex attributes.
             glVertexAttribPointer(positions.get(), 3, GL_FLOAT, GL_FALSE, sizeof(glm::vec3), (GLvoid*)0);
 
-            glDrawElements(GL_TRIANGLES, 6 * 6, GL_UNSIGNED_BYTE, (GLvoid*)0);
+            glDrawElements(GL_TRIANGLES, 6 * 6, GL_UNSIGNED_SHORT, (GLvoid*)0);
 
             // Cleanup
             glBindBuffer(GL_ARRAY_BUFFER, GL_NONE);
@@ -381,8 +381,8 @@ void GuiViewport3D::onDraw(sp::RenderTarget& renderer)
                 0.f, 0.f
             };
             glVertexAttribPointer(texcoords.get(), 2, GL_FLOAT, GL_FALSE, 0, (GLvoid*)coords.begin());
-            std::initializer_list<uint8_t> indices{ 0, 2, 1, 0, 3, 2 };
-            glDrawElements(GL_TRIANGLES, 6, GL_UNSIGNED_BYTE, std::begin(indices));
+            std::initializer_list<uint16_t> indices{ 0, 2, 1, 0, 3, 2 };
+            glDrawElements(GL_TRIANGLES, 6, GL_UNSIGNED_SHORT, std::begin(indices));
         }
     }
 

--- a/src/spaceObjects/beamEffect.cpp
+++ b/src/spaceObjects/beamEffect.cpp
@@ -101,8 +101,8 @@ void BeamEffect::draw3DTransparent()
         glVertexAttribPointer(positions.get(), 3, GL_FLOAT, GL_FALSE, sizeof(VertexAndTexCoords), (GLvoid*)quad.data());
         glVertexAttribPointer(texcoords.get(), 2, GL_FLOAT, GL_FALSE, sizeof(VertexAndTexCoords), (GLvoid*)((char*)quad.data() + sizeof(glm::vec3)));
         // Draw the beam
-        std::initializer_list<uint8_t> indices = { 0, 1, 2, 2, 3, 0 };
-        glDrawElements(GL_TRIANGLES, 6, GL_UNSIGNED_BYTE, std::begin(indices));
+        std::initializer_list<uint16_t> indices = { 0, 1, 2, 2, 3, 0 };
+        glDrawElements(GL_TRIANGLES, 6, GL_UNSIGNED_SHORT, std::begin(indices));
 
     }
 
@@ -132,8 +132,8 @@ void BeamEffect::draw3DTransparent()
         textureManager.getTexture("texture/fire_ring.png")->bind();
         glVertexAttribPointer(positions.get(), 3, GL_FLOAT, GL_FALSE, sizeof(VertexAndTexCoords), (GLvoid*)quad.data());
         glVertexAttribPointer(texcoords.get(), 2, GL_FLOAT, GL_FALSE, sizeof(VertexAndTexCoords), (GLvoid*)((char*)quad.data() + sizeof(glm::vec3)));
-        std::initializer_list<uint8_t> indices = { 0, 1, 2, 2, 3, 0 };
-        glDrawElements(GL_TRIANGLES, 6, GL_UNSIGNED_BYTE, std::begin(indices));
+        std::initializer_list<uint16_t> indices = { 0, 1, 2, 2, 3, 0 };
+        glDrawElements(GL_TRIANGLES, 6, GL_UNSIGNED_SHORT, std::begin(indices));
     }
 }
 

--- a/src/spaceObjects/blackHole.cpp
+++ b/src/spaceObjects/blackHole.cpp
@@ -59,8 +59,8 @@ void BlackHole::draw3DTransparent()
     glVertexAttribPointer(positions.get(), 3, GL_FLOAT, GL_FALSE, sizeof(VertexAndTexCoords), (GLvoid*)quad.data());
     glVertexAttribPointer(texcoords.get(), 2, GL_FLOAT, GL_FALSE, sizeof(VertexAndTexCoords), (GLvoid*)((char*)quad.data() + sizeof(glm::vec3)));
 
-    std::initializer_list<uint8_t> indices = { 0, 2, 1, 0, 3, 2 };
-    glDrawElements(GL_TRIANGLES, 6, GL_UNSIGNED_BYTE, std::begin(indices));
+    std::initializer_list<uint16_t> indices = { 0, 2, 1, 0, 3, 2 };
+    glDrawElements(GL_TRIANGLES, 6, GL_UNSIGNED_SHORT, std::begin(indices));
     glBlendFunc(GL_ONE, GL_ONE);
 }
 

--- a/src/spaceObjects/electricExplosionEffect.cpp
+++ b/src/spaceObjects/electricExplosionEffect.cpp
@@ -51,7 +51,7 @@ ElectricExplosionEffect::ElectricExplosionEffect()
         glBufferData(GL_ARRAY_BUFFER, max_quad_count * 4 * vertex_size, nullptr, GL_DYNAMIC_DRAW);
 
         // Create initial data.
-        std::array<uint8_t, 6 * max_quad_count> indices;
+        std::array<uint16_t, 6 * max_quad_count> indices;
         std::array<glm::vec2, 4 * max_quad_count> texcoords;
         for (auto i = 0U; i < max_quad_count; ++i)
         {
@@ -72,7 +72,7 @@ ElectricExplosionEffect::ElectricExplosionEffect()
         // Update texcoords
         glBufferSubData(GL_ARRAY_BUFFER, max_quad_count * 4 * sizeof(glm::vec3), texcoords.size() * sizeof(glm::vec2), texcoords.data());
         // Upload indices
-        glBufferData(GL_ELEMENT_ARRAY_BUFFER, indices.size() * sizeof(uint8_t), indices.data(), GL_STATIC_DRAW);
+        glBufferData(GL_ELEMENT_ARRAY_BUFFER, indices.size() * sizeof(uint16_t), indices.data(), GL_STATIC_DRAW);
     }
 }
 
@@ -160,7 +160,7 @@ void ElectricExplosionEffect::draw3DTransparent()
         // upload
         glBufferSubData(GL_ARRAY_BUFFER, 0, vertices.size() * sizeof(glm::vec3), vertices.data());
         
-        glDrawElements(GL_TRIANGLES, 6 * active_quads, GL_UNSIGNED_BYTE, nullptr);
+        glDrawElements(GL_TRIANGLES, 6 * active_quads, GL_UNSIGNED_SHORT, nullptr);
         n += active_quads;
     }
 }

--- a/src/spaceObjects/explosionEffect.cpp
+++ b/src/spaceObjects/explosionEffect.cpp
@@ -49,7 +49,7 @@ ExplosionEffect::ExplosionEffect()
         glBufferData(GL_ARRAY_BUFFER, max_quad_count * 4 * vertex_size, nullptr, GL_DYNAMIC_DRAW);
 
         // Create initial data.
-        std::array<uint8_t, 6 * max_quad_count> indices;
+        std::array<uint16_t, 6 * max_quad_count> indices;
         std::array<glm::vec2, 4 * max_quad_count> texcoords;
         for (auto i = 0U; i < max_quad_count; ++i)
         {
@@ -70,7 +70,7 @@ ExplosionEffect::ExplosionEffect()
         // Update texcoords
         glBufferSubData(GL_ARRAY_BUFFER, max_quad_count * 4 * sizeof(glm::vec3), texcoords.size() * sizeof(glm::vec2), texcoords.data());
         // Upload indices
-        glBufferData(GL_ELEMENT_ARRAY_BUFFER, indices.size() * sizeof(uint8_t), indices.data(), GL_STATIC_DRAW);
+        glBufferData(GL_ELEMENT_ARRAY_BUFFER, indices.size() * sizeof(uint16_t), indices.data(), GL_STATIC_DRAW);
 
     }
 }
@@ -136,7 +136,7 @@ void ExplosionEffect::draw3DTransparent()
             // upload single vertex
             glBufferSubData(GL_ARRAY_BUFFER, 0, 4 * sizeof(glm::vec3), vertices.data());
 
-            glDrawElements(GL_TRIANGLES, 6, GL_UNSIGNED_BYTE, nullptr);
+            glDrawElements(GL_TRIANGLES, 6, GL_UNSIGNED_SHORT, nullptr);
         }
     }
     shader = ShaderRegistry::ScopedShader(ShaderRegistry::Shaders::Billboard);
@@ -173,7 +173,7 @@ void ExplosionEffect::draw3DTransparent()
         // upload
         glBufferSubData(GL_ARRAY_BUFFER, 0, vertices.size() * sizeof(glm::vec3), vertices.data());
         
-        glDrawElements(GL_TRIANGLES, 6 * active_quads, GL_UNSIGNED_BYTE, nullptr);
+        glDrawElements(GL_TRIANGLES, 6 * active_quads, GL_UNSIGNED_SHORT, nullptr);
         n += active_quads;
     }
 }

--- a/src/spaceObjects/planet.cpp
+++ b/src/spaceObjects/planet.cpp
@@ -349,8 +349,8 @@ void Planet::draw3DTransparent()
         glVertexAttribPointer(positions.get(), 3, GL_FLOAT, GL_FALSE, sizeof(VertexAndTexCoords), (GLvoid*)quad.data());
         glVertexAttribPointer(texcoords.get(), 2, GL_FLOAT, GL_FALSE, sizeof(VertexAndTexCoords), (GLvoid*)((char*)quad.data() + sizeof(glm::vec3)));
 
-        std::initializer_list<uint8_t> indices = { 0, 2, 1, 0, 3, 2 };
-        glDrawElements(GL_TRIANGLES, 6, GL_UNSIGNED_BYTE, std::begin(indices));
+        std::initializer_list<uint16_t> indices = { 0, 2, 1, 0, 3, 2 };
+        glDrawElements(GL_TRIANGLES, 6, GL_UNSIGNED_SHORT, std::begin(indices));
     }
 }
 

--- a/src/spaceObjects/wormHole.cpp
+++ b/src/spaceObjects/wormHole.cpp
@@ -93,8 +93,8 @@ void WormHole::draw3DTransparent()
 
         glVertexAttribPointer(positions.get(), 3, GL_FLOAT, GL_FALSE, sizeof(VertexAndTexCoords), (GLvoid*)quad.data());
         glVertexAttribPointer(texcoords.get(), 2, GL_FLOAT, GL_FALSE, sizeof(VertexAndTexCoords), (GLvoid*)((char*)quad.data() + sizeof(glm::vec3)));
-        std::initializer_list<uint8_t> indices = { 0, 2, 1, 0, 3, 2 };
-        glDrawElements(GL_TRIANGLES, 6, GL_UNSIGNED_BYTE, std::begin(indices));
+        std::initializer_list<uint16_t> indices = { 0, 2, 1, 0, 3, 2 };
+        glDrawElements(GL_TRIANGLES, 6, GL_UNSIGNED_SHORT, std::begin(indices));
     }
 }
 


### PR DESCRIPTION
This was really a pessimization on my part: most GPUs prefer shorts and will convert to u8 to u16 anyway (even getting a 'performance warning' about it on my system with the debug context).