### PR TITLE
clock displays formatted time

### DIFF
--- a/src/gameGlobalInfo.cpp
+++ b/src/gameGlobalInfo.cpp
@@ -229,6 +229,16 @@ void GameGlobalInfo::destroy()
     MultiplayerObject::destroy();
 }
 
+string GameGlobalInfo::getMissionTime() {
+    unsigned int seconds = gameGlobalInfo->elapsed_time;
+    unsigned int minutes = (seconds / 60) % 60;
+    unsigned int hours = (seconds / 60 / 60) % 24;
+    seconds = seconds % 60;
+    char buf[9];
+    std::snprintf(buf, 9, "%02d:%02d:%02d", hours, minutes, seconds);
+    return string(buf);
+}
+
 string getSectorName(glm::vec2 position)
 {
     constexpr float sector_size = 20000;

--- a/src/gameGlobalInfo.h
+++ b/src/gameGlobalInfo.h
@@ -108,6 +108,7 @@ public:
 
     virtual void update(float delta) override;
     virtual void destroy() override;
+    string getMissionTime();
 
     string getNextShipCallsign();
 };

--- a/src/screens/crew4/operationsScreen.cpp
+++ b/src/screens/crew4/operationsScreen.cpp
@@ -101,7 +101,9 @@ void OperationScreen::onDraw(sp::RenderTarget& target)
     if (science->radar_view->isVisible())
     {
         info_reputation->setValue(string(my_spaceship->getReputationPoints(), 0))->show();
-        info_clock->setValue(string(gameGlobalInfo->elapsed_time, 0))->show();
+
+        // Update mission clock
+        info_clock->setValue(gameGlobalInfo->getMissionTime())->show();
     }
     else
     {

--- a/src/screens/crew6/relayScreen.cpp
+++ b/src/screens/crew6/relayScreen.cpp
@@ -293,7 +293,10 @@ void RelayScreen::onDraw(sp::RenderTarget& renderer)
         hack_target_button->setVisible(my_spaceship->getCanHack());
 
         info_reputation->setValue(string(my_spaceship->getReputationPoints(), 0));
-        info_clock->setValue(string(gameGlobalInfo->elapsed_time, 0));
+
+        // Update mission clock
+        info_clock->setValue(gameGlobalInfo->getMissionTime());
+
         launch_probe_button->setText(tr("Launch Probe") + " (" + string(my_spaceship->scan_probe_stock) + ")");
     }
 

--- a/src/screens/gm/gameMasterScreen.cpp
+++ b/src/screens/gm/gameMasterScreen.cpp
@@ -331,7 +331,7 @@ void GameMasterScreen::update(float delta)
     player_comms_hail->setVisible(has_player_ship);
 
     // Update mission clock
-    info_clock->setValue(string(gameGlobalInfo->elapsed_time, 0));
+    info_clock->setValue(gameGlobalInfo->getMissionTime());
 
     std::unordered_map<string, string> selection_info;
 

--- a/src/spaceObjects/playerSpaceship.cpp
+++ b/src/spaceObjects/playerSpaceship.cpp
@@ -918,7 +918,7 @@ void PlayerSpaceship::addToShipLog(string message, glm::u8vec4 color)
         ships_log.erase(ships_log.begin());
 
     // Timestamp a log entry, color it, and add it to the end of the log.
-    ships_log.emplace_back(string(gameGlobalInfo->elapsed_time, 1) + string(": "), message, color);
+    ships_log.emplace_back(gameGlobalInfo->getMissionTime() + string(": "), message, color);
 }
 
 void PlayerSpaceship::addToShipLogBy(string message, P<SpaceObject> target)


### PR DESCRIPTION
Relay/GM/ShipLogs show mission time in hh:mm:ss format, instead of seconds.