### PR TITLE
[#1903] Don't try to dock with ships already docked with yourself

### DIFF
--- a/src/screenComponents/dockingButton.cpp
+++ b/src/screenComponents/dockingButton.cpp
@@ -89,12 +89,22 @@ P<SpaceObject> GuiDockingButton::findDockingTarget()
 {
     PVector<Collisionable> obj_list = CollisionManager::queryArea(my_spaceship->getPosition() - glm::vec2(1000, 1000), my_spaceship->getPosition() + glm::vec2(1000, 1000));
     P<SpaceObject> dock_object;
-    foreach(Collisionable, obj, obj_list)
+
+    for (P<Collisionable> obj : obj_list)
     {
         dock_object = obj;
-        if (dock_object && dock_object != my_spaceship && dock_object->canBeDockedBy(my_spaceship) != DockStyle::None && glm::length(dock_object->getPosition() - my_spaceship->getPosition()) < 1000.0f + dock_object->getRadius())
+
+        if (dock_object
+            && dock_object != my_spaceship
+            && dock_object->getDockedWith() != my_spaceship
+            && dock_object->canBeDockedBy(my_spaceship) != DockStyle::None
+            && glm::length(dock_object->getPosition() - my_spaceship->getPosition()) < 1000.0f + dock_object->getRadius())
+        {
             break;
+        }
+
         dock_object = NULL;
     }
+
     return dock_object;
 }

--- a/src/spaceObjects/spaceObject.h
+++ b/src/spaceObjects/spaceObject.h
@@ -225,6 +225,7 @@ public:
     virtual std::vector<std::pair<ESystem, float> > getHackingTargets();
     virtual void hackFinished(P<SpaceObject> source, string target);
     virtual void takeDamage(float damage_amount, DamageInfo info) {}
+    virtual P<SpaceObject> getDockedWith() { return NULL; }
     virtual std::unordered_map<string, string> getGMInfo() { return std::unordered_map<string, string>(); }
     virtual string getExportLine() { return ""; }
 

--- a/src/spaceObjects/spaceship.h
+++ b/src/spaceObjects/spaceship.h
@@ -337,7 +337,7 @@ public:
     P<SpaceObject> getTarget();
 
     bool isDocked(P<SpaceObject> target) { return docking_state == DS_Docked && docking_target == target; }
-    P<SpaceObject> getDockedWith() { if (docking_state == DS_Docked) return docking_target; return NULL; }
+    virtual P<SpaceObject> getDockedWith() override { if (docking_state == DS_Docked) return docking_target; return NULL; }
     bool canStartDocking() { return current_warp <= 0.0f && (!has_jump_drive || jump_delay <= 0.0f); }
     EDockingState getDockingState() { return docking_state; }
     virtual DockStyle getDockedStyle() override { return docked_style; }


### PR DESCRIPTION
Building on #1906, also don't try to dock with a ship that's already docked with our ship.

For example, given Benedict callsign "Spock" initiated and successfully externally docked to another Benedict callsign "Kirk", "Spock" still appears to "Kirk" as a valid docking target.  If "Kirk" attempts to dock with "Spock", "Kirk" enters an endless loop of trying to rotate to dock with "Spock", which moves as "Kirk" rotates.

This could benefit from a potentially recursive check of dockable ships that are docked to ships that are docked to the player; it's still possible to enter an endless docking cycle in those more edge cases of 3+ ships chained together.

This PR also cancels docking if the docking target is moved >1U away from the docking ship.