### PR TITLE
[#1904] Hide callsigns for internally docked ships

### DIFF
--- a/src/screenComponents/radarView.cpp
+++ b/src/screenComponents/radarView.cpp
@@ -673,7 +673,7 @@ void GuiRadarView::drawObjects(sp::RenderTarget& renderer)
         if (obj != *my_spaceship && rect.overlaps(object_rect))
         {
             obj->drawOnRadar(renderer, object_position_on_screen, scale, view_rotation, long_range);
-            if (show_callsigns && obj->getCallSign() != "")
+            if (show_callsigns && obj->getCallSign() != "" && obj->getDockedStyle() != DockStyle::Internal)
                 renderer.drawText(sp::Rect(object_position_on_screen.x, object_position_on_screen.y - 15, 0, 0), obj->getCallSign(), sp::Alignment::Center, 15, bold_font);
         }
     };

--- a/src/spaceObjects/spaceObject.h
+++ b/src/spaceObjects/spaceObject.h
@@ -201,6 +201,7 @@ public:
     virtual void setCallSign(string new_callsign) { callsign = new_callsign; }
     virtual string getCallSign() { return callsign; }
     virtual DockStyle canBeDockedBy(P<SpaceObject> obj) { return DockStyle::None; }
+    virtual DockStyle getDockedStyle() { return DockStyle::None; }
     virtual bool canRestockMissiles() { return false; }
     virtual bool hasShield() { return false; }
     virtual bool canHideInNebula() { return true; }

--- a/src/spaceObjects/spaceship.h
+++ b/src/spaceObjects/spaceship.h
@@ -342,6 +342,7 @@ public:
     P<SpaceObject> getDockedWith() { if (docking_state == DS_Docked) return docking_target; return NULL; }
     bool canStartDocking() { return current_warp <= 0.0f && (!has_jump_drive || jump_delay <= 0.0f); }
     EDockingState getDockingState() { return docking_state; }
+    virtual DockStyle getDockedStyle() override { return docked_style; }
     int getWeaponStorage(EMissileWeapons weapon) { if (weapon == MW_None) return 0; return weapon_storage[weapon]; }
     int getWeaponStorageMax(EMissileWeapons weapon) { if (weapon == MW_None) return 0; return weapon_storage_max[weapon]; }
     void setWeaponStorage(EMissileWeapons weapon, int amount) { if (weapon == MW_None) return; weapon_storage[weapon] = amount; }


### PR DESCRIPTION
Fixes #1904.

Adds `SpaceObject:getDockedStyle()`, where it always returns `DockStyle::None`, and overrides it in `SpaceShip:getDockedStyle()` to return `docked_style`. RadarView then checks if `getDockedStyle() != DockStyle::Internal`.

Benedict with 8 internally docked fighters, on master branch:

![image](https://user-images.githubusercontent.com/19192104/220232319-8379ae73-aa56-45ca-9788-9e058c9f66ae.png)

Benedict with 8 internally docked fighters, with this PR:

![image](https://user-images.githubusercontent.com/19192104/220231994-888cf115-3e81-47bd-9c66-e04e810b62a7.png)