### PR TITLE
[SpaceShip] Update beam export strings, add scripting functions

### DIFF
--- a/src/shipTemplate.h
+++ b/src/shipTemplate.h
@@ -165,6 +165,7 @@ public:
      * Convenience function to set the texture of a beam by index.
      */
     void setBeamTexture(int index, string texture);
+
     void setBeamWeaponEnergyPerFire(int index, float energy) { if (index < 0 || index >= max_beam_weapons) return; return beams[index].setEnergyPerFire(energy); }
     void setBeamWeaponHeatPerFire(int index, float heat) { if (index < 0 || index >= max_beam_weapons) return; return beams[index].setHeatPerFire(heat); }
 

--- a/src/spaceObjects/spaceship.h
+++ b/src/spaceObjects/spaceship.h
@@ -441,6 +441,10 @@ public:
 
     float getBeamWeaponCycleTime(int index) { if (index < 0 || index >= max_beam_weapons) return 0.0; return beam_weapons[index].getCycleTime(); }
     float getBeamWeaponDamage(int index) { if (index < 0 || index >= max_beam_weapons) return 0.0; return beam_weapons[index].getDamage(); }
+    EDamageType getBeamWeaponDamageType(int index) { if (index < 0 || index >= max_beam_weapons) return DT_Energy; return beam_weapons[index].getDamageType(); }
+
+    string getBeamWeaponTexture(int index) { if (index < 0 || index >= max_beam_weapons) return ""; return beam_weapons[index].getBeamTexture(); }
+
     float getBeamWeaponEnergyPerFire(int index) { if (index < 0 || index >= max_beam_weapons) return 0.0; return beam_weapons[index].getEnergyPerFire(); }
     float getBeamWeaponHeatPerFire(int index) { if (index < 0 || index >= max_beam_weapons) return 0.0; return beam_weapons[index].getHeatPerFire(); }
 
@@ -505,13 +509,15 @@ public:
     // Return a string that can be appended to an object create function in the lua scripting.
     // This function is used in getScriptExport calls to adjust for tweaks done in the GM screen.
     string getScriptExportModificationsOnTemplate();
-    
 };
 
 float frequencyVsFrequencyDamageFactor(int beam_frequency, int shield_frequency);
 
 string getMissileWeaponName(EMissileWeapons missile);
 string getLocaleMissileWeaponName(EMissileWeapons missile);
+string getDamageTypeName(EDamageType type);
+
+REGISTER_MULTIPLAYER_ENUM(EDamageType);
 REGISTER_MULTIPLAYER_ENUM(EMissileWeapons);
 REGISTER_MULTIPLAYER_ENUM(EWeaponTubeState);
 REGISTER_MULTIPLAYER_ENUM(EMainScreenSetting);

--- a/src/spaceObjects/spaceshipParts/beamWeapon.cpp
+++ b/src/spaceObjects/spaceshipParts/beamWeapon.cpp
@@ -78,6 +78,11 @@ void BeamWeapon::setDamageType(EDamageType type)
     damage_type = type;
 }
 
+EDamageType BeamWeapon::getDamageType()
+{
+    return damage_type;
+}
+
 void BeamWeapon::setDirection(float direction)
 {
     this->direction = direction;

--- a/src/spaceObjects/spaceshipParts/beamWeapon.h
+++ b/src/spaceObjects/spaceshipParts/beamWeapon.h
@@ -25,6 +25,7 @@ public:
     glm::u8vec4 getArcFireColor();
 
     void setDamageType(EDamageType type);
+    EDamageType getDamageType();
 
     void setDirection(float direction);
     float getDirection();


### PR DESCRIPTION
- Adds SpaceShip:getBeamWeaponDamageType(), SpaceShip:getBeamWeaponTexture() scripting functions
- Handles impulse_max_reverse_speed in setImpulseMaxSpeed exports (fixes #1891)
- Adds setAcceleration export
- Splits setBeamWeapon and setBeamWeaponTurret export conditions
- Adds setBeamWeaponTexture, setBeamWeaponEnergyPerFire, setBeamWeaponHeatPerFire, and setBeamWeaponDamageType exports