### PR TITLE
Add cmake/android/ to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -47,3 +47,4 @@ logs
 build*/
 _build*/
 cmake/_win32/
+cmake/android/


### PR DESCRIPTION
For Android builds, cmake builds put the Android SDK, SDL, and AndroidManifest.xml in `cmake/android/`, so git should ignore that path.