### PR TITLE
Player Cruiser replacement

### DIFF
--- a/scripts/model_data.lua
+++ b/scripts/model_data.lua
@@ -584,3 +584,25 @@ for type=1,5 do
         model:setIllumination("transport_space_ship_" .. type .. "/transport_space_ship_" .. type .. "_illumination.png")
     end
 end
+
+model = ModelData()
+model:setName("battleship_destroyer_5_upgraded_2")	--Cruiser PII
+model:setMesh("battleship_destroyer_5_upgraded/battleship_destroyer_5_upgraded.model")
+model:setTexture("battleship_destroyer_5_upgraded/battleship_destroyer_5_upgraded_color.jpg")
+model:setSpecular("battleship_destroyer_5_upgraded/battleship_destroyer_5_upgraded_specular.jpg")
+model:setIllumination("battleship_destroyer_5_upgraded/battleship_destroyer_5_upgraded_illumination.jpg")
+model:setScale(4)
+model:setRadius(200)
+
+-- Visual positions of the beams/missiletubes (blender: -X, Y, Z)
+model:addBeamPosition(-2, -31, -0.5)
+model:addBeamPosition(-2,  31, -0.5)
+model:addBeamPosition(35, -11, 0)
+model:addBeamPosition(35,  11, 0)
+model:addTubePosition(27, 0, -0.5)
+model:addTubePosition(27, 0, -0.5)
+model:addEngineEmitter(-33, 0, 0,  1.0, 0.2, 0.1, 16.0)
+model:addEngineEmitter(-28, 13, -0,  1.0, 0.2, 0.1, 13.0)
+model:addEngineEmitter(-28,-13, -0,  1.0, 0.2, 0.1, 13.0)
+model:addEngineEmitter(-27, 24, 0,  1.0, 0.2, 0.1, 5.0)
+model:addEngineEmitter(-27,-24, 0,  1.0, 0.2, 0.1, 5.0)

--- a/scripts/shiptemplates/corvette.lua
+++ b/scripts/shiptemplates/corvette.lua
@@ -355,3 +355,48 @@ var2:setBeamWeaponTurret( 0, 90,   0, 6)
 var2:setBeamWeaponTurret( 1, 90, 180, 6)
 var2:setJumpDrive(false)
 var2:setWarpSpeed(750)
+
+template = ShipTemplate():setName("Cruiser 2"):setLocaleName(_("Cruiser 2")):setClass(_("class", "Corvette"), _("subclass", "Destroyer")):setModel("battleship_destroyer_5_upgraded_2"):setType("playership")
+template:setRadarTrace("cruiser.png")
+--                 Arc, Dir,  Range, CycleTime, Dmg
+template:setBeam(0, 90, -15, 1000.0, 6.0, 8)
+template:setBeam(1, 90,  15, 1000.0, 6.0, 8)
+template:setBeam(2, 60, -15,  800.0, 6.0, 5)
+template:setBeam(3, 60,  15,  800.0, 6.0, 5)
+-- Setup 3 missile tubes. 2 forward at a slight angle, and 1 in the rear exclusive for mines.
+template:setTubes(3, 8.0) -- Amount of torpedo tubes, and loading time of the tubes.
+template:setTubeDirection(0, -5):weaponTubeDisallowMissle(0, "Mine")
+template:setTubeDirection(1, 5):weaponTubeDisallowMissle(1, "Mine")
+template:setTubeDirection(2, 180):setWeaponTubeExclusiveFor(2, "Mine")
+template:setHull(200)
+template:setShields(100, 100)
+template:setSpeed(80, 12, 20)
+template:setWarpSpeed(0)
+template:setJumpDrive(true)
+template:setCombatManeuver(400, 250)
+template:setWeaponStorage("Homing", 12)
+template:setWeaponStorage("Nuke", 4)
+template:setWeaponStorage("Mine", 8)
+template:setWeaponStorage("EMP", 6)
+
+template:setRepairCrewCount(4)
+template:addRoomSystem(2, 0, 2, 1, "BeamWeapons")
+template:addRoomSystem(1, 1, 2, 2, "Warp")
+template:addRoomSystem(3, 2, 2, 1, "Maneuver")
+template:addRoomSystem(0, 3, 2, 2, "RearShield")
+template:addRoomSystem(2, 3, 2, 2, "Reactor")
+template:addRoom(4, 3, 2, 2)
+template:addRoomSystem(6, 3, 1, 2, "FrontShield")
+template:addRoomSystem(1, 5, 2, 2, "JumpDrive")
+template:addRoomSystem(3, 5, 2, 1, "MissileSystem")
+template:addRoomSystem(2, 7, 2, 1, "Impulse")
+
+template:addDoor(2, 1, true);
+template:addDoor(3, 2, false);
+template:addDoor(1, 3, true);
+template:addDoor(2, 3, false);
+template:addDoor(1, 5, true);
+template:addDoor(3, 5, true);
+template:addDoor(4, 3, false);
+template:addDoor(6, 4, false);
+template:addDoor(2, 7, true);


### PR DESCRIPTION
These suggested changes keep the 3D model in general use. The Player Cruiser can now only be deployed by the game master. This template, the Cruiser 2, is available for general use.

## File changes

### model_data.lua
- Clone the existing battleship_destroyer_5_upgraded model and name it battleship_destroyer_5_upgraded_2
- Add two more visual beam source positions on the front of the ship where the guns stick out like the ones at the rear on the "wings"
- This model will be used in the Cruiser 2 player ship template
### corvette.lua
This template is similar to the original Player Cruiser template  
#### Differences:
- Original beams reduced from 10 damage per hit to 8 damage per hit
- Two additional beams added to correspond to the new visual sources on the updated model
  - arc: 60  
  - range: 800  
  - damage: 5  
  - Even though these beams are shorter range, since they're mounted further forward, they reach nearly as far as the other beams  
- Stronger shields (100,100 vs 80,80)
- Different speed (80, 12, 20 vs 90, 15, 20)
- One more repair crew (4 vs the default 3)
- Engineering ship layout more closely matches the overhead silhouette of the battleship_destroyer_5_upgraded model. The original rooms were identical to the Atlantis