### PR TITLE
httpServer: use server selected ship as default

### DIFF
--- a/src/httpScriptAccess.cpp
+++ b/src/httpScriptAccess.cpp
@@ -47,6 +47,10 @@ EEHttpServer::EEHttpServer(int port, string static_file_path)
 
         string luaCode;
         string objectId = "getPlayerShip(-1)";
+        if (my_spaceship) {
+            int index = gameGlobalInfo->findPlayerShip(my_spaceship);
+            objectId = "getPlayerShip("+std::to_string(index+1)+")";
+        }
         std::unordered_map<string, string>::const_iterator i;
         P<ScriptObject> script;
         string output;
@@ -114,6 +118,10 @@ EEHttpServer::EEHttpServer(int port, string static_file_path)
 
         string luaCode;
         string objectId = "getPlayerShip(-1)";
+        if (my_spaceship) {
+            int index = gameGlobalInfo->findPlayerShip(my_spaceship);
+            objectId = "getPlayerShip("+std::to_string(index+1)+")";
+        }
         std::unordered_map<string, string>::const_iterator i;
         P<ScriptObject> script;
         string output;


### PR DESCRIPTION
When the httpserver is used on a client, get.lua can now be used to access the selected ship.

This can be useful in the following scenario:
* Multiple playerships are on the server.
* A player wants to control their ship using custom controls, that communicate with the game using the lua-api get.lua endpoint.
* The player can start the httpserver on their own client PC and connect their script to localhost.
* The player selects the desired ship in the ship selection screen.
* With this change, the players ship is selected as default object and the players script does no longer need to search all existing playerships until they find their ships index.