### PR TITLE
Fixed URL for EE website in script_refernce.

### DIFF
--- a/compile_script_docs.py
+++ b/compile_script_docs.py
@@ -496,7 +496,7 @@ rel="stylesheet"
         stream.write('<div class="section">')
         stream.write("<h1>EmptyEpsilon Scripting Reference</h1>")
         stream.write("<p>This is the EmptyEpsilon script reference for this version of EmptyEpsilon.</p>")
-        stream.write('<p>By no means this is a guide to help you scripting, you should check <a href="http://emptyepsilon.org/">emptyepsilon.org</a> for the guide on scripting. ')
+        stream.write('<p>By no means this is a guide to help you scripting, you should check <a href="https://daid.github.io/EmptyEpsilon/#tabs=4">EmptyEpsilon website</a> for the guide on scripting. ')
         stream.write("As well as check the already existing scenario and ship data files on how to get started.</p>")
         stream.write("</div>\n")
 


### PR DESCRIPTION
It bugged be, that emptyepsilon.org is no longer redirecting in its default form, fixed URL in script_reference.html to where the EE will redirect anyways.  

Actually, the web itself can redirect if there is `www` in www.emptyepsilon.org but then SSL certificates bugs you. 

Also, Beacon of Light also lists `EmptyEpsilon.org` in description (and therefore in translation files), but I am not going to fix that: 
`The Beacon of Light scenario, built from the series at EmptyEpsilon.org.`

But the series that once was on the website is probably no longer there. Maybe time to update the mission description as well? 

Not setting it as draft. If this gets merged, I will create an issue with Beacon of Light series description since I am not sure how to approach that fix. 