### PR TITLE
[GuiObjectCreationView] Loop template names with reference type

### DIFF
--- a/src/screens/gm/objectCreationView.cpp
+++ b/src/screens/gm/objectCreationView.cpp
@@ -123,7 +123,7 @@ GuiObjectCreationView::GuiObjectCreationView(GuiContainer* owner)
         setCreateScript("PlayerSpaceship():setFactionId(" + string(faction_selector->getSelectionIndex()) + ")",":setTemplate(\"" + value + "\")");
     });
     player_ship_listbox->setTextSize(20)->setButtonHeight(30)->setPosition(-20, 20, sp::Alignment::TopRight)->setSize(300, 460);
-    for (const auto template_name : player_template_names)
+    for (const auto& template_name : player_template_names)
     {
         auto shipTemplate=ShipTemplate::getTemplate(template_name);
         if (shipTemplate)


### PR DESCRIPTION
Address this warning on compilation:

```
objectCreationView.cpp: In constructor ‘GuiObjectCreationView::GuiObjectCreationView(GuiContainer*)’:
126:21: warning: loop variable ‘template_name’ creates a copy from type ‘const string’ [-Wrange-loop-construct]
  126 |     for (const auto template_name : player_template_names)
      |                     ^~~~~~~~~~~~~
126:21: note: use reference type to prevent copying
  126 |     for (const auto template_name : player_template_names)
      |                     ^~~~~~~~~~~~~
      |                     &
```