### PR TITLE
[#1739] Add keybinds to adjust impulse by 1%, 10% increments

### DIFF
--- a/src/gui/hotkeyConfig.cpp
+++ b/src/gui/hotkeyConfig.cpp
@@ -102,7 +102,11 @@ Keys::Keys() :
 
     //helms
     helms_increase_impulse("HELMS_IMPULSE_INCREASE", "Up"),
+    helms_increase_impulse_1("HELMS_IMPULSE_INCREASE_1"),
+    helms_increase_impulse_10("HELMS_IMPULSE_INCREASE_10"),
     helms_decrease_impulse("HELMS_IMPULSE_DECREASE", "Down"),
+    helms_decrease_impulse_1("HELMS_IMPULSE_DECREASE_1"),
+    helms_decrease_impulse_10("HELMS_IMPULSE_DECREASE_10"),
     helms_set_impulse("HELMS_SET_IMPULSE", {"joy:0:axis:1", "gamecontroller:0:axis:lefty"}),
     helms_zero_impulse("HELMS_IMPULSE_ZERO", "Space"),
     helms_max_impulse("HELMS_IMPULSE_MAX"),
@@ -304,7 +308,11 @@ void Keys::init()
 
     //helms
     helms_increase_impulse.setLabel(tr("hotkey_menu", "Helms"), tr("hotkey_Helms", "Increase impulse"));
+    helms_increase_impulse_1.setLabel(tr("hotkey_menu", "Helms"), tr("hotkey_Helms", "Increase impulse 1%"));
+    helms_increase_impulse_10.setLabel(tr("hotkey_menu", "Helms"), tr("hotkey_Helms", "Increase impulse 10%"));
     helms_decrease_impulse.setLabel(tr("hotkey_menu", "Helms"), tr("hotkey_Helms", "Decrease impulse"));
+    helms_decrease_impulse_1.setLabel(tr("hotkey_menu", "Helms"), tr("hotkey_Helms", "Decrease impulse 1%"));
+    helms_decrease_impulse_10.setLabel(tr("hotkey_menu", "Helms"), tr("hotkey_Helms", "Decrease impulse 10%"));
     helms_set_impulse.setLabel(tr("hotkey_menu", "Helms"), tr("hotkey_Helms", "Set impulse (joystick)"));
     helms_zero_impulse.setLabel(tr("hotkey_menu", "Helms"), tr("hotkey_Helms", "Zero impulse"));
     helms_max_impulse.setLabel(tr("hotkey_menu", "Helms"), tr("hotkey_Helms", "Max impulse"));

--- a/src/gui/hotkeyConfig.h
+++ b/src/gui/hotkeyConfig.h
@@ -43,7 +43,11 @@ public:
 
     //helms
     sp::io::Keybinding helms_increase_impulse;
+    sp::io::Keybinding helms_increase_impulse_1;
+    sp::io::Keybinding helms_increase_impulse_10;
     sp::io::Keybinding helms_decrease_impulse;
+    sp::io::Keybinding helms_decrease_impulse_1;
+    sp::io::Keybinding helms_decrease_impulse_10;
     sp::io::Keybinding helms_set_impulse;
     sp::io::Keybinding helms_zero_impulse;
     sp::io::Keybinding helms_max_impulse;

--- a/src/screenComponents/impulseControls.cpp
+++ b/src/screenComponents/impulseControls.cpp
@@ -34,16 +34,24 @@ void GuiImpulseControls::onUpdate()
 {
     if (my_spaceship && isVisible())
     {
-        float change = keys.helms_increase_impulse.getValue() - keys.helms_decrease_impulse.getValue();
+        const float change = keys.helms_increase_impulse.getValue() - keys.helms_decrease_impulse.getValue();
         if (change != 0.0f)
-            my_spaceship->commandImpulse(std::min(1.0f, slider->getValue() + change * 0.1f));
+            my_spaceship->commandImpulse(std::clamp(-1.0f, 1.0f, slider->getValue() + change * 0.01f));
+        if (keys.helms_increase_impulse_1.getDown())
+            my_spaceship->commandImpulse(std::min(1.0f, slider->getValue() + 0.01f));
+        if (keys.helms_decrease_impulse_1.getDown())
+            my_spaceship->commandImpulse(std::max(-1.0f, slider->getValue() - 0.01f));
+        if (keys.helms_increase_impulse_10.getDown())
+            my_spaceship->commandImpulse(std::min(1.0f, slider->getValue() + 0.1f));
+        if (keys.helms_decrease_impulse_10.getDown())
+            my_spaceship->commandImpulse(std::max(-1.0f, slider->getValue() - 0.1f));
         if (keys.helms_zero_impulse.getDown())
             my_spaceship->commandImpulse(0.0f);
         if (keys.helms_max_impulse.getDown())
             my_spaceship->commandImpulse(1.0f);
         if (keys.helms_min_impulse.getDown())
             my_spaceship->commandImpulse(-1.0f);
-        
+
         float set_value = keys.helms_set_impulse.getValue();
         if (set_value != my_spaceship->impulse_request && (set_value != 0.0f || set_active))
         {

--- a/src/screenComponents/impulseControls.cpp
+++ b/src/screenComponents/impulseControls.cpp
@@ -25,7 +25,7 @@ void GuiImpulseControls::onDraw(sp::RenderTarget& target)
 {
     if (my_spaceship)
     {
-        label->setValue(string(int(my_spaceship->current_impulse * 100)) + "%");
+        label->setValue(string(static_cast<int>(std::round(my_spaceship->current_impulse * 100.0f))) + "%");
         slider->setValue(my_spaceship->impulse_request);
     }
 }


### PR DESCRIPTION
To restore some of the impulse keybind behavior prior to the SDL2 migration, add optional keybinds to adjust impulse up and down by 1% and 10% increments.

This PR also clamps the lower bound of the impulse command (it was possible before to have a player-issued impulse command < -1.0) and fixes incorrect rounding by float-to-int cast in the control's impulse% label.