### PR TITLE
Change GM function to GM message in scenario basic

### DIFF
--- a/scripts/scenario_00_basic.lua
+++ b/scripts/scenario_00_basic.lua
@@ -245,8 +245,8 @@ function gmVictoryYesNo()
     addGMFunction(_("buttonGM", "Yes"), function() 
         victory("Human Navy")
         clearGMFunctions()
-        addGMFunction(_("buttonGM", "Players have won"), function() string.format("") end)
-        addGMFunction(_("buttonGM", "Scenario ended"), function() string.format("") end)
+        addGMMessage(_([[Players have won.
+Scenario ended.]]))
     end)
     addGMFunction(_("buttonGM", "No"), gmButtons)
 end


### PR DESCRIPTION
The end message after confirming Victory in scenario basic is a bit confusing. I was wondering quite a while what those two buttons were supposed to do, as they don't do anything. Then I realized that they were just meant to be info texts. As there is no such thing like GM info (i.e. counterpart to custom info), I choose to replace the buttons with a GM message instead.