### PR TITLE
Update the pause button state on the gm screen

### DIFF
--- a/src/screens/gm/gameMasterScreen.cpp
+++ b/src/screens/gm/gameMasterScreen.cpp
@@ -272,6 +272,11 @@ void GameMasterScreen::update(float delta)
         if (game_server)
             engine->setGameSpeed(0.0);
     }
+    if (engine->getGameSpeed() == 0.0f) {
+        pause_button->setActive(true);
+    } else {
+        pause_button->setActive(false);
+    }
 
     bool has_object = false;
     bool has_cpu_ship = false;


### PR DESCRIPTION
If the pause hotkey was pressed on the gm screen the pause state was
changed without updating the state of the button.