### PR TITLE
[#1816] Add ShipWindow to ECrewPositions and autoconnect

### DIFF
--- a/compile_script_docs.py
+++ b/compile_script_docs.py
@@ -506,7 +506,7 @@ rel="stylesheet"
         stream.write("<ul>\n")
         stream.write('<li><a name="enum_Color">Color</a>: A string that can either be a hex color code (#rrggbb), three comma-separated rgb integers (rrr,ggg,bbb), or one of the following: "black", "white", "red", "green", "blue", "yellow", "magenta", "cyan". Invalid values default to white.</li>\n')
         stream.write('<li><a name="enum_EAlertLevel">EAlertLevel<a/>: sets "normal", "yellow", "red" (<code>playerSpaceship.hpp</code>), returns "Normal", "YELLOW ALERT", "RED ALERT" (<code>playerSpaceship.cpp</code>)</li>\n')
-        stream.write('<li><a name="enum_ECrewPosition">ECrewPosition</a>: "Helms", "Weapons", "Engineering", "Science", "Relay", "Tactical", "Engineering+", "Operations", "Single", "DamageControl", "PowerManagement", "Database", "AltRelay", "CommsOnly", "ShipLog" (<code>playerInfo.cpp</code>)</li>\n')
+        stream.write('<li><a name="enum_ECrewPosition">ECrewPosition</a>: "Helms", "Weapons", "Engineering", "Science", "Relay", "Tactical", "Engineering+", "Operations", "Single", "DamageControl", "PowerManagement", "Database", "AltRelay", "CommsOnly", "ShipLog", "ShipWindow" (<code>playerInfo.cpp</code>)</li>\n')
         stream.write('<li><a name="enum_EDockingState">EDockingState</a>: 0 (not docking), 1 (docking), 2 (docked) (<code>spaceship.h</code>)</li>\n')
         stream.write('<li><a name="enum_EMainScreenOverlay">EMainScreenOverlay</a>: "hidecomms", "showcomms" (<code>spaceship.hpp</code>)</li>\n')
         stream.write('<li><a name="enum_EMainScreenSetting">EMainScreenSetting</a>: "front", "back", "left", "right", "target", "tactical", "longrange" (<code>spaceship.hpp</code>)</li>\n')

--- a/src/menus/shipSelectionScreen.cpp
+++ b/src/menus/shipSelectionScreen.cpp
@@ -490,7 +490,7 @@ CrewPositionSelection::CrewPositionSelection(GuiContainer* owner, string id, int
     (new GuiLabel(three, "CREW_POSITION_SELECT_LABEL", tr("Alternative options"), 30))->addBackground()->setSize(GuiElement::GuiSizeMax, 50)->setMargins(15, 0);
     layout = new GuiElement(three, "");
     layout->setMargins(25, 50)->setSize(GuiElement::GuiSizeMax, GuiElement::GuiSizeMax)->setAttribute("layout", "vertical");
-    for(int n=int(singlePilot) + 1; n<int(max_crew_positions); n++)
+    for(int n=int(singlePilot) + 1; n<int(shipWindow); n++)
         create_crew_position_button(layout, n);
 
     // Main screen controls button
@@ -534,7 +534,7 @@ void CrewPositionSelection::onUpdate()
     bool any_selected = main_screen_button->getValue() || window_button->getValue() || topdown_button->getValue();
     // If a position already has a player on the currently selected player ship,
     // indicate that on the button.
-    for(int n = 0; n < max_crew_positions; n++)
+    for(int n = 0; n < shipWindow; n++)
     {
         string button_text = getCrewPositionName(ECrewPosition(n));
         if (my_spaceship)
@@ -565,7 +565,7 @@ void CrewPositionSelection::onUpdate()
 
 void CrewPositionSelection::disableAllExcept(GuiToggleButton* button)
 {
-    for(int n = 0; n < max_crew_positions; n++)
+    for(int n = 0; n < shipWindow; n++)
     {
         if (crew_position_button[n] != button)
         {

--- a/src/playerInfo.cpp
+++ b/src/playerInfo.cpp
@@ -1,6 +1,8 @@
 #include <i18n.h>
 #include "playerInfo.h"
+#include "preferenceManager.h"
 #include "screens/mainScreen.h"
+#include "screens/windowScreen.h"
 #include "screens/crewStationScreen.h"
 
 #include "screens/crew6/helmsScreen.h"
@@ -177,6 +179,12 @@ void PlayerInfo::spawnUI(int monitor_index, RenderLayer* render_layer)
     {
         new ScreenMainScreen(render_layer);
     }
+    else if (crew_position[shipWindow] & (1 << monitor_index))
+    {
+        uint8_t window_flags = PreferencesManager::get("ship_window_flags", "1").toInt();
+        float window_angle = PreferencesManager::get("ship_window_angle", "0").toFloat();
+        new WindowScreen(render_layer, window_angle, window_flags);
+    }
     else
     {
         CrewStationScreen* screen = new CrewStationScreen(render_layer, bool(main_screen & (1 << monitor_index)));
@@ -265,6 +273,7 @@ string getCrewPositionName(ECrewPosition position)
     case altRelay: return tr("station","Strategic Map");
     case commsOnly: return tr("station","Comms");
     case shipLog: return tr("station","Ship's Log");
+    case shipWindow: return tr("station","Ship Window");
     default: return "ErrUnk: " + string(position);
     }
 }
@@ -288,6 +297,7 @@ string getCrewPositionIcon(ECrewPosition position)
     case altRelay: return "";
     case commsOnly: return "";
     case shipLog: return "";
+    case shipWindow: return "";
     default: return "ErrUnk: " + string(position);
     }
 }
@@ -334,6 +344,8 @@ template<> void convert<ECrewPosition>::param(lua_State* L, int& idx, ECrewPosit
         cp = commsOnly;
     else if (str == "shiplog")
         cp = shipLog;
+    else if (str == "shipwindow")
+        cp = shipWindow;
     else
         luaL_error(L, "Unknown value for crew position: %s", str.c_str());
 }

--- a/src/playerInfo.h
+++ b/src/playerInfo.h
@@ -25,6 +25,7 @@ enum ECrewPosition
     altRelay,
     commsOnly,
     shipLog,
+    shipWindow,
     max_crew_positions
 };
 


### PR DESCRIPTION
- Adds the Ship Window extra view as crew position 16/"shipwindow".
- Adds the `ship_window_angle` option, for now used only on autoconnect.

Example:

```
EmptyEpsilon autoconnect=16 ship_window_angle=45 ship_window_flags=1
```

Fixes #1816.