### PR TITLE
CinematicView: add button to cycle through all ships

### DIFF
--- a/src/gui/hotkeyConfig.cpp
+++ b/src/gui/hotkeyConfig.cpp
@@ -9,6 +9,7 @@ Keys keys;
 Keys::CinematicKeys::CinematicKeys() :
     toggle_ui("CINEMATIC_TOGGLE_UI", "H"),
     lock_camera("CINEMATIC_LOCK_CAMERA", "L"),
+    cycle_camera("CINEMATIC_CYCLE_CAMERA", "C"),
     previous_player_ship("CINEMATIC_PREVIOUS_PLAYER_SHIP", "J"),
     next_player_ship("CINEMATIC_NEXT_PLAYER_SHIP", "K"),
     move_forward("CINEMATIC_MOVE_FORWARD", "W"),
@@ -29,6 +30,7 @@ void Keys::CinematicKeys::init()
     const auto localized_category = tr("hotkey_menu", "Cinematic View");
     toggle_ui.setLabel(localized_category, tr("hotkey_Cinematic", "Toggle UI"));
     lock_camera.setLabel(localized_category, tr("hotkey_Cinematic", "Camera lock"));
+    cycle_camera.setLabel(localized_category, tr("hotkey_Cinematic", "Camera cycle"));
     previous_player_ship.setLabel(localized_category, tr("hotkey_Cinematic", "Cycle previous player ship"));
     next_player_ship.setLabel(localized_category, tr("hotkey_Cinematic", "Cycle next player ship"));
     move_forward.setLabel(localized_category, tr("hotkey_Cinematic", "Move forward"));

--- a/src/gui/hotkeyConfig.h
+++ b/src/gui/hotkeyConfig.h
@@ -138,6 +138,7 @@ public:
         void init();
         sp::io::Keybinding toggle_ui;
         sp::io::Keybinding lock_camera;
+        sp::io::Keybinding cycle_camera;
         sp::io::Keybinding previous_player_ship;
         sp::io::Keybinding next_player_ship;
         sp::io::Keybinding move_forward;

--- a/src/screens/cinematicViewScreen.h
+++ b/src/screens/cinematicViewScreen.h
@@ -19,6 +19,7 @@ private:
     GuiSelector* camera_lock_selector;
     GuiToggleButton* camera_lock_toggle;
     GuiToggleButton* camera_lock_tot_toggle;
+    GuiToggleButton* camera_lock_cycle_toggle;
     float min_camera_distance;
     float max_camera_distance;
     glm::vec2 camera_rotation_vector{0, 0};
@@ -46,6 +47,8 @@ private:
     float tot_angle;
     float tot_distance_2D;
     float tot_distance_3D;
+
+    float cycle_time;
 
 public:
     explicit CinematicViewScreen(RenderLayer* render_layer, int playerShip = 0);


### PR DESCRIPTION
When cycling is active, the cinematc view switches to the next ship every 30 seconds.
This is intended to give spectators of the game a more varying impression.