### PR TITLE
[SpaceShip] Add getters for _request and current_ values

### DIFF
--- a/src/spaceObjects/spaceship.cpp
+++ b/src/spaceObjects/spaceship.cpp
@@ -225,6 +225,13 @@ REGISTER_SCRIPT_SUBCLASS_NO_CREATE(SpaceShip, ShipTemplateBasedObject)
     /// ship:setImpulseMaxSpeed(30,20) -- sets the max forward speed to 30 and reverse to 20
     /// ship:setImpulseMaxSpeed(30) -- sets the max forward and reverse speed to 30
     REGISTER_SCRIPT_CLASS_FUNCTION(SpaceShip, setImpulseMaxSpeed);
+    /// Returns the requested impulse percentage, as a value between -1.0 (full reverse) and 1.0 (full ahead).
+    /// Example: ship:getImpulseCurrent()
+    REGISTER_SCRIPT_CLASS_FUNCTION(SpaceShip, getImpulseRequest);
+    /// Returns the current impulse percentage, as a value between -1.0 (full reverse) and 1.0 (full ahead).
+    /// When this value differs from the requested value, the ship is accelerating or decelerating toward the requested value.
+    /// Example: ship:getImpulseActive()
+    REGISTER_SCRIPT_CLASS_FUNCTION(SpaceShip, getImpulseActive);
     /// Returns this SpaceShip's maximum rotational speed, in degrees per second?
     /// Example: ship:getRotationMaxSpeed()
     REGISTER_SCRIPT_CLASS_FUNCTION(SpaceShip, getRotationMaxSpeed);
@@ -247,6 +254,20 @@ REGISTER_SCRIPT_SUBCLASS_NO_CREATE(SpaceShip, ShipTemplateBasedObject)
     /// The boost value sets the forward maneuver capacity, and the strafe value sets the lateral maneuver capacity.
     /// Example: ship:setCombatManeuver(400,250) -- sets boost capacity to 400 and lateral to 250
     REGISTER_SCRIPT_CLASS_FUNCTION(SpaceShip, setCombatManeuver);
+    /// Returns the requested combat maneuver boost value.
+    /// Example: ship:getCombatManeuverBoostRequest()
+    REGISTER_SCRIPT_CLASS_FUNCTION(SpaceShip, getCombatManeuverBoostRequest);
+    /// Returns the requested combat maneuver strafe value.
+    /// Example: ship:getCombatManeuverStrafeRequest()
+    REGISTER_SCRIPT_CLASS_FUNCTION(SpaceShip, getCombatManeuverStrafeRequest);
+    /// Returns the current combat maneuver boost value.
+    /// When this value differs from the requested value, the ship is accelerating or decelerating toward the requested value.
+    /// Example: ship:getCombatManeuverBoostActive()
+    REGISTER_SCRIPT_CLASS_FUNCTION(SpaceShip, getCombatManeuverBoostActive);
+    /// Returns the current combat maneuver strafe value.
+    /// When this value differs from the requested value, the ship is accelerating or decelerating toward the requested value.
+    /// Example: ship:getCombatManeuverStrafeActive()
+    REGISTER_SCRIPT_CLASS_FUNCTION(SpaceShip, getCombatManeuverStrafeActive);
     /// Returns whether the SpaceShip has a jump drive.
     /// Example: ship:hasJumpDrive()
     REGISTER_SCRIPT_CLASS_FUNCTION(SpaceShip, hasJumpDrive);
@@ -276,6 +297,9 @@ REGISTER_SCRIPT_SUBCLASS_NO_CREATE(SpaceShip, ShipTemplateBasedObject)
     /// System effectiveness can modify this delay.
     /// Example: ship:getJumpDelay()
     REGISTER_SCRIPT_CLASS_FUNCTION(SpaceShip, getJumpDelay);
+    /// Returns the currently set jump distance.
+    /// Example: ship:getJumpDistance()
+    REGISTER_SCRIPT_CLASS_FUNCTION(SpaceShip, getJumpDistance);
     /// Returns whether this SpaceShip has a warp drive.
     /// Example: ship:hasWarpDrive()
     REGISTER_SCRIPT_CLASS_FUNCTION(SpaceShip, hasWarpDrive);
@@ -292,6 +316,13 @@ REGISTER_SCRIPT_SUBCLASS_NO_CREATE(SpaceShip, ShipTemplateBasedObject)
     /// Actual warp speed can be modified by "warp" system effectiveness.
     /// Example: ship:getWarpSpeed();
     REGISTER_SCRIPT_CLASS_FUNCTION(SpaceShip, getWarpSpeed);
+    /// Returns the requested warp level.
+    /// Example: ship:getWarpRequest()
+    REGISTER_SCRIPT_CLASS_FUNCTION(SpaceShip, getWarpRequest);
+    /// Returns the current warp level.
+    /// When this value differs from the requested value, the ship is accelerating or decelerating toward the requested value.
+    /// Example: ship:getWarpActive()
+    REGISTER_SCRIPT_CLASS_FUNCTION(SpaceShip, getWarpActive);
     /// Returns the arc, in degrees, for the BeamWeapon with the given index on this SpaceShip.
     /// Example: ship:getBeamWeaponArc(0); -- returns beam weapon 0's arc
     REGISTER_SCRIPT_CLASS_FUNCTION(SpaceShip, getBeamWeaponArc);

--- a/src/spaceObjects/spaceship.cpp
+++ b/src/spaceObjects/spaceship.cpp
@@ -298,7 +298,10 @@ REGISTER_SCRIPT_SUBCLASS_NO_CREATE(SpaceShip, ShipTemplateBasedObject)
     /// Example: ship:getJumpDelay()
     REGISTER_SCRIPT_CLASS_FUNCTION(SpaceShip, getJumpDelay);
     /// Returns the currently set jump distance.
-    /// Example: ship:getJumpDistance()
+    /// Returns 0 if the ship hasn't yet initiated a jump.
+    /// Example: 
+    /// -- Ship has initiated a 10U jump
+    /// ship:getJumpDistance() -- returns 10000
     REGISTER_SCRIPT_CLASS_FUNCTION(SpaceShip, getJumpDistance);
     /// Returns whether this SpaceShip has a warp drive.
     /// Example: ship:hasWarpDrive()

--- a/src/spaceObjects/spaceship.h
+++ b/src/spaceObjects/spaceship.h
@@ -375,6 +375,8 @@ public:
         impulse_max_speed = forward_speed; 
         impulse_max_reverse_speed = reverse_speed.value_or(forward_speed);
     }
+    float getImpulseRequest() { return impulse_request; }
+    float getImpulseActive() { return current_impulse; }
     float getSystemCoolantRate(ESystem system) const { if (system >= SYS_COUNT) return 0.f; if (system <= SYS_None) return 0.f; return systems[system].coolant_rate_per_second; }
     void setSystemCoolantRate(ESystem system, float rate) { if (system >= SYS_COUNT) return; if (system <= SYS_None) return; systems[system].coolant_rate_per_second = rate; }
     float getRotationMaxSpeed() { return turn_speed; }
@@ -386,9 +388,17 @@ public:
         impulse_reverse_acceleration = reverse_acceleration.value_or(acceleration);
     }
     void setCombatManeuver(float boost, float strafe) { combat_maneuver_boost_speed = boost; combat_maneuver_strafe_speed = strafe; }
+    float getCombatManeuverBoostRequest() { return combat_maneuver_boost_request; }
+    float getCombatManeuverBoostActive() { return combat_maneuver_boost_active; }
+    float getCombatManeuverStrafeRequest() { return combat_maneuver_strafe_request; }
+    float getCombatManeuverStrafeActive() { return combat_maneuver_strafe_active; }
     bool hasJumpDrive() { return has_jump_drive; }
     void setJumpDrive(bool has_jump) { has_jump_drive = has_jump; }
     void setJumpDriveRange(float min, float max) { jump_drive_min_distance = min; jump_drive_max_distance = max; }
+    float getJumpDriveCharge() { return jump_drive_charge; }
+    void setJumpDriveCharge(float charge) { jump_drive_charge = charge; }
+    float getJumpDelay() { return jump_delay; }
+    float getJumpDistance() { return jump_distance; }
     bool hasWarpDrive() { return has_warp_drive; }
     void setWarpDrive(bool has_warp)
     {
@@ -409,10 +419,9 @@ public:
         } else {
             return 0.0f;
         }
-     }
-    float getJumpDriveCharge() { return jump_drive_charge; }
-    void setJumpDriveCharge(float charge) { jump_drive_charge = charge; }
-    float getJumpDelay() { return jump_delay; }
+    }
+    float getWarpRequest() { return warp_request; }
+    float getWarpActive() { return current_warp; }
 
     float getBeamWeaponArc(int index) { if (index < 0 || index >= max_beam_weapons) return 0.0; return beam_weapons[index].getArc(); }
     float getBeamWeaponDirection(int index) { if (index < 0 || index >= max_beam_weapons) return 0.0; return beam_weapons[index].getDirection(); }


### PR DESCRIPTION
Add getters for current/active and requested impulse, jump, warp, and combat maneuver values.

Towards #1833.