### PR TITLE
 [scenario_00] Initialize default scenario settings

### DIFF
--- a/scripts/scenario_00_basic.lua
+++ b/scripts/scenario_00_basic.lua
@@ -291,8 +291,20 @@ end
 
 --- Initialize scenario.
 function init()
-    -- Spawn a player Atlantis.
-    player = PlayerSpaceship():setFaction("Human Navy"):setTemplate(getScenarioSetting("PlayerShip"))
+    -- Initialize scenario settings
+    setting_playership = "Atlantis"
+    setting_enemies = "Normal"
+    setting_time = "Unlimited"
+
+    -- Load settings if defined
+    settings = getAllScenarioSettings()
+    if #settings > 0 then
+        setting_playership = settings["PlayerShip"]
+        setting_enemies = settings["Enemies"]
+        setting_time = settings["Time"]
+    end
+    -- Spawn a player ship.
+    player = PlayerSpaceship():setFaction("Human Navy"):setTemplate(setting_playership)
     player:setCallSign(ship_names[irandom(1, #ship_names)])
     if not player:hasWarpDrive() and not player:hasJumpDrive() then
         player:setWarpDrive(true)
@@ -369,8 +381,8 @@ function init()
         ["Easy"] = 3,
         ["Empty"] = 0
     }
-    local enemy_group_count = counts[getScenarioSetting("Enemies")]
-    assert(enemy_group_count, "unknown enemies setting: " .. getScenarioSetting("Enemies") .. " could not set enemy_group_count")
+    local enemy_group_count = counts[setting_enemies]
+    assert(enemy_group_count, "unknown enemies setting: " .. setting_enemies .. " could not set enemy_group_count")
 
     local timesetting = {
         ["Unlimited"] = nil,
@@ -378,7 +390,7 @@ function init()
         ["30min"] = 30 * 60,
         ["60min"] = 60 * 60,
     }
-    gametimeleft = timesetting[getScenarioSetting("Time")]
+    gametimeleft = timesetting[setting_time]
     if gametimeleft ~= nil then
         timewarning = gametimeleft - 5 * 60
     end

--- a/src/gameGlobalInfo.cpp
+++ b/src/gameGlobalInfo.cpp
@@ -468,6 +468,23 @@ static int getScenarioSetting(lua_State* L)
 /// Returns a scenario setting, or an empty string if the setting is not found.
 REGISTER_SCRIPT_FUNCTION(getScenarioSetting);
 
+static int getAllScenarioSettings(lua_State* L)
+{
+    // Convert to an ordered map to avoid an infinite loop when converting to a Lua table
+    std::map<string,string> scenario_settings_map;
+    for (const auto& setting : gameGlobalInfo->scenario_settings)
+        scenario_settings_map.insert(std::make_pair(setting.first, setting.second));
+
+    return convert<std::map<string,string>>::returnType(L, scenario_settings_map);
+}
+/// PVector<string> getAllScenarioSettings()
+/// Return a table of all scenario setting keys and values.
+/// If none are set, returns an empty table.
+/// Example:
+/// settings = getAllScenarioSettings()
+/// if (settings["Enemies"]) ...
+REGISTER_SCRIPT_FUNCTION(getAllScenarioSettings);
+
 static int getGameLanguage(lua_State* L)
 {
     lua_pushstring(L, PreferencesManager::get("language", "en").c_str());


### PR DESCRIPTION
When run with `headless` or `server_scenario` options, default scenario settings aren't set, breaking the scenario. Initialize using the defaults manually, then apply the settings if they exist. See #1817.