### PR TITLE
[GuiListbox] Implement themed hover behavior on entries

### DIFF
--- a/src/gui/gui2_canvas.cpp
+++ b/src/gui/gui2_canvas.cpp
@@ -124,6 +124,7 @@ void GuiCanvas::runUpdates(GuiContainer* parent)
             delete element;
         }else{
             element->hover = element->rect.contains(mouse_position);
+            element->hover_coordinates = mouse_position;
 
             element->onUpdate();
             if (element->isVisible())

--- a/src/gui/gui2_element.h
+++ b/src/gui/gui2_element.h
@@ -22,6 +22,7 @@ protected:
     bool visible;
     bool enabled;
     bool hover;
+    glm::vec2 hover_coordinates;
     bool focus;
     string id;
 public:

--- a/src/gui/gui2_listbox.cpp
+++ b/src/gui/gui2_listbox.cpp
@@ -40,8 +40,10 @@ void GuiListbox::onDraw(sp::RenderTarget& renderer)
 {
     hover = false;
     const auto& back = back_style->get(getState());
+    const auto& back_hover = back_style->get(State::Hover);
     const auto& front = front_style->get(getState());
     const auto& back_selected = back_selected_style->get(getState());
+    const auto& back_selected_hover = back_selected_style->get(State::Hover);
     const auto& front_selected = front_selected_style->get(getState());
 
     scroll->setValueSize(rect.size.y);
@@ -58,9 +60,14 @@ void GuiListbox::onDraw(sp::RenderTarget& renderer)
     int index = 0;
     for(auto& e : entries) {
         if (button_rect.position.y + button_rect.size.y >= rect.position.y && button_rect.position.y <= rect.position.y + rect.size.y) {
-            auto* b = &back;
+            auto* b = button_rect.contains(hover_coordinates) ? &back_hover : &back;
             auto* f = &front;
-            if (index == selection_index) { b = &back_selected; f = &front_selected; }
+            if (index == selection_index)
+            {
+                b = button_rect.contains(hover_coordinates) ? &back_selected_hover : &back_selected;
+                f = &front_selected;
+            }
+
             renderer.drawStretchedHVClipped(button_rect, rect, button_height*0.5f, b->texture, b->color);
             auto prepared = f->font->prepare(e.name, 32, text_size, button_rect.size, sp::Alignment::Center, sp::Font::FlagClip);
             for(auto& c : prepared.data)


### PR DESCRIPTION
Pass hover coordinates from GuiCanvas so elements like GuiListbox can manage hover state, then use those coordinates to implement hover state on GuiListbox entries.

Master:

![image](https://user-images.githubusercontent.com/19192104/222928971-e47c2610-e5ed-4b20-9a64-f3aeb2533204.png)

![image](https://user-images.githubusercontent.com/19192104/222928981-8ee8461d-4719-4b65-96c3-cd6912350a61.png)


With this PR:

![image](https://user-images.githubusercontent.com/19192104/222928911-c24fd2cf-a617-4db7-98b8-78eab07a3fb5.png)

![image](https://user-images.githubusercontent.com/19192104/222928922-12d02dfc-2d33-4488-9725-4ba9d52afba1.png)
