### PR TITLE
[SpaceShip] Don't try to dock with yourself

### DIFF
--- a/src/spaceObjects/spaceship.cpp
+++ b/src/spaceObjects/spaceship.cpp
@@ -1289,10 +1289,15 @@ void SpaceShip::initializeJump(float distance)
 
 void SpaceShip::requestDock(P<SpaceObject> target)
 {
-    if (!target || docking_state != DS_NotDocking || target->canBeDockedBy(this) == DockStyle::None)
+    if (!target
+        || target == this
+        || docking_state != DS_NotDocking
+        || target->canBeDockedBy(this) == DockStyle::None)
         return;
+
     if (glm::length(getPosition() - target->getPosition()) > 1000 + target->getRadius())
         return;
+
     if (!canStartDocking())
         return;
 


### PR DESCRIPTION
`requestDock` doesn't check whether its docking target is itself, which can lead to #711 via use of `PlayerSpaceship:commandDock()`. This checks for that condition.

Might be related to #1903.