### PR TITLE
[build] Fix -Wconversion double-to-float truncation warnings

### DIFF
--- a/src/ai/fighterAI.cpp
+++ b/src/ai/fighterAI.cpp
@@ -62,11 +62,11 @@ void FighterAI::runAttack(P<SpaceObject> target)
             }
         }
 
-        flyTowards(target->getPosition(), 500.0);
+        flyTowards(target->getPosition(), 500.0f);
 
-        if (distance < 500 + target->getRadius())
+        if (distance < 500.0f + target->getRadius())
         {
-            aggression += random(0, 0.05);
+            aggression += random(0.0f, 0.05f);
 
             attack_state = evade;
             timeout = 30.0f - std::min(aggression, 1.0f) * 20.0f;
@@ -81,7 +81,7 @@ void FighterAI::runAttack(P<SpaceObject> target)
         if (owner->shield_level[0] < owner->shield_max[0] * (1.0f - aggression))
         {
             attack_state = recharge;
-            aggression += random(0.1, 0.25);
+            aggression += random(0.1f, 0.25f);
             timeout = 60.0f - std::min(aggression, 1.0f) * 20.0f;
         }
         break;

--- a/src/beamTemplate.cpp
+++ b/src/beamTemplate.cpp
@@ -12,8 +12,8 @@ BeamTemplate::BeamTemplate()
     damage = 0;
     beam_texture = "texture/beam_orange.png";
 
-    energy_per_beam_fire = 3.0;
-    heat_per_beam_fire = 0.02;
+    energy_per_beam_fire = 3.0f;
+    heat_per_beam_fire = 0.02f;
 }
 
 string BeamTemplate::getBeamTexture()
@@ -64,7 +64,7 @@ float BeamTemplate::getRange()
 void BeamTemplate::setRange(float range)
 {
     if(range <= 0)
-        this->range = 0.1;
+        this->range = 0.1f;
     else
         this->range = range;
 }
@@ -123,7 +123,7 @@ float BeamTemplate::getCycleTime()
 void BeamTemplate::setCycleTime(float cycle_time)
 {
     if(cycle_time <= 0)
-        this->cycle_time = 0.1;
+        this->cycle_time = 0.1f;
     else
         this->cycle_time = cycle_time;
 }

--- a/src/gameGlobalInfo.cpp
+++ b/src/gameGlobalInfo.cpp
@@ -43,7 +43,7 @@ GameGlobalInfo::GameGlobalInfo()
     registerMemberReplication(&hacking_difficulty);
     registerMemberReplication(&hacking_games);
     registerMemberReplication(&global_message);
-    registerMemberReplication(&global_message_timeout, 1.0);
+    registerMemberReplication(&global_message_timeout, 1.0f);
     registerMemberReplication(&banner_string);
     registerMemberReplication(&victory_faction);
     registerMemberReplication(&use_beam_shield_frequencies);
@@ -51,11 +51,11 @@ GameGlobalInfo::GameGlobalInfo()
     registerMemberReplication(&allow_main_screen_tactical_radar);
     registerMemberReplication(&allow_main_screen_long_range_radar);
     registerMemberReplication(&gm_control_code);
-    registerMemberReplication(&elapsed_time, 0.1);
+    registerMemberReplication(&elapsed_time, 0.1f);
 
     for(unsigned int n=0; n<factionInfo.size(); n++)
         reputation_points.push_back(0);
-    registerMemberReplication(&reputation_points, 1.0);
+    registerMemberReplication(&reputation_points, 1.0f);
 }
 
 //due to a suspected compiler bug this deconstructor needs to be explicitly defined

--- a/src/repairCrew.h
+++ b/src/repairCrew.h
@@ -20,8 +20,8 @@ enum ERepairCrewDirection
 
 class RepairCrew : public MultiplayerObject, public Updatable
 {
-    static constexpr float move_speed = 2.0;
-    static constexpr float repair_per_second = 0.007;
+    static constexpr float move_speed = 2.0f;
+    static constexpr float repair_per_second = 0.007f;
 public:
     glm::vec2 position{0,0};
     glm::ivec2 target_position{0,0};

--- a/src/screenComponents/databaseView.cpp
+++ b/src/screenComponents/databaseView.cpp
@@ -175,7 +175,7 @@ void DatabaseViewComponent::display()
     {
         for(unsigned int n=0; n<selected_entry->keyValuePairs.size(); n++)
         {
-            (new GuiKeyValueDisplay(keyvalue_container, "", 0.37, selected_entry->keyValuePairs[n].key, selected_entry->keyValuePairs[n].value))->setSize(GuiElement::GuiSizeMax, 40);
+            (new GuiKeyValueDisplay(keyvalue_container, "", 0.37f, selected_entry->keyValuePairs[n].key, selected_entry->keyValuePairs[n].value))->setSize(GuiElement::GuiSizeMax, 40);
         }
     } else {
         keyvalue_container->destroy();

--- a/src/screenComponents/frequencyCurve.cpp
+++ b/src/screenComponents/frequencyCurve.cpp
@@ -25,7 +25,7 @@ void GuiFrequencyCurve::onDraw(sp::RenderTarget& renderer)
                     f = frequencyVsFrequencyDamageFactor(frequency, n);
                 else
                     f = frequencyVsFrequencyDamageFactor(n, frequency);
-                f = Tween<float>::linear(f, 0.5, 1.5, 0.1, 1.0);
+                f = Tween<float>::linear(f, 0.5f, 1.5f, 0.1f, 1.0f);
                 float h = (rect.size.y - 50) * f;
                 sp::Rect bar_rect(x, rect.position.y + rect.size.y - 10 - h, w * 0.8f, h);
                 if (more_damage_is_positive)

--- a/src/screenComponents/impulseControls.cpp
+++ b/src/screenComponents/impulseControls.cpp
@@ -13,7 +13,7 @@ GuiImpulseControls::GuiImpulseControls(GuiContainer* owner, string id)
         if (my_spaceship)
             my_spaceship->commandImpulse(value);
     });
-    slider->addSnapValue(0.0, 0.1)->setPosition(0, 0, sp::Alignment::TopLeft)->setSize(50, GuiElement::GuiSizeMax);
+    slider->addSnapValue(0.0f, 0.1f)->setPosition(0, 0, sp::Alignment::TopLeft)->setSize(50, GuiElement::GuiSizeMax);
 
     label = new GuiKeyValueDisplay(this, id, 0.5, tr("slider", "Impulse"), "0%");
     label->setTextSize(30)->setPosition(50, 0, sp::Alignment::TopLeft)->setSize(40, GuiElement::GuiSizeMax);

--- a/src/screens/crew1/singlePilotScreen.cpp
+++ b/src/screens/crew1/singlePilotScreen.cpp
@@ -70,13 +70,13 @@ SinglePilotScreen::SinglePilotScreen(GuiContainer* owner)
 
     auto stats = new GuiElement(this, "STATS");
     stats->setPosition(-20, -20, sp::Alignment::BottomRight)->setSize(240, 160)->setAttribute("layout", "vertical");
-    energy_display = new GuiKeyValueDisplay(stats, "ENERGY_DISPLAY", 0.45, tr("Energy"), "");
+    energy_display = new GuiKeyValueDisplay(stats, "ENERGY_DISPLAY", 0.45f, tr("Energy"), "");
     energy_display->setIcon("gui/icons/energy")->setTextSize(20)->setSize(240, 40);
-    heading_display = new GuiKeyValueDisplay(stats, "HEADING_DISPLAY", 0.45, tr("Heading"), "");
+    heading_display = new GuiKeyValueDisplay(stats, "HEADING_DISPLAY", 0.45f, tr("Heading"), "");
     heading_display->setIcon("gui/icons/heading")->setTextSize(20)->setSize(240, 40);
-    velocity_display = new GuiKeyValueDisplay(stats, "VELOCITY_DISPLAY", 0.45, tr("Speed"), "");
+    velocity_display = new GuiKeyValueDisplay(stats, "VELOCITY_DISPLAY", 0.45f, tr("Speed"), "");
     velocity_display->setIcon("gui/icons/speed")->setTextSize(20)->setSize(240, 40);
-    shields_display = new GuiKeyValueDisplay(stats, "SHIELDS_DISPLAY", 0.45, tr("Shields"), "");
+    shields_display = new GuiKeyValueDisplay(stats, "SHIELDS_DISPLAY", 0.45f, tr("Shields"), "");
     shields_display->setIcon("gui/icons/shields")->setTextSize(20)->setSize(240, 40);
 
     // Unlocked missile aim dial and lock controls.

--- a/src/screens/crew4/tacticalScreen.cpp
+++ b/src/screens/crew4/tacticalScreen.cpp
@@ -66,13 +66,13 @@ TacticalScreen::TacticalScreen(GuiContainer* owner)
     stats->setPosition(20, 100, sp::Alignment::TopLeft)->setSize(240, 160)->setAttribute("layout", "vertical");
 
     // Ship statistics in the top left corner.
-    energy_display = new GuiKeyValueDisplay(stats, "ENERGY_DISPLAY", 0.45, tr("Energy"), "");
+    energy_display = new GuiKeyValueDisplay(stats, "ENERGY_DISPLAY", 0.45f, tr("Energy"), "");
     energy_display->setIcon("gui/icons/energy")->setTextSize(20)->setSize(240, 40);
-    heading_display = new GuiKeyValueDisplay(stats, "HEADING_DISPLAY", 0.45, tr("Heading"), "");
+    heading_display = new GuiKeyValueDisplay(stats, "HEADING_DISPLAY", 0.45f, tr("Heading"), "");
     heading_display->setIcon("gui/icons/heading")->setTextSize(20)->setSize(240, 40);
-    velocity_display = new GuiKeyValueDisplay(stats, "VELOCITY_DISPLAY", 0.45, tr("Speed"), "");
+    velocity_display = new GuiKeyValueDisplay(stats, "VELOCITY_DISPLAY", 0.45f, tr("Speed"), "");
     velocity_display->setIcon("gui/icons/speed")->setTextSize(20)->setSize(240, 40);
-    shields_display = new GuiKeyValueDisplay(stats, "SHIELDS_DISPLAY", 0.45, tr("Shields"), "");
+    shields_display = new GuiKeyValueDisplay(stats, "SHIELDS_DISPLAY", 0.45f, tr("Shields"), "");
     shields_display->setIcon("gui/icons/shields")->setTextSize(20)->setSize(240, 40);
 
     // Weapon tube loading controls in the bottom left corner.

--- a/src/screens/crew6/engineeringScreen.cpp
+++ b/src/screens/crew6/engineeringScreen.cpp
@@ -30,15 +30,15 @@ EngineeringScreen::EngineeringScreen(GuiContainer* owner, ECrewPosition crew_pos
     auto stats = new GuiElement(this, "ENGINEER_STATS");
     stats->setPosition(20, 100, sp::Alignment::TopLeft)->setSize(240, 200)->setAttribute("layout", "vertical");
 
-    energy_display = new GuiKeyValueDisplay(stats, "ENERGY_DISPLAY", 0.45, tr("Energy"), "");
+    energy_display = new GuiKeyValueDisplay(stats, "ENERGY_DISPLAY", 0.45f, tr("Energy"), "");
     energy_display->setIcon("gui/icons/energy")->setTextSize(20)->setSize(240, 40);
-    hull_display = new GuiKeyValueDisplay(stats, "HULL_DISPLAY", 0.45, tr("health","Hull"), "");
+    hull_display = new GuiKeyValueDisplay(stats, "HULL_DISPLAY", 0.45f, tr("health","Hull"), "");
     hull_display->setIcon("gui/icons/hull")->setTextSize(20)->setSize(240, 40);
-    front_shield_display = new GuiKeyValueDisplay(stats, "SHIELDS_DISPLAY", 0.45, tr("shields", "Front"), "");
+    front_shield_display = new GuiKeyValueDisplay(stats, "SHIELDS_DISPLAY", 0.45f, tr("shields", "Front"), "");
     front_shield_display->setIcon("gui/icons/shields-fore")->setTextSize(20)->setSize(240, 40);
-    rear_shield_display = new GuiKeyValueDisplay(stats, "SHIELDS_DISPLAY", 0.45, tr("shields", "Rear"), "");
+    rear_shield_display = new GuiKeyValueDisplay(stats, "SHIELDS_DISPLAY", 0.45f, tr("shields", "Rear"), "");
     rear_shield_display->setIcon("gui/icons/shields-aft")->setTextSize(20)->setSize(240, 40);
-    coolant_display = new GuiKeyValueDisplay(stats, "COOLANT_DISPLAY", 0.45, tr("total","Coolant"), "");
+    coolant_display = new GuiKeyValueDisplay(stats, "COOLANT_DISPLAY", 0.45f, tr("total","Coolant"), "");
     coolant_display->setIcon("gui/icons/coolant")->setTextSize(20)->setSize(240, 40);
 
     self_destruct_button = new GuiSelfDestructButton(this, "SELF_DESTRUCT");
@@ -453,7 +453,7 @@ void EngineeringScreen::addSystemEffect(string key, string value)
 {
     if (system_effects_index == system_effects.size())
     {
-        GuiKeyValueDisplay* item = new GuiKeyValueDisplay(system_effects_container, "", 0.7, key, value);
+        GuiKeyValueDisplay* item = new GuiKeyValueDisplay(system_effects_container, "", 0.7f, key, value);
         item->setTextSize(20)->setSize(GuiElement::GuiSizeMax, 40);
         system_effects.push_back(item);
     }else{

--- a/src/screens/crew6/helmsScreen.cpp
+++ b/src/screens/crew6/helmsScreen.cpp
@@ -70,11 +70,11 @@ HelmsScreen::HelmsScreen(GuiContainer* owner)
     heading_hint = new GuiLabel(this, "HEADING_HINT", "", 30);
     heading_hint->setAlignment(sp::Alignment::Center)->setSize(0, 0);
 
-    energy_display = new GuiKeyValueDisplay(this, "ENERGY_DISPLAY", 0.45, tr("Energy"), "");
+    energy_display = new GuiKeyValueDisplay(this, "ENERGY_DISPLAY", 0.45f, tr("Energy"), "");
     energy_display->setIcon("gui/icons/energy")->setTextSize(20)->setPosition(20, 100, sp::Alignment::TopLeft)->setSize(240, 40);
-    heading_display = new GuiKeyValueDisplay(this, "HEADING_DISPLAY", 0.45, tr("Heading"), "");
+    heading_display = new GuiKeyValueDisplay(this, "HEADING_DISPLAY", 0.45f, tr("Heading"), "");
     heading_display->setIcon("gui/icons/heading")->setTextSize(20)->setPosition(20, 140, sp::Alignment::TopLeft)->setSize(240, 40);
-    velocity_display = new GuiKeyValueDisplay(this, "VELOCITY_DISPLAY", 0.45, tr("Speed"), "");
+    velocity_display = new GuiKeyValueDisplay(this, "VELOCITY_DISPLAY", 0.45f, tr("Speed"), "");
     velocity_display->setIcon("gui/icons/speed")->setTextSize(20)->setPosition(20, 180, sp::Alignment::TopLeft)->setSize(240, 40);
 
     GuiElement* engine_layout = new GuiElement(this, "ENGINE_LAYOUT");

--- a/src/screens/crew6/relayScreen.cpp
+++ b/src/screens/crew6/relayScreen.cpp
@@ -78,10 +78,10 @@ RelayScreen::RelayScreen(GuiContainer* owner, bool allow_comms)
     auto sidebar = new GuiElement(this, "SIDE_BAR");
     sidebar->setPosition(-20, 150, sp::Alignment::TopRight)->setSize(250, GuiElement::GuiSizeMax)->setAttribute("layout", "vertical");
 
-    info_callsign = new GuiKeyValueDisplay(sidebar, "SCIENCE_CALLSIGN", 0.4, tr("Callsign"), "");
+    info_callsign = new GuiKeyValueDisplay(sidebar, "SCIENCE_CALLSIGN", 0.4f, tr("Callsign"), "");
     info_callsign->setSize(GuiElement::GuiSizeMax, 30);
 
-    info_faction = new GuiKeyValueDisplay(sidebar, "SCIENCE_FACTION", 0.4, tr("Faction"), "");
+    info_faction = new GuiKeyValueDisplay(sidebar, "SCIENCE_FACTION", 0.4f, tr("Faction"), "");
     info_faction->setSize(GuiElement::GuiSizeMax, 30);
 
     zoom_slider = new GuiSlider(this, "ZOOM_SLIDER", 50000.0f, 6250.0f, 50000.0f, [this](float value) {

--- a/src/screens/crew6/scienceScreen.cpp
+++ b/src/screens/crew6/scienceScreen.cpp
@@ -93,17 +93,17 @@ ScienceScreen::ScienceScreen(GuiContainer* owner, ECrewPosition crew_position)
     scan_button->setSize(GuiElement::GuiSizeMax, 50)->setVisible(my_spaceship && my_spaceship->getCanScan());
 
     // Simple scan data.
-    info_callsign = new GuiKeyValueDisplay(info_sidebar, "SCIENCE_CALLSIGN", 0.4, tr("Callsign"), "");
+    info_callsign = new GuiKeyValueDisplay(info_sidebar, "SCIENCE_CALLSIGN", 0.4f, tr("Callsign"), "");
     info_callsign->setSize(GuiElement::GuiSizeMax, 30);
-    info_distance = new GuiKeyValueDisplay(info_sidebar, "SCIENCE_DISTANCE", 0.4, tr("science","Distance"), "");
+    info_distance = new GuiKeyValueDisplay(info_sidebar, "SCIENCE_DISTANCE", 0.4f, tr("science","Distance"), "");
     info_distance->setSize(GuiElement::GuiSizeMax, 30);
-    info_heading = new GuiKeyValueDisplay(info_sidebar, "SCIENCE_HEADING", 0.4, tr("Bearing"), "");
+    info_heading = new GuiKeyValueDisplay(info_sidebar, "SCIENCE_HEADING", 0.4f, tr("Bearing"), "");
     info_heading->setSize(GuiElement::GuiSizeMax, 30);
-    info_relspeed = new GuiKeyValueDisplay(info_sidebar, "SCIENCE_REL_SPEED", 0.4, tr("Rel. Speed"), "");
+    info_relspeed = new GuiKeyValueDisplay(info_sidebar, "SCIENCE_REL_SPEED", 0.4f, tr("Rel. Speed"), "");
     info_relspeed->setSize(GuiElement::GuiSizeMax, 30);
-    info_faction = new GuiKeyValueDisplay(info_sidebar, "SCIENCE_FACTION", 0.4, tr("Faction"), "");
+    info_faction = new GuiKeyValueDisplay(info_sidebar, "SCIENCE_FACTION", 0.4f, tr("Faction"), "");
     info_faction->setSize(GuiElement::GuiSizeMax, 30);
-    info_type = new GuiKeyValueDisplay(info_sidebar, "SCIENCE_TYPE", 0.4, tr("science","Type"), "");
+    info_type = new GuiKeyValueDisplay(info_sidebar, "SCIENCE_TYPE", 0.4f, tr("science","Type"), "");
     info_type->setSize(GuiElement::GuiSizeMax, 30);
     info_type_button = new GuiButton(info_type, "SCIENCE_TYPE_BUTTON", tr("database", "DB"), [this]() {
         P<SpaceShip> ship = targets.get();
@@ -119,9 +119,9 @@ ScienceScreen::ScienceScreen(GuiContainer* owner, ECrewPosition crew_position)
         }
     });
     info_type_button->setTextSize(20)->setPosition(0, 1, sp::Alignment::TopLeft)->setSize(50, 28);
-    info_shields = new GuiKeyValueDisplay(info_sidebar, "SCIENCE_SHIELDS", 0.4, tr("science", "Shields"), "");
+    info_shields = new GuiKeyValueDisplay(info_sidebar, "SCIENCE_SHIELDS", 0.4f, tr("science", "Shields"), "");
     info_shields->setSize(GuiElement::GuiSizeMax, 30);
-    info_hull = new GuiKeyValueDisplay(info_sidebar, "SCIENCE_HULL", 0.4, tr("science", "Hull"), "");
+    info_hull = new GuiKeyValueDisplay(info_sidebar, "SCIENCE_HULL", 0.4f, tr("science", "Hull"), "");
     info_hull->setSize(GuiElement::GuiSizeMax, 30);
 
     // Full scan data

--- a/src/screens/crew6/weaponsScreen.cpp
+++ b/src/screens/crew6/weaponsScreen.cpp
@@ -77,11 +77,11 @@ WeaponsScreen::WeaponsScreen(GuiContainer* owner)
     auto stats = new GuiElement(this, "WEAPONS_STATS");
     stats->setPosition(20, 100, sp::Alignment::TopLeft)->setSize(240, 120)->setAttribute("layout", "vertical");
 
-    energy_display = new GuiKeyValueDisplay(stats, "ENERGY_DISPLAY", 0.45, tr("Energy"), "");
+    energy_display = new GuiKeyValueDisplay(stats, "ENERGY_DISPLAY", 0.45f, tr("Energy"), "");
     energy_display->setIcon("gui/icons/energy")->setTextSize(20)->setSize(240, 40);
-    front_shield_display = new GuiKeyValueDisplay(stats, "FRONT_SHIELD_DISPLAY", 0.45, tr("shields","Front"), "");
+    front_shield_display = new GuiKeyValueDisplay(stats, "FRONT_SHIELD_DISPLAY", 0.45f, tr("shields","Front"), "");
     front_shield_display->setIcon("gui/icons/shields-fore")->setTextSize(20)->setSize(240, 40);
-    rear_shield_display = new GuiKeyValueDisplay(stats, "REAR_SHIELD_DISPLAY", 0.45, tr("shields", "Rear"), "");
+    rear_shield_display = new GuiKeyValueDisplay(stats, "REAR_SHIELD_DISPLAY", 0.45f, tr("shields", "Rear"), "");
     rear_shield_display->setIcon("gui/icons/shields-aft")->setTextSize(20)->setSize(240, 40);
 
     if (gameGlobalInfo->use_beam_shield_frequencies)

--- a/src/screens/extra/damcon.cpp
+++ b/src/screens/extra/damcon.cpp
@@ -17,12 +17,12 @@ DamageControlScreen::DamageControlScreen(GuiContainer* owner)
     auto system_health_layout = new GuiElement(this, "DAMCON_LAYOUT");
     system_health_layout->setPosition(0, 0, sp::Alignment::CenterLeft)->setSize(300, 600)->setAttribute("layout", "vertical");
 
-    hull_display = new GuiKeyValueDisplay(system_health_layout, "HULL", 0.8, tr("damagecontrol", "Hull"), "0%");
+    hull_display = new GuiKeyValueDisplay(system_health_layout, "HULL", 0.8f, tr("damagecontrol", "Hull"), "0%");
     hull_display->setSize(GuiElement::GuiSizeMax, 40);
 
     for(unsigned int n=0; n<SYS_COUNT; n++)
     {
-        system_health[n] = new GuiKeyValueDisplay(system_health_layout, "DAMCON_HEALTH_" + string(n), 0.8, getLocaleSystemName(ESystem(n)), "0%");
+        system_health[n] = new GuiKeyValueDisplay(system_health_layout, "DAMCON_HEALTH_" + string(n), 0.8f, getLocaleSystemName(ESystem(n)), "0%");
         system_health[n]->setSize(GuiElement::GuiSizeMax, 40);
     }
 

--- a/src/screens/extra/powerManagement.cpp
+++ b/src/screens/extra/powerManagement.cpp
@@ -16,9 +16,9 @@ PowerManagementScreen::PowerManagementScreen(GuiContainer* owner)
 {
     selected_system = SYS_None;
 
-    energy_display = new GuiKeyValueDisplay(this, "ENERGY_DISPLAY", 0.45, tr("Energy"), "");
+    energy_display = new GuiKeyValueDisplay(this, "ENERGY_DISPLAY", 0.45f, tr("Energy"), "");
     energy_display->setIcon("gui/icons/energy")->setTextSize(20)->setPosition(20, 20, sp::Alignment::TopLeft)->setSize(285, 40);
-    coolant_display = new GuiKeyValueDisplay(this, "COOLANT_DISPLAY", 0.45, tr("Coolant"), "");
+    coolant_display = new GuiKeyValueDisplay(this, "COOLANT_DISPLAY", 0.45f, tr("Coolant"), "");
     coolant_display->setIcon("gui/icons/coolant")->setTextSize(20)->setPosition(315, 20, sp::Alignment::TopLeft)->setSize(280, 40);
     GuiElement* layout = new GuiElement(this, "");
     layout->setPosition(20, 60, sp::Alignment::TopLeft)->setSize(GuiElement::GuiSizeMax, 400)->setAttribute("layout", "horizontal");
@@ -47,7 +47,7 @@ PowerManagementScreen::PowerManagementScreen(GuiContainer* owner)
             if (my_spaceship)
                 my_spaceship->commandSetSystemPowerRequest(ESystem(n), value);
         });
-        systems[n].power_slider->addSnapValue(1.0, 0.1)->setPosition(50, 50, sp::Alignment::TopLeft)->setSize(55, 340);
+        systems[n].power_slider->addSnapValue(1.0f, 0.1f)->setPosition(50, 50, sp::Alignment::TopLeft)->setSize(55, 340);
 
         systems[n].coolant_bar = new GuiProgressbar(box, "", 0.0, 10.0, 0.0);
         systems[n].coolant_bar->setDrawBackground(false)->setPosition(132.5, 60, sp::Alignment::TopLeft)->setSize(50, 320);

--- a/src/screens/gm/tweak.cpp
+++ b/src/screens/gm/tweak.cpp
@@ -548,12 +548,12 @@ GuiShipTweakBeamweapons::GuiShipTweakBeamweapons(GuiContainer* owner)
     (new GuiLabel(right_col, "", tr("beam", "Turret rotation rate:"), 20))->setSize(GuiElement::GuiSizeMax, 30);
     // 25 is an arbitrary limit to add granularity; values greater than 25
     // result in practicaly instantaneous turret rotation anyway.
-    turret_rotation_rate_slider = new GuiSlider(right_col, "", 0.0, 250.0, 0.0, [this](float value) {
+    turret_rotation_rate_slider = new GuiSlider(right_col, "", 0.0f, 250.0f, 0.0f, [this](float value) {
         // Divide a large value for granularity.
         if (value > 0)
             target->beam_weapons[beam_index].setTurretRotationRate(value / 10.0f);
         else
-            target->beam_weapons[beam_index].setTurretRotationRate(0.0);
+            target->beam_weapons[beam_index].setTurretRotationRate(0.0f);
     });
     turret_rotation_rate_slider->setSize(GuiElement::GuiSizeMax, 30);
     // Override overlay label.
@@ -561,19 +561,19 @@ GuiShipTweakBeamweapons::GuiShipTweakBeamweapons(GuiContainer* owner)
     turret_rotation_rate_overlay_label->setSize(GuiElement::GuiSizeMax, GuiElement::GuiSizeMax);
 
     (new GuiLabel(right_col, "", tr("beam", "Range:"), 20))->setSize(GuiElement::GuiSizeMax, 30);
-    range_slider = new GuiSlider(right_col, "", 0.0, 5000.0, 0.0, [this](float value) {
+    range_slider = new GuiSlider(right_col, "", 0.0f, 5000.0f, 0.0f, [this](float value) {
         target->beam_weapons[beam_index].setRange(roundf(value / 100) * 100);
     });
     range_slider->addOverlay()->setSize(GuiElement::GuiSizeMax, 30);
 
     (new GuiLabel(right_col, "", tr("beam", "Cycle time:"), 20))->setSize(GuiElement::GuiSizeMax, 30);
-    cycle_time_slider = new GuiSlider(right_col, "", 0.1, 20.0, 0.0, [this](float value) {
+    cycle_time_slider = new GuiSlider(right_col, "", 0.1f, 20.0f, 0.0f, [this](float value) {
         target->beam_weapons[beam_index].setCycleTime(value);
     });
     cycle_time_slider->addOverlay()->setSize(GuiElement::GuiSizeMax, 30);
 
     (new GuiLabel(right_col, "", tr("beam", "Damage:"), 20))->setSize(GuiElement::GuiSizeMax, 30);
-    damage_slider = new GuiSlider(right_col, "", 0.1, 50.0, 0.0, [this](float value) {
+    damage_slider = new GuiSlider(right_col, "", 0.1f, 50.0f, 0.0f, [this](float value) {
         target->beam_weapons[beam_index].setDamage(value);
     });
     damage_slider->addOverlay()->setSize(GuiElement::GuiSizeMax, 30);
@@ -618,9 +618,9 @@ GuiShipTweakSystems::GuiShipTweakSystems(GuiContainer* owner)
             target->systems[n].health = std::min(value,target->systems[n].health_max);
         });
         system_damage[n]->setSize(GuiElement::GuiSizeMax, 30);
-        system_damage[n]->addSnapValue(-1.0, 0.01);
-        system_damage[n]->addSnapValue( 0.0, 0.01);
-        system_damage[n]->addSnapValue( 1.0, 0.01);
+        system_damage[n]->addSnapValue(-1.0f, 0.01f);
+        system_damage[n]->addSnapValue( 0.0f, 0.01f);
+        system_damage[n]->addSnapValue( 1.0f, 0.01f);
 
         (new GuiLabel(center_col, "", tr("{system} health max").format({{"system", getLocaleSystemName(system)}}), 20))->setSize(GuiElement::GuiSizeMax, 30);
         system_health_max[n] = new GuiSlider(center_col, "", -1.0, 1.0, 1.0, [this, n](float value) {
@@ -628,17 +628,17 @@ GuiShipTweakSystems::GuiShipTweakSystems(GuiContainer* owner)
             target->systems[n].health = std::min(value,target->systems[n].health);
         });
         system_health_max[n]->setSize(GuiElement::GuiSizeMax, 30);
-        system_health_max[n]->addSnapValue(-1.0, 0.01);
-        system_health_max[n]->addSnapValue( 0.0, 0.01);
-        system_health_max[n]->addSnapValue( 1.0, 0.01);
+        system_health_max[n]->addSnapValue(-1.0f, 0.01f);
+        system_health_max[n]->addSnapValue( 0.0f, 0.01f);
+        system_health_max[n]->addSnapValue( 1.0f, 0.01f);
 
         (new GuiLabel(right_col, "", tr("{system} heat").format({{"system", getLocaleSystemName(system)}}), 20))->setSize(GuiElement::GuiSizeMax, 30);
         system_heat[n] = new GuiSlider(right_col, "", 0.0, 1.0, 0.0, [this, n](float value) {
             target->systems[n].heat_level = value;
         });
         system_heat[n]->setSize(GuiElement::GuiSizeMax, 30);
-        system_heat[n]->addSnapValue( 0.0, 0.01);
-        system_heat[n]->addSnapValue( 1.0, 0.01);
+        system_heat[n]->addSnapValue( 0.0f, 0.01f);
+        system_heat[n]->addSnapValue( 1.0f, 0.01f);
     }
 }
 
@@ -1168,7 +1168,7 @@ GuiObjectTweakBase::GuiObjectTweakBase(GuiContainer* owner)
 
     // Set object's heading.
     (new GuiLabel(right_col, "", tr("Heading:"), 30))->setSize(GuiElement::GuiSizeMax, 50);
-    heading_slider = new GuiSlider(right_col, "", 0.0, 359.9, 0.0, [this](float value) {
+    heading_slider = new GuiSlider(right_col, "", 0.0f, 359.9f, 0.0f, [this](float value) {
         target->setHeading(value);
     });
     heading_slider->addOverlay()->setSize(GuiElement::GuiSizeMax, 40);

--- a/src/spaceObjects/beamEffect.cpp
+++ b/src/spaceObjects/beamEffect.cpp
@@ -64,9 +64,9 @@ BeamEffect::BeamEffect()
 : SpaceObject(1000, "BeamEffect")
 {
     has_weight = false;
-    setRadarSignatureInfo(0.0, 0.3, 0.0);
-    setCollisionRadius(1.0);
-    lifetime = 1.0;
+    setRadarSignatureInfo(0.0f, 0.3f, 0.0f);
+    setCollisionRadius(1.0f);
+    lifetime = 1.0f;
     sourceId = -1;
     target_id = -1;
     beam_texture = "texture/beam_orange.png";
@@ -74,12 +74,12 @@ BeamEffect::BeamEffect()
     beam_fire_sound_power = 1;
     beam_sound_played = false;
     fire_ring = true;
-    registerMemberReplication(&lifetime, 0.1);
+    registerMemberReplication(&lifetime, 0.1f);
     registerMemberReplication(&sourceId);
     registerMemberReplication(&target_id);
     registerMemberReplication(&sourceOffset);
     registerMemberReplication(&targetOffset);
-    registerMemberReplication(&targetLocation, 1.0);
+    registerMemberReplication(&targetLocation, 1.0f);
     registerMemberReplication(&hitNormal);
     registerMemberReplication(&beam_texture);
     registerMemberReplication(&beam_fire_sound);
@@ -179,16 +179,16 @@ void BeamEffect::update(float delta)
     if (target)
         targetLocation = target->getPosition() + glm::vec2(targetOffset.x, targetOffset.y);
 
-    if (source && delta > 0 && !beam_sound_played)
+    if (source && delta > 0.0f && !beam_sound_played)
     {
         float volume = 50.0f + (beam_fire_sound_power * 75.0f);
         float pitch = (1.0f / beam_fire_sound_power) + random(-0.1f, 0.1f);
-        soundManager->playSound(beam_fire_sound, source->getPosition(), 400.0, 0.6, pitch, volume);
+        soundManager->playSound(beam_fire_sound, source->getPosition(), 400.0f, 0.6f, pitch, volume);
         beam_sound_played = true;
     }
 
     lifetime -= delta;
-    if (lifetime < 0)
+    if (lifetime < 0.0f)
         destroy();
 }
 

--- a/src/spaceObjects/blackHole.cpp
+++ b/src/spaceObjects/blackHole.cpp
@@ -33,7 +33,7 @@ BlackHole::BlackHole()
 {
     update_delta = 0.0;
     PathPlannerManager::getInstance()->addAvoidObject(this, 7000);
-    setRadarSignatureInfo(0.9, 0, 0);
+    setRadarSignatureInfo(0.9f, 0.0f, 0.0f);
 }
 
 void BlackHole::update(float delta)

--- a/src/spaceObjects/electricExplosionEffect.cpp
+++ b/src/spaceObjects/electricExplosionEffect.cpp
@@ -148,8 +148,8 @@ void ElectricExplosionEffect::drawOnRadar(sp::RenderTarget& renderer, glm::vec2 
 
 void ElectricExplosionEffect::update(float delta)
 {
-    if (delta > 0 && lifetime == maxLifetime)
-        soundManager->playSound("sfx/emp_explosion.wav", getPosition(), size * 2, 0.6);
+    if (delta > 0.0f && lifetime == maxLifetime)
+        soundManager->playSound("sfx/emp_explosion.wav", getPosition(), size * 2.0f, 0.6f);
     lifetime -= delta;
     if (lifetime < 0)
         destroy();

--- a/src/spaceObjects/explosionEffect.cpp
+++ b/src/spaceObjects/explosionEffect.cpp
@@ -161,7 +161,7 @@ void ExplosionEffect::drawOnRadar(sp::RenderTarget& renderer, glm::vec2 position
 void ExplosionEffect::update(float delta)
 {
     if (delta > 0 && lifetime == maxLifetime)
-        soundManager->playSound(explosion_sound, getPosition(), size * 2, 0.6);
+        soundManager->playSound(explosion_sound, getPosition(), size * 2.0f, 0.6f);
     lifetime -= delta;
     if (lifetime < 0)
         destroy();

--- a/src/spaceObjects/mine.cpp
+++ b/src/spaceObjects/mine.cpp
@@ -37,9 +37,9 @@ Mine::Mine()
     setCollisionRadius(trigger_range);
     triggered = false;
     triggerTimeout = triggerDelay;
-    ejectTimeout = 0.0;
-    particleTimeout = 0.0;
-    setRadarSignatureInfo(0.0, 0.05, 0.0);
+    ejectTimeout = 0.0f;
+    particleTimeout = 0.0f;
+    setRadarSignatureInfo(0.0f, 0.05f, 0.0f);
 
     PathPlannerManager::getInstance()->addAvoidObject(this, blastRange * 1.2f);
 }
@@ -58,7 +58,7 @@ void Mine::draw3DTransparent()
 
 void Mine::drawOnRadar(sp::RenderTarget& renderer, glm::vec2 position, float scale, float rotation, bool long_range)
 {
-    renderer.drawSprite("radar/blip.png", position, 0.3 * 32);
+    renderer.drawSprite("radar/blip.png", position, 0.3f * 32.0f);
 }
 
 void Mine::drawOnGMRadar(sp::RenderTarget& renderer, glm::vec2 position, float scale, float rotation, bool long_range)
@@ -74,7 +74,7 @@ void Mine::update(float delta)
     }else{
         glm::vec3 pos = glm::vec3(getPosition().x, getPosition().y, 0);
         ParticleEngine::spawn(pos, pos + glm::vec3(random(-100, 100), random(-100, 100), random(-100, 100)), glm::vec3(1, 1, 1), glm::vec3(0, 0, 1), 30, 0, 10.0);
-        particleTimeout = 0.4;
+        particleTimeout = 0.4f;
     }
 
     if (ejectTimeout > 0.0f)
@@ -118,7 +118,7 @@ void Mine::explode()
     e->setSize(blastRange);
     e->setPosition(getPosition());
     e->setOnRadar(true);
-    e->setRadarSignatureInfo(0.0, 0.0, 0.2);
+    e->setRadarSignatureInfo(0.0f, 0.0f, 0.2f);
 
     if (on_destruction.isSet())
     {

--- a/src/spaceObjects/missiles/EMPMissile.cpp
+++ b/src/spaceObjects/missiles/EMPMissile.cpp
@@ -17,7 +17,7 @@ EMPMissile::EMPMissile()
 : MissileWeapon("EMPMissile", MissileWeaponData::getDataFor(MW_EMP))
 {
     avoid_area_added = false;
-    setRadarSignatureInfo(0.0, 0.5, 0.1);
+    setRadarSignatureInfo(0.0f, 0.5f, 0.1f);
 }
 
 void EMPMissile::explode()
@@ -29,7 +29,7 @@ void EMPMissile::explode()
     e->setSize(category_modifier * blast_range);
     e->setPosition(getPosition());
     e->setOnRadar(true);
-    e->setRadarSignatureInfo(0.0, 1.0, 0.0);
+    e->setRadarSignatureInfo(0.0f, 1.0f, 0.0f);
 }
 
 

--- a/src/spaceObjects/missiles/homingMissile.cpp
+++ b/src/spaceObjects/missiles/homingMissile.cpp
@@ -15,16 +15,16 @@ REGISTER_MULTIPLAYER_CLASS(HomingMissile, "HomingMissile");
 HomingMissile::HomingMissile()
 : MissileWeapon("HomingMissile", MissileWeaponData::getDataFor(MW_Homing))
 {
-    setRadarSignatureInfo(0.0, 0.1, 0.2);
+    setRadarSignatureInfo(0.0f, 0.1f, 0.2f);
 }
 
 void HomingMissile::hitObject(P<SpaceObject> object)
 {
     DamageInfo info(owner, DT_Kinetic, getPosition());
-    object->takeDamage(category_modifier * 35, info);
+    object->takeDamage(category_modifier * 35.0f, info);
     P<ExplosionEffect> e = new ExplosionEffect();
-    e->setSize(category_modifier * 30);
+    e->setSize(category_modifier * 30.0f);
     e->setPosition(getPosition());
     e->setOnRadar(true);
-    e->setRadarSignatureInfo(0.0, 0.0, 0.5);
+    e->setRadarSignatureInfo(0.0f, 0.0f, 0.5f);
 }

--- a/src/spaceObjects/missiles/hvli.cpp
+++ b/src/spaceObjects/missiles/hvli.cpp
@@ -16,7 +16,7 @@ REGISTER_MULTIPLAYER_CLASS(HVLI, "HVLI");
 HVLI::HVLI()
 : MissileWeapon("HVLI", MissileWeaponData::getDataFor(MW_HVLI))
 {
-    setRadarSignatureInfo(0.1, 0.0, 0.0);
+    setRadarSignatureInfo(0.1f, 0.0f, 0.0f);
     setCollisionBox({10, 30}); // Make it a bit harder to the HVLI to phase trough smaller enemies
 }
 
@@ -25,12 +25,12 @@ void HVLI::hitObject(P<SpaceObject> object)
     DamageInfo info(owner, DT_Kinetic, getPosition());
     float alive_for = MissileWeaponData::getDataFor(MW_HVLI).lifetime - lifetime;
     if (alive_for > 2.0f)
-        object->takeDamage(category_modifier * 10, info);
+        object->takeDamage(category_modifier * 10.0f, info);
     else
-        object->takeDamage(category_modifier * 10 * (alive_for / 2.0f), info);
+        object->takeDamage(category_modifier * 10.0f * (alive_for / 2.0f), info);
     P<ExplosionEffect> e = new ExplosionEffect();
-    e->setSize(category_modifier * 20);
+    e->setSize(category_modifier * 20.0f);
     e->setPosition(getPosition());
     e->setOnRadar(true);
-    setRadarSignatureInfo(0.0, 0.0, 0.1);
+    setRadarSignatureInfo(0.0f, 0.0f, 0.1f);
 }

--- a/src/spaceObjects/missiles/missileWeapon.cpp
+++ b/src/spaceObjects/missiles/missileWeapon.cpp
@@ -62,7 +62,7 @@ void MissileWeapon::drawOnRadar(sp::RenderTarget& renderer, glm::vec2 position, 
 {
     if (long_range) return;
 
-    renderer.drawRotatedSprite("radar/arrow.png", position, 32 * (0.25f + 0.25f * category_modifier), getRotation()-rotation, data.color);
+    renderer.drawRotatedSprite("radar/arrow.png", position, 32.0f * (0.25f + 0.25f * category_modifier), getRotation() - rotation, data.color);
 }
 
 void MissileWeapon::update(float delta)
@@ -74,20 +74,20 @@ void MissileWeapon::update(float delta)
 
     if (!launch_sound_played)
     {
-        soundManager->playSound(data.fire_sound, getPosition(), 400.0, 0.6, (1.0f + random(-0.2f, 0.2f)) * size_speed_modifier);
+        soundManager->playSound(data.fire_sound, getPosition(), 400.0f, 0.6f, (1.0f + random(-0.2f, 0.2f)) * size_speed_modifier);
         launch_sound_played = true;
     }
 
     // Since we do want the range to remain the same, ensure that slow missiles don't die down as fast.
     lifetime -= delta * size_speed_modifier;
-    if (lifetime < 0 && isServer())
+    if (lifetime < 0.0f && isServer())
     {
         lifeEnded();
         destroy();
     }
     setVelocity(vec2FromAngle(getRotation()) * data.speed * size_speed_modifier);
 
-    if (delta > 0)
+    if (delta > 0.0f)
     {
         ParticleEngine::spawn(glm::vec3(getPosition().x, getPosition().y, 0), glm::vec3(getPosition().x, getPosition().y, 0), glm::vec3(1, 0.8, 0.8), glm::vec3(0, 0, 0), 5, 20, 5.0);
     }

--- a/src/spaceObjects/missiles/nuke.cpp
+++ b/src/spaceObjects/missiles/nuke.cpp
@@ -18,7 +18,7 @@ Nuke::Nuke()
 : MissileWeapon("Nuke", MissileWeaponData::getDataFor(MW_Nuke))
 {
     avoid_area_added = false;
-    setRadarSignatureInfo(0.0, 0.7, 0.1);
+    setRadarSignatureInfo(0.0f, 0.7f, 0.1f);
 }
 
 void Nuke::explode()
@@ -31,7 +31,7 @@ void Nuke::explode()
     e->setPosition(getPosition());
     e->setOnRadar(true);
     e->setExplosionSound("sfx/nuke_explosion.wav");
-    setRadarSignatureInfo(0.0, 0.7, 1.0);
+    setRadarSignatureInfo(0.0f, 0.7f, 1.0f);
 }
 
 void Nuke::hitObject(P<SpaceObject> object)

--- a/src/spaceObjects/nebula.cpp
+++ b/src/spaceObjects/nebula.cpp
@@ -20,7 +20,6 @@ struct VertexAndTexCoords
     glm::vec2 texcoords;
 };
 
-
 /// A Nebula is a piece of space terrain with a 5U radius that blocks long-range radar, but not short-range radar.
 /// This hides any SpaceObjects inside of a Nebula, as well as SpaceObjects on the other side of its radar "shadow", from any SpaceShip outside of it.
 /// Likewise, a SpaceShip fully inside of a nebula has effectively no long-range radar functionality.
@@ -41,7 +40,7 @@ Nebula::Nebula()
     setCollisionRadius(1);
     setRotation(random(0, 360));
     radar_visual = irandom(1, 3);
-    setRadarSignatureInfo(0.0, 0.8, -1.0);
+    setRadarSignatureInfo(0.0f, 0.8f, -1.0f);
 
     registerMemberReplication(&radar_visual);
 

--- a/src/spaceObjects/playerSpaceship.cpp
+++ b/src/spaceObjects/playerSpaceship.cpp
@@ -549,32 +549,32 @@ PlayerSpaceship::PlayerSpaceship()
     for(unsigned int faction_id = 0; faction_id < factionInfo.size(); faction_id++)
         setScannedStateForFaction(faction_id, SS_FullScan);
 
-    updateMemberReplicationUpdateDelay(&target_rotation, 0.1);
+    updateMemberReplicationUpdateDelay(&target_rotation, 0.1f);
     registerMemberReplication(&can_scan);
     registerMemberReplication(&can_hack);
     registerMemberReplication(&can_dock);
     registerMemberReplication(&can_combat_maneuver);
     registerMemberReplication(&can_self_destruct);
     registerMemberReplication(&can_launch_probe);
-    registerMemberReplication(&hull_damage_indicator, 0.5);
-    registerMemberReplication(&jump_indicator, 0.5);
-    registerMemberReplication(&energy_level, 0.1);
-    registerMemberReplication(&energy_warp_per_second, .5f);
-    registerMemberReplication(&energy_shield_use_per_second, .5f);
+    registerMemberReplication(&hull_damage_indicator, 0.5f);
+    registerMemberReplication(&jump_indicator, 0.5f);
+    registerMemberReplication(&energy_level, 0.1f);
+    registerMemberReplication(&energy_warp_per_second, 0.5f);
+    registerMemberReplication(&energy_shield_use_per_second, 0.5f);
     registerMemberReplication(&max_energy_level);
     registerMemberReplication(&main_screen_setting);
     registerMemberReplication(&main_screen_overlay);
-    registerMemberReplication(&scanning_delay, 0.5);
+    registerMemberReplication(&scanning_delay, 0.5f);
     registerMemberReplication(&scanning_complexity);
     registerMemberReplication(&scanning_depth);
     registerMemberReplication(&shields_active);
-    registerMemberReplication(&shield_calibration_delay, 0.5);
+    registerMemberReplication(&shield_calibration_delay, 0.5f);
     registerMemberReplication(&auto_repair_enabled);
     registerMemberReplication(&max_coolant);
     registerMemberReplication(&auto_coolant_enabled);
     registerMemberReplication(&beam_system_target);
     registerMemberReplication(&comms_state);
-    registerMemberReplication(&comms_open_delay, 1.0);
+    registerMemberReplication(&comms_open_delay, 1.0f);
     registerMemberReplication(&comms_reply_message);
     registerMemberReplication(&comms_target_name);
     registerMemberReplication(&comms_incomming_message);
@@ -582,7 +582,7 @@ PlayerSpaceship::PlayerSpaceship()
     registerMemberReplication(&waypoints);
     registerMemberReplication(&scan_probe_stock);
     registerMemberReplication(&activate_self_destruct);
-    registerMemberReplication(&self_destruct_countdown, 0.2);
+    registerMemberReplication(&self_destruct_countdown, 0.2f);
     registerMemberReplication(&alert_level);
     registerMemberReplication(&linked_science_probe_id);
     registerMemberReplication(&control_code);
@@ -616,13 +616,13 @@ PlayerSpaceship::PlayerSpaceship()
         systems[n].power_factor = default_system_power_factors[n];
 
         registerMemberReplication(&systems[n].power_level);
-        registerMemberReplication(&systems[n].power_rate_per_second, .5f);
+        registerMemberReplication(&systems[n].power_rate_per_second, 0.5f);
         registerMemberReplication(&systems[n].power_request);
         registerMemberReplication(&systems[n].coolant_level);
-        registerMemberReplication(&systems[n].coolant_rate_per_second, .5f);
+        registerMemberReplication(&systems[n].coolant_rate_per_second, 0.5f);
         registerMemberReplication(&systems[n].coolant_request);
-        registerMemberReplication(&systems[n].heat_level, 1.0);
-        registerMemberReplication(&systems[n].heat_rate_per_second, .5f);
+        registerMemberReplication(&systems[n].heat_level, 1.0f);
+        registerMemberReplication(&systems[n].heat_rate_per_second, 0.5f);
         registerMemberReplication(&systems[n].power_factor);
     }
 
@@ -831,7 +831,7 @@ void PlayerSpaceship::update(float delta)
             ExplosionEffect* e = new ExplosionEffect();
             e->setSize(1000.0f);
             e->setPosition(getPosition());
-            e->setRadarSignatureInfo(0.0, 0.4, 0.4);
+            e->setRadarSignatureInfo(0.0f, 0.4f, 0.4f);
 
             DamageInfo info(this, DT_Kinetic, getPosition());
             SpaceObject::damageArea(getPosition(), 500, 30, 60, info, 0.0);
@@ -907,7 +907,7 @@ void PlayerSpaceship::update(float delta)
                         ExplosionEffect* e = new ExplosionEffect();
                         e->setSize(self_destruct_size * 0.67f);
                         e->setPosition(getPosition() + rotateVec2(glm::vec2(0, random(0, self_destruct_size * 0.33f)), random(0, 360)));
-                        e->setRadarSignatureInfo(0.0, 0.6, 0.6);
+                        e->setRadarSignatureInfo(0.0f, 0.6f, 0.6f);
                     }
 
                     DamageInfo info(this, DT_Kinetic, getPosition());
@@ -930,7 +930,7 @@ void PlayerSpaceship::update(float delta)
         }
 
         // If opening comms, tick the comms open delay timer.
-        if (comms_open_delay > 0)
+        if (comms_open_delay > 0.0f)
             comms_open_delay -= delta;
     }
 

--- a/src/spaceObjects/scanProbe.cpp
+++ b/src/spaceObjects/scanProbe.cpp
@@ -61,17 +61,17 @@ ScanProbe::ScanProbe()
   probe_speed(1000.0f)
 {
     // Probe persists for 10 minutes.
-    lifetime = 60 * 10;
+    lifetime = 60.0f * 10.0f;
     // Probe has not arrived yet.
     has_arrived = false;
 
-    registerMemberReplication(&owner_id, 0.5);
-    registerMemberReplication(&probe_speed, 0.1);
-    registerMemberReplication(&target_position, 0.1);
-    registerMemberReplication(&lifetime, 60.0);
+    registerMemberReplication(&owner_id, 0.5f);
+    registerMemberReplication(&probe_speed, 0.1f);
+    registerMemberReplication(&target_position, 0.1f);
+    registerMemberReplication(&lifetime, 60.0f);
 
     // Give the probe a small electrical radar signature.
-    setRadarSignatureInfo(0.0, 0.2, 0.0);
+    setRadarSignatureInfo(0.0f, 0.2f, 0.0f);
 
     // Randomly select a probe model.
     switch(irandom(1, 3))

--- a/src/spaceObjects/shipTemplateBasedObject.cpp
+++ b/src/spaceObjects/shipTemplateBasedObject.cpp
@@ -406,7 +406,7 @@ void ShipTemplateBasedObject::takeHullDamage(float damage_amount, DamageInfo& in
     hull_strength -= damage_amount;
     if (hull_strength <= 0.0f && !can_be_destroyed)
     {
-        hull_strength = 1;
+        hull_strength = 1.0f;
     }
     if (hull_strength <= 0.0f)
     {
@@ -431,7 +431,7 @@ float ShipTemplateBasedObject::getShieldDamageFactor(DamageInfo& info, int shiel
 
 float ShipTemplateBasedObject::getShieldRechargeRate(int shield_index)
 {
-    return 0.3;
+    return 0.3f;
 }
 
 void ShipTemplateBasedObject::setTemplate(string template_name)

--- a/src/spaceObjects/spaceStation.cpp
+++ b/src/spaceObjects/spaceStation.cpp
@@ -29,7 +29,7 @@ SpaceStation::SpaceStation()
     restocks_scan_probes = true;
     restocks_missiles_docked = true;
     comms_script_name = "comms_station.lua";
-    setRadarSignatureInfo(0.2, 0.5, 0.5);
+    setRadarSignatureInfo(0.2f, 0.5f, 0.5f);
 
     callsign = "DS" + string(getMultiplayerId());
 }
@@ -69,7 +69,7 @@ void SpaceStation::destroyedByDamage(DamageInfo& info)
     ExplosionEffect* e = new ExplosionEffect();
     e->setSize(getRadius());
     e->setPosition(getPosition());
-    e->setRadarSignatureInfo(0.0, 0.4, 0.4);
+    e->setRadarSignatureInfo(0.0f, 0.4f, 0.4f);
 
     if (info.instigator)
     {

--- a/src/spaceObjects/supplyDrop.cpp
+++ b/src/spaceObjects/supplyDrop.cpp
@@ -35,7 +35,7 @@ SupplyDrop::SupplyDrop()
         weapon_storage[n] = 0;
 
     energy = 0.0;
-    setRadarSignatureInfo(0.0, 0.1, 0.1);
+    setRadarSignatureInfo(0.0f, 0.1f, 0.1f);
 
     model_info.setData("ammo_box");
 }

--- a/src/spaceObjects/warpJammer.cpp
+++ b/src/spaceObjects/warpJammer.cpp
@@ -46,11 +46,11 @@ PVector<WarpJammer> WarpJammer::jammer_list;
 WarpJammer::WarpJammer()
 : SpaceObject(100, "WarpJammer")
 {
-    range = 7000.0;
-    hull = 50;
+    range = 7000.0f;
+    hull = 50.0f;
 
     jammer_list.push_back(this);
-    setRadarSignatureInfo(0.05, 0.5, 0.0);
+    setRadarSignatureInfo(0.05f, 0.5f, 0.0f);
 
     registerMemberReplication(&range);
 
@@ -74,7 +74,7 @@ void WarpJammer::drawOnRadar(sp::RenderTarget& renderer, glm::vec2 position, flo
         color = glm::u8vec4(200, 150, 100, 64);
         if (my_spaceship && my_spaceship->isEnemy(this))
             color = glm::u8vec4(255, 0, 0, 64);
-        renderer.drawCircleOutline(position, range*scale, 2.0, color);
+        renderer.drawCircleOutline(position, range * scale, 2.0f, color);
     }
 }
 
@@ -83,12 +83,12 @@ void WarpJammer::takeDamage(float damage_amount, DamageInfo info)
     if (info.type == DT_EMP)
         return;
     hull -= damage_amount;
-    if (hull <= 0)
+    if (hull <= 0.0f)
     {
         P<ExplosionEffect> e = new ExplosionEffect();
         e->setSize(getRadius());
         e->setPosition(getPosition());
-        e->setRadarSignatureInfo(0.5, 0.5, 0.1);
+        e->setRadarSignatureInfo(0.5f, 0.5f, 0.1f);
 
         if (on_destruction.isSet())
         {

--- a/src/spaceObjects/wormHole.cpp
+++ b/src/spaceObjects/wormHole.cpp
@@ -53,7 +53,7 @@ WormHole::WormHole()
     pathPlanner = PathPlannerManager::getInstance();
     pathPlanner->addAvoidObject(this, (DEFAULT_COLLISION_RADIUS * AVOIDANCE_MULTIPLIER) );
 
-    setRadarSignatureInfo(0.9, 0.0, 0.0);
+    setRadarSignatureInfo(0.9f, 0.0f, 0.0f);
 
     // Choose a texture to show on radar
     radar_visual = irandom(1, 3);


### PR DESCRIPTION
A build with the `-Wconversion` compiler flag generates 97 `float-conversion` double-to-float truncation warnings in GCC, such as:

```
EmptyEpsilon/src/beamTemplate.cpp:16:26:
warning:
conversion from ‘double’ to ‘float’ changes value from ‘2.0e-2’ to ‘1.99999996e-2f’
[-Wfloat-conversion]
```

This PR `f`-suffixes decimal numbers generating these warnings to make them explicitly floats, and others that aren't generating warnings but are inconsistently presented near changed values.

Values aren't changed, only suffixed.