### PR TITLE
[SupplyDrop] Check and pass Player or SpaceShip onPickUp

### DIFF
--- a/src/spaceObjects/supplyDrop.cpp
+++ b/src/spaceObjects/supplyDrop.cpp
@@ -60,9 +60,18 @@ void SupplyDrop::collide(Collisionable* target, float force)
                 picked_up = true;
             }
         }
+
+        // If a callback is set, pick up the drop and pass the ship.
         if (on_pickup_callback.isSet())
         {
-            on_pickup_callback.call<void>(P<SupplyDrop>(this), player);
+            if (player)
+            {
+                on_pickup_callback.call<void>(P<SupplyDrop>(this), player);
+            }
+            else
+            {
+                on_pickup_callback.call<void>(P<SupplyDrop>(this), ship);
+            }
             picked_up = true;
         }
 


### PR DESCRIPTION
Pass the appropriate object to the `SupplyDrop:onPickUp()` callback if a non-player SpaceShip collides with the SupplyDrop.

Closes #1802.