### PR TITLE
fix debugRenderer rendering offscreen

### DIFF
--- a/src/gui/debugRenderer.cpp
+++ b/src/gui/debugRenderer.cpp
@@ -50,7 +50,7 @@ void DebugRenderer::render(sp::RenderTarget& renderer)
 
     if (show_timing_graph)
     {
-        auto window_size = renderer.getPhysicalSize();
+        auto window_size = renderer.getVirtualSize();
         if (timing_graph_points.size() > size_t(window_size.x))
             timing_graph_points.clear();
         timing_graph_points.push_back(engine->getEngineTiming());


### PR DESCRIPTION
It was often rendering offscreen, partly or completely