### PR TITLE
Fix glow effect interpolation

### DIFF
--- a/src/hardware/hardwareMappingEffects.cpp
+++ b/src/hardware/hardwareMappingEffects.cpp
@@ -46,7 +46,7 @@ float HardwareMappingEffectGlow::onActive()
         back = !back;
     float f = timer.getProgress();
     if (back)
-        return min_value * (f - 1.0f) + max_value * (2.0f - f);
+        return min_value * (f) + max_value * (1.0f - f);
     else
         return min_value * (1.0f - f) + max_value * (f);
 }


### PR DESCRIPTION
The logic for computing brightness in the Glow effect was incorrect, causing brightness to jump around when switching from increasing to decreasing brightness, and not properly fading to min_value. I've corrected the formula for interpolating from max_value to min_value.