### PR TITLE
Script doc sorting

### DIFF
--- a/compile_script_docs.py
+++ b/compile_script_docs.py
@@ -375,44 +375,8 @@ rel="stylesheet"
         stream.write("</div>")
 
         for d in self._definitions:
-            if isinstance(d, ScriptClass):
-                stream.write('<div class="ui-widget ui-widget-content ui-corner-all">\n')
-                stream.write('<h2><a name="class_%s">%s</a></h2>\n' % (d.name, d.name))
-                stream.write(
-                    "<div>%s</div>"
-                    % (d.description.replace("<", "&lt;").replace("\n", "<br>"))
-                )
-                if d.parent is not None:
-                    stream.write(
-                        'Subclass of: <a href="#class_%s">%s</a>'
-                        % (d.parent.name, d.parent.name)
-                    )
-                stream.write("<dl>")
-                for func in d.functions:
-                    if func.parameters is None:
-                        stream.write(
-                            "<dt>%s:%s [NOT FOUND; see SeriousProton]</dt>"
-                            % (d.name, func.name)
-                        )
-                        print("Failed to find parameters for %s:%s" % (d.name, func.name))
-                    else:
-                        stream.write(
-                            "<dt>%s:%s(%s)</dt>"
-                            % (d.name, func.name, func.parameters.replace("<", "&lt;"))
-                        )
-                    stream.write(
-                        "<dd>%s</dd>"
-                        % (func.description.replace("<", "&lt;").replace("\n", "<br>"))
-                    )
-                for member in d.members:
-                    stream.write("<dt>%s:%s</dt>" % (d.name, member.name))
-                    stream.write(
-                        "<dd>%s</dd>"
-                        % (member.description.replace("<", "&lt;").replace("\n", "<br>")
-                        )
-                    )
-                stream.write("</dl>")
-                stream.write("</div>")
+            if isinstance(d, ScriptClass) and d.parent is None:
+                self.outputClasses(d, stream)
 
         stream.write('<script src="http://daid.github.io/EmptyEpsilon/jquery.min.js"></script>')
         stream.write('<script src="http://daid.github.io/EmptyEpsilon/jquery-ui.min.js"></script>')
@@ -427,6 +391,48 @@ rel="stylesheet"
             for c in sorted_children:
                 self.outputClassTree(c, stream)
             stream.write("</ul>\n")
+
+    def outputClasses(self, scriptClass, stream):
+        stream.write('<div class="ui-widget ui-widget-content ui-corner-all">\n')
+        stream.write('<h2><a name="class_%s">%s</a></h2>\n' % (scriptClass.name, scriptClass.name))
+        stream.write(
+            "<div>%s</div>"
+            % (scriptClass.description.replace("<", "&lt;").replace("\n", "<br>"))
+        )
+        if scriptClass.parent is not None:
+            stream.write(
+                'Subclass of: <a href="#class_%s">%s</a>'
+                % (scriptClass.parent.name, scriptClass.parent.name)
+            )
+        stream.write("<dl>")
+        for func in scriptClass.functions:
+            if func.parameters is None:
+                stream.write(
+                    "<dt>%s:%s [NOT FOUND; see SeriousProton]</dt>"
+                    % (scriptClass.name, func.name)
+                )
+                print("Failed to find parameters for %s:%s" % (scriptClass.name, func.name))
+            else:
+                stream.write(
+                    "<dt>%s:%s(%s)</dt>"
+                    % (scriptClass.name, func.name, func.parameters.replace("<", "&lt;"))
+                )
+            stream.write(
+                "<dd>%s</dd>"
+                % (func.description.replace("<", "&lt;").replace("\n", "<br>"))
+            )
+        for member in scriptClass.members:
+            stream.write("<dt>%s:%s</dt>" % (scriptClass.name, member.name))
+            stream.write(
+                "<dd>%s</dd>"
+                % (member.description.replace("<", "&lt;").replace("\n", "<br>")
+                   )
+            )
+        stream.write("</dl>")
+        stream.write("</div>")
+        sorted_children = sorted(scriptClass.children, key=lambda definition: definition.name)
+        for c in sorted_children:
+            self.outputClasses(c, stream)
 
 
 if __name__ == "__main__":

--- a/compile_script_docs.py
+++ b/compile_script_docs.py
@@ -79,14 +79,6 @@ class ScriptClass(object):
             ret += ":%s" % (func)
         return "{%s}" % (ret)
 
-    def outputClassTree(self, stream):
-        stream.write('<li><a href="#class_%s">%s</a>\n' % (self.name, self.name))
-        if len(self.children) > 0:
-            stream.write("<ul>")
-            for c in self.children:
-                c.outputClassTree(stream)
-            stream.write("</ul>\n")
-
 
 class DocumentationGenerator(object):
     def __init__(self):
@@ -365,7 +357,7 @@ rel="stylesheet"
         stream.write("<ul>")
         for d in self._definitions:
             if isinstance(d, ScriptClass) and d.parent is None:
-                d.outputClassTree(stream)
+                self.outputClassTree(d, stream)
         stream.write("</ul>")
         stream.write("</div>")
 
@@ -426,6 +418,15 @@ rel="stylesheet"
         stream.write('<script src="http://daid.github.io/EmptyEpsilon/jquery-ui.min.js"></script>')
         stream.write("</body>")
         stream.write("</html>")
+
+    def outputClassTree(self, scriptClass, stream):
+        stream.write('<li><a href="#class_%s">%s</a>\n' % (scriptClass.name, scriptClass.name))
+        if len(scriptClass.children) > 0:
+            sorted_children = sorted(scriptClass.children, key=lambda definition: definition.name)
+            stream.write("<ul>")
+            for c in sorted_children:
+                self.outputClassTree(c, stream)
+            stream.write("</ul>\n")
 
 
 if __name__ == "__main__":

--- a/compile_script_docs.py
+++ b/compile_script_docs.py
@@ -113,7 +113,7 @@ class DocumentationGenerator(object):
                     self.addFile(os.path.join(os.path.dirname(filename), m.group(1)))
 
     def readFunctionInfo(self):
-        for filename in self._files:
+        for filename in sorted(self._files):
             if not filename.endswith(".h"):
                 continue
             description = ""
@@ -140,7 +140,7 @@ class DocumentationGenerator(object):
                             )
 
     def readScriptDefinitions(self):
-        for filename in self._files:
+        for filename in sorted(self._files):
             description = ""
             current_class = None
             # print("Processing: %s" % (filename))


### PR DESCRIPTION
Fixes [#1708](https://github.com/daid/EmptyEpsilon/issues/1708)

The file list is sorted alphabetically before being used and the class references are printed by base class with the same recursive ordering as with the class tree generation.

Also, I moved `outputClassTree` from `ScriptClass` to `DocumentationGenerator`, since it's really more about document generation than metadata of the class