### PR TITLE
[#1892] Separate strafe and boost power-damage indicators

### DIFF
--- a/src/screenComponents/combatManeuver.cpp
+++ b/src/screenComponents/combatManeuver.cpp
@@ -25,7 +25,7 @@ GuiCombatManeuver::GuiCombatManeuver(GuiContainer* owner, string id)
     slider->setPosition(0, -50, sp::Alignment::BottomCenter)->setSize(GuiElement::GuiSizeMax, 165);
 
     (new GuiPowerDamageIndicator(slider, id + "_STRAFE_INDICATOR", SYS_Maneuver, sp::Alignment::CenterLeft))->setPosition(0, 0, sp::Alignment::BottomLeft)->setSize(GuiElement::GuiSizeMax, 50);
-    (new GuiPowerDamageIndicator(slider, id + "_BOOST_INDICATOR", SYS_Impulse, sp::Alignment::BottomLeft))->setPosition(0, 0, sp::Alignment::BottomLeft)->setSize(GuiElement::GuiSizeMax, 50);
+    (new GuiPowerDamageIndicator(slider, id + "_BOOST_INDICATOR", SYS_Impulse, sp::Alignment::BottomLeft))->setPosition(0, -50, sp::Alignment::BottomLeft)->setSize(GuiElement::GuiSizeMax, 50);
 }
 
 void GuiCombatManeuver::onUpdate()


### PR DESCRIPTION
The combat maneuver control has two separate power/damage indicators for boost and strafe. Move the combat maneuver control's boost power/damage indicator so it doesn't overlap the strafe indicator.

Fixes #1892, kind of, but doesn't answer for players which system is causing each alarm.

Master branch:

![image](https://user-images.githubusercontent.com/19192104/220270643-be7cf3b8-3b13-4339-85b8-08661b6d7e93.png)

![image](https://user-images.githubusercontent.com/19192104/220270678-dcb0d775-6a43-447a-8ddb-d602a50e456a.png)

![image](https://user-images.githubusercontent.com/19192104/220270711-534cf62f-d8d1-4985-9f7c-20ad85676b90.png)

With this change:

![image](https://user-images.githubusercontent.com/19192104/220270132-78e9e309-9f94-47b3-a402-846be64efe46.png)

![image](https://user-images.githubusercontent.com/19192104/220270228-fb83ceec-c3c5-4f30-a42b-621b0af57de9.png)

![image](https://user-images.githubusercontent.com/19192104/220270250-2eb4cbff-6544-4776-ba2e-f17c7ec3c0fd.png)
