### PR TITLE
[#1933] Validate impulse_request values

### DIFF
--- a/src/ai/ai.cpp
+++ b/src/ai/ai.cpp
@@ -598,14 +598,21 @@ void ShipAI::flyTowards(glm::vec2 target, float keep_distance)
         if (pathPlanner.route.size() > 1)
             keep_distance = 0.0;
 
-        if (distance > keep_distance + owner->impulse_max_speed * 5.0f)
-            owner->setImpulseRequest(1.0f);
-        else
-            owner->setImpulseRequest((distance - keep_distance) / owner->impulse_max_speed * 5.0f);
-        if (rotation_diff > 90)
-            owner->setImpulseRequest(-owner->impulse_request);
-        else if (rotation_diff < 45)
-            owner->setImpulseRequest(owner->impulse_request * (1.0f - ((rotation_diff - 45.0f) / 45.0f)));
+        // setImpulseRequest only if impulse_max_speed is greater than 0.0
+        if (owner->impulse_max_speed > 0.0f)
+        {
+            owner->setImpulseRequest(0.0f);
+        } else {
+            if (distance > keep_distance + owner->impulse_max_speed * 5.0f)
+                owner->setImpulseRequest(1.0f);
+            else
+                owner->setImpulseRequest((distance - keep_distance) / owner->impulse_max_speed * 5.0f);
+
+            if (rotation_diff > 90)
+                owner->setImpulseRequest(-owner->impulse_request);
+            else if (rotation_diff < 45)
+                owner->setImpulseRequest(owner->impulse_request * (1.0f - ((rotation_diff - 45.0f) / 45.0f)));
+        }
     }
 }
 

--- a/src/ai/ai.cpp
+++ b/src/ai/ai.cpp
@@ -600,17 +600,15 @@ void ShipAI::flyTowards(glm::vec2 target, float keep_distance)
 
         // setImpulseRequest only if impulse_max_speed is greater than 0.0
         if (owner->impulse_max_speed > 0.0f)
-        {
-            owner->setImpulseRequest(0.0f);
-        } else {
+        {}
             if (distance > keep_distance + owner->impulse_max_speed * 5.0f)
                 owner->setImpulseRequest(1.0f);
             else
                 owner->setImpulseRequest((distance - keep_distance) / owner->impulse_max_speed * 5.0f);
 
-            if (rotation_diff > 90)
+            if (rotation_diff > 90.0f)
                 owner->setImpulseRequest(-owner->impulse_request);
-            else if (rotation_diff < 45)
+            else if (rotation_diff < 45.0f)
                 owner->setImpulseRequest(owner->impulse_request * (1.0f - ((rotation_diff - 45.0f) / 45.0f)));
         }
     }

--- a/src/ai/ai.cpp
+++ b/src/ai/ai.cpp
@@ -52,7 +52,7 @@ void ShipAI::run(float delta)
 {
     owner->target_rotation = owner->getRotation();
     owner->warp_request = 0.0;
-    owner->impulse_request = 0.0f;
+    owner->setImpulseRequest(0.0f);
 
     updateWeaponState(delta);
     if (update_target_delay > 0.0f)
@@ -599,13 +599,13 @@ void ShipAI::flyTowards(glm::vec2 target, float keep_distance)
             keep_distance = 0.0;
 
         if (distance > keep_distance + owner->impulse_max_speed * 5.0f)
-            owner->impulse_request = 1.0f;
+            owner->setImpulseRequest(1.0f);
         else
-            owner->impulse_request = (distance - keep_distance) / owner->impulse_max_speed * 5.0f;
+            owner->setImpulseRequest((distance - keep_distance) / owner->impulse_max_speed * 5.0f);
         if (rotation_diff > 90)
-            owner->impulse_request = -owner->impulse_request;
+            owner->setImpulseRequest(-owner->impulse_request);
         else if (rotation_diff < 45)
-            owner->impulse_request *= 1.0f - ((rotation_diff - 45.0f) / 45.0f);
+            owner->setImpulseRequest(owner->impulse_request * (1.0f - ((rotation_diff - 45.0f) / 45.0f)));
     }
 }
 
@@ -633,19 +633,19 @@ void ShipAI::flyFormation(P<SpaceObject> target, glm::vec2 offset)
         {
             float angle_diff = angleDifference(owner->target_rotation, owner->getRotation());
             if (angle_diff > 10.0f)
-                owner->impulse_request = 0.0f;
+                owner->setImpulseRequest(0.0f);
             else if (angle_diff > 5.0f)
-                owner->impulse_request = (10.0f - angle_diff) / 5.0f;
+                owner->setImpulseRequest((10.0f - angle_diff) / 5.0f);
             else
-                owner->impulse_request = 1.0f;
+                owner->setImpulseRequest(1.0f);
         }else{
             if (distance > r / 2.0f)
             {
                 owner->target_rotation += angleDifference(owner->target_rotation, target->getRotation()) * (1.0f - distance / r);
-                owner->impulse_request = distance / r;
+                owner->setImpulseRequest(distance / r);
             }else{
                 owner->target_rotation = target->getRotation();
-                owner->impulse_request = 0.0f;
+                owner->setImpulseRequest(0.0f);
             }
         }
     }else{

--- a/src/ai/ai.cpp
+++ b/src/ai/ai.cpp
@@ -600,7 +600,7 @@ void ShipAI::flyTowards(glm::vec2 target, float keep_distance)
 
         // setImpulseRequest only if impulse_max_speed is greater than 0.0
         if (owner->impulse_max_speed > 0.0f)
-        {}
+        {
             if (distance > keep_distance + owner->impulse_max_speed * 5.0f)
                 owner->setImpulseRequest(1.0f);
             else

--- a/src/ai/fighterAI.cpp
+++ b/src/ai/fighterAI.cpp
@@ -93,7 +93,7 @@ void FighterAI::runAttack(P<SpaceObject> target)
         else
         {
             owner->target_rotation = evade_direction;
-            owner->impulse_request = 1.0;
+            owner->setImpulseRequest(1.0f);
         }
         break;
     case recharge:

--- a/src/spaceObjects/spaceship.cpp
+++ b/src/spaceObjects/spaceship.cpp
@@ -460,7 +460,7 @@ SpaceShip::SpaceShip(string multiplayerClassName, float multiplayer_significant_
     setCollisionPhysics(true, false);
 
     target_rotation = getRotation();
-    impulse_request = 0;
+    impulse_request = 0.0f;
     current_impulse = 0;
     has_warp_drive = true;
     warp_request = 0;
@@ -960,9 +960,9 @@ void SpaceShip::update(float delta)
             else
                 target_rotation = vec2ToAngle(getPosition() - docking_target->getPosition());
             if (fabs(angleDifference(target_rotation, getRotation())) < 10.0f)
-                impulse_request = -1.f;
+                setImpulseRequest(-1.f);
             else
-                impulse_request = 0.f;
+                setImpulseRequest(0.f);
         }
         if (docking_state == DS_Docked)
         {
@@ -985,7 +985,7 @@ void SpaceShip::update(float delta)
                     }
                 }
             }
-            impulse_request = 0.f;
+            setImpulseRequest(0.f);
         }
         if ((docking_state == DS_Docked) || (docking_state == DS_Docking))
             warp_request = 0;
@@ -1102,10 +1102,9 @@ void SpaceShip::update(float delta)
             }
         }
         current_warp = 0.f;
-        if (impulse_request > 1.0f)
-            impulse_request = 1.0f;
-        if (impulse_request < -1.0f)
-            impulse_request = -1.0f;
+        // Validate impulse request; this might not be necessary.
+        setImpulseRequest(impulse_request);
+
         if (current_impulse < impulse_request)
         {
             if (cap_speed > 0)
@@ -1312,7 +1311,7 @@ void SpaceShip::requestUndock()
     {
         docked_style = DockStyle::None;
         docking_state = DS_NotDocking;
-        impulse_request = 0.5;
+        setImpulseRequest(0.5f);
     }
 }
 
@@ -1321,7 +1320,7 @@ void SpaceShip::abortDock()
     if (docking_state == DS_Docking)
     {
         docking_state = DS_NotDocking;
-        impulse_request = 0.f;
+        setImpulseRequest(0.f);
         warp_request = 0;
         target_rotation = getRotation();
     }

--- a/src/spaceObjects/spaceship.h
+++ b/src/spaceObjects/spaceship.h
@@ -375,6 +375,7 @@ public:
         impulse_max_speed = forward_speed; 
         impulse_max_reverse_speed = reverse_speed.value_or(forward_speed);
     }
+    void setImpulseRequest(float request) { impulse_request = std::clamp(request, -1.0f, 1.0f); }
     float getSystemCoolantRate(ESystem system) const { if (system >= SYS_COUNT) return 0.f; if (system <= SYS_None) return 0.f; return systems[system].coolant_rate_per_second; }
     void setSystemCoolantRate(ESystem system, float rate) { if (system >= SYS_COUNT) return; if (system <= SYS_None) return; systems[system].coolant_rate_per_second = rate; }
     float getRotationMaxSpeed() { return turn_speed; }


### PR DESCRIPTION
#1933 shows that directly setting `impulse_request` on a `SpaceShip` can result in unusable or poorly defined values, such as infinity/-infinity from dividing by 0 impulse speed on Odins and Defense Platforms.

Add a `setImpulseRequest()` function that clamps the passed value and replace direct modifications of `impulse_request` with it.

Fixes #1933.