### PR TITLE
resetBanner on GameGlobalInfo:reset

### DIFF
--- a/src/gameGlobalInfo.cpp
+++ b/src/gameGlobalInfo.cpp
@@ -177,6 +177,7 @@ void GameGlobalInfo::reset()
     allow_new_player_ships = true;
     global_message = "";
     global_message_timeout = 0.0f;
+    banner_string = "";
 
     //Pause the game
     engine->setGameSpeed(0.0);


### PR DESCRIPTION
banner was not reset, causing the banner of the last mission to appear on main screen.