### PR TITLE
Warp Jammer range getter, hull getter and setter.

### DIFF
--- a/src/spaceObjects/playerSpaceship.cpp
+++ b/src/spaceObjects/playerSpaceship.cpp
@@ -80,8 +80,9 @@ REGISTER_SCRIPT_SUBCLASS(PlayerSpaceship, SpaceShip)
     REGISTER_SCRIPT_CLASS_FUNCTION(PlayerSpaceship, addCustomMessageWithCallback);
     REGISTER_SCRIPT_CLASS_FUNCTION(PlayerSpaceship, removeCustom);
 
+    /// Gets what part (hull, shields,... ) will be targeted on enemy, returns index to ESystem, -1 is hull.
     REGISTER_SCRIPT_CLASS_FUNCTION(PlayerSpaceship, getBeamSystemTarget);
-    /// Gets the name of the target system, instead of the ID
+    /// Gets the name (content of ESystem) of the target system, instead of the ID
     REGISTER_SCRIPT_CLASS_FUNCTION(PlayerSpaceship, getBeamSystemTargetName);
 
     // Command functions

--- a/src/spaceObjects/spaceship.cpp
+++ b/src/spaceObjects/spaceship.cpp
@@ -34,6 +34,8 @@ REGISTER_SCRIPT_SUBCLASS_NO_CREATE(SpaceShip, ShipTemplateBasedObject)
     REGISTER_SCRIPT_CLASS_FUNCTION(SpaceShip, isDocked);
     REGISTER_SCRIPT_CLASS_FUNCTION(SpaceShip, getDockedWith);
     REGISTER_SCRIPT_CLASS_FUNCTION(SpaceShip, getDockingState);
+    /// Returns gets this ship target.
+    /// For example enemy targetted by player ship's weapons.
     REGISTER_SCRIPT_CLASS_FUNCTION(SpaceShip, getTarget);
     REGISTER_SCRIPT_CLASS_FUNCTION(SpaceShip, getWeaponStorage);
     REGISTER_SCRIPT_CLASS_FUNCTION(SpaceShip, getWeaponStorageMax);

--- a/src/spaceObjects/warpJammer.cpp
+++ b/src/spaceObjects/warpJammer.cpp
@@ -9,7 +9,16 @@
 /// A warp jammer.
 REGISTER_SCRIPT_SUBCLASS(WarpJammer, SpaceObject)
 {
+    /// Gets jamming range (circle with jammer in the middle inside which no warp/jump will be possible).
+    REGISTER_SCRIPT_CLASS_FUNCTION(WarpJammer, getRange);
+    /// Sets jamming range (circle with jammer in the middle inside which no warp/jump will be possible).
     REGISTER_SCRIPT_CLASS_FUNCTION(WarpJammer, setRange);
+
+    /// Gets current hull of warpJammer.
+    REGISTER_SCRIPT_CLASS_FUNCTION(WarpJammer, getHull);
+    /// Sets current hull of warpJammer.
+    REGISTER_SCRIPT_CLASS_FUNCTION(WarpJammer, setHull);
+
     /// Set a function that will be called if the warp jammer is taking damage.
     /// First argument given to the function will be the warp jammer, the second the instigator SpaceObject (or nil).
     REGISTER_SCRIPT_CLASS_FUNCTION(WarpJammer, onTakingDamage);

--- a/src/spaceObjects/warpJammer.h
+++ b/src/spaceObjects/warpJammer.h
@@ -19,6 +19,9 @@ public:
     void setRange(float range) { this->range = range; }
     float getRange() { return range; }
 
+    void setHull(float hull) { this->hull = hull; }
+    float getHull() { return hull; }
+
     virtual void drawOnRadar(sp::RenderTarget& renderer, glm::vec2 position, float scale, float rotation, bool long_range) override;
 
     virtual bool canBeTargetedBy(P<SpaceObject> other)  override { return true; }


### PR DESCRIPTION
Not sure if I should register `WarpJammer`'s `hull` attribute to member replication with `registerMemberReplication`. 

But since Hull is nowhere to be seen (yet, but there is getter so LUA script can get the value), I am not sure if it should be added there or not. 


Also when I was debugging this code (with demo LUA missions) I added some clarifications to LUA bindings elsewhere I had to test to know what it is really doing (sorry for mixing it into one commit). 