### PR TITLE
[tweak] Add STBO (including Station), acceleration, warp speed tweaks

### DIFF
--- a/src/screens/gm/tweak.h
+++ b/src/screens/gm/tweak.h
@@ -22,7 +22,7 @@ enum ETweakType
     TW_Object,  // TODO: Space object
     TW_Jammer,  // WarpJammer
     TW_Ship,    // Ships
-    TW_Station, // TODO: Space stations
+    TW_Station, // Space stations
     TW_Player,  // Player ships
     TW_Asteroid // Asteroid
 };
@@ -48,25 +48,42 @@ private:
     std::vector<GuiTweakPage*> pages;
 };
 
+class GuiTweakShipTemplateBasedObject : public GuiTweakPage
+{
+private:
+    P<ShipTemplateBasedObject> target;
+
+    GuiTextEntry* type_name;
+    GuiSlider* hull_max_slider;
+    GuiSlider* hull_slider;
+    GuiToggleButton* can_be_destroyed_toggle;
+    GuiToggleButton* shares_energy_with_docked_toggle;
+    GuiToggleButton* repairs_docked_toggle;
+    GuiToggleButton* restocks_scan_probes_toggle;
+    GuiToggleButton* restocks_cpuship_weapons_toggle;
+    GuiSlider* short_range_radar_slider;
+    GuiSlider* long_range_radar_slider;
+public:
+    GuiTweakShipTemplateBasedObject(GuiContainer* owner);
+
+    virtual void onDraw(sp::RenderTarget& target) override;
+
+    virtual void open(P<SpaceObject> target) override;
+};
+
 class GuiTweakShip : public GuiTweakPage
 {
 private:
     P<SpaceShip> target;
 
-    GuiTextEntry* type_name;
     GuiToggleButton* warp_toggle;
     GuiToggleButton* jump_toggle;
     GuiSlider* impulse_speed_slider;
     GuiSlider* impulse_reverse_speed_slider;
     GuiSlider* turn_speed_slider;
-    GuiSlider* hull_max_slider;
-    GuiSlider* hull_slider;
     GuiSlider* jump_charge_slider;
     GuiSlider* jump_min_distance_slider;
     GuiSlider* jump_max_distance_slider;
-    GuiToggleButton* can_be_destroyed_toggle;
-    GuiSlider* short_range_radar_slider;
-    GuiSlider* long_range_radar_slider;
 public:
     GuiTweakShip(GuiContainer* owner);
 

--- a/src/screens/gm/tweak.h
+++ b/src/screens/gm/tweak.h
@@ -54,13 +54,13 @@ private:
     P<ShipTemplateBasedObject> target;
 
     GuiTextEntry* type_name;
-    GuiSlider* hull_max_slider;
-    GuiSlider* hull_slider;
-    GuiToggleButton* can_be_destroyed_toggle;
     GuiToggleButton* shares_energy_with_docked_toggle;
     GuiToggleButton* repairs_docked_toggle;
     GuiToggleButton* restocks_scan_probes_toggle;
     GuiToggleButton* restocks_cpuship_weapons_toggle;
+    GuiSlider* hull_max_slider;
+    GuiSlider* hull_slider;
+    GuiToggleButton* can_be_destroyed_toggle;
     GuiSlider* short_range_radar_slider;
     GuiSlider* long_range_radar_slider;
 public:
@@ -76,14 +76,18 @@ class GuiTweakShip : public GuiTweakPage
 private:
     P<SpaceShip> target;
 
-    GuiToggleButton* warp_toggle;
-    GuiToggleButton* jump_toggle;
     GuiSlider* impulse_speed_slider;
+    GuiSlider* impulse_acceleration_slider;
     GuiSlider* impulse_reverse_speed_slider;
+    GuiSlider* impulse_reverse_acceleration_slider;
     GuiSlider* turn_speed_slider;
-    GuiSlider* jump_charge_slider;
+    GuiToggleButton* docking_state_toggle;
+    GuiToggleButton* warp_toggle;
+    GuiSlider* warp_speed_slider;
+    GuiToggleButton* jump_toggle;
     GuiSlider* jump_min_distance_slider;
     GuiSlider* jump_max_distance_slider;
+    GuiSlider* jump_charge_slider;
 public:
     GuiTweakShip(GuiContainer* owner);
 


### PR DESCRIPTION
Moves tweakable properties common between ships and stations (hull, type, destructibility, radar ranges) to a new "Template-based" tweak tab, and adds docking services (can repair, shares energy with, etc.) to it.

In the vacated space from moving those settings from the Ship tab, add forward/reverse acceleration sliders, a warp speed slider, and a docking state indicator. If the ship is a PlayerSpaceship, the docking state indicator can be clicked in DS_Docking or DS_Docked states to force the ship to abort or undock. (CpuShips can be forced to abort or undock by giving them new orders.)

Ship:

![image](https://user-images.githubusercontent.com/19192104/221238183-27ce2821-0b54-47e5-bc56-fcbdc25d3e24.png)

![image](https://user-images.githubusercontent.com/19192104/221238215-228682cb-a276-49a8-b0b4-5c4ce014baed.png)

Station:

![image](https://user-images.githubusercontent.com/19192104/221238271-85e089f8-66fd-4e78-95ca-0969ae9560a9.png)
