### PR TITLE
[FactionInfo] Refactor

### DIFF
--- a/compile_script_docs.py
+++ b/compile_script_docs.py
@@ -189,7 +189,7 @@ def translate_type(c_type, name):
     if res is not None:
         return VariadicType(translate_type(res.group(1).strip(), name))
 
-    if c_type in ('EAlertLevel', 'ECrewPosition', 'EMissileSizes', 'EMissileWeapons', 'EScannedState', 'ESystem', 'EMainScreenSetting', 'EMainScreenOverlay', 'EDockingState', 'ScriptSimpleCallback'):
+    if c_type in ('EAlertLevel', 'ECrewPosition', 'EFriendVsFoeState', 'EMissileSizes', 'EMissileWeapons', 'EScannedState', 'ESystem', 'EMainScreenSetting', 'EMainScreenOverlay', 'EDockingState', 'ScriptSimpleCallback'):
         return EnumType(c_type)
 
     if c_type in ('int', 'float', 'double', 'int32_t', 'int8_t', 'uint32_t', 'uint8_t'):
@@ -508,6 +508,7 @@ rel="stylesheet"
         stream.write('<li><a name="enum_EAlertLevel">EAlertLevel<a/>: sets "normal", "yellow", "red" (<code>playerSpaceship.hpp</code>), returns "Normal", "YELLOW ALERT", "RED ALERT" (<code>playerSpaceship.cpp</code>)</li>\n')
         stream.write('<li><a name="enum_ECrewPosition">ECrewPosition</a>: "Helms", "Weapons", "Engineering", "Science", "Relay", "Tactical", "Engineering+", "Operations", "Single", "DamageControl", "PowerManagement", "Database", "AltRelay", "CommsOnly", "ShipLog" (<code>playerInfo.cpp</code>)</li>\n')
         stream.write('<li><a name="enum_EDockingState">EDockingState</a>: 0 (not docking), 1 (docking), 2 (docked) (<code>spaceship.h</code>)</li>\n')
+        stream.write('<li><a name="enum_EFriendVsFoeState">EFriendVsFoeState</a>: "friendly", "neutral", "enemy" (<code>factionInfo.hpp</code>)</li>\n')
         stream.write('<li><a name="enum_EMainScreenOverlay">EMainScreenOverlay</a>: "hidecomms", "showcomms" (<code>spaceship.hpp</code>)</li>\n')
         stream.write('<li><a name="enum_EMainScreenSetting">EMainScreenSetting</a>: "front", "back", "left", "right", "target", "tactical", "longrange" (<code>spaceship.hpp</code>)</li>\n')
         stream.write('<li><a name="enum_EMissileSizes">EMissileSizes</a>: "small", "medium", "large" (<code>missileWeaponData.hpp</code>)</li>\n')

--- a/src/factionInfo.cpp
+++ b/src/factionInfo.cpp
@@ -257,9 +257,7 @@ EFactionVsFactionState FactionInfo::getState(P<FactionInfo> other)
 
 EFactionVsFactionState FactionInfo::getState(uint8_t idx0, uint8_t idx1)
 {
-    if (idx0 >= MAX_FACTIONS) return FVF_Neutral;
-    if (idx1 >= MAX_FACTIONS) return FVF_Neutral;
-    if (!factionInfo[idx0] || !factionInfo[idx1]) return FVF_Neutral;
+    if (idx0 >= MAX_FACTIONS || idx1 >= MAX_FACTIONS || !factionInfo[idx0] || !factionInfo[idx1]) { return FVF_Neutral };
     return factionInfo[idx0]->getState(factionInfo[idx1]);
 }
 

--- a/src/factionInfo.cpp
+++ b/src/factionInfo.cpp
@@ -101,7 +101,7 @@ REGISTER_SCRIPT_FUNCTION(getFactions)
 static int getFactionInfo(lua_State* L)
 {
     auto name = luaL_checkstring(L, 1);
-    for(unsigned int n = 0; n < MAX_FACTIONS; n++)
+    for (size_t n = 0; n < MAX_FACTIONS; n++)
         if (factionInfo[n] && factionInfo[n]->getName() == name)
             return convert<P<FactionInfo>>::returnType(L, factionInfo[n]);
     return 0;
@@ -125,7 +125,7 @@ FactionInfo::FactionInfo()
     registerMemberReplication(&friend_mask);
 
     if (game_server) {
-        for(size_t n=0; n<MAX_FACTIONS; n++)
+        for (size_t n = 0; n < MAX_FACTIONS; n++)
         {
             if (!factionInfo[n]) {
                 factionInfo[n] = this;
@@ -265,6 +265,7 @@ EFactionVsFactionState FactionInfo::getState(uint8_t idx0, uint8_t idx1)
 
 unsigned int FactionInfo::findFactionId(string name)
 {
+    // Returning n, so using unsigned int.
     for(unsigned int n = 0; n < MAX_FACTIONS; n++)
         if (factionInfo[n] && factionInfo[n]->name == name)
             return n;
@@ -274,7 +275,7 @@ unsigned int FactionInfo::findFactionId(string name)
 
 void FactionInfo::reset()
 {
-    for(unsigned int n = 0; n < MAX_FACTIONS; n++)
+    for (size_t n = 0; n < MAX_FACTIONS; n++)
         if (factionInfo[n])
             factionInfo[n]->destroy();
 }

--- a/src/factionInfo.cpp
+++ b/src/factionInfo.cpp
@@ -25,6 +25,10 @@
 /// faction:setDescription(_("The United Stellar Navy, or USN...")) -- sets a translatable description for this faction
 REGISTER_SCRIPT_CLASS(FactionInfo)
 {
+    /// Returns this faction's internal ID, which is assigned upon creation.
+    /// Valid values are 0 to 31, as limited by MAX_FACTIONS in factionInfo.h.
+    /// Example: faction:getFactionId()
+    REGISTER_SCRIPT_CLASS_FUNCTION(FactionInfo, getFactionId);
     /// Returns this faction's internal string name.
     /// Example: faction:getName()
     REGISTER_SCRIPT_CLASS_FUNCTION(FactionInfo, getName);
@@ -134,7 +138,6 @@ FactionInfo::FactionInfo()
                 return;
             }
         }
-
         LOG(ERROR) << "Failed to add a faction beyond the limit of " << MAX_FACTIONS << " factions.";
         destroy();
     }

--- a/src/factionInfo.cpp
+++ b/src/factionInfo.cpp
@@ -9,7 +9,7 @@
 /// For example, these relationships determine whether a SpaceObject can be targeted by weapons, docked with, or receive comms from another SpaceObject.
 /// If a faction doesn't have a relationship with another faction, it treats those factions as neutral by default.
 /// Therefore, new factions are neutral toward all other factions by default.
-/// Faction relationships set via setEnemy(), setFriendly(), and setNeutral() are are automatically reciprocated.
+/// Faction relationships set via setEnemy(), setFriendly(), and setNeutral() are automatically reciprocated.
 ///
 /// If this faction consideres another faction to be hostile, it can target and fire weapons at it, and CpuShips with certain orders might pursue it.
 /// If neutral, this faction can't target and fire weapons at the other faction, and other factions can dock with its stations or dockable ships.

--- a/src/factionInfo.cpp
+++ b/src/factionInfo.cpp
@@ -130,7 +130,7 @@ FactionInfo::FactionInfo()
                 return;
             }
         }
-        LOG(ERROR) << "Tried to add a faction beyond the limit of " << MAX_FACTIONS << " factions.";
+        LOG(ERROR) << "Failed to add a faction beyond the limit of " << MAX_FACTIONS << " factions.";
         destroy();
     }
 }
@@ -141,15 +141,15 @@ FactionInfo::~FactionInfo()
 
 void FactionInfo::update(float delta)
 {
-    if (index != 255)
-        factionInfo[index] = this;
+    if (index < MAX_FACTIONS) { factionInfo[index] = this; }
+    else { LOG(ERROR) << "Faction " << name << "has index " << index << " outside of limit " << MAX_FACTIONS << "."; }
 }
 
 void FactionInfo::setNeutral(P<FactionInfo> other)
 {
     if (!other)
     {
-        LOG(WARNING) << "Tried to set an undefined faction to be an enemy of " << name;
+        LOG(WARNING) << "Failed to set an undefined faction to be neutral with " << name;
         return;
     }
 
@@ -163,7 +163,7 @@ void FactionInfo::setEnemy(P<FactionInfo> other)
 {
     if (!other)
     {
-        LOG(WARNING) << "Tried to set an undefined faction to be an enemy of " << name;
+        LOG(WARNING) << "Failed to set an undefined faction to be an enemy of " << name;
         return;
     }
 
@@ -177,7 +177,7 @@ void FactionInfo::setFriendly(P<FactionInfo> other)
 {
     if (!other)
     {
-        LOG(WARNING) << "Tried to set an undefined faction to be friendly with " << name;
+        LOG(WARNING) << "Failed to set an undefined faction to be friendly with " << name;
         return;
     }
 
@@ -204,22 +204,10 @@ void FactionInfo::setRelationshipWith(P<FactionInfo> other, EFactionVsFactionSta
         return;
     }
 
-    if (state == FVF_Enemy)
-    {
-        setEnemy(other);
-    }
-    else if (state == FVF_Friendly)
-    {
-        setFriendly(other);
-    }
-    else if (state == FVF_Neutral)
-    {
-        setNeutral(other);
-    }
-    else
-    {
-        LOG(WARNING) << "Tried to set an incorrect faction relationship state";
-    }
+    if (state == FVF_Enemy) { setEnemy(other); }
+    else if (state == FVF_Friendly) { setFriendly(other); }
+    else if (state == FVF_Neutral) { setNeutral(other); }
+    else { LOG(ERROR) << "Given faction relationship state is invalid."; }
 }
 
 EFactionVsFactionState FactionInfo::getRelationshipWith(P<FactionInfo> other)
@@ -256,10 +244,10 @@ EFactionVsFactionState FactionInfo::getState(uint8_t idx0, uint8_t idx1)
 unsigned int FactionInfo::findFactionId(string name)
 {
     // Returning n, so using unsigned int.
-    for(unsigned int n = 0; n < MAX_FACTIONS; n++)
+    for (unsigned int n = 0; n < MAX_FACTIONS; n++)
         if (factionInfo[n] && factionInfo[n]->name == name)
             return n;
-    LOG(ERROR) << "Failed to find faction: " << name;
+    LOG(ERROR) << "Failed to find faction named " << name;
     return 0;
 }
 

--- a/src/factionInfo.cpp
+++ b/src/factionInfo.cpp
@@ -199,25 +199,11 @@ void FactionInfo::setFriendly(P<FactionInfo> other)
 
 void FactionInfo::resetAllRelationships()
 {
-    for (size_t n = 0; n < MAX_FACTIONS; n++)
+    for (size_t idx = 0; idx < MAX_FACTIONS; idx++)
     {
-        if (factionInfo[n] && factionInfo[n] != this)
-            this->setNeutral(factionInfo[n]);
+        if (factionInfo[idx] && factionInfo[idx] != this)
+            this->setNeutral(factionInfo[idx]);
     }
-}
-
-void FactionInfo::setRelationshipWith(P<FactionInfo> other, EFactionVsFactionState state)
-{
-    if (!other)
-    {
-        LOG(WARNING) << "Given setRelationshipWith faction is invalid.";
-        return;
-    }
-
-    if (state == FVF_Enemy) { setEnemy(other); }
-    else if (state == FVF_Friendly) { setFriendly(other); }
-    else if (state == FVF_Neutral) { setNeutral(other); }
-    else { LOG(ERROR) << "Given faction relationship state is invalid."; }
 }
 
 EFactionVsFactionState FactionInfo::getRelationshipWith(P<FactionInfo> other)
@@ -234,21 +220,46 @@ EFactionVsFactionState FactionInfo::getRelationshipWith(P<FactionInfo> other)
     return FVF_Neutral;
 }
 
-EFactionVsFactionState FactionInfo::getState(uint8_t idx0, uint8_t idx1)
+void FactionInfo::setRelationshipWith(P<FactionInfo> other, EFactionVsFactionState state)
+{
+    if (!other)
+    {
+        LOG(WARNING) << "Given setRelationshipWith faction is invalid.";
+        return;
+    }
+
+    if (state == FVF_Enemy) { setEnemy(other); }
+    else if (state == FVF_Friendly) { setFriendly(other); }
+    else if (state == FVF_Neutral) { setNeutral(other); }
+    else { LOG(ERROR) << "Given faction relationship state is invalid."; }
+}
+
+EFactionVsFactionState FactionInfo::getRelationshipBetween(uint8_t idx0, uint8_t idx1)
 {
     if (idx0 >= MAX_FACTIONS || idx1 >= MAX_FACTIONS)
     {
-        LOG(ERROR) << "Given getState index is outside the limit of " << MAX_FACTIONS << " factions. Returning Neutral.";
+        LOG(ERROR) << "Given getRelationshipBetween index is outside the limit of " << MAX_FACTIONS << " factions. Returning Neutral.";
         return FVF_Neutral;
     }
 
     if (!factionInfo[idx0] || !factionInfo[idx1])
     {
-        LOG(ERROR) << "No faction at the given getState index. Returning Neutral.";
+        LOG(ERROR) << "No faction at the given getRelationshipBetween index. Returning Neutral.";
         return FVF_Neutral;
     }
 
     return factionInfo[idx0]->getRelationshipWith(factionInfo[idx1]);
+}
+
+EFactionVsFactionState FactionInfo::getRelationshipBetween(P<FactionInfo> faction0, P<FactionInfo> faction1)
+{
+    if (!faction0 || !faction1)
+    {
+        LOG(ERROR) << "Given faction is invalid. Returning Neutral.";
+        return FVF_Neutral;
+    }
+
+    return faction0->getRelationshipWith(faction1);
 }
 
 unsigned int FactionInfo::findFactionId(string name)

--- a/src/factionInfo.cpp
+++ b/src/factionInfo.cpp
@@ -267,12 +267,9 @@ EFactionVsFactionState FactionInfo::getRelationshipBetween(P<FactionInfo> factio
 
 unsigned int FactionInfo::findFactionId(string name)
 {
-    // Returning n, so using unsigned int.
+    // Returning n, so using unsigned int instead of size_t.
     for (unsigned int idx = 0; idx < MAX_FACTIONS; idx++)
-    {
-        if (factionInfo[idx] && factionInfo[idx]->name == name)
-            return idx;
-    }
+        if (factionInfo[idx] && factionInfo[idx]->name == name) { return idx; }
 
     LOG(ERROR) << "Failed to find faction named " << name;
     return 0;

--- a/src/factionInfo.cpp
+++ b/src/factionInfo.cpp
@@ -92,7 +92,7 @@ static int getFactions(lua_State* L)
 /// PVector<FactionInfo> getFactions()
 /// Returns a 1-indexed table of all factions.
 /// Example: getFactions()[2] -- returns the second-indexed faction
-REGISTER_SCRIPT_FUNCTION(getFactions)
+REGISTER_SCRIPT_FUNCTION(getFactions);
 
 static int getFactionInfo(lua_State* L)
 {

--- a/src/factionInfo.cpp
+++ b/src/factionInfo.cpp
@@ -114,13 +114,8 @@ REGISTER_SCRIPT_FUNCTION(getFactionInfo);
 
 REGISTER_MULTIPLAYER_CLASS(FactionInfo, "FactionInfo");
 FactionInfo::FactionInfo()
-: MultiplayerObject("FactionInfo")
+: MultiplayerObject("FactionInfo"), index(255), gm_color({255, 255, 255, 255}), enemy_mask(0), friend_mask(0)
 {
-    index = 255;
-    gm_color = {255,255,255,255};
-    enemy_mask = 0;
-    friend_mask = 0;
-
     registerMemberReplication(&index);
     registerMemberReplication(&gm_color);
     registerMemberReplication(&name);

--- a/src/factionInfo.cpp
+++ b/src/factionInfo.cpp
@@ -122,16 +122,19 @@ FactionInfo::FactionInfo()
     registerMemberReplication(&enemy_mask);
     registerMemberReplication(&friend_mask);
 
-    if (game_server) {
-        for (size_t n = 0; n < MAX_FACTIONS; n++)
+    if (game_server)
+    {
+        for (size_t idx = 0; idx < MAX_FACTIONS; idx++)
         {
-            if (!factionInfo[n]) {
-                factionInfo[n] = this;
-                index = n;
+            if (!factionInfo[idx])
+            {
+                factionInfo[idx] = this;
+                index = idx;
                 setFriendly(this);
                 return;
             }
         }
+
         LOG(ERROR) << "Failed to add a faction beyond the limit of " << MAX_FACTIONS << " factions.";
         destroy();
     }
@@ -265,21 +268,23 @@ EFactionVsFactionState FactionInfo::getRelationshipBetween(P<FactionInfo> factio
 unsigned int FactionInfo::findFactionId(string name)
 {
     // Returning n, so using unsigned int.
-    for (unsigned int n = 0; n < MAX_FACTIONS; n++)
-        if (factionInfo[n] && factionInfo[n]->name == name)
-            return n;
+    for (unsigned int idx = 0; idx < MAX_FACTIONS; idx++)
+    {
+        if (factionInfo[idx] && factionInfo[idx]->name == name)
+            return idx;
+    }
+
     LOG(ERROR) << "Failed to find faction named " << name;
     return 0;
 }
 
 void FactionInfo::reset()
 {
-    for (size_t n = 0; n < MAX_FACTIONS; n++)
-        if (factionInfo[n])
-            factionInfo[n]->destroy();
+    for (size_t idx = 0; idx < MAX_FACTIONS; idx++)
+        if (factionInfo[idx]) { factionInfo[idx]->destroy(); }
 }
 
-/* Define script conversion function for the EFactionVsFactionState enum. */
+// Define script conversion function for the EFactionVsFactionState enum.
 template<> void convert<EFactionVsFactionState>::param(lua_State* L, int& idx, EFactionVsFactionState& state)
 {
     string str = string(luaL_checkstring(L, idx++)).lower();

--- a/src/factionInfo.cpp
+++ b/src/factionInfo.cpp
@@ -260,8 +260,9 @@ unsigned int FactionInfo::findFactionId(string name)
     for (unsigned int idx = 0; idx < MAX_FACTIONS; idx++)
         if (factionInfo[idx] && factionInfo[idx]->name == name) { return idx; }
 
-    LOG(ERROR) << "Failed to find faction named " << name;
-    return 0;
+    // Return the invalid default faction ID on failure.
+    LOG(ERROR) << "Failed to find faction named " << name << ", returning 255.";
+    return 255;
 }
 
 void FactionInfo::reset()

--- a/src/factionInfo.cpp
+++ b/src/factionInfo.cpp
@@ -25,9 +25,15 @@
 /// faction:setDescription(_("The United Stellar Navy, or USN...")) -- sets a translatable description for this faction
 REGISTER_SCRIPT_CLASS(FactionInfo)
 {
+    /// Returns this faction's internal string name.
+    /// Example: faction:getName()
+    REGISTER_SCRIPT_CLASS_FUNCTION(FactionInfo, getName);
     /// Sets this faction's internal string name, used to reference this faction regardless of EmptyEpsilon's language setting.
     /// Example: faction:setName("USN")
     REGISTER_SCRIPT_CLASS_FUNCTION(FactionInfo, setName);
+    /// Returns this faction's name as presented in the currently configured user interface language.
+    /// Example: faction:getLocaleName()
+    REGISTER_SCRIPT_CLASS_FUNCTION(FactionInfo, getLocaleName);
     /// Sets this faction's name as presented in the user interface.
     /// Wrap the string in the _() function to make it available for translation.
     /// Example: faction:setLocaleName(_("USN"))
@@ -36,6 +42,9 @@ REGISTER_SCRIPT_CLASS(FactionInfo)
     /// Defaults to white (255,255,255).
     /// Example: faction:setGMColor(255,0,0) -- sets the color to red
     REGISTER_SCRIPT_CLASS_FUNCTION(FactionInfo, setGMColor);
+    /// Returns this faction's longform description as shown in its Factions ScienceDatabase child entry.
+    /// Example: faction:getDescription()
+    REGISTER_SCRIPT_CLASS_FUNCTION(FactionInfo, getDescription);
     /// Sets this faction's longform description as shown in its Factions ScienceDatabase child entry.
     /// Wrap the string in the _() function to make it available for translation.
     /// Example: faction:setDescription(_("The United Stellar Navy, or USN...")) -- sets a translatable description for this faction
@@ -67,6 +76,27 @@ REGISTER_SCRIPT_CLASS(FactionInfo)
 }
 
 std::array<P<FactionInfo>, 32> factionInfo;
+
+static int getFactions(lua_State* L)
+{
+    PVector<FactionInfo> factions;
+    factions.reserve(32);
+    for (auto index = 0; index < 32; ++index)
+    {
+        auto faction = factionInfo[index];
+
+        if (faction)
+        {
+            factions.emplace_back(std::move(faction));
+        }
+    }
+
+    return convert<PVector<FactionInfo>>::returnType(L, factions);
+}
+/// PVector<FactionInfo> getFactions()
+/// Returns a 1-indexed table of all factions.
+/// Example: getFactions()[2] -- returns the second-indexed faction
+REGISTER_SCRIPT_FUNCTION(getFactions)
 
 static int getFactionInfo(lua_State* L)
 {

--- a/src/factionInfo.cpp
+++ b/src/factionInfo.cpp
@@ -147,6 +147,14 @@ void FactionInfo::update(float delta)
     else { LOG(ERROR) << "Faction " << name << "has index " << index << " outside of limit " << MAX_FACTIONS << "."; }
 }
 
+void FactionInfo::setName(string name)
+{
+    this->name = name;
+
+    // Also set the locale name if it's unset.
+    if (locale_name == "") { setLocaleName(name); }
+}
+
 void FactionInfo::setNeutral(P<FactionInfo> other)
 {
     if (!other)

--- a/src/factionInfo.cpp
+++ b/src/factionInfo.cpp
@@ -259,22 +259,19 @@ void FactionInfo::reset()
 }
 
 /* Define script conversion function for the EFactionVsFactionState enum. */
-template<> void convert<EFactionVsFactionState>::param(lua_State* L, int& idx, EFactionVsFactionState& efvfs)
+template<> void convert<EFactionVsFactionState>::param(lua_State* L, int& idx, EFactionVsFactionState& state)
 {
     string str = string(luaL_checkstring(L, idx++)).lower();
-    if (str == "friendly")
-        efvfs = FVF_Friendly;
-    else if (str == "neutral")
-        efvfs = FVF_Neutral;
-    else if (str == "enemy" || str == "hostile")
-        efvfs = FVF_Enemy;
-    else
-        efvfs = FVF_Neutral;
+
+    if (str == "friendly") { state = FVF_Friendly; }
+    else if (str == "neutral") { state = FVF_Neutral; }
+    else if (str == "enemy" || str == "hostile") { state = FVF_Enemy; }
+    else { state = FVF_Neutral; }
 }
 
-template<> int convert<EFactionVsFactionState>::returnType(lua_State* L, EFactionVsFactionState efvfs)
+template<> int convert<EFactionVsFactionState>::returnType(lua_State* L, EFactionVsFactionState state)
 {
-    switch(efvfs)
+    switch (state)
     {
     case FVF_Friendly:
         lua_pushstring(L, "friendly");

--- a/src/factionInfo.cpp
+++ b/src/factionInfo.cpp
@@ -3,7 +3,7 @@
 #include "multiplayer_server.h"
 
 /// A FactionInfo object contains presentation details and faction relationships for member SpaceObjects.
-/// EmptyEpsilon has a hardcoded limit of 32 factions.
+/// EmptyEpsilon has a hardcoded limit of 32 factions (MAX_FACTIONS in factionInfo.h).
 ///
 /// SpaceObjects belong to a faction that determines which objects are friendly, neutral, or hostile toward them.
 /// For example, these relationships determine whether a SpaceObject can be targeted by weapons, docked with, or receive comms from another SpaceObject.
@@ -101,7 +101,7 @@ REGISTER_SCRIPT_FUNCTION(getFactions)
 static int getFactionInfo(lua_State* L)
 {
     auto name = luaL_checkstring(L, 1);
-    for(unsigned int n = 0; n < factionInfo.size(); n++)
+    for(unsigned int n = 0; n < MAX_FACTIONS; n++)
         if (factionInfo[n] && factionInfo[n]->getName() == name)
             return convert<P<FactionInfo>>::returnType(L, factionInfo[n]);
     return 0;
@@ -125,7 +125,7 @@ FactionInfo::FactionInfo()
     registerMemberReplication(&friend_mask);
 
     if (game_server) {
-        for(size_t n=0; n<factionInfo.size(); n++)
+        for(size_t n=0; n<MAX_FACTIONS; n++)
         {
             if (!factionInfo[n]) {
                 factionInfo[n] = this;
@@ -134,7 +134,7 @@ FactionInfo::FactionInfo()
                 return;
             }
         }
-        LOG(ERROR) << "There is a limit of 32 factions.";
+        LOG(ERROR) << "Tried to add a faction beyond the limit of " << MAX_FACTIONS << " factions.";
         destroy();
     }
 }
@@ -257,15 +257,15 @@ EFactionVsFactionState FactionInfo::getState(P<FactionInfo> other)
 
 EFactionVsFactionState FactionInfo::getState(uint8_t idx0, uint8_t idx1)
 {
-    if (idx0 >= factionInfo.size()) return FVF_Neutral;
-    if (idx1 >= factionInfo.size()) return FVF_Neutral;
+    if (idx0 >= MAX_FACTIONS) return FVF_Neutral;
+    if (idx1 >= MAX_FACTIONS) return FVF_Neutral;
     if (!factionInfo[idx0] || !factionInfo[idx1]) return FVF_Neutral;
     return factionInfo[idx0]->getState(factionInfo[idx1]);
 }
 
 unsigned int FactionInfo::findFactionId(string name)
 {
-    for(unsigned int n = 0; n < factionInfo.size(); n++)
+    for(unsigned int n = 0; n < MAX_FACTIONS; n++)
         if (factionInfo[n] && factionInfo[n]->name == name)
             return n;
     LOG(ERROR) << "Failed to find faction: " << name;
@@ -274,7 +274,7 @@ unsigned int FactionInfo::findFactionId(string name)
 
 void FactionInfo::reset()
 {
-    for(unsigned int n = 0; n < factionInfo.size(); n++)
+    for(unsigned int n = 0; n < MAX_FACTIONS; n++)
         if (factionInfo[n])
             factionInfo[n]->destroy();
 }

--- a/src/factionInfo.cpp
+++ b/src/factionInfo.cpp
@@ -77,22 +77,20 @@ REGISTER_SCRIPT_CLASS(FactionInfo)
 
 std::array<P<FactionInfo>, MAX_FACTIONS> factionInfo;
 
-static int getFactions(lua_State* L)
+static int getFactionInfos(lua_State* L)
 {
     PVector<FactionInfo> factions;
     factions.reserve(MAX_FACTIONS);
-    for (size_t i = 0; i < MAX_FACTIONS; ++i)
-    {
-        auto faction = factionInfo[i];
-        if (faction) { factions.emplace_back(std::move(faction)); }
-    }
+
+    for (size_t idx = 0; idx < MAX_FACTIONS; ++idx)
+        if (factionInfo[idx]) { factions.emplace_back(std::move(factionInfo[idx])); }
 
     return convert<PVector<FactionInfo>>::returnType(L, factions);
 }
-/// PVector<FactionInfo> getFactions()
-/// Returns a 1-indexed table of all factions.
-/// Example: getFactions()[2] -- returns the second-indexed faction
-REGISTER_SCRIPT_FUNCTION(getFactions);
+/// PVector<FactionInfo> getFactionInfos()
+/// Returns a 1-indexed table of all FactionInfo objects.
+/// Example: getFactionInfos()[2] -- returns the second-indexed faction
+REGISTER_SCRIPT_FUNCTION(getFactionInfos);
 
 static int getFactionInfo(lua_State* L)
 {

--- a/src/factionInfo.cpp
+++ b/src/factionInfo.cpp
@@ -81,14 +81,10 @@ static int getFactions(lua_State* L)
 {
     PVector<FactionInfo> factions;
     factions.reserve(MAX_FACTIONS);
-    for (auto i = 0; i < MAX_FACTIONS; ++i)
+    for (size_t i = 0; i < MAX_FACTIONS; ++i)
     {
         auto faction = factionInfo[i];
-
-        if (faction)
-        {
-            factions.emplace_back(std::move(faction));
-        }
+        if (faction) { factions.emplace_back(std::move(faction)); }
     }
 
     return convert<PVector<FactionInfo>>::returnType(L, factions);
@@ -100,7 +96,7 @@ REGISTER_SCRIPT_FUNCTION(getFactions)
 
 static int getFactionInfo(lua_State* L)
 {
-    auto name = luaL_checkstring(L, 1);
+    const auto* name = luaL_checkstring(L, 1);
     for (size_t n = 0; n < MAX_FACTIONS; n++)
         if (factionInfo[n] && factionInfo[n]->getName() == name)
             return convert<P<FactionInfo>>::returnType(L, factionInfo[n]);
@@ -193,25 +189,10 @@ void FactionInfo::setFriendly(P<FactionInfo> other)
 
 void FactionInfo::resetAllRelationships()
 {
-    // Reset this faction's masks.
-    enemy_mask = 0;
-    friend_mask = 0;
-
-    // Reset each other faction's relationship with this faction.
-    for (auto faction : factionInfo)
+    for (size_t n = 0; n < MAX_FACTIONS; n++)
     {
-        if (faction)
-        {
-            if (faction != this)
-            {
-                faction->friend_mask &=~(1U << index);
-                faction->enemy_mask &=~(1 << index);
-            }
-        }
-        else
-        {
-            break;
-        }
+        if (factionInfo[n] && factionInfo[n] != this)
+            this->setNeutral(factionInfo[n]);
     }
 }
 

--- a/src/factionInfo.cpp
+++ b/src/factionInfo.cpp
@@ -75,15 +75,15 @@ REGISTER_SCRIPT_CLASS(FactionInfo)
     REGISTER_SCRIPT_CLASS_FUNCTION(FactionInfo, resetAllRelationships);
 }
 
-std::array<P<FactionInfo>, 32> factionInfo;
+std::array<P<FactionInfo>, MAX_FACTIONS> factionInfo;
 
 static int getFactions(lua_State* L)
 {
     PVector<FactionInfo> factions;
-    factions.reserve(32);
-    for (auto index = 0; index < 32; ++index)
+    factions.reserve(MAX_FACTIONS);
+    for (auto i = 0; i < MAX_FACTIONS; ++i)
     {
-        auto faction = factionInfo[index];
+        auto faction = factionInfo[i];
 
         if (faction)
         {

--- a/src/factionInfo.cpp
+++ b/src/factionInfo.cpp
@@ -61,20 +61,21 @@ REGISTER_SCRIPT_CLASS(FactionInfo)
     /// other_faction = getFactionInfoByName("Exuari")
     /// faction:setRelationship(other_faction,"enemy") -- sets a hostile relationship with Exuari
     REGISTER_SCRIPT_CLASS_FUNCTION(FactionInfo, setRelationshipWith);
-    /// Sets the given faction to be hostile to SpaceObjects of this faction.
+    /// Sets this faction to be hostile to SpaceObjects of the given faction.
     /// For example, Spaceships of this faction can target and fire at SpaceShips of the given faction, and vice versa.
     /// Warning: A faction can be designated as hostile to itself, but the behavior is not well-defined.
     /// Example: faction:setEnemy("Exuari") -- sets the Exuari to be hostile toward this faction
     REGISTER_SCRIPT_CLASS_FUNCTION(FactionInfo, setEnemy);
-    /// Sets the given faction to be friendly to SpaceObjects of this faction.
+    /// Sets this faction to be friendly to SpaceObjects of the given faction.
     /// For example, PlayerSpaceships of this faction can gain reputation with it.
     /// Example: faction:setFriendly("Human Navy") -- sets the Human Navy to be friendly toward this faction
     REGISTER_SCRIPT_CLASS_FUNCTION(FactionInfo, setFriendly);
-    /// Sets the given faction to be neutral toward SpaceObjects of this faction.
+    /// Sets this faction to be neutral toward SpaceObjects of the given faction.
     /// This resets any existing faction relationship between this faction and the given faction.
     /// Example: faction:setNeutral("Human Navy") -- sets the Human Navy to be neutral toward this faction
     REGISTER_SCRIPT_CLASS_FUNCTION(FactionInfo, setNeutral);
-    /// Resets all relationships that this faction has with other factions to neutrality.
+    /// Removes all relationships involving this faction, which resets them to neutrality.
+    /// This is equivalent to running faction:setNeutral(...) while looping through every other faction as the argument.
     /// Example: faction:resetAllRelationships() -- removes all existing faction relationships
     REGISTER_SCRIPT_CLASS_FUNCTION(FactionInfo, resetAllRelationships);
 }

--- a/src/factionInfo.cpp
+++ b/src/factionInfo.cpp
@@ -147,7 +147,7 @@ FactionInfo::~FactionInfo()
 void FactionInfo::update(float delta)
 {
     if (index < MAX_FACTIONS) { factionInfo[index] = this; }
-    else { LOG(ERROR) << "Faction " << name << "has index " << index << " outside of limit " << MAX_FACTIONS << "."; }
+    else { LOG(ERROR) << "Faction " << name << "has index " << index << " outside of limit " << MAX_FACTIONS; }
 }
 
 void FactionInfo::setName(string name)
@@ -252,17 +252,6 @@ EFactionVsFactionState FactionInfo::getRelationshipBetween(uint8_t idx0, uint8_t
     }
 
     return factionInfo[idx0]->getRelationshipWith(factionInfo[idx1]);
-}
-
-EFactionVsFactionState FactionInfo::getRelationshipBetween(P<FactionInfo> faction0, P<FactionInfo> faction1)
-{
-    if (!faction0 || !faction1)
-    {
-        LOG(ERROR) << "Given faction is invalid. Returning Neutral.";
-        return FVF_Neutral;
-    }
-
-    return faction0->getRelationshipWith(faction1);
 }
 
 unsigned int FactionInfo::findFactionId(string name)

--- a/src/factionInfo.cpp
+++ b/src/factionInfo.cpp
@@ -16,7 +16,7 @@
 /// If friendly, this faction acts as neutral but also shares short-range radar with PlayerSpaceships in Relay, and can grant reputation points to PlayerSpaceships of the same faction.
 ///
 /// Many scenario and comms scripts also give friendly factions benefits at a reputation cost that netural factions do not.
-/// Factions are loaded from resources/factionInfo.lua upon launching a scenario, and accessed by using the getFactionInfo() global function.
+/// Factions are loaded from resources/factionInfo.lua upon launching a scenario, and accessed by using the getFactions() or getFactionInfoByName() global functions.
 ///
 /// Example:
 /// faction = FactionInfo():setName("USN"):setLocaleName(_("USN")) -- sets the internal and translatable faction names
@@ -54,7 +54,7 @@ REGISTER_SCRIPT_CLASS(FactionInfo)
     REGISTER_SCRIPT_CLASS_FUNCTION(FactionInfo, getRelationshipWith);
     /// Sets this faction's relationship with the given faction to the given state.
     /// Example:
-    /// other_faction = getFactionInfo("Exuari")
+    /// other_faction = getFactionInfoByName("Exuari")
     /// faction:setRelationship(other_faction,"enemy") -- sets a hostile relationship with Exuari
     REGISTER_SCRIPT_CLASS_FUNCTION(FactionInfo, setRelationshipWith);
     /// Sets the given faction to be hostile to SpaceObjects of this faction.
@@ -92,19 +92,23 @@ static int getFactionInfos(lua_State* L)
 /// Example: getFactionInfos()[2] -- returns the second-indexed faction
 REGISTER_SCRIPT_FUNCTION(getFactionInfos);
 
-static int getFactionInfo(lua_State* L)
+static int getFactionInfoByName(lua_State* L)
 {
     const auto* name = luaL_checkstring(L, 1);
-    for (size_t n = 0; n < MAX_FACTIONS; n++)
-        if (factionInfo[n] && factionInfo[n]->getName() == name)
-            return convert<P<FactionInfo>>::returnType(L, factionInfo[n]);
+
+    for (size_t idx = 0; idx < MAX_FACTIONS; idx++)
+    {
+        if (factionInfo[idx] && factionInfo[idx]->getName() == name)
+            return convert<P<FactionInfo>>::returnType(L, factionInfo[idx]);
+    }
+
     return 0;
 }
-/// P<FactionInfo> getFactionInfo(string faction_name)
-/// Returns a reference to the FactionInfo object with the given name.
+/// P<FactionInfo> getFactionInfoByName(string faction_name)
+/// Returns a reference to the first FactionInfo object found with the given name.
 /// Use this to modify faction details and relationships with FactionInfo functions.
-/// Example: faction = getFactionInfo("Human Navy") -- faction = the Human Navy FactionInfo object
-REGISTER_SCRIPT_FUNCTION(getFactionInfo);
+/// Example: faction = getFactionInfoByName("Human Navy") -- faction = the Human Navy FactionInfo object
+REGISTER_SCRIPT_FUNCTION(getFactionInfoByName);
 
 REGISTER_MULTIPLAYER_CLASS(FactionInfo, "FactionInfo");
 FactionInfo::FactionInfo()

--- a/src/factionInfo.h
+++ b/src/factionInfo.h
@@ -68,6 +68,8 @@ public:
      */
     void setFriendly(P<FactionInfo> other);
 
+    void setRelationship(P<FactionInfo> other, EFactionVsFactionState state);
+    EFactionVsFactionState getRelationship(P<FactionInfo> other);
     EFactionVsFactionState getState(P<FactionInfo> other);
 
     static EFactionVsFactionState getState(uint8_t idx0, uint8_t idx1);

--- a/src/factionInfo.h
+++ b/src/factionInfo.h
@@ -9,7 +9,7 @@
 
 
 class FactionInfo;
-const uint8_t MAX_FACTIONS = 32;
+const size_t MAX_FACTIONS = 32;
 extern std::array<P<FactionInfo>, MAX_FACTIONS> factionInfo;
 
 enum EFactionVsFactionState

--- a/src/factionInfo.h
+++ b/src/factionInfo.h
@@ -26,6 +26,8 @@ public:
     virtual ~FactionInfo();
 
     virtual void update(float delta) override;
+
+    uint8_t getFactionId() { return this->index; }
     /*!
      * \brief Set name of faction.
      * \param Name Name of the faction

--- a/src/factionInfo.h
+++ b/src/factionInfo.h
@@ -30,7 +30,7 @@ public:
      * \brief Set name of faction.
      * \param Name Name of the faction
      */
-    void setName(string name) { this->name = name; if (locale_name == "") { locale_name = name; } }
+    void setName(string name);
     void setLocaleName(string name) { this->locale_name = name; }
 
     /*!

--- a/src/factionInfo.h
+++ b/src/factionInfo.h
@@ -87,7 +87,8 @@ public:
      * \return Enum state value
      */
     EFactionVsFactionState getRelationshipWith(P<FactionInfo> other);
-    static EFactionVsFactionState getState(uint8_t idx0, uint8_t idx1);
+    static EFactionVsFactionState getRelationshipBetween(uint8_t idx0, uint8_t idx1);
+    static EFactionVsFactionState getRelationshipBetween(P<FactionInfo> faction0, P<FactionInfo> faction1);
     static unsigned int findFactionId(string name);
 
     static void reset(); //Destroy all FactionInfo objects

--- a/src/factionInfo.h
+++ b/src/factionInfo.h
@@ -30,7 +30,7 @@ public:
      * \brief Set name of faction.
      * \param Name Name of the faction
      */
-    void setName(string name) { this->name = name; if (locale_name == "") locale_name = name; }
+    void setName(string name) { this->name = name; if (locale_name == "") { locale_name = name; } }
     void setLocaleName(string name) { this->locale_name = name; }
 
     /*!
@@ -81,14 +81,12 @@ public:
      * \brief Sets this faction's relationship using EFactionVsFactionState
      * \param faction state enum value
      */
-    void setRelationship(P<FactionInfo> other, EFactionVsFactionState state);
+    void setRelationshipWith(P<FactionInfo> other, EFactionVsFactionState state);
     /*!
      * \brief Returns this faction's relationship using EFactionVsFactionState
      * \return Enum state value
      */
-    EFactionVsFactionState getRelationship(P<FactionInfo> other);
-
-    EFactionVsFactionState getState(P<FactionInfo> other);
+    EFactionVsFactionState getRelationshipWith(P<FactionInfo> other);
     static EFactionVsFactionState getState(uint8_t idx0, uint8_t idx1);
     static unsigned int findFactionId(string name);
 

--- a/src/factionInfo.h
+++ b/src/factionInfo.h
@@ -67,6 +67,15 @@ public:
      * \param faction info object.
      */
     void setFriendly(P<FactionInfo> other);
+    /*!
+     * \brief Reverts this faction to neutrality with the given faction.
+     * \param faction info object.
+     */
+    void setNeutral(P<FactionInfo> other);
+    /*!
+     * \brief Reverts all of this faction's relationships with other factions to neutrality.
+     */
+    void resetAllRelationships();
 
     void setRelationship(P<FactionInfo> other, EFactionVsFactionState state);
     EFactionVsFactionState getRelationship(P<FactionInfo> other);

--- a/src/factionInfo.h
+++ b/src/factionInfo.h
@@ -88,7 +88,6 @@ public:
      */
     EFactionVsFactionState getRelationshipWith(P<FactionInfo> other);
     static EFactionVsFactionState getRelationshipBetween(uint8_t idx0, uint8_t idx1);
-    static EFactionVsFactionState getRelationshipBetween(P<FactionInfo> faction0, P<FactionInfo> faction1);
     static unsigned int findFactionId(string name);
 
     static void reset(); //Destroy all FactionInfo objects

--- a/src/factionInfo.h
+++ b/src/factionInfo.h
@@ -9,7 +9,8 @@
 
 
 class FactionInfo;
-extern std::array<P<FactionInfo>, 32> factionInfo;
+const uint8_t MAX_FACTIONS = 32;
+extern std::array<P<FactionInfo>, MAX_FACTIONS> factionInfo;
 
 enum EFactionVsFactionState
 {

--- a/src/factionInfo.h
+++ b/src/factionInfo.h
@@ -77,11 +77,18 @@ public:
      * \brief Reverts all of this faction's relationships with other factions to neutrality.
      */
     void resetAllRelationships();
-
+    /*!
+     * \brief Sets this faction's relationship using EFactionVsFactionState
+     * \param faction state enum value
+     */
     void setRelationship(P<FactionInfo> other, EFactionVsFactionState state);
+    /*!
+     * \brief Returns this faction's relationship using EFactionVsFactionState
+     * \return Enum state value
+     */
     EFactionVsFactionState getRelationship(P<FactionInfo> other);
-    EFactionVsFactionState getState(P<FactionInfo> other);
 
+    EFactionVsFactionState getState(P<FactionInfo> other);
     static EFactionVsFactionState getState(uint8_t idx0, uint8_t idx1);
     static unsigned int findFactionId(string name);
 

--- a/src/scienceDatabase.cpp
+++ b/src/scienceDatabase.cpp
@@ -437,7 +437,7 @@ void fillDefaultDatabaseData()
                 continue;
 
             string stance = tr("stance", "Neutral");
-            switch(FactionInfo::getState(n, m))
+            switch(FactionInfo::getRelationshipBetween(n, m))
             {
                 case FVF_Neutral: stance = tr("stance", "Neutral"); break;
                 case FVF_Enemy: stance = tr("stance", "Enemy"); break;

--- a/src/screenComponents/indicatorOverlays.cpp
+++ b/src/screenComponents/indicatorOverlays.cpp
@@ -125,9 +125,9 @@ void GuiIndicatorOverlays::onDraw(sp::RenderTarget& renderer)
             EFactionVsFactionState fvf_state = FVF_Neutral;
             if (my_spaceship)
             {
-                fvf_state = FactionInfo::getState(gameGlobalInfo->getVictoryFactionId(), my_spaceship->getFactionId());
+                fvf_state = FactionInfo::getRelationshipBetween(gameGlobalInfo->getVictoryFactionId(), my_spaceship->getFactionId());
             }
-            switch(fvf_state)
+            switch (fvf_state)
             {
             case FVF_Enemy:
                 victory_label->setText(tr("Defeat!"));

--- a/src/spaceObjects/spaceObject.cpp
+++ b/src/spaceObjects/spaceObject.cpp
@@ -413,21 +413,17 @@ void SpaceObject::setScanningParameters(int complexity, int depth)
 bool SpaceObject::isEnemy(P<SpaceObject> obj)
 {
     if (obj)
-    {
-        return FactionInfo::getState(faction_id, obj->faction_id) == FVF_Enemy;
-    } else {
-        return false;
-    }
+        return FactionInfo::getRelationshipBetween(faction_id, obj->faction_id) == FVF_Enemy;
+
+    return false;
 }
 
 bool SpaceObject::isFriendly(P<SpaceObject> obj)
 {
     if (obj)
-    {
-        return FactionInfo::getState(faction_id, obj->faction_id) == FVF_Friendly;
-    } else {
-        return false;
-    }
+        return FactionInfo::getRelationshipBetween(faction_id, obj->faction_id) == FVF_Friendly;
+
+    return false;
 }
 
 void SpaceObject::damageArea(glm::vec2 position, float blast_range, float min_damage, float max_damage, DamageInfo info, float min_range)

--- a/src/spaceObjects/spaceship.cpp
+++ b/src/spaceObjects/spaceship.cpp
@@ -1716,24 +1716,25 @@ void SpaceShip::addBroadcast(int threshold, string message)
 
     for(int n=0; n<GameGlobalInfo::max_player_ships; n++)
     {
-        bool addtolog = 0;
+        bool addtolog = false;
         P<PlayerSpaceship> ship = gameGlobalInfo->getPlayerShip(n);
+
         if (ship)
         {
             if (this->isFriendly(ship))
             {
                 color = glm::u8vec4(154, 255, 154, 255); //ally = light green
-                addtolog = 1;
+                addtolog = true;
             }
-            else if ((FactionInfo::getState(this->getFactionId(), ship->getFactionId()) == FVF_Neutral) && ((threshold >= FVF_Neutral)))
+            else if (FactionInfo::getRelationshipBetween(this->getFactionId(), ship->getFactionId()) == FVF_Neutral && threshold >= FVF_Neutral)
             {
                 color = glm::u8vec4(128,128,128, 255); //neutral = grey
-                addtolog = 1;
+                addtolog = true;
             }
-            else if ((this->isEnemy(ship)) && (threshold == FVF_Enemy))
+            else if (this->isEnemy(ship) && threshold == FVF_Enemy)
             {
                 color = glm::u8vec4(255,102,102, 255); //enemy = light red
-                addtolog = 1;
+                addtolog = true;
             }
 
             if (addtolog)


### PR DESCRIPTION
Refactor FactionInfo to close #530.

- Add new global scripting function `getFactionInfos()` to return all FactionInfo objects.
- Convert `EFriendVsFoeState` enum to "friendly", "enemy", "neutral" in scripting and add to scripting docs
- Set factionInfo limit in a constant and use it instead of `factionInfo.size()`
- Add `getFactionId()` and expose to scripting
- Expose `getName()`, `getLocaleName()`, `getDescription()` to scripting
- Add `getRelationshipWith()` and `setRelationshipWith()` and expose to scripting.
  - `getRelationshipWith()` replaces `getState()` in internal usage.
- Add `setNeutral()` to reset a faction's friend/enemy mask toward another faction, and `resetAllRelationships()` to set all relationships to neutral.

This adds potential breaking changes:

- Renames `getFactionInfo()` to `getFactionInfoByName()`. This function isn't used in scenarios that ship with EE, but might be used by others.
- `findFactionId()` (not exposed to scripting) now returns 255 instead of 0 on an failed response, to avoid returning a valid faction ID unexpectedly.