### PR TITLE
Tweaks on the Discord icon of the community page

### DIFF
--- a/main.css
+++ b/main.css
@@ -97,9 +97,10 @@ a.download:hover {
 }
 
 a.discord::after {
-    content: " ";
-    background: url(discord.svg);
-    background-size: contain;
+    content: url(discord.svg);
+    margin-left: 4px;
+    position: relative;
+    top: 3px;
 }
 
 #icons {


### PR DESCRIPTION
This just ensures it displays properly (tested on Firefox, desktop version), plus it roughly aligns it to be inline with the text.