### PR TITLE
[GameGlobalInfo] Initialize scenario settings on start

### DIFF
--- a/src/gameGlobalInfo.cpp
+++ b/src/gameGlobalInfo.cpp
@@ -1,6 +1,7 @@
 #include <i18n.h>
 #include "gameGlobalInfo.h"
 #include "preferenceManager.h"
+#include "scenarioInfo.h"
 #include "scienceDatabase.h"
 #include "multiplayer_client.h"
 #include "soundManager.h"
@@ -186,6 +187,24 @@ void GameGlobalInfo::reset()
     {
         p->reset();
     }
+}
+
+void GameGlobalInfo::initializeScenarioSettings(string filename)
+{
+    // Parse the scenario metadata for default settings.
+    // Use this for non-interactive scenario loading, like headless and
+    // server_scenario game preferences.
+    ScenarioInfo info(filename);
+    LOG(INFO) << "Initializing settings for scenario " << info.name;
+
+    for(auto& setting : info.settings)
+    {
+        LOG(INFO) << setting.key << " scenario setting set to " << setting.default_option;
+        gameGlobalInfo->scenario_settings[setting.key] = setting.default_option;
+    }
+
+    // Set the scenario name.
+    gameGlobalInfo->scenario = info.name;
 }
 
 void GameGlobalInfo::startScenario(string filename)

--- a/src/gameGlobalInfo.cpp
+++ b/src/gameGlobalInfo.cpp
@@ -189,25 +189,42 @@ void GameGlobalInfo::reset()
     }
 }
 
-void GameGlobalInfo::initializeScenarioSettings(string filename)
+void GameGlobalInfo::setScenarioSettings(const string filename, std::unordered_map<string, string> new_settings)
 {
-    // Parse the scenario metadata for default settings.
-    // Use this for non-interactive scenario loading, like headless and
-    // server_scenario game preferences.
+    // Use the parsed scenario metadata.
     ScenarioInfo info(filename);
-    LOG(INFO) << "Initializing settings for scenario " << info.name;
-
-    for(auto& setting : info.settings)
-    {
-        LOG(INFO) << setting.key << " scenario setting set to " << setting.default_option;
-        gameGlobalInfo->scenario_settings[setting.key] = setting.default_option;
-    }
 
     // Set the scenario name.
     gameGlobalInfo->scenario = info.name;
+    LOG(INFO) << "Configuring settings for scenario " << gameGlobalInfo->scenario;
+
+    // Set each scenario setting to either a matching passed new value, or the
+    // default if there's no match (or no new value).
+    for(auto& setting : info.settings)
+    {
+        // Initialize with defaults.
+        gameGlobalInfo->scenario_settings[setting.key] = setting.default_option;
+
+        // If new settings were passed ...
+        if (!new_settings.empty())
+        {
+            // ... confirm that this setting key exists in the new settings.
+            if (new_settings.find(setting.key) != new_settings.end())
+            {
+                if (new_settings[setting.key] != "")
+                {
+                    // If so, override the default with the new value.
+                    gameGlobalInfo->scenario_settings[setting.key] = new_settings[setting.key];
+                }
+            }
+        }
+
+        // Log scenario setting confirmation.
+        LOG(INFO) << setting.key << " scenario setting set to " << gameGlobalInfo->scenario_settings[setting.key];
+    }
 }
 
-void GameGlobalInfo::startScenario(string filename)
+void GameGlobalInfo::startScenario(string filename, std::unordered_map<string, string> new_settings)
 {
     reset();
 
@@ -233,6 +250,10 @@ void GameGlobalInfo::startScenario(string filename)
     int max_cycles = PreferencesManager::get("script_cycle_limit", "0").toInt();
     if (max_cycles > 0)
         script->setMaxRunCycles(max_cycles);
+
+    // Initialize scenario settings.
+    setScenarioSettings(filename, new_settings);
+
     script->run(filename);
     engine->registerObject("scenario", script);
 
@@ -487,7 +508,6 @@ static int getScenarioVariation(lua_State* L)
         lua_pushstring(L, "None");
     return 1;
 }
-
 // this returns the "variation" scenario setting for backwards compatibility
 /// string getScenarioVariation()
 /// [DEPRECATED]
@@ -530,8 +550,7 @@ public:
 
     virtual void update(float delta) override
     {
-        gameGlobalInfo->scenario_settings = settings;
-        gameGlobalInfo->startScenario(script_name);
+        gameGlobalInfo->startScenario(script_name, settings);
         destroy();
     }
 private:
@@ -543,11 +562,30 @@ static int setScenario(lua_State* L)
 {
     string script_name = luaL_checkstring(L, 1);
     string variation = luaL_optstring(L, 2, "");
-    //This could be called from a currently active scenario script.
+
+    // Script filename must not be an empty string.
+    if (script_name == "")
+    {
+        LOG(ERROR) << "setScenario() requires a non-empty value.";
+        return 1;
+    }
+
+    if (variation != "")
+    {
+        LOG(WARNING) << "LUA: DEPRECATED setScenario() called with scenario variation. Passing the value as the \"variation\" scenario setting instead.";
+        // Start the scenario, passing the "variation" scenario setting.
+        new ScenarioChanger(script_name, {{"variation", variation}});
+    }
+    else
+    {
+        // Start the scenario with defaults.
+        new ScenarioChanger(script_name, {{}});
+    }
+
+    // This could be called from a currently active scenario script.
     // Calling GameGlobalInfo::startScenario is unsafe at this point,
     // as this will destroy the lua state that this function is running in.
-    //So use the ScenarioChanger object which will do the change in the update loop. Which is safe.
-    new ScenarioChanger(script_name, {{"variation", variation}});
+    // So use the ScenarioChanger object which will do the change in the update loop. Which is safe.
     return 0;
 }
 /// void setScenario(string script_name, std::optional<string> variation_name)

--- a/src/gameGlobalInfo.h
+++ b/src/gameGlobalInfo.h
@@ -104,8 +104,8 @@ public:
     void addScript(P<Script> script);
     //Reset the global game state (called when we want to load a new scenario, and clear out this one)
     void reset();
-    void initializeScenarioSettings(string filename);
-    void startScenario(string filename);
+    void setScenarioSettings(const string filename, std::unordered_map<string, string> new_settings);
+    void startScenario(string filename, std::unordered_map<string, string> new_settings = {});
 
     virtual void update(float delta) override;
     virtual void destroy() override;

--- a/src/gameGlobalInfo.h
+++ b/src/gameGlobalInfo.h
@@ -104,6 +104,7 @@ public:
     void addScript(P<Script> script);
     //Reset the global game state (called when we want to load a new scenario, and clear out this one)
     void reset();
+    void initializeScenarioSettings(string filename);
     void startScenario(string filename);
 
     virtual void update(float delta) override;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -399,7 +399,7 @@ int main(int argc, char** argv)
         new EpsilonServer(defaultServerPort);
 
         // Load the scenario and open the ship selection screen.
-        startScenarioWithoutInteraction(PreferencesManager::get("server_scenario"));
+        gameGlobalInfo->startScenario(PreferencesManager::get("server_scenario"));
         new ShipSelectionScreen();
     }
 
@@ -440,15 +440,6 @@ int main(int argc, char** argv)
     return 0;
 }
 
-void startScenarioWithoutInteraction(string filename)
-{
-    // Initialize scenario settings to defaults.
-    gameGlobalInfo->initializeScenarioSettings(filename);
-
-    // Load the scenario.
-    gameGlobalInfo->startScenario(filename);
-}
-
 void returnToMainMenu(RenderLayer* render_layer)
 {
     if (render_layer != defaultRenderLayer) // Handle secondary monitors
@@ -463,7 +454,7 @@ void returnToMainMenu(RenderLayer* render_layer)
         if (PreferencesManager::get("headless_name") != "") game_server->setServerName(PreferencesManager::get("headless_name"));
         if (PreferencesManager::get("headless_password") != "") game_server->setPassword(PreferencesManager::get("headless_password").upper());
         if (PreferencesManager::get("headless_internet") == "1") game_server->registerOnMasterServer(PreferencesManager::get("registry_registration_url", "http://daid.eu/ee/register.php"));
-        startScenarioWithoutInteraction(PreferencesManager::get("headless"));
+        gameGlobalInfo->startScenario(PreferencesManager::get("headless"));
 
         if (PreferencesManager::get("startpaused") != "1")
             engine->setGameSpeed(1.0);

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -391,8 +391,15 @@ int main(int argc, char** argv)
         returnToMainMenu(defaultRenderLayer);
     else
     {
+        // server_scenario creates a server running the specified scenario
+        // using its defined default settings, and launches directly into
+        // the ship selection screen instead of the main menu.
+
+        // Create the server.
         new EpsilonServer(defaultServerPort);
-        gameGlobalInfo->startScenario(PreferencesManager::get("server_scenario"));
+
+        // Load the scenario and open the ship selection screen.
+        startScenarioWithoutInteraction(PreferencesManager::get("server_scenario"));
         new ShipSelectionScreen();
     }
 
@@ -433,6 +440,15 @@ int main(int argc, char** argv)
     return 0;
 }
 
+void startScenarioWithoutInteraction(string filename)
+{
+    // Initialize scenario settings to defaults.
+    gameGlobalInfo->initializeScenarioSettings(filename);
+
+    // Load the scenario.
+    gameGlobalInfo->startScenario(filename);
+}
+
 void returnToMainMenu(RenderLayer* render_layer)
 {
     if (render_layer != defaultRenderLayer) // Handle secondary monitors
@@ -447,7 +463,7 @@ void returnToMainMenu(RenderLayer* render_layer)
         if (PreferencesManager::get("headless_name") != "") game_server->setServerName(PreferencesManager::get("headless_name"));
         if (PreferencesManager::get("headless_password") != "") game_server->setPassword(PreferencesManager::get("headless_password").upper());
         if (PreferencesManager::get("headless_internet") == "1") game_server->registerOnMasterServer(PreferencesManager::get("registry_registration_url", "http://daid.eu/ee/register.php"));
-        gameGlobalInfo->startScenario(PreferencesManager::get("headless"));
+        startScenarioWithoutInteraction(PreferencesManager::get("headless"));
 
         if (PreferencesManager::get("startpaused") != "1")
             engine->setGameSpeed(1.0);

--- a/src/main.h
+++ b/src/main.h
@@ -18,7 +18,6 @@ extern PostProcessor* warpPostProcessor;
 extern PVector<Window> windows;
 extern std::vector<RenderLayer*> window_render_layers;
 
-void startScenarioWithoutInteraction(string filename);
 void returnToMainMenu(RenderLayer*);
 void returnToShipSelection(RenderLayer*);
 void returnToOptionMenu();

--- a/src/main.h
+++ b/src/main.h
@@ -18,6 +18,7 @@ extern PostProcessor* warpPostProcessor;
 extern PVector<Window> windows;
 extern std::vector<RenderLayer*> window_render_layers;
 
+void startScenarioWithoutInteraction(string filename);
 void returnToMainMenu(RenderLayer*);
 void returnToShipSelection(RenderLayer*);
 void returnToOptionMenu();

--- a/src/menus/serverCreationScreen.cpp
+++ b/src/menus/serverCreationScreen.cpp
@@ -285,6 +285,7 @@ void ServerScenarioSelectionScreen::loadScenarioList(const string& category)
 ServerScenarioOptionsScreen::ServerScenarioOptionsScreen(string filename)
 {
     ScenarioInfo info(filename);
+    scenario_settings = {};
 
     new GuiOverlay(this, "", colorConfig.background);
     (new GuiOverlay(this, "", glm::u8vec4{255,255,255,255}))->setTextureTiled("gui/background/crosses.png");
@@ -304,11 +305,11 @@ ServerScenarioOptionsScreen::ServerScenarioOptionsScreen(string filename)
         }
         (new GuiLabel(container, "", setting.key_localized, 30))->addBackground()->setSize(GuiElement::GuiSizeMax, 50);
         auto selector = new GuiSelector(container, "", [this, info, setting](int index, string value) {
-            gameGlobalInfo->scenario_settings[setting.key] = value;
+            this->scenario_settings[setting.key] = value;
             for(auto& option : setting.options)
                 if (option.value == value)
                     description_per_setting[setting.key]->setText(option.description);
-            start_button->setEnable(gameGlobalInfo->scenario_settings.size() >= info.settings.size());
+            start_button->setEnable(this->scenario_settings.size() >= info.settings.size());
         });
         selector->setSize(GuiElement::GuiSizeMax, 50);
         for(auto& option : setting.options)
@@ -317,7 +318,7 @@ ServerScenarioOptionsScreen::ServerScenarioOptionsScreen(string filename)
             if (option.value == setting.default_option)
             {
                 selector->setSelectionIndex(selector->entryCount() - 1);
-                gameGlobalInfo->scenario_settings[setting.key] = option.value;
+                this->scenario_settings[setting.key] = option.value;
             }
         }
         auto description = new GuiScrollText(container, "", setting.description);
@@ -338,7 +339,7 @@ ServerScenarioOptionsScreen::ServerScenarioOptionsScreen(string filename)
     start_button = new GuiButton(this, "START_SCENARIO", tr("Start scenario"), [this, info, filename]() {
         // Start the selected scenario.
         gameGlobalInfo->scenario = info.name;
-        gameGlobalInfo->startScenario(filename);
+        gameGlobalInfo->startScenario(filename, this->scenario_settings);
 
         // Destroy this screen and move on to ship selection.
         destroy();
@@ -346,5 +347,5 @@ ServerScenarioOptionsScreen::ServerScenarioOptionsScreen(string filename)
         new ScriptErrorRenderer(mouseLayer);
     });
     start_button->setPosition(250, -50, sp::Alignment::BottomCenter)->setSize(300, 50);
-    start_button->setEnable(gameGlobalInfo->scenario_settings.size() >= info.settings.size());
+    start_button->setEnable(scenario_settings.size() >= info.settings.size());
 }

--- a/src/menus/serverCreationScreen.h
+++ b/src/menus/serverCreationScreen.h
@@ -57,6 +57,7 @@ public:
 
 private:
     GuiButton* start_button;
+    std::unordered_map<string,string> scenario_settings;
     std::unordered_map<string, GuiScrollText*> description_per_setting;
 };
 


### PR DESCRIPTION
Add `gameGlobalInfo->setScenarioSettings()` function, which takes
the scenario filename and an optional settings map. This always
initializes the setting defaults, then applies any passed settings
over them.

Rewrite `gameGlobalInfo->startScenario()` to take optional settings
and pass them to `setScenarioSettings()` prior to launching the
scenario.

Revise ServerScenarioOptionsScreen to collect settings and pass
them to `gameGlobalInfo->startScenario()` on scenario load, instead
of directly manipulating the `gameGlobalInfo->scenario_settings` map.

Fixes #1817.