### PR TITLE
Fix hacking

### DIFF
--- a/src/spaceObjects/playerSpaceship.cpp
+++ b/src/spaceObjects/playerSpaceship.cpp
@@ -1664,7 +1664,7 @@ void PlayerSpaceship::onReceiveClientCommand(int32_t client_id, sp::io::DataBuff
         break;
     case CMD_HACKING_FINISHED:
         {
-            uint32_t id;
+            int32_t id;
             string target_system;
             packet >> id >> target_system;
             P<SpaceObject> obj = game_server->getObjectById(id);


### PR DESCRIPTION
Network changes make the representation of uint32 and int32 differ at lower values. This resulted in hacks showing as successful but not altering how hacked a system is.