### PR TITLE
lua minigame for micrometeorites point defense

### DIFF
--- a/scripts/locale/utils_micrometeorites.de.po
+++ b/scripts/locale/utils_micrometeorites.de.po
@@ -2,7 +2,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: \n"
 "POT-Creation-Date: \n"
-"PO-Revision-Date: \n"
+"PO-Revision-Date: 2023-11-20 11:57+0100\n"
 "Last-Translator: \n"
 "Language-Team: \n"
 "Language: de_DE\n"
@@ -11,23 +11,31 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 "X-Generator: Poedit 3.1.1\n"
+"X-Poedit-Basepath: .\n"
 
-#: scripts/utils_micrometeorites.lua:17
-msgid "Micrometeorite Defense"
+#: scripts/utils_micrometeorites.lua:26 scripts/utils_micrometeorites.lua:91
+#: scripts/utils_micrometeorites.lua:118
+msgid "MicroMeteorite Defense"
 msgstr "Mikrometeoriten-Abwehr"
 
-#: scripts/utils_micrometeorites.lua:18
-msgid "!!! IMPACT IMMINENT !!!"
-msgstr "!!! EINSCHLAG STEHT BEVOR !!!"
-
-#: scripts/utils_micrometeorites.lua:19
-msgid "Right"
-msgstr "Rechts"
-
-#: scripts/utils_micrometeorites.lua:20
+#: scripts/utils_micrometeorites.lua:27 scripts/utils_micrometeorites.lua:92
+#: scripts/utils_micrometeorites.lua:119
 msgid "Left"
 msgstr "Links"
 
-#: scripts/utils_micrometeorites.lua:21
-msgid "in"
-msgstr "in"
+#: scripts/utils_micrometeorites.lua:28 scripts/utils_micrometeorites.lua:93
+#: scripts/utils_micrometeorites.lua:120
+msgid "Right"
+msgstr "Rechts"
+
+#: scripts/utils_micrometeorites.lua:54
+msgid "!!! IMPACT IMMINENT !!!"
+msgstr "!!! EINSCHLAG STEHT BEVOR !!!"
+
+#: scripts/utils_micrometeorites.lua:68
+msgid "Left in"
+msgstr "Links in"
+
+#: scripts/utils_micrometeorites.lua:70
+msgid "Right in"
+msgstr "Rechts in"

--- a/scripts/locale/utils_micrometeorites.de.po
+++ b/scripts/locale/utils_micrometeorites.de.po
@@ -1,0 +1,33 @@
+msgid ""
+msgstr ""
+"Project-Id-Version: \n"
+"POT-Creation-Date: \n"
+"PO-Revision-Date: \n"
+"Last-Translator: \n"
+"Language-Team: \n"
+"Language: de_DE\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=2; plural=(n != 1);\n"
+"X-Generator: Poedit 3.1.1\n"
+
+#: scripts/utils_micrometeorites.lua:17
+msgid "Micrometeorite Defense"
+msgstr "Mikrometeoriten-Abwehr"
+
+#: scripts/utils_micrometeorites.lua:18
+msgid "!!! IMPACT IMMINENT !!!"
+msgstr "!!! EINSCHLAG STEHT BEVOR !!!"
+
+#: scripts/utils_micrometeorites.lua:19
+msgid "Right"
+msgstr "Rechts"
+
+#: scripts/utils_micrometeorites.lua:20
+msgid "Left"
+msgstr "Links"
+
+#: scripts/utils_micrometeorites.lua:21
+msgid "in"
+msgstr "in"

--- a/scripts/utils_micrometeorites.lua
+++ b/scripts/utils_micrometeorites.lua
@@ -1,15 +1,15 @@
-
 -- Utils for micrometeorite point defense
 -----------
 -- Usage -- 
 -----------
--- For each player ship you want to add micrometeorites for:
+-- Place this line somewhere in the update function:
+-- MicroMeteorites:updateAll(delta)
 
--- In init function:
+-- To add MicroMeteorites to a ship
 -- MicroMeteorites:init([playership])
 
--- In update function:
--- MicroMeteorites:update(delta,[playership])
+-- To remove MicroMeteorites from a ship:
+-- MicroMeteorites:remove([playership])
 
 require('utils.lua')
 
@@ -46,6 +46,13 @@ function MicroMeteorites:update(delta,player_ship)
 	end	
 end
 
+function MicroMeteorites:updateAll(delta)
+    for _, p in ipairs(getActivePlayerShips()) do
+        if p ~= nil then
+            MicroMeteorites:update(delta,p)
+		end
+	end
+end
 
 function MicroMeteorites:timer(delta,player_ship)
     if (not player_ship:getShieldsActive()) and player_ship:hasPlayerAtPosition("Weapons") then -- do not bother the player when shields are up or no weapons officer is around (tactical and single pilot are busy enough)

--- a/scripts/utils_micrometeorites.lua
+++ b/scripts/utils_micrometeorites.lua
@@ -24,7 +24,7 @@ function MicroMeteorites:init(player_ship)
 	player_ship.micrometeorite_phase = 1
 
 	player_ship:addCustomInfo("Weapons","point_defense_info",_("MicroMeteorite Defense"),10)
-	player_ship:addCustomButton("Weapons","point_defense_btn_left",_("« LEFT"),function () MicroMeteorites:fired(1,player_ship) end,11)
+	player_ship:addCustomButton("Weapons","point_defense_btn_left",_("« Left"),function () MicroMeteorites:fired(1,player_ship) end,11)
 	player_ship:addCustomButton("Weapons","point_defense_btn_right",_("» Right"),function () MicroMeteorites:fired(2,player_ship) end,12)
 end
 
@@ -89,7 +89,7 @@ function MicroMeteorites:incoming(delta,player_ship)
         
         --reset info and buttons
         player_ship:addCustomInfo("Weapons","point_defense_info",_("MicroMeteorite Defense"),10)
-		player_ship:addCustomButton("Weapons","point_defense_btn_left",_("« LEFT"),function () MicroMeteorites:fired(1,player_ship) end,11)
+		player_ship:addCustomButton("Weapons","point_defense_btn_left",_("« Left"),function () MicroMeteorites:fired(1,player_ship) end,11)
 		player_ship:addCustomButton("Weapons","point_defense_btn_right",_("» Right"),function () MicroMeteorites:fired(2,player_ship) end,12)
         
         player_ship.micrometeorite_phase=1
@@ -116,7 +116,7 @@ function MicroMeteorites:fired(button_direction,player_ship)
 			
 			--reset info and buttons
 			player_ship:addCustomInfo("Weapons","point_defense_info",_("MicroMeteorite Defense"),10)
-			player_ship:addCustomButton("Weapons","point_defense_btn_left",_("« LEFT"),function () MicroMeteorites:fired(1,player_ship) end,11)
+			player_ship:addCustomButton("Weapons","point_defense_btn_left",_("« Left"),function () MicroMeteorites:fired(1,player_ship) end,11)
 			player_ship:addCustomButton("Weapons","point_defense_btn_right",_("» Right"),function () MicroMeteorites:fired(2,player_ship) end,12)
         
 			player_ship.micrometeorite_phase=1

--- a/scripts/utils_micrometeorites.lua
+++ b/scripts/utils_micrometeorites.lua
@@ -1,3 +1,4 @@
+
 -- Utils for micrometeorite point defense
 -----------
 -- Usage -- 
@@ -24,8 +25,8 @@ function MicroMeteorites:init(player_ship)
 	player_ship.micrometeorite_phase = 1
 
 	player_ship:addCustomInfo("Weapons","point_defense_info",_("MicroMeteorite Defense"),10)
-	player_ship:addCustomButton("Weapons","point_defense_btn_left",_("« Left"),function () MicroMeteorites:fired(1,player_ship) end,11)
-	player_ship:addCustomButton("Weapons","point_defense_btn_right",_("» Right"),function () MicroMeteorites:fired(2,player_ship) end,12)
+	player_ship:addCustomButton("Weapons","point_defense_btn_left","« ".._("Left"),function () MicroMeteorites:fired(1,player_ship) end,11)
+	player_ship:addCustomButton("Weapons","point_defense_btn_right","» ".._("Right"),function () MicroMeteorites:fired(2,player_ship) end,12)
 end
 
 function MicroMeteorites:remove(player_ship)
@@ -36,7 +37,7 @@ function MicroMeteorites:remove(player_ship)
 end
 
 
-function MicroMeteorites:update(delta,player_ship) 
+function MicroMeteorites:update(delta,player_ship)
 	if player_ship.micrometeorite_phase == 1 then
 		MicroMeteorites:timer(delta,player_ship)
 	end
@@ -44,6 +45,7 @@ function MicroMeteorites:update(delta,player_ship)
 		MicroMeteorites:incoming(delta,player_ship)
 	end	
 end
+
 
 function MicroMeteorites:timer(delta,player_ship)
     if (not player_ship:getShieldsActive()) and player_ship:hasPlayerAtPosition("Weapons") then -- do not bother the player when shields are up or no weapons officer is around (tactical and single pilot are busy enough)
@@ -63,7 +65,6 @@ function MicroMeteorites:incoming(delta,player_ship)
     
     if player_ship.micrometeorite_impact_time < player_ship.micrometeorite_impact_countdown-1 then
         player_ship.micrometeorite_impact_countdown=player_ship.micrometeorite_impact_countdown-1
-        print (player_ship.micrometeorite_impact_countdown)
         if player_ship.micrometeorite_direction==1 then
             player_ship:addCustomButton("Weapons","point_defense_btn_left","« ".._("Left in").." "..(player_ship.micrometeorite_impact_countdown),function () MicroMeteorites:fired(1,player_ship) end,11)          			
         else
@@ -89,9 +90,9 @@ function MicroMeteorites:incoming(delta,player_ship)
         
         --reset info and buttons
         player_ship:addCustomInfo("Weapons","point_defense_info",_("MicroMeteorite Defense"),10)
-		player_ship:addCustomButton("Weapons","point_defense_btn_left",_("« Left"),function () MicroMeteorites:fired(1,player_ship) end,11)
-		player_ship:addCustomButton("Weapons","point_defense_btn_right",_("» Right"),function () MicroMeteorites:fired(2,player_ship) end,12)
-        
+        player_ship:addCustomButton("Weapons","point_defense_btn_left","« ".._("Left"),function () MicroMeteorites:fired(1,player_ship) end,11)
+        player_ship:addCustomButton("Weapons","point_defense_btn_right","» ".._("Right"),function () MicroMeteorites:fired(2,player_ship) end,12)
+
         player_ship.micrometeorite_phase=1
     end
 
@@ -99,7 +100,6 @@ end
 
 function MicroMeteorites:fired(button_direction,player_ship)
 	if player_ship:getSystemHeat("beamweapons")<0.99 and player_ship:getSystemHealth("beamweapons")>0.0 and player_ship:getSystemPower("beamweapons")>0.1 then
-		print (player_ship:getSystemHeat("beamweapons"))
 		x, y = player_ship:getPosition()
 		if button_direction==1 then
 			beam_angle=math.random(315,350)+player_ship:getRotation()
@@ -116,15 +116,15 @@ function MicroMeteorites:fired(button_direction,player_ship)
 			
 			--reset info and buttons
 			player_ship:addCustomInfo("Weapons","point_defense_info",_("MicroMeteorite Defense"),10)
-			player_ship:addCustomButton("Weapons","point_defense_btn_left",_("« Left"),function () MicroMeteorites:fired(1,player_ship) end,11)
-			player_ship:addCustomButton("Weapons","point_defense_btn_right",_("» Right"),function () MicroMeteorites:fired(2,player_ship) end,12)
+            player_ship:addCustomButton("Weapons","point_defense_btn_left","« ".._("Left"),function () MicroMeteorites:fired(1,player_ship) end,11)
+            player_ship:addCustomButton("Weapons","point_defense_btn_right","» ".._("Right"),function () MicroMeteorites:fired(2,player_ship) end,12)
         
 			player_ship.micrometeorite_phase=1
-			BeamEffect():setSource(player_ship, 0, 0, 0):setTarget(debris, 0, 0):setDuration(0.5):setRing(false):setTexture("texture/beam_blue.png")
+			BeamEffect():setSource(player_ship, 0, 0, 0):setTarget(debris, 0, 0):setDuration(0.5):setRing(false):setTexture("texture/beam_blue.png"):setBeamFireSoundPower(0.1)
 			ExplosionEffect():setPosition(x+xx,y+yy):setSize(5)
 			player_ship.micrometeorite_direction=0
 		else
-			BeamEffect():setSource(player_ship, 0, 0, 0):setTarget(debris, 0, 0):setDuration(0.5):setRing(false):setTexture("texture/beam_blue.png")
+			BeamEffect():setSource(player_ship, 0, 0, 0):setTarget(debris, 0, 0):setDuration(0.5):setRing(false):setTexture("texture/beam_blue.png"):setBeamFireSoundPower(0.1)
 			player_ship:setSystemHeat("beamweapons", player_ship:getSystemHeat("beamweapons")+0.1) -- some heat to prevent button spamming
 		end
 		debris:destroy()

--- a/scripts/utils_micrometeorites.lua
+++ b/scripts/utils_micrometeorites.lua
@@ -1,0 +1,133 @@
+-- Utils for micrometeorite point defense
+-----------
+-- Usage -- 
+-----------
+-- For each player ship you want to add micrometeorites for:
+
+-- In init function:
+-- MicroMeteorites:init([playership])
+
+-- In update function:
+-- MicroMeteorites:update(delta,[playership])
+
+require('utils.lua')
+
+MicroMeteorites ={}
+
+function MicroMeteorites:init(player_ship)
+	player_ship.micrometeorite_impact_time=5	-- time to react after warning
+	player_ship.micrometeorite_delay_min=20		-- minimal...
+	player_ship.micrometeorite_delay_max=30		-- ...and maximal delay between two impact warnings
+	
+	player_ship.micrometeorite_impact_countdown=player_ship.micrometeorite_impact_time
+	player_ship.micrometeorite_time=math.random(player_ship.micrometeorite_delay_min,player_ship.micrometeorite_delay_max)
+	player_ship.micrometeorite_phase = 1
+
+	player_ship:addCustomInfo("Weapons","point_defense_info",_("MicroMeteorite Defense"),10)
+	player_ship:addCustomButton("Weapons","point_defense_btn_left","« LEFT",function () MicroMeteorites:fired(1,player_ship) end,11)
+	player_ship:addCustomButton("Weapons","point_defense_btn_right","» Right",function () MicroMeteorites:fired(2,player_ship) end,12)
+end
+
+function MicroMeteorites:remove(player_ship)
+	player_ship:removeCustom("point_defense_info")
+	player_ship:removeCustom("point_defense_btn_left")
+	player_ship:removeCustom("point_defense_btn_right")
+	player_ship.micrometeorite_phase = 0
+end
+
+
+function MicroMeteorites:update(delta,player_ship) 
+	if player_ship.micrometeorite_phase == 1 then
+		MicroMeteorites:timer(delta,player_ship)
+	end
+	if player_ship.micrometeorite_phase == 2 then
+		MicroMeteorites:incoming(delta,player_ship)
+	end	
+end
+
+function MicroMeteorites:timer(delta,player_ship)
+    if (not player_ship:getShieldsActive()) and player_ship:hasPlayerAtPosition("Weapons") then -- do not bother the player when shields are up or no weapons officer is around (tactical and single pilot are busy enough)
+        player_ship.micrometeorite_time = player_ship.micrometeorite_time - delta
+        if player_ship.micrometeorite_time <= 0 then
+            player_ship.micrometeorite_direction = math.random(1,2)
+            player_ship.micrometeorite_phase = 2
+            player_ship:addCustomInfo("Weapons","point_defense_info","!!! IMPACT IMMINENT !!!",10)
+        end
+    end
+    
+end
+
+function MicroMeteorites:incoming(delta,player_ship)
+    
+    player_ship.micrometeorite_impact_time=player_ship.micrometeorite_impact_time-delta
+    
+    if player_ship.micrometeorite_impact_time < player_ship.micrometeorite_impact_countdown-1 then
+        player_ship.micrometeorite_impact_countdown=player_ship.micrometeorite_impact_countdown-1
+        print (player_ship.micrometeorite_impact_countdown)
+        if player_ship.micrometeorite_direction==1 then
+            player_ship:addCustomButton("Weapons","point_defense_btn_left","« ".."Left in".." "..(player_ship.micrometeorite_impact_countdown),function () MicroMeteorites:fired(1,player_ship) end,11)          			
+        else
+            player_ship:addCustomButton("Weapons","point_defense_btn_right","« ".."Right in".." "..(player_ship.micrometeorite_impact_countdown),function () MicroMeteorites:fired(2,player_ship) end,12)
+        end
+    end    
+    
+    if player_ship.micrometeorite_impact_time <= 0 then
+        player_ship.micrometeorite_impact_time=5
+        x, y = player_ship:getPosition()
+		if player_ship.micrometeorite_direction==1 then
+		 explosion_angle=math.random(315,350)+player_ship:getRotation()
+		else if player_ship.micrometeorite_direction==2 then
+		 explosion_angle=math.random(10,45)+player_ship:getRotation()
+		end
+		end
+		xx, yy = vectorFromAngle(explosion_angle, 150)
+		ExplosionEffect():setPosition(x+xx,y+yy):setSize(10)
+		player_ship:takeDamage(5,"kinetic",x+xx,y+yy)
+        
+        player_ship.micrometeorite_impact_countdown=5
+        player_ship.micrometeorite_time=math.random(player_ship.micrometeorite_delay_min,player_ship.micrometeorite_delay_max)
+        
+        --reset info and buttons
+        player_ship:addCustomInfo("Weapons","point_defense_info",_("MicroMeteorite Defense"),10)
+		player_ship:addCustomButton("Weapons","point_defense_btn_left","« LEFT",function () MicroMeteorites:fired(1,player_ship) end,11)
+		player_ship:addCustomButton("Weapons","point_defense_btn_right","» Right",function () MicroMeteorites:fired(2,player_ship) end,12)
+        
+        player_ship.micrometeorite_phase=1
+    end
+
+end
+
+function MicroMeteorites:fired(button_direction,player_ship)
+	if player_ship:getSystemHeat("beamweapons")<0.99 and player_ship:getSystemHealth("beamweapons")>0.0 and player_ship:getSystemPower("beamweapons")>0.1 then
+		print (player_ship:getSystemHeat("beamweapons"))
+		x, y = player_ship:getPosition()
+		if button_direction==1 then
+			beam_angle=math.random(315,350)+player_ship:getRotation()
+			else if button_direction==2 then
+				beam_angle=math.random(10,45)+player_ship:getRotation()
+			end
+		end
+		xx, yy = vectorFromAngle(beam_angle, 200*player_ship.micrometeorite_impact_time+100)
+		debris=Artifact():setPosition(x+xx, y+yy):setRadarTraceColor(255,200,100);
+		if player_ship.micrometeorite_direction==button_direction then
+			player_ship.micrometeorite_impact_time=5
+			player_ship.micrometeorite_impact_countdown=5
+			player_ship.micrometeorite_time=math.random(player_ship.micrometeorite_delay_min,player_ship.micrometeorite_delay_max)
+			
+			--reset info and buttons
+			player_ship:addCustomInfo("Weapons","point_defense_info",_("MicroMeteorite Defense"),10)
+			player_ship:addCustomButton("Weapons","point_defense_btn_left","« LEFT",function () MicroMeteorites:fired(1,player_ship) end,11)
+			player_ship:addCustomButton("Weapons","point_defense_btn_right","» Right",function () MicroMeteorites:fired(2,player_ship) end,12)
+        
+			player_ship.micrometeorite_phase=1
+			BeamEffect():setSource(player_ship, 0, 0, 0):setTarget(debris, 0, 0):setDuration(0.5):setRing(false):setTexture("texture/beam_blue.png")
+			ExplosionEffect():setPosition(x+xx,y+yy):setSize(5)
+			player_ship.micrometeorite_direction=0
+		else
+			BeamEffect():setSource(player_ship, 0, 0, 0):setTarget(debris, 0, 0):setDuration(0.5):setRing(false):setTexture("texture/beam_blue.png")
+			player_ship:setSystemHeat("beamweapons", player_ship:getSystemHeat("beamweapons")+0.1) -- some heat to prevent button spamming
+		end
+		debris:destroy()
+	end
+end
+

--- a/scripts/utils_micrometeorites.lua
+++ b/scripts/utils_micrometeorites.lua
@@ -24,8 +24,8 @@ function MicroMeteorites:init(player_ship)
 	player_ship.micrometeorite_phase = 1
 
 	player_ship:addCustomInfo("Weapons","point_defense_info",_("MicroMeteorite Defense"),10)
-	player_ship:addCustomButton("Weapons","point_defense_btn_left","« LEFT",function () MicroMeteorites:fired(1,player_ship) end,11)
-	player_ship:addCustomButton("Weapons","point_defense_btn_right","» Right",function () MicroMeteorites:fired(2,player_ship) end,12)
+	player_ship:addCustomButton("Weapons","point_defense_btn_left",_("« LEFT"),function () MicroMeteorites:fired(1,player_ship) end,11)
+	player_ship:addCustomButton("Weapons","point_defense_btn_right",_("» Right"),function () MicroMeteorites:fired(2,player_ship) end,12)
 end
 
 function MicroMeteorites:remove(player_ship)
@@ -51,7 +51,7 @@ function MicroMeteorites:timer(delta,player_ship)
         if player_ship.micrometeorite_time <= 0 then
             player_ship.micrometeorite_direction = math.random(1,2)
             player_ship.micrometeorite_phase = 2
-            player_ship:addCustomInfo("Weapons","point_defense_info","!!! IMPACT IMMINENT !!!",10)
+            player_ship:addCustomInfo("Weapons","point_defense_info",_("!!! IMPACT IMMINENT !!!"),10)
         end
     end
     
@@ -65,9 +65,9 @@ function MicroMeteorites:incoming(delta,player_ship)
         player_ship.micrometeorite_impact_countdown=player_ship.micrometeorite_impact_countdown-1
         print (player_ship.micrometeorite_impact_countdown)
         if player_ship.micrometeorite_direction==1 then
-            player_ship:addCustomButton("Weapons","point_defense_btn_left","« ".."Left in".." "..(player_ship.micrometeorite_impact_countdown),function () MicroMeteorites:fired(1,player_ship) end,11)          			
+            player_ship:addCustomButton("Weapons","point_defense_btn_left","« ".._("Left in").." "..(player_ship.micrometeorite_impact_countdown),function () MicroMeteorites:fired(1,player_ship) end,11)          			
         else
-            player_ship:addCustomButton("Weapons","point_defense_btn_right","« ".."Right in".." "..(player_ship.micrometeorite_impact_countdown),function () MicroMeteorites:fired(2,player_ship) end,12)
+            player_ship:addCustomButton("Weapons","point_defense_btn_right","« ".._("Right in").." "..(player_ship.micrometeorite_impact_countdown),function () MicroMeteorites:fired(2,player_ship) end,12)
         end
     end    
     
@@ -89,8 +89,8 @@ function MicroMeteorites:incoming(delta,player_ship)
         
         --reset info and buttons
         player_ship:addCustomInfo("Weapons","point_defense_info",_("MicroMeteorite Defense"),10)
-		player_ship:addCustomButton("Weapons","point_defense_btn_left","« LEFT",function () MicroMeteorites:fired(1,player_ship) end,11)
-		player_ship:addCustomButton("Weapons","point_defense_btn_right","» Right",function () MicroMeteorites:fired(2,player_ship) end,12)
+		player_ship:addCustomButton("Weapons","point_defense_btn_left",_("« LEFT"),function () MicroMeteorites:fired(1,player_ship) end,11)
+		player_ship:addCustomButton("Weapons","point_defense_btn_right",_("» Right"),function () MicroMeteorites:fired(2,player_ship) end,12)
         
         player_ship.micrometeorite_phase=1
     end
@@ -116,8 +116,8 @@ function MicroMeteorites:fired(button_direction,player_ship)
 			
 			--reset info and buttons
 			player_ship:addCustomInfo("Weapons","point_defense_info",_("MicroMeteorite Defense"),10)
-			player_ship:addCustomButton("Weapons","point_defense_btn_left","« LEFT",function () MicroMeteorites:fired(1,player_ship) end,11)
-			player_ship:addCustomButton("Weapons","point_defense_btn_right","» Right",function () MicroMeteorites:fired(2,player_ship) end,12)
+			player_ship:addCustomButton("Weapons","point_defense_btn_left",_("« LEFT"),function () MicroMeteorites:fired(1,player_ship) end,11)
+			player_ship:addCustomButton("Weapons","point_defense_btn_right",_("» Right"),function () MicroMeteorites:fired(2,player_ship) end,12)
         
 			player_ship.micrometeorite_phase=1
 			BeamEffect():setSource(player_ship, 0, 0, 0):setTarget(debris, 0, 0):setDuration(0.5):setRing(false):setTexture("texture/beam_blue.png")

--- a/scripts/utils_micrometeorites.lua
+++ b/scripts/utils_micrometeorites.lua
@@ -116,6 +116,7 @@ function MicroMeteorites:fired(button_direction,player_ship)
 		end
 		xx, yy = vectorFromAngle(beam_angle, 200*player_ship.micrometeorite_impact_time+100)
 		debris=Artifact():setPosition(x+xx, y+yy):setRadarTraceColor(255,200,100);
+        debris.components.lifetime = {lifetime=.01}
 		if player_ship.micrometeorite_direction==button_direction then
 			player_ship.micrometeorite_impact_time=5
 			player_ship.micrometeorite_impact_countdown=5
@@ -134,7 +135,6 @@ function MicroMeteorites:fired(button_direction,player_ship)
 			BeamEffect():setSource(player_ship, 0, 0, 0):setTarget(debris, 0, 0):setDuration(0.5):setRing(false):setTexture("texture/beam_blue.png"):setBeamFireSoundPower(0.1)
 			player_ship:setSystemHeat("beamweapons", player_ship:getSystemHeat("beamweapons")+0.1) -- some heat to prevent button spamming
 		end
-		debris:destroy()
 	end
 end
 


### PR DESCRIPTION
This is some plugin style lua script that provides an extremly simple "minigame" for the weapons console.
![micrometeorite](https://user-images.githubusercontent.com/25465934/216316713-4082da06-5588-4ebe-9003-c0befcbceec5.jpg)

It is basically an attempt to keep weapons on their toes outside of combat or scripted events. 
Every now and then, a micrometeorite is detected, and weapons has a short time windows to shoot it down by pressing the right button.
In can be en- and disabled per player ship. With shields on, it is always inactive, as this is a rough indicator of being in combat. In game, this could be explained by stating that micrometeorites are just absorbed by the shield.
It is also inactive when no weapons officer is present, as tactical and single pilot are busy enough.

I am not quite sure about the actual utility of this, but I figured publishing I might be useful anyways, at the very least as an example of modularization for scenario writers, so one might be encouraged to outsource systems so that they can be reused in other scenarios.
Shoutout to @hemmond, looking into the custom elements wrapper helped me a lot with OOP-izing the minigame.

I also added translation tags, although I am not sure if utility scripts are translatable at all. But as those tags did no harm either, I added them anyway