### PR TITLE
net boot config_manager crash fix. 

### DIFF
--- a/netboot/config_manager.py
+++ b/netboot/config_manager.py
@@ -35,15 +35,16 @@ class Client:
                 key, value = map(str.strip, line.strip().split("=", 1))
                 if key == "instance_name":
                     self.__name = value
-                elif key == "autoconnect" and value is None:
-                    self.__auto_connect = False
-                elif key == "autoconnect" and value:
-                    position = int(value)
-                    if position <= 0:
-                        self.__auto_connect = False
+                elif key == "autoconnect":
+                    if value:
+                        position = int(value)
+                        if position <= 0:
+                            self.__auto_connect = False
+                        else:
+                            self.__auto_connect = True
+                            self.__station = self.POSITIONS[position]
                     else:
-                        self.__auto_connect = True
-                        self.__station = self.POSITIONS[position]
+                        self.__auto_connect = False
                 elif key == "autoconnectship":
                     self.__ship = value
             f.close()


### PR DESCRIPTION
I've started working on my netboot system again now that my gatherings are starting to happen again.  I discovered that if I grab the default configuration that's generated when I exit EE and put it in my configs dir in the PXE environment the config_manager would crash when I would list ships. 

I tracked this down to trying to force None to be an int. I did a little logic around this to set the autoconnect correctly if there's no value set. 