### PR TITLE
[android] Bump NDK to 23c, update Android build doc

### DIFF
--- a/android/Readme.md
+++ b/android/Readme.md
@@ -1,15 +1,53 @@
-Building for android depends on the cmake toolchain file in cmake/android.toolchain
+Building for Android depends on the cmake toolchain file in `cmake/android.toolchain`, and having `cmake` and [Oracle Java 8 or newer JRE and JDK packages](https://www.oracle.com/java/technologies/downloads/) for your OS installed. (OpenJDK does NOT work for building!)
 
-This toolchain file does a few things next to being just a toolchain file:
-* It downloads and install the android SDK + NDK with all required tools. This requires accepting a license
-* It downloads and compiles SFML with requirements and installs those in the NDK folder
-* Builds an APK from the compiled sources
+In addition configuring the EE build, this toolchain file does a few additional things:
 
-Because of this, building EE for android should be as easy as:
+-   Downloads and installs the android SDK + NDK with all required tools. This requires accepting a license.
+-   Downloads and compiles SDL2 with requirements and installs those in the NDK folder.
+-   Builds an APK from the compiled sources.
+
+## Build for 32-bit ARM v7
+
+Building 32-bit EE for Android should be as easy as running from the repo root:
+
 ```
 mkdir _build_android
 cd _build_android
-cmake .. -DCMAKE_TOOLCHAIN_FILE=../cmake/android.toolchain -DSERIOUS_PROTON_DIR=../../SeriousProton
-make -j 5
+cmake .. -G Ninja -DSERIOUS_PROTON_DIR=../../SeriousProton -DCMAKE_TOOLCHAIN_FILE=../cmake/android.toolchain
+ninja
 ```
-Note that this only works on linux. Building from windows is not supported at the moment.
+
+## Build for 64-bit ARM v8
+
+Some newer devices, such as the Pixel 7 series, won't run 32-bit Android apps.
+
+To build 64-bit EE for Android, add the `-DANDROID_ABI=arm64-v8a` flag:
+
+```
+mkdir _build_android_64
+cd _build_android_64
+cmake .. -G Ninja -DSERIOUS_PROTON_DIR=../../SeriousProton -DCMAKE_TOOLCHAIN_FILE=../cmake/android.toolchain -DANDROID_ABI=arm64-v8a
+ninja
+```
+
+## Troubleshooting
+
+### "CMAKE_MAKE_PROGRAM is not set"
+
+If you encounter a `CMAKE_MAKE_PROGRAM is not set` error, make sure you've installed `make`. If you've installed it, ensure it's in your `$PATH`/`%PATH%`; if it is and it still fails, add `-DCMAKE_MAKE_PROGRAM=$(which make)` to manually specify its location.
+
+### "jarsigner error"
+
+If you encounter a `jarsigner error: java.lang.RuntimeException: keystore load: ... (No such file or directory)` error, you need to create a keystore. The Android build script uses:
+
+```
+keytool -genkey -alias ${ANDROID_SIGN_KEY_NAME} -keyalg RSA -keysize 2048 -validity 10000
+```
+
+where the default `ANDROID_SIGN_KEY_NAME` is `"Android"` and the default password is `password`, and the command generates the keystore file at `~/.keystore`.
+
+### "Invalid keystore format"
+
+If you have a keystore but get a `keystore load: Invalid keystore format` error, ensure that the keystore conforms to the above command's flags and is at the specified location. See `cmake/android.toolchain` for details.
+
+Note that this only works on Linux. Building for Android from Windows is not supported at the moment.

--- a/cmake/android.toolchain
+++ b/cmake/android.toolchain
@@ -17,7 +17,7 @@
 set(ANDROID_SDK_PATH "" CACHE PATH "Location of the android SDK installation.")
 set(ANDROID_API_MIN "16" CACHE STRING "Minimal API version for android build, any device below this version is not supported.")
 set(ANDROID_API_TARGET "26" CACHE STRING "Targeting API version for android, any features above this version cannot be used.")
-set(ANDROID_NDK_VERSION "19.2.5345600" CACHE STRING "NDK version to use. Be mindful, this is brittle across SDL2/CMake/NDK configurations.")
+set(ANDROID_NDK_VERSION "23.2.8568313" CACHE STRING "NDK version to use. Be mindful, this is brittle across SDL2/CMake/NDK configurations.")
 set(ANDROID_ABI "armeabi-v7a" CACHE STRING "Target ABI")
 
 # Signing key to use to sign the APK. You can generate one with:


### PR DESCRIPTION
This allows for building to 64-bit ARM v8 targets with the -DANDROID_ABI=arm64-v8a cmake flag without breaking on zeux/meshoptimizer#534, and documents it.

Changing the NDK might break builds on pre-2015 Android ARM v7 devices that don't support NEON (ARM Advanced SIMD). If so, see https://developer.android.com/ndk/guides/cpu-arm-neon