### PR TITLE
[PlayerSpaceship] Deprecate redundant energy functions

### DIFF
--- a/scripts/scenario_44_outpost.lua
+++ b/scripts/scenario_44_outpost.lua
@@ -15490,15 +15490,15 @@ function commonServiceOptions()
 			end)
 		end
 		local offer_power = false
-		if comms_source:getEnergyLevel() < comms_source:getEnergyLevelMax()/2 then
+		if comms_source:getEnergy() < comms_source:getMaxEnergy()/2 then
 			offer_power = true
 		end
 		if offer_power then
-			local power_charge = math.floor((comms_source:getEnergyLevelMax() - comms_source:getEnergyLevel())/3)
+			local power_charge = math.floor((comms_source:getMaxEnergy() - comms_source:getEnergy())/3)
 			addCommsReply(string.format(_("ship-comms","Quick charge the main batteries (%i reputation)"),power_charge),function()
 				if distance(comms_source,comms_target) < 5000 then
 					if comms_source:takeReputationPoints(power_charge) then
-						comms_source:setEnergyLevel(comms_source:getEnergyLevelMax())
+						comms_source:setEnergy(comms_source:getMaxEnergy())
 						comms_source:commandSetSystemPowerRequest("reactor",1)
 						comms_source:setSystemPower("reactor",1)
 						comms_source:setSystemHeat("reactor",2)

--- a/scripts/scenario_74_omicron.lua
+++ b/scripts/scenario_74_omicron.lua
@@ -6382,15 +6382,15 @@ function commonServiceOptions()
 			end)
 		end
 		local offer_power = false
-		if comms_source:getEnergyLevel() < comms_source:getEnergyLevelMax()/2 then
+		if comms_source:getEnergy() < comms_source:getMaxEnergy()/2 then
 			offer_power = true
 		end
 		if offer_power then
-			local power_charge = math.floor((comms_source:getEnergyLevelMax() - comms_source:getEnergyLevel())/3)
+			local power_charge = math.floor((comms_source:getMaxEnergy() - comms_source:getEnergy())/3)
 			addCommsReply(string.format(_("shipServices-comms", "Quick charge the main batteries (%i reputation)"),power_charge),function()
 				if distance(comms_source,comms_target) < 5000 then
 					if comms_source:takeReputationPoints(power_charge) then
-						comms_source:setEnergyLevel(comms_source:getEnergyLevelMax())
+						comms_source:setEnergy(comms_source:getMaxEnergy())
 						comms_source:commandSetSystemPowerRequest("reactor",1)
 						comms_source:setSystemPower("reactor",1)
 						comms_source:setSystemHeat("reactor",2)

--- a/src/spaceObjects/playerSpaceship.cpp
+++ b/src/spaceObjects/playerSpaceship.cpp
@@ -84,20 +84,17 @@ REGISTER_SCRIPT_SUBCLASS(PlayerSpaceship, SpaceShip)
     /// Example: player:isCommsScriptOpen()
     REGISTER_SCRIPT_CLASS_FUNCTION(PlayerSpaceship, isCommsScriptOpen);
 
-    /// Sets this PlayerSpaceship's energy level.
-    /// Values are limited from 0 to the energy level max. Negative or excess values are capped to the limits.
-    /// Example: player:setEnergyLevel(1000) -- sets the ship's energy to either 1000 or the max limit, whichever is lower
+    /// [DEPRECATED]
+    /// As SpaceShip:setEnergy()
     REGISTER_SCRIPT_CLASS_FUNCTION(PlayerSpaceship, setEnergyLevel);
-    /// Sets this PlayerSpaceship's energy capacity.
-    /// Valid values are 0 or any positive number.
-    /// If the new limit is lower than the ship's current energy level, this also reduces the energy level.
-    /// Example: player:setEnergyLevelMax(1000) -- sets the ship's energy limit to 1000
+    /// [DEPRECATED]
+    /// As SpaceShip:setMaxEnergy()
     REGISTER_SCRIPT_CLASS_FUNCTION(PlayerSpaceship, setEnergyLevelMax);
-    /// Returns this PlayerSpaceship's energy level.
-    /// Example: player:getEnergyLevel()
+    /// [DEPRECATED]
+    /// As SpaceShip:getEnergy()
     REGISTER_SCRIPT_CLASS_FUNCTION(PlayerSpaceship, getEnergyLevel);
-    /// Returns this PlayerSpaceship's energy capacity.
-    /// Example: player:getEnergyLevelMax()
+    /// [DEPRECATED]
+    /// As SpaceShip:getMaxEnergy()
     REGISTER_SCRIPT_CLASS_FUNCTION(PlayerSpaceship, getEnergyLevelMax);
 
     /// Returns how much energy is consumed per second by this PlayerSpaceship's shields while active.

--- a/src/spaceObjects/playerSpaceship.h
+++ b/src/spaceObjects/playerSpaceship.h
@@ -198,10 +198,11 @@ public:
     void switchCommsToGM();
     void closeComms();
 
-    void setEnergyLevel(float amount) { energy_level = std::max(0.0f, std::min(max_energy_level, amount)); }
-    void setEnergyLevelMax(float amount) { max_energy_level = std::max(0.0f, amount); energy_level = std::min(energy_level, max_energy_level); }
-    float getEnergyLevel() { return energy_level; }
-    float getEnergyLevelMax() { return max_energy_level; }
+    // Deprecated energy getters/setters; see SpaceShip
+    void setEnergyLevel(float amount) { LOG(Warning, "PlayerSpaceship: Deprecated setEnergyLevel() called. Use setEnergy() instead."); setEnergy(amount); }
+    void setEnergyLevelMax(float amount) { LOG(Warning, "PlayerSpaceship: Deprecated setEnergyLevelMax() called. Use setMaxEnergy() instead."); setMaxEnergy(amount); }
+    float getEnergyLevel() { LOG(Warning, "PlayerSpaceship: Deprecated getEnergyLevel() called. Use getEnergy() instead."); return getEnergy(); }
+    float getEnergyLevelMax() { LOG(Warning, "PlayerSpaceship: Deprecated getEnergyLevelMax() called. Use getMaxEnergy() instead."); return getMaxEnergy(); }
 
     void setCanScan(bool enabled) { can_scan = enabled; }
     bool getCanScan() { return can_scan; }

--- a/src/spaceObjects/spaceship.cpp
+++ b/src/spaceObjects/spaceship.cpp
@@ -116,17 +116,16 @@ REGISTER_SCRIPT_SUBCLASS_NO_CREATE(SpaceShip, ShipTemplateBasedObject)
     REGISTER_SCRIPT_CLASS_FUNCTION(SpaceShip, getMaxEnergy);
     /// Sets this SpaceShip's energy capacity.
     /// CpuShips don't consume energy. Setting this value has no effect on their behavior or functionality.
-    /// For PlayerSpaceships, see PlayerSpaceship:setEnergyLevelMax().
+    /// Valid values are any greater than or equal to 0.
     /// Example: ship:setMaxEnergy(800)
     REGISTER_SCRIPT_CLASS_FUNCTION(SpaceShip, setMaxEnergy);
     /// Returns this SpaceShip's energy level.
     /// Example: ship:getEnergy()
     REGISTER_SCRIPT_CLASS_FUNCTION(SpaceShip, getEnergy);
     /// Sets this SpaceShip's energy level.
-    /// Valid values are any greater than 0 and less than the energy capacity (getMaxEnergy()).
-    /// Invalid values are ignored.
+    /// Valid values are from 0 to the ship's energy capacity (getMaxEnergy()).
+    /// Invalid values are capped to this range.
     /// CpuShips don't consume energy. Setting this value has no effect on their behavior or functionality.
-    /// For PlayerSpaceships, see PlayerSpaceship:setEnergyLevel().
     /// Example: ship:setEnergy(1000) -- sets the ship's energy to 1000 if its capacity is 1000 or more
     REGISTER_SCRIPT_CLASS_FUNCTION(SpaceShip, setEnergy);
     /// Returns whether this SpaceShip has the given system.

--- a/src/spaceObjects/spaceship.h
+++ b/src/spaceObjects/spaceship.h
@@ -346,9 +346,9 @@ public:
     void setWeaponStorage(EMissileWeapons weapon, int amount) { if (weapon == MW_None) return; weapon_storage[weapon] = amount; }
     void setWeaponStorageMax(EMissileWeapons weapon, int amount) { if (weapon == MW_None) return; weapon_storage_max[weapon] = amount; weapon_storage[weapon] = std::min(int(weapon_storage[weapon]), amount); }
     float getMaxEnergy() { return max_energy_level; }
-    void setMaxEnergy(float amount) { if (amount > 0.0f) { max_energy_level = amount;} }
+    void setMaxEnergy(float amount) { max_energy_level = std::max(0.0f, amount); energy_level = std::min(energy_level, max_energy_level); }
     float getEnergy() { return energy_level; }
-    void setEnergy(float amount) { if ( (amount > 0.0f) && (amount <= max_energy_level)) { energy_level = amount; } }
+    void setEnergy(float amount) { energy_level = std::max(0.0f, std::min(max_energy_level, amount)); }
     float getSystemHackedLevel(ESystem system) { if (system >= SYS_COUNT) return 0.0; if (system <= SYS_None) return 0.0; return systems[system].hacked_level; }
     void setSystemHackedLevel(ESystem system, float hacked_level) { if (system >= SYS_COUNT) return; if (system <= SYS_None) return; systems[system].hacked_level = std::min(1.0f, std::max(0.0f, hacked_level)); }
     float getSystemHealth(ESystem system) { if (system >= SYS_COUNT) return 0.0; if (system <= SYS_None) return 0.0; return systems[system].health; }


### PR DESCRIPTION
PlayerSpaceship has redundant getter/setter functions for energy:

- `getEnergyLevel()`
- `setEnergyLevel()`
- `getEnergyLevelMax()`
- `setEnergyLevelMax()`

Deprecate these in favor of the parent SpaceShip class's functions:

- `getEnergy()`
- `setEnergy()`
- `getMaxEnergy()`
- `setMaxEnergy()`

Move the PlayerSpaceship energy setter logic, which capped values
to a range of 0 to max_energy_level, to the SpaceShip class's
behavior, which discarded values less than 0 but accepted all
others.

Replace use of these `...EnergyLevel...` functions.