### PR TITLE
Use cmake's built-in tar command

### DIFF
--- a/cmake/mingw.toolchain
+++ b/cmake/mingw.toolchain
@@ -24,7 +24,7 @@ if(NOT SDL2_ROOT)
 
     if(NOT IS_DIRECTORY "${WIN32_BASE}/SDL2-2.0.16")
         file(DOWNLOAD http://libsdl.org/release/SDL2-devel-2.0.16-mingw.tar.gz "${WIN32_BASE}/SDL2.tar.gz" SHOW_PROGRESS EXPECTED_HASH SHA256=2bfe48628aa9635c12eac7d421907e291525de1d0b04b3bca4a5bd6e6c881a6f)
-        execute_process_ex(COMMAND tar -xzvf SDL2.tar.gz WORKING_DIRECTORY "${WIN32_BASE}")
+        execute_process_ex(COMMAND ${CMAKE_COMMAND} -E tar xzvf SDL2.tar.gz WORKING_DIRECTORY "${WIN32_BASE}")
         execute_process_ex(COMMAND sed -i "s|set(prefix .*)|set(prefix \"${WIN32_BASE}/SDL2-2.0.16/i686-w64-mingw32/\")|g" ${WIN32_BASE}/SDL2-2.0.16/i686-w64-mingw32/lib/cmake/SDL2/sdl2-config.cmake)
     endif()
     
@@ -35,7 +35,7 @@ if(NOT SDL2_ROOT)
     if(NOT IS_DIRECTORY "${DRMINGW_ROOT}")
         file(DOWNLOAD https://github.com/jrfonseca/drmingw/releases/download/0.8.2/drmingw-0.8.2-win32.7z ${WIN32_BASE}/drmingw.7z SHOW_PROGRESS)
         execute_process_ex(
-            COMMAND "7z" "x" "drmingw.7z"
+            COMMAND ${CMAKE_COMMAND} -E tar "x" "drmingw.7z"
             WORKING_DIRECTORY ${WIN32_BASE})
     endif()
 endif()


### PR DESCRIPTION
This cuts the dependency to the 7z command.