### PR TITLE
[ShipTemplate] Use import values for getSystemName() enum conversion

### DIFF
--- a/src/shipTemplate.cpp
+++ b/src/shipTemplate.cpp
@@ -555,15 +555,15 @@ string getSystemName(ESystem system)
 {
     switch(system)
     {
-    case SYS_Reactor: return "Reactor";
-    case SYS_BeamWeapons: return "Beam Weapons";
-    case SYS_MissileSystem: return "Missile System";
-    case SYS_Maneuver: return "Maneuvering";
-    case SYS_Impulse: return "Impulse Engines";
-    case SYS_Warp: return "Warp Drive";
-    case SYS_JumpDrive: return "Jump Drive";
-    case SYS_FrontShield: return "Front Shield Generator";
-    case SYS_RearShield: return "Rear Shield Generator";
+    case SYS_Reactor: return "reactor";
+    case SYS_BeamWeapons: return "beamweapons";
+    case SYS_MissileSystem: return "missilesystem";
+    case SYS_Maneuver: return "maneuvering";
+    case SYS_Impulse: return "impulse";
+    case SYS_Warp: return "warp";
+    case SYS_JumpDrive: return "jumpdrive";
+    case SYS_FrontShield: return "frontshield";
+    case SYS_RearShield: return "rearshield";
     default:
         return "UNKNOWN";
     }

--- a/src/spaceObjects/playerSpaceship.cpp
+++ b/src/spaceObjects/playerSpaceship.cpp
@@ -2281,22 +2281,22 @@ string PlayerSpaceship::getExportLine()
             auto difference = std::fabs(current_factor - default_factor) > std::numeric_limits<float>::epsilon();
             if (difference)
             {
-                result += ":setSystemPowerFactor(" + string(system) + ", " + string(current_factor, 1) + ")";
+                result += ":setSystemPowerFactor(\"" + getSystemName(system) + "\", " + string(current_factor, 1) + ")";
             }
 
             if (std::fabs(getSystemCoolantRate(system) - ShipSystem::default_coolant_rate_per_second) > std::numeric_limits<float>::epsilon())
             {
-                result += ":setSystemCoolantRate(" + string(system) + ", " + string(getSystemCoolantRate(system), 2) + ")";
+                result += ":setSystemCoolantRate(\"" + getSystemName(system) + "\", " + string(getSystemCoolantRate(system), 2) + ")";
             }
 
             if (std::fabs(getSystemHeatRate(system) - ShipSystem::default_heat_rate_per_second) > std::numeric_limits<float>::epsilon())
             {
-                result += ":setSystemHeatRate(" + string(system) + ", " + string(getSystemHeatRate(system), 2) + ")";
+                result += ":setSystemHeatRate(\"" + getSystemName(system) + "\", " + string(getSystemHeatRate(system), 2) + ")";
             }
 
             if (std::fabs(getSystemPowerRate(system) - ShipSystem::default_power_rate_per_second) > std::numeric_limits<float>::epsilon())
             {
-                result += ":setSystemPowerRate(" + string(system) + ", " + string(getSystemPowerRate(system), 2) + ")";
+                result += ":setSystemPowerRate(\"" + getSystemName(system) + "\", " + string(getSystemPowerRate(system), 2) + ")";
             }
         }
     }


### PR DESCRIPTION
`ShipTemplate:getLocaleSystemName()` still returns the long string for the given language, so `getSystemName()`'s values should use the short system names that scripts use via the converter in shipTemplate.hpp.

With that change, we can then use `getSystemName(system)` in export lines instead of `string(system)`, which just writes the integer instead of converting the system name and creates output that doesn't work. (Fixes #1832)