### PR TITLE
Print the class name with every member (EmptyEpsilon#1737)

### DIFF
--- a/compile_script_docs.py
+++ b/compile_script_docs.py
@@ -588,12 +588,13 @@ rel="stylesheet"
             else:
                 stream.write("<dt>")
                 type = translate_type(func.return_type, func.name)
+                member_name = scriptClass.name + ":" + func.name
                 if type is None:
                     # Methods returning void automatically return themselves
-                    stream.write(self.print_type(ClassType(scriptClass.name), func.name, True))
+                    stream.write(self.print_type(ClassType(scriptClass.name), member_name, True))
                     func.description = (func.description + "\nReturns the object it was called on.").strip()
                 else:
-                    stream.write(self.print_type(type, func.name, True))
+                    stream.write(self.print_type(type, member_name, True))
                 stream.write("(")
                 first = True
                 for (type, name) in func.get_parameters():
@@ -607,7 +608,7 @@ rel="stylesheet"
                 % (func.description.replace("<", "&lt;").replace("\n", "<br>"))
             )
         for member in scriptClass.members:
-            stream.write("<dt>%s</dt>" % (member.name))
+            stream.write("<dt>%s:%s</dt>" % (scriptClass.name, member.name))
             stream.write(
                 "<dd>%s</dd>"
                 % (member.description.replace("<", "&lt;").replace("\n", "<br>")


### PR DESCRIPTION
Addresses this: https://github.com/daid/EmptyEpsilon/issues/1737
Changes this:

![ModelData setRadius](https://user-images.githubusercontent.com/361185/161426497-818c55dc-8b0e-46a5-9ac0-5f981a8315d8.png)
To this
![ModelData ModelData:setRadius](https://user-images.githubusercontent.com/361185/161426560-60c8f220-25d5-4ca5-9236-4a53487149fc.png)

If you really want that. I personally still don't like it.