### PR TITLE
[ShipTemplate] Validate setHull() functions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@
 
 ### Fixed
 
+- ShipTemplate:setHull() and ShipTemplateBasedObject:setHull() respect limits #1811
 - ShipTemplate:copy() respects tube count limit for tubes, instead of beam count limit #1810
 - URL for EmptyEpsilon website in scripting reference fixed #1791
 - Relay can once again select alert level buttons #1786

--- a/src/shipTemplate.h
+++ b/src/shipTemplate.h
@@ -176,7 +176,7 @@ public:
     void setTubeSize(int index, EMissileSizes size);
 
     void setTubeDirection(int index, float direction);
-    void setHull(float amount) { hull = amount; }
+    void setHull(float amount) { if (amount < 0) return; hull = amount; };
     void setShields(const std::vector<float>& values);
     void setSpeed(float impulse, float turn, float acceleration, std::optional<float> reverse_speed, std::optional<float> reverse_acceleration);
     void setCombatManeuver(float boost, float strafe);

--- a/src/spaceObjects/shipTemplateBasedObject.h
+++ b/src/spaceObjects/shipTemplateBasedObject.h
@@ -68,7 +68,7 @@ public:
 
     float getHull() { return hull_strength; }
     float getHullMax() { return hull_max; }
-    void setHull(float amount) { if (amount < 0) return; hull_strength = amount; }
+    void setHull(float amount) { if (amount < 0) return; hull_strength = std::min(amount, hull_max); }
     void setHullMax(float amount) { if (amount < 0) return; hull_max = amount; hull_strength = std::max(hull_strength, hull_max); }
     virtual bool getShieldsActive() { return true; }
 


### PR DESCRIPTION
ShipTemplate:setHull() allows setting negative hull values. Since ShipTemplateBasedObject:setTemplate() doesn't validate the template values, enforce a minimum hull of 0 in the template. Negative values are discarded. A ShipTemplate with a negative setHull value should fall back on the default template value (70).

ShipTemplateBasedObject:setHull() allows setting valus greater than hull_max. If passed a value larger than the max, cap it to the max.