### PR TITLE
[cmake] Set CMAKE_INSTALL_PREFIX for RPM builds

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,8 @@
 
 - Mission time clock now uses `hh:mm:ss`-formatted time #1773
 - Stats on Operations screen resized to match other screens #1774
+- Build changes
+  - RPM CPack builds with `-DCPACK_GENERATOR="RPM"` now set resource paths #1840
 - API changes
   - HTTP script access now uses the server-selected player ship as the default #1776
 - Translation updates

--- a/cmake/CPackProjectConfig.cmake.in
+++ b/cmake/CPackProjectConfig.cmake.in
@@ -1,6 +1,6 @@
 if(CPACK_GENERATOR MATCHES "DEB" OR CPACK_GENERATOR MATCHES "RPM")
     # On UNIX, the CMAKE_INSTALL_PREFIX will default to /usr/local.
-    # But the debian *package* will default to put everything under /usr.
+    # But DEB and RPM *packages* will default to put everything under /usr.
     # Since the resource path are hardcoded inside EE, make sure they line up.
     set(CPACK_PACKAGING_INSTALL_PREFIX "@CMAKE_INSTALL_PREFIX@")
 endif()

--- a/cmake/CPackProjectConfig.cmake.in
+++ b/cmake/CPackProjectConfig.cmake.in
@@ -1,4 +1,4 @@
-if(CPACK_GENERATOR MATCHES "DEB")
+if(CPACK_GENERATOR MATCHES "DEB" OR CPACK_GENERATOR MATCHES "RPM")
     # On UNIX, the CMAKE_INSTALL_PREFIX will default to /usr/local.
     # But the debian *package* will default to put everything under /usr.
     # Since the resource path are hardcoded inside EE, make sure they line up.


### PR DESCRIPTION
When manually setting -DCPACK_GENERATOR="RPM", the resulting package installs the binary to /usr/bin and resources to /usr/share/emptyepsilon on Fedora 37, and EE fails to find its resources, scripts, and packs directories.

The default CMAKE_INSTALL_FULL_DATADIR path, used by RESOURCE_DATA_DIR to override EE's hardcoded resource paths, is apparently /usr/local/share. DEB CPack builds already override CPACK_PACKAGING_INSTALL_PREFIX, so also do so on RPM CPack builds.