### PR TITLE
Make the ship's log bigger

### DIFF
--- a/src/components/shiplog.cpp
+++ b/src/components/shiplog.cpp
@@ -9,9 +9,9 @@ void ShipLog::add(const string& message, glm::u8vec4 color)
 
 void ShipLog::add(const string& prefix, const string& message, glm::u8vec4 color)
 {
-    // Cap the ship's log size to 100 entries. If it exceeds that limit,
+    // Cap the ship's log size to 10,000 entries. If it exceeds that limit,
     // start erasing entries from the beginning.
-    if (entries.size() > 100)
+    if (entries.size() > 10000)
         entries.erase(entries.begin());
 
     // Timestamp a log entry, color it, and add it to the end of the log.


### PR DESCRIPTION
Originally submitted as a naïve constant tweak that caused UI performance problems, UI usability problems, and network performance problems.

With @oznogon 's help and some additional work in the engine, these are all fixed. Changes in SeriousProton were rejected while it was migrated to the ECS codebase. Now that ECS has merged and the log code has been adjusted, this change is ready to go.

This patch depends on:
- https://github.com/daid/EmptyEpsilon/pull/2299
~- https://github.com/daid/SeriousProton/pull/239~
- https://github.com/daid/EmptyEpsilon/pull/2019
- https://github.com/daid/EmptyEpsilon/pull/2021
- https://github.com/daid/EmptyEpsilon/pull/2022