### PR TITLE
small template fix and de satellite translation

### DIFF
--- a/scripts/locale/shiptemplates/satellites.de.po
+++ b/scripts/locale/shiptemplates/satellites.de.po
@@ -11,18 +11,28 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 "X-Generator: Poedit 3.0.1\n"
+
+#: scripts/shiptemplates/satellites.lua:1
+msgctxt "ship"
+msgid "ANT 615"
+msgstr ""
+
 #: scripts/shiptemplates/satellites.lua:1
 msgctxt "class"
-msgid "Satellites"
-msgstr ""
+msgid "Satellite"
+msgstr "Satellit"
+
 #: scripts/shiptemplates/satellites.lua:1
 msgctxt "subclass"
 msgid "Sentry Series"
-msgstr ""
+msgstr "Sentry-Reihe"
+
 #: scripts/shiptemplates/satellites.lua:2
 msgid ""
 "Military satellite from the old days, back when the earth's population was "
 "much more divided than today. Its original purpose was probably to take out "
 "other satellites."
 msgstr ""
-#, fuzzy
+"Militärsatellit aus den alten Tagen, als die Menscheit weit stärker "
+"gespalten war als heutzutage. Sein ursprünglicher Zweck war wahrscheinlich, "
+"andere Satelliten zu zerstören."

--- a/scripts/shiptemplates/satellites.lua
+++ b/scripts/shiptemplates/satellites.lua
@@ -1,4 +1,4 @@
-template = ShipTemplate():setName("ANT 615"):setModel("combatsat"):setClass(_("class", "Satellites"),_("subclass", "Sentry Series"))
+template = ShipTemplate():setName("ANT 615"):setLocaleName(_("ship", "ANT 615")):setModel("combatsat"):setClass(_("class", "Satellite"),_("subclass", "Sentry Series"))
 template:setDescription(_("Military satellite from the old days, back when the earth's population was much more divided than today. Its original purpose was probably to take out other satellites."))
 template:setRadarTrace("combatsat.png")
 --                 Arc,Dir,Range,CycleTime, Dmg


### PR DESCRIPTION
While translating the satellites template, I  also made two small fixes on the template:

- Changed class name from plural to singular, as in the other class names to be consistent.
- Added the locale name (does not matter by now, but it will in case the DB button bug may be fixed some day)