### PR TITLE
Compile out NetworkAudioRecorder on Android

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -296,10 +296,15 @@ int main(int argc, char** argv)
         }
     }
 
+    // On Android, this requires the 'record audio' permissions,
+    // which is always a scary thing for users.
+    // Since there is no way to access it (yet) via a touchscreen, compile out.
+#if !defined(ANDROID)
     // Set up voice chat and key bindings.
     NetworkAudioRecorder* nar = new NetworkAudioRecorder();
     nar->addKeyActivation(&keys.voice_all, 0);
     nar->addKeyActivation(&keys.voice_ship, 1);
+#endif
 
     P<HardwareController> hardware_controller = new HardwareController();
 #ifdef CONFIG_DIR


### PR DESCRIPTION
It requires the 'record audio' permission, which is always a bit scary to give.
Since there's no keybinds anyway to access it on Android, just disable so we can forego the permission altogether.

Note that currently EE *doesn't* request that permission: on most devices, this is silently ignored and the recording device just fails to open, but on some other it leads to a start up crash, which is what @StarryWisdom encountered.