### PR TITLE
[Asteroid] Refactor asteroid rendering on radar

### DIFF
--- a/src/spaceObjects/asteroid.cpp
+++ b/src/spaceObjects/asteroid.cpp
@@ -81,9 +81,6 @@ void Asteroid::drawOnRadar(sp::RenderTarget& renderer, glm::vec2 position, float
         setRadius(size);
 
     renderer.drawSprite("radar/blip.png", position, std::max(6.0f, (getRadius() * 2.0f) * scale), glm::u8vec4(255, 200, 100, 255));
-#ifdef DEBUG
-    renderer.drawCircleOutline(position, std::max(3.0f, getRadius() * scale), 2.0f, glm::u8vec4(255, 200, 100, 255));
-#endif // DEBUG
 }
 
 void Asteroid::collide(Collisionable* target, float force)

--- a/src/spaceObjects/asteroid.cpp
+++ b/src/spaceObjects/asteroid.cpp
@@ -80,10 +80,10 @@ void Asteroid::drawOnRadar(sp::RenderTarget& renderer, glm::vec2 position, float
     if (size != getRadius())
         setRadius(size);
 
-    float size = getRadius() * scale / 64.0f;
-    if (size < 0.2f)
-        size = 0.2f;
-    renderer.drawSprite("radar/blip.png", position, size * 32.0f, glm::u8vec4(255, 200, 100, 255));
+    renderer.drawSprite("radar/blip.png", position, std::max(6.0f, (getRadius() * 2.0f) * scale), glm::u8vec4(255, 200, 100, 255));
+#ifdef DEBUG
+    renderer.drawCircleOutline(position, std::max(3.0f, getRadius() * scale), 2.0f, glm::u8vec4(255, 200, 100, 255));
+#endif // DEBUG
 }
 
 void Asteroid::collide(Collisionable* target, float force)


### PR DESCRIPTION
Fixes #1893.

Replaces the sprite sizing logic for asteroids to use `getRadius() * 2` for the sprite width.

In master branch behavior, large asteroids (>150 radius) are drawn much smaller on radar than their radius. 10, 250, 500 radius from left to right:

![image](https://user-images.githubusercontent.com/19192104/220208710-7a3b0bcd-e8d7-42d2-9c06-37dabedc8a3c.png)

![image](https://user-images.githubusercontent.com/19192104/220208754-f0e1fe68-6896-429a-b4d9-391a2cb86bf3.png)

With this PR, radius 10, 250, 500 from left to right:

![image](https://user-images.githubusercontent.com/19192104/220208445-043b9851-5c8d-4127-8936-a23f54ed23e4.png)

![image](https://user-images.githubusercontent.com/19192104/220208512-751f2b5d-0ab7-4ea1-8869-4f328899fb67.png)

With this PR in a debug build, which draws an extra circle outline using `getRadius()`:

![image](https://user-images.githubusercontent.com/19192104/220208312-69de1b49-b25f-4c6d-b0b5-361f8cac53b2.png)

![image](https://user-images.githubusercontent.com/19192104/220208383-85ea10b3-9439-457a-87f6-631c30257a89.png)