### PR TITLE
Ability to directly start a scenario and server creation screen

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -399,6 +399,12 @@ void returnToMainMenu()
     else if (PreferencesManager::get("tutorial").toInt())
     {
         new TutorialGame(true);
+    }
+    else if (PreferencesManager::get("server_scenario") != "")
+    {
+        new EpsilonServer();
+        gameGlobalInfo->startScenario(PreferencesManager::get("server_scenario"));
+        new ShipSelectionScreen();
     }else{
         new MainMenu();
     }

--- a/src/menus/serverCreationScreen.cpp
+++ b/src/menus/serverCreationScreen.cpp
@@ -15,6 +15,7 @@
 #include "gui/gui2_panel.h"
 #include "gui/gui2_scrolltext.h"
 #include "scenarioInfo.h"
+#include "menus/mainMenus.h"
 #include "main.h"
 
 
@@ -77,7 +78,10 @@ ServerSetupScreen::ServerSetupScreen()
     // Close server button.
     (new GuiButton(this, "CLOSE_SERVER", tr("Close"), [this]() {
         destroy();
-        returnToMainMenu();
+        if (PreferencesManager::get("server_scenario")=="")
+            returnToMainMenu();
+        else
+            new MainMenu(); // If there is an auto scenario set, avoid endless loops and go directly to the Main Menu
     }))->setPosition(-250, -50, sp::Alignment::BottomCenter)->setSize(300, 50);
 
     // Start server button.


### PR DESCRIPTION
This introduces a new preferencemanager option "server_scenerio" (not entirely sure about the name, maybe something like "quickstart" is better?)
It works similar to the headless version, but with a graphical window (does not query _startpaused_ though, maybe that could be added.)

The reason for this PR was that testing testing small adjustments/variations in code/scenarios/assets require multiple restarts, which can get tedious, especially with the new server gui. Often you can get around that by a combination of _headless_ and _autoconnect_ or a regular client, but e.G. you cannot enter the the GM screen that way.