### PR TITLE
[SpaceShip] Remove extraneous getGMInfo override

### DIFF
--- a/src/spaceObjects/spaceship.cpp
+++ b/src/spaceObjects/spaceship.cpp
@@ -1744,13 +1744,6 @@ void SpaceShip::addBroadcast(int threshold, string message)
     }
 }
 
-std::unordered_map<string, string> SpaceShip::getGMInfo()
-{
-    std::unordered_map<string, string> ret;
-    ret = ShipTemplateBasedObject::getGMInfo();
-    return ret;
-}
-
 string SpaceShip::getScriptExportModificationsOnTemplate()
 {
     // Exports attributes common to ships as Lua script function calls.

--- a/src/spaceObjects/spaceship.h
+++ b/src/spaceObjects/spaceship.h
@@ -336,8 +336,6 @@ public:
 
     P<SpaceObject> getTarget();
 
-    virtual std::unordered_map<string, string> getGMInfo() override;
-
     bool isDocked(P<SpaceObject> target) { return docking_state == DS_Docked && docking_target == target; }
     P<SpaceObject> getDockedWith() { if (docking_state == DS_Docked) return docking_target; return NULL; }
     bool canStartDocking() { return current_warp <= 0.0f && (!has_jump_drive || jump_delay <= 0.0f); }


### PR DESCRIPTION
SpaceShip::getGMInfo() inherits ShipTemplateBasedObject::getGMInfo() and overrides it, but only calls and returns the result of the inherited method. Removing this override doesn't change the behavior of selecting SpaceShips, CpuShips, or PlayerSpaceships on the GM screen.

Remove the extraneous override to use the inherited function.