### PR TITLE
[ShipTemplate] Fix max tube limit on copy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@
 
 ### Fixed
 
+- ShipTemplate:copy() respects tube count limit for tubes, instead of beam count limit #1810
 - URL for EmptyEpsilon website in scripting reference fixed #1791
 - Relay can once again select alert level buttons #1786
 - Main screen comms info no longer persists after it should be closed

--- a/src/shipTemplate.cpp
+++ b/src/shipTemplate.cpp
@@ -562,7 +562,7 @@ P<ShipTemplate> ShipTemplate::copy(string new_name)
     for(int n=0; n<max_beam_weapons; n++)
         result->beams[n] = beams[n];
     result->weapon_tube_count = weapon_tube_count;
-    for(int n=0; n<max_beam_weapons; n++)
+    for(int n=0; n<max_weapon_tubes; n++)
         result->weapon_tube[n] = weapon_tube[n];
     result->hull = hull;
     result->shield_count = shield_count;


### PR DESCRIPTION
No functional difference; max_beam_weapons and max_weapon_tubes are both 16.