### PR TITLE
[EE_GuiLIB] Align onDraw argument name definitions to implementations

### DIFF
--- a/src/gui/gui2_advancedscrolltext.h
+++ b/src/gui/gui2_advancedscrolltext.h
@@ -33,7 +33,7 @@ public:
     GuiAdvancedScrollText* removeEntry(int index);
     GuiAdvancedScrollText* clearEntries();
 
-    virtual void onDraw(sp::RenderTarget& target) override;
+    virtual void onDraw(sp::RenderTarget& renderer) override;
 };
 
 #endif//GUI2_ADVANCEDSCROLLTEXT_H

--- a/src/gui/gui2_arrow.h
+++ b/src/gui/gui2_arrow.h
@@ -11,7 +11,7 @@ private:
 public:
     GuiArrow(GuiContainer* owner, string id, float angle);
 
-    virtual void onDraw(sp::RenderTarget& target) override;
+    virtual void onDraw(sp::RenderTarget& renderer) override;
 
     GuiArrow* setColor(glm::u8vec4 color) { this->color = color; return this; }
     GuiArrow* setAngle(float angle) { this->angle = angle; return this; }

--- a/src/gui/gui2_arrowbutton.h
+++ b/src/gui/gui2_arrowbutton.h
@@ -10,7 +10,7 @@ protected:
 public:
     GuiArrowButton(GuiContainer* owner, string id, float angle, func_t func);
 
-    virtual void onDraw(sp::RenderTarget& target) override;
+    virtual void onDraw(sp::RenderTarget& renderer) override;
 };
 
 #endif//GUI2_ARROWBUTTON_H

--- a/src/gui/gui2_button.h
+++ b/src/gui/gui2_button.h
@@ -22,7 +22,7 @@ protected:
 public:
     GuiButton(GuiContainer* owner, string id, string text, func_t func);
 
-    virtual void onDraw(sp::RenderTarget& target) override;
+    virtual void onDraw(sp::RenderTarget& renderer) override;
     virtual bool onMouseDown(sp::io::Pointer::Button button, glm::vec2 position, sp::io::Pointer::ID id) override;
     virtual void onMouseUp(glm::vec2 position, sp::io::Pointer::ID id) override;
 

--- a/src/gui/gui2_element.h
+++ b/src/gui/gui2_element.h
@@ -43,7 +43,7 @@ public:
     virtual ~GuiElement();
 
     virtual void onUpdate() {}
-    virtual void onDraw(sp::RenderTarget& window) {}
+    virtual void onDraw(sp::RenderTarget& renderer) {}
     virtual bool onMouseDown(sp::io::Pointer::Button button, glm::vec2 position, sp::io::Pointer::ID id);
     virtual void onMouseDrag(glm::vec2 position, sp::io::Pointer::ID id);
     virtual void onMouseUp(glm::vec2 position, sp::io::Pointer::ID id);

--- a/src/gui/gui2_image.h
+++ b/src/gui/gui2_image.h
@@ -12,7 +12,7 @@ private:
 public:
     GuiImage(GuiContainer* owner, string id, string texture_name);
 
-    virtual void onDraw(sp::RenderTarget& target) override;
+    virtual void onDraw(sp::RenderTarget& renderer) override;
 
     GuiImage* setColor(glm::u8vec4 color) { this->color = color; return this; }
     GuiImage* setAngle(float angle) { this->angle = angle; return this; }

--- a/src/gui/gui2_keyvaluedisplay.h
+++ b/src/gui/gui2_keyvaluedisplay.h
@@ -10,7 +10,7 @@ class GuiKeyValueDisplay : public GuiElement
 public:
     GuiKeyValueDisplay(GuiContainer* owner, const string& id, float div_distance, const string& key, const string& value);
 
-    virtual void onDraw(sp::RenderTarget& target) override;
+    virtual void onDraw(sp::RenderTarget& renderer) override;
 
     GuiKeyValueDisplay* setKey(const string& key);
     GuiKeyValueDisplay* setValue(const string& value);

--- a/src/gui/gui2_label.h
+++ b/src/gui/gui2_label.h
@@ -20,7 +20,7 @@ protected:
 public:
     GuiLabel(GuiContainer* owner, string id, string text, float text_size);
 
-    virtual void onDraw(sp::RenderTarget& target) override;
+    virtual void onDraw(sp::RenderTarget& renderer) override;
 
     GuiLabel* setText(string text);
     string getText() const;
@@ -39,7 +39,7 @@ protected:
 public:
     GuiAutoSizeLabel(GuiContainer* owner, string id, string text, glm::vec2 min_size, glm::vec2 max_size, float min_text_size, float max_text_size);
 
-    virtual void onDraw(sp::RenderTarget& target) override;
+    virtual void onDraw(sp::RenderTarget& renderer) override;
     virtual void onUpdate() override;
 };
 

--- a/src/gui/gui2_listbox.h
+++ b/src/gui/gui2_listbox.h
@@ -27,7 +27,7 @@ public:
 
     GuiListbox* scrollTo(int index);
 
-    virtual void onDraw(sp::RenderTarget& target) override;
+    virtual void onDraw(sp::RenderTarget& renderer) override;
     virtual bool onMouseDown(sp::io::Pointer::Button button, glm::vec2 position, sp::io::Pointer::ID id) override;
     virtual void onMouseUp(glm::vec2 position, sp::io::Pointer::ID id) override;
 };

--- a/src/gui/gui2_overlay.h
+++ b/src/gui/gui2_overlay.h
@@ -16,7 +16,7 @@ private:
 public:
     GuiOverlay(GuiContainer* owner, string id, glm::u8vec4 color);
 
-    virtual void onDraw(sp::RenderTarget& target) override;
+    virtual void onDraw(sp::RenderTarget& renderer) override;
 
     GuiOverlay* setColor(glm::u8vec4 color);
     GuiOverlay* setAlpha(int alpha);

--- a/src/gui/gui2_panel.h
+++ b/src/gui/gui2_panel.h
@@ -12,7 +12,7 @@ protected:
 public:
     GuiPanel(GuiContainer* owner, string id);
 
-    virtual void onDraw(sp::RenderTarget& window) override;
+    virtual void onDraw(sp::RenderTarget& renderer) override;
     virtual bool onMouseDown(sp::io::Pointer::Button button, glm::vec2 position, sp::io::Pointer::ID id) override;
 };
 

--- a/src/gui/gui2_progressbar.h
+++ b/src/gui/gui2_progressbar.h
@@ -20,7 +20,7 @@ protected:
 public:
     GuiProgressbar(GuiContainer* owner, string id, float min_value, float max_value, float start_value);
 
-    virtual void onDraw(sp::RenderTarget& target) override;
+    virtual void onDraw(sp::RenderTarget& renderer) override;
 
     GuiProgressbar* setValue(float value);
     GuiProgressbar* setRange(float min_value, float max_value);

--- a/src/gui/gui2_resizabledialog.h
+++ b/src/gui/gui2_resizabledialog.h
@@ -12,7 +12,7 @@ class GuiResizableDialog : public GuiPanel
 public:
     GuiResizableDialog(GuiContainer* owner, string id, string title);
 
-    virtual void onDraw(sp::RenderTarget& target) override;
+    virtual void onDraw(sp::RenderTarget& renderer) override;
 
     virtual bool onMouseDown(sp::io::Pointer::Button button, glm::vec2 position, sp::io::Pointer::ID id) override;
     virtual void onMouseDrag(glm::vec2 position, sp::io::Pointer::ID id) override;

--- a/src/gui/gui2_rotationdial.h
+++ b/src/gui/gui2_rotationdial.h
@@ -15,7 +15,7 @@ protected:
 public:
     GuiRotationDial(GuiContainer* owner, string id, float min_value, float max_value, float start_value, func_t func);
 
-    virtual void onDraw(sp::RenderTarget& target) override;
+    virtual void onDraw(sp::RenderTarget& renderer) override;
     virtual bool onMouseDown(sp::io::Pointer::Button button, glm::vec2 position, sp::io::Pointer::ID id) override;
     virtual void onMouseDrag(glm::vec2 position, sp::io::Pointer::ID id) override;
     virtual void onMouseUp(glm::vec2 position, sp::io::Pointer::ID id) override;

--- a/src/gui/gui2_scrollbar.h
+++ b/src/gui/gui2_scrollbar.h
@@ -25,7 +25,7 @@ protected:
 public:
     GuiScrollbar(GuiContainer* owner, string id, int min_value, int max_value, int start_value, func_t func);
 
-    virtual void onDraw(sp::RenderTarget& target) override;
+    virtual void onDraw(sp::RenderTarget& renderer) override;
     virtual bool onMouseDown(sp::io::Pointer::Button button, glm::vec2 position, sp::io::Pointer::ID id) override;
     virtual void onMouseDrag(glm::vec2 position, sp::io::Pointer::ID id) override;
     virtual void onMouseUp(glm::vec2 position, sp::io::Pointer::ID id) override;

--- a/src/gui/gui2_scrolltext.h
+++ b/src/gui/gui2_scrolltext.h
@@ -23,7 +23,7 @@ public:
 
     GuiScrollText* setScrollbarWidth(float width);
 
-    virtual void onDraw(sp::RenderTarget& target) override;
+    virtual void onDraw(sp::RenderTarget& renderer) override;
 };
 
 #endif//GUI_SCROLLTEXT_H

--- a/src/gui/gui2_selector.h
+++ b/src/gui/gui2_selector.h
@@ -19,7 +19,7 @@ protected:
 public:
     GuiSelector(GuiContainer* owner, string id, func_t func);
 
-    virtual void onDraw(sp::RenderTarget& window) override;
+    virtual void onDraw(sp::RenderTarget& renderer) override;
     virtual bool onMouseDown(sp::io::Pointer::Button button, glm::vec2 position, sp::io::Pointer::ID id) override;
     virtual void onMouseUp(glm::vec2 position, sp::io::Pointer::ID id) override;
 

--- a/src/gui/gui2_slider.h
+++ b/src/gui/gui2_slider.h
@@ -20,7 +20,7 @@ protected:
 public:
     GuiBasicSlider(GuiContainer* owner, string id, float min_value, float max_value, float start_value, func_t func);
 
-    virtual void onDraw(sp::RenderTarget& window) override;
+    virtual void onDraw(sp::RenderTarget& renderer) override;
     virtual bool onMouseDown(sp::io::Pointer::Button button, glm::vec2 position, sp::io::Pointer::ID id) override;
     virtual void onMouseDrag(glm::vec2 position, sp::io::Pointer::ID id) override;
     virtual void onMouseUp(glm::vec2 position, sp::io::Pointer::ID id) override;
@@ -46,7 +46,7 @@ protected:
 public:
     GuiSlider(GuiContainer* owner, string id, float min_value, float max_value, float start_value, func_t func);
 
-    virtual void onDraw(sp::RenderTarget& window) override;
+    virtual void onDraw(sp::RenderTarget& renderer) override;
     virtual bool onMouseDown(sp::io::Pointer::Button button, glm::vec2 position, sp::io::Pointer::ID id) override;
     virtual void onMouseDrag(glm::vec2 position, sp::io::Pointer::ID id) override;
     virtual void onMouseUp(glm::vec2 position, sp::io::Pointer::ID id) override;
@@ -79,7 +79,7 @@ protected:
 public:
     GuiSlider2D(GuiContainer* owner, string id, glm::vec2 min_value, glm::vec2 max_value, glm::vec2 start_value, func_t func);
 
-    virtual void onDraw(sp::RenderTarget& window) override;
+    virtual void onDraw(sp::RenderTarget& renderer) override;
     virtual bool onMouseDown(sp::io::Pointer::Button button, glm::vec2 position, sp::io::Pointer::ID id) override;
     virtual void onMouseDrag(glm::vec2 position, sp::io::Pointer::ID id) override;
     virtual void onMouseUp(glm::vec2 position, sp::io::Pointer::ID id) override;

--- a/src/gui/gui2_textentry.h
+++ b/src/gui/gui2_textentry.h
@@ -34,7 +34,7 @@ public:
     GuiTextEntry(GuiContainer* owner, string id, string text);
     virtual ~GuiTextEntry();
 
-    virtual void onDraw(sp::RenderTarget& window) override;
+    virtual void onDraw(sp::RenderTarget& renderer) override;
     virtual bool onMouseDown(sp::io::Pointer::Button button, glm::vec2 position, sp::io::Pointer::ID id) override;
     virtual void onMouseDrag(glm::vec2 position, sp::io::Pointer::ID id) override;
     virtual void onTextInput(const string& text) override;

--- a/src/gui/gui2_togglebutton.h
+++ b/src/gui/gui2_togglebutton.h
@@ -16,7 +16,7 @@ protected:
 public:
     GuiToggleButton(GuiContainer* owner, string id, string text, func_t func);
 
-    virtual void onDraw(sp::RenderTarget& target) override;
+    virtual void onDraw(sp::RenderTarget& renderer) override;
 
     bool getValue() const;
     GuiToggleButton* setValue(bool value);


### PR DESCRIPTION
Several GUI element defintions use "target" or "window" for onDraw function RenderTarget names, but implementations consistently use "renderer". Fix this mismatch by consistently using "renderer" in definitions.