### PR TITLE
Change icon installation path

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -731,5 +731,5 @@ include(CPack)
 
 if(UNIX AND NOT APPLE)
   install(FILES EmptyEpsilon.desktop DESTINATION "share/applications")
-  install(FILES logo.png DESTINATION "share/icons" RENAME "EmptyEpsilon.png")
+  install(FILES logo.png DESTINATION "share/icons/hicolor/1024x1024/apps" RENAME "EmptyEpsilon.png")
 endif()


### PR DESCRIPTION
The icons for custom programs should be installed in the appropriate subdirectories of the hicolor theme, not the root of the icons folder.

From the [specification](https://specifications.freedesktop.org/icon-theme-spec/icon-theme-spec-latest.html):

>In order to have a place for third party applications to install their icons there should always exist a theme called "hicolor" [1]. The data for the hicolor theme is available for download at: http://www.freedesktop.org/software/icon-theme/. Implementations are required to look in the "hicolor" theme if an icon was not found in the current theme.

I believe the current implementation only works due to fallback mechanisms.