### PR TITLE
Escape key loop

### DIFF
--- a/src/screens/crewStationScreen.cpp
+++ b/src/screens/crewStationScreen.cpp
@@ -170,10 +170,16 @@ void CrewStationScreen::update(float delta)
 
     if (keys.escape.getDown())
     {
-        destroy();
-        soundManager->stopMusic();
-        impulse_sound->stop();
-        returnToShipSelection(getRenderLayer());
+        if (PreferencesManager::get("autoconnect").toInt())
+        {
+            LOG(INFO) << "You hit escape and want out! but you'll be back, you will see, all your base will belong to me.";
+        }
+        else {
+            destroy();
+            soundManager->stopMusic();
+            impulse_sound->stop();
+            returnToShipSelection(getRenderLayer());
+        }
     }
     if (keys.help.getDown())
     {

--- a/src/screens/crewStationScreen.cpp
+++ b/src/screens/crewStationScreen.cpp
@@ -170,11 +170,9 @@ void CrewStationScreen::update(float delta)
 
     if (keys.escape.getDown())
     {
-        if (PreferencesManager::get("autoconnect").toInt())
+        //If we're using autoconnect do nothing on escape, otherwise go back to the ship selection. 
+        if (!(PreferencesManager::get("autoconnect").toInt()))
         {
-            LOG(INFO) << "You hit escape and want out! but you'll be back, you will see, all your base will belong to me.";
-        }
-        else {
             destroy();
             soundManager->stopMusic();
             impulse_sound->stop();


### PR DESCRIPTION
If you're using autoconnect and someone hits escape it will lock the station down and go into an infinite loop of trying to reconnect to the station.  Rather than allow this loop to happen at all this code just ignores the escape button if autoconnect is being used. 
