### PR TITLE
[tweak] Add beam heat/energy per fire

### DIFF
--- a/src/screens/gm/tweak.cpp
+++ b/src/screens/gm/tweak.cpp
@@ -407,7 +407,7 @@ GuiShipTweakMissileTubes::GuiShipTweakMissileTubes(GuiContainer* owner)
     });
     size_selector->addEntry(tr("tube", "Small"),MS_Small);
     size_selector->addEntry(tr("tube", "Medium"),MS_Medium);
-    size_selector->addEntry(tr("tube", "large"),MS_Large);
+    size_selector->addEntry(tr("tube", "Large"),MS_Large);
     size_selector->setSelectionIndex(MS_Medium);
     size_selector->setSize(GuiElement::GuiSizeMax, 40);
 
@@ -553,7 +553,7 @@ GuiShipTweakBeamweapons::GuiShipTweakBeamweapons(GuiContainer* owner)
         if (value > 0)
             target->beam_weapons[beam_index].setTurretRotationRate(value / 10.0f);
         else
-            target->beam_weapons[beam_index].setTurretRotationRate(0.0);
+            target->beam_weapons[beam_index].setTurretRotationRate(0.0f);
     });
     turret_rotation_rate_slider->setSize(GuiElement::GuiSizeMax, 30);
     // Override overlay label.
@@ -571,6 +571,25 @@ GuiShipTweakBeamweapons::GuiShipTweakBeamweapons(GuiContainer* owner)
         target->beam_weapons[beam_index].setCycleTime(value);
     });
     cycle_time_slider->addOverlay()->setSize(GuiElement::GuiSizeMax, 30);
+
+    (new GuiLabel(right_col, "", tr("beam", "Energy used per fire:"), 20))->setSize(GuiElement::GuiSizeMax, 30);
+    energy_per_fire_slider = new GuiSlider(right_col, "", 0.0, 20.0, 0.0, [this](float value) {
+        target->beam_weapons[beam_index].setEnergyPerFire(value);
+    });
+    energy_per_fire_slider->addOverlay()->setSize(GuiElement::GuiSizeMax, 30);
+
+    (new GuiLabel(right_col, "", tr("beam", "Heat generated per fire:"), 20))->setSize(GuiElement::GuiSizeMax, 30);
+    heat_per_fire_slider = new GuiSlider(right_col, "", 0.0, 250.0, 0.0, [this](float value) {
+        // Divide a large value for granularity.
+        if (value > 0)
+            target->beam_weapons[beam_index].setHeatPerFire(value / 100.0f);
+        else
+            target->beam_weapons[beam_index].setHeatPerFire(0.0f);
+    });
+    heat_per_fire_slider->setSize(GuiElement::GuiSizeMax, 30);
+    // Override overlay label.
+    heat_per_fire_overlay_label = new GuiLabel(heat_per_fire_slider, "", "", 30);
+    heat_per_fire_overlay_label->setSize(GuiElement::GuiSizeMax, GuiElement::GuiSizeMax);
 
     (new GuiLabel(right_col, "", tr("beam", "Damage:"), 20))->setSize(GuiElement::GuiSizeMax, 30);
     damage_slider = new GuiSlider(right_col, "", 0.1, 50.0, 0.0, [this](float value) {
@@ -591,6 +610,9 @@ void GuiShipTweakBeamweapons::onDraw(sp::RenderTarget& renderer)
     turret_rotation_rate_slider->setValue(target->beam_weapons[beam_index].getTurretRotationRate() * 10.0f);
     turret_rotation_rate_overlay_label->setText(string(target->beam_weapons[beam_index].getTurretRotationRate()));
     cycle_time_slider->setValue(target->beam_weapons[beam_index].getCycleTime());
+    energy_per_fire_slider->setValue(target->beam_weapons[beam_index].getEnergyPerFire());
+    heat_per_fire_slider->setValue(target->beam_weapons[beam_index].getHeatPerFire() * 100.0f);
+    heat_per_fire_overlay_label->setText(string(target->beam_weapons[beam_index].getHeatPerFire()));
     damage_slider->setValue(target->beam_weapons[beam_index].getDamage());
 }
 

--- a/src/screens/gm/tweak.h
+++ b/src/screens/gm/tweak.h
@@ -167,6 +167,9 @@ private:
     GuiSlider* turret_rotation_rate_slider;
     GuiLabel* turret_rotation_rate_overlay_label;
     GuiSlider* cycle_time_slider;
+    GuiSlider* energy_per_fire_slider;
+    GuiSlider* heat_per_fire_slider;
+    GuiLabel* heat_per_fire_overlay_label;
     GuiSlider* damage_slider;
 public:
     GuiShipTweakBeamweapons(GuiContainer* owner);


### PR DESCRIPTION
Adds sliders for changing heat generated and energy consumed per beam fire to the GM tweaks panel's Beams tab.

Energy per fire slider range is 0-20, heat per fire range is 0-2.5.

![image](https://user-images.githubusercontent.com/19192104/220223002-b1858369-6e7b-4a13-adcb-9dd8f4408ead.png)
