### PR TITLE
[CpuShip] Prevent orderAttack() from targeting non-hostiles

### DIFF
--- a/src/spaceObjects/cpuShip.cpp
+++ b/src/spaceObjects/cpuShip.cpp
@@ -279,10 +279,19 @@ void CpuShip::orderAttack(P<SpaceObject> object)
 {
     if (!object)
         return;
-    orders = AI_Attack;
-    order_target = object;
-    order_target_location = glm::vec2(0, 0);
-    this->addBroadcast(FVF_Friendly, tr("cpulog", "Moving to attack {callsign}!").format({{"callsign", object->getCallSign()}}));
+    
+    // Attack only if the target is hostile.
+    // Otherwise we just chase the target without firing on it.
+    if (this->isEnemy(object))
+    {
+        orders = AI_Attack;
+        order_target = object;
+        order_target_location = glm::vec2(0, 0);
+        this->addBroadcast(FVF_Friendly, tr("cpulog", "Moving to attack {callsign}!").format({{"callsign", object->getCallSign()}}));
+    } else {
+        LOG(WARNING) << "Tried to give " + this->getCallSign() + " an order to attack a non-hostile target";
+        return;
+    }
 }
 
 void CpuShip::orderDock(P<SpaceObject> object)


### PR DESCRIPTION
Because CpuShip:orderAttack() doesn't check if the target is hostile, it can be used to attempt to attack non-hostile targets. SpaceShips won't fire at non-hostile targets, so the result is poorly defined.

When using orderAttack(), check first if the target is hostile. If it isn't, write a warning to the game log and ignore the order.