### PR TITLE
[#1923] Un-minimize GM chats after closing them

### DIFF
--- a/src/screens/gm/chatDialog.cpp
+++ b/src/screens/gm/chatDialog.cpp
@@ -105,4 +105,5 @@ void GameMasterChatDialog::onClose()
         player->closeComms();
     }
     hide();
+    minimize(false);
 }


### PR DESCRIPTION
Closing a GM chat window doesn't destroy it; they're created and hidden for all player connections on GM screen initialization, and closing a GM chat window only hides it.

So closing a GM chat window that's minimized doesn't reset its minimized state, but when it's re-opened it inconsistently displays the normal-sized chat window but with no text or input.

Reset the minimized state upon close to false to avoid this behavior.

Fixes #1923.