### PR TITLE
Default station comms - add more options for reinforcements

### DIFF
--- a/scripts/comms_station.lua
+++ b/scripts/comms_station.lua
@@ -48,7 +48,11 @@ function commsStationMainMenu(comms_source, comms_target)
             },
             service_cost = {
                 supplydrop = 100,
-                reinforcements = 150
+                reinforcements = 150,
+                phobos_reinforcement = 300,
+                amk3_reinforcement = 100,
+                hornet_reinforcement = 100,
+                amk8_reinforcement = 200,
             },
             reputation_cost_multipliers = {
                 friend = 1.0,
@@ -235,6 +239,30 @@ end
 -- @tparam PlayerSpaceship comms_source
 -- @tparam SpaceStation comms_target
 function commsStationReinforcements(comms_source, comms_target)
+	setCommsMessage(_("commsStation", "What kind of reinforcement ship would you like?"))
+	addCommsReply(string.format(_("commsStation", "Adder MK3 (%d rep)"), getServiceCost(comms_source, comms_target, "amk3_reinforcement")), function()
+		string.format("")
+		commsStationSpecificReinforcement(comms_source, comms_target, "amk3_reinforcement")
+	end)
+	addCommsReply(string.format(_("commsStation", "MU52 Hornet (%d rep)"), getServiceCost(comms_source, comms_target, "hornet_reinforcement")), function()
+		string.format("")
+		commsStationSpecificReinforcement(comms_source, comms_target, "hornet_reinforcement")
+	end)
+	addCommsReply(string.format(_("commsStation", "Standard Adder MK5 (%d rep)"), getServiceCost(comms_source, comms_target, "reinforcements")), function()
+		string.format("")
+		commsStationSpecificReinforcement(comms_source, comms_target, "reinforcements")
+	end)
+	addCommsReply(string.format(_("commsStation", "Adder MK8 (%d rep)"), getServiceCost(comms_source, comms_target, "amk8_reinforcement")), function()
+		string.format("")
+		commsStationSpecificReinforcement(comms_source, comms_target, "amk8_reinforcement")
+	end)
+	addCommsReply(string.format(_("commsStation", "Phobos T3 (%d rep)"), getServiceCost(comms_source, comms_target, "phobos_reinforcement")), function()
+		string.format("")
+		commsStationSpecificReinforcement(comms_source, comms_target, "phobos_reinforcement")
+	end)
+    addCommsReply(_("button", "Back"), commsStationMainMenu)
+end
+function commsStationSpecificReinforcement(comms_source, comms_target, reinforcement_type)
     if comms_source:getWaypointCount() < 1 then
         setCommsMessage(_("commsStation", "You need to set a waypoint before you can request reinforcements."))
     else
@@ -244,8 +272,15 @@ function commsStationReinforcements(comms_source, comms_target)
                 formatWaypoint(n),
                 function(comms_source, comms_target)
                     local message
-                    if comms_source:takeReputationPoints(getServiceCost(comms_source, comms_target, "reinforcements")) then
-                        local ship = CpuShip():setFactionId(comms_target:getFactionId()):setPosition(comms_target:getPosition()):setTemplate("Adder MK5"):setScanned(true):orderDefendLocation(comms_source:getWaypoint(n))
+                    if comms_source:takeReputationPoints(getServiceCost(comms_source, comms_target, reinforcement_type)) then
+                    	local reinforcement_template = {
+                    		["amk3_reinforcement"] = 	"Adder MK3",
+                    		["hornet_reinforcement"] =	"MU52 Hornet",
+                    		["reinforcements"] =		"Adder MK5",
+                    		["amk8_reinforcement"] =	"Adder MK8",
+                    		["phobos_reinforcement"] =	"Phobos T3",
+                    	}
+                        local ship = CpuShip():setFactionId(comms_target:getFactionId()):setPosition(comms_target:getPosition()):setTemplate(reinforcement_template[reinforcement_type]):setScanned(true):orderDefendLocation(comms_source:getWaypoint(n))
                         message = string.format(_("commsStation", "We have dispatched %s to assist at %s."), ship:getCallSign(), formatWaypoint(n))
                     else
                         message = _("commsStation", "Not enough reputation!")


### PR DESCRIPTION
- Add reinforcement services and their associated costs to comms_data 
  - Adder MK3 for 100 reputation. Comparison to Adder MK5: 
    - Weaker hull
    - Weaker shields
    - Slower speed
  - MU52 Hornet for 100 reputation Comparison to Adder MK5: 
    - Weaker hull
    - Weaker shields
    - No missiles
    - Fewer beams
    - Faster speed
  - Adder MK5 for 150 reputation (current reinforcement ship type)
  - Adder MK8 for 200 reputation. Comparison to Adder MK5
    - Stronger shields
    - Better maneuverability
    - Narrower, longer, stronger sniping beam
  - Phobos T3 for 300 reputation. Comparison to Adder MK5
    - Stronger hull
    - Stronger shields, front and rear arcs
    - Slower speed
    - Longer, stronger, wider beams; two emplacements vs. three
    - Two forward missile tubes 
    - More HVLIs
    - Load-out includes homing missiles
- Add comms reply prompt buttons for each reinforcement type
- Spawn the appropriate reinforcement ship based on selected reinforcement type

![Screen Shot 2022-02-23 at 1 31 57 PM](https://user-images.githubusercontent.com/35241832/155394455-9fa1789a-2eb8-4316-814a-cb4888abd694.png)

