### PR TITLE
[tweak] Add WarpJammer hull slider, export

### DIFF
--- a/src/screens/gm/tweak.cpp
+++ b/src/screens/gm/tweak.cpp
@@ -293,6 +293,12 @@ GuiJammerTweak::GuiJammerTweak(GuiContainer* owner)
         target->setRange(round(value/100)*100);
     });
     jammer_range_slider->addOverlay()->setSize(GuiElement::GuiSizeMax, 40);
+
+    (new GuiLabel(right_col, "", tr("Hull current:"), 30))->setSize(GuiElement::GuiSizeMax, 50);
+    hull_slider = new GuiSlider(right_col, "", 0.0, 500, 0.0, [this](float value) {
+        target->setHull(roundf(value));
+    });
+    hull_slider->addOverlay()->setSize(GuiElement::GuiSizeMax, 40);
 }
 
 void GuiJammerTweak::open(P<SpaceObject> target)
@@ -304,6 +310,7 @@ void GuiJammerTweak::open(P<SpaceObject> target)
 void GuiJammerTweak::onDraw(sp::RenderTarget& renderer)
 {
     jammer_range_slider->setValue(target->getRange());
+    hull_slider->setValue(target->getHull());
 }
 
 GuiAsteroidTweak::GuiAsteroidTweak(GuiContainer* owner)

--- a/src/screens/gm/tweak.h
+++ b/src/screens/gm/tweak.h
@@ -81,6 +81,7 @@ private:
     P<WarpJammer> target;
 
     GuiSlider* jammer_range_slider;
+    GuiSlider* hull_slider;
 public:
     GuiJammerTweak(GuiContainer* owner);
 

--- a/src/spaceObjects/warpJammer.cpp
+++ b/src/spaceObjects/warpJammer.cpp
@@ -165,9 +165,15 @@ void WarpJammer::onDestruction(ScriptSimpleCallback callback)
 
 string WarpJammer::getExportLine()
 {
-    string ret = "WarpJammer():setFaction(\"" + getFaction() + "\"):setPosition(" + string(getPosition().x, 0) + ", " + string(getPosition().y, 0) + ")";
+    string ret = "WarpJammer():setFaction(\"" + getFaction() + "\")";
+    ret += ":setPosition(" + string(getPosition().x, 0) + ", " + string(getPosition().y, 0) + ")";
+
     if (getRange() != 7000.0f) {
-	    ret += ":setRange("+string(getRange())+")";
+        ret += ":setRange("+string(getRange())+")";
     }
+    if (getHull() != 50.0f) {
+        ret += ":setHull(" + string(getHull()) + ")";
+    }
+
     return ret;
 }


### PR DESCRIPTION
Adds a GM tweak slider for WarpJammer hull strength:

![image](https://user-images.githubusercontent.com/19192104/210192934-d920c3a0-706f-44db-b80d-7e880c62b819.png)

"Copy selected" on the GM screen in the above screenshot also now exports `setHull()` if modified:

```
    WarpJammer():setFaction("Independent"):setPosition(-778, -6333):setHull(94.00)
```

Fixes #1803