### PR TITLE
[FactionInfo] Expose getter and setter for faction relationships

### DIFF
--- a/compile_script_docs.py
+++ b/compile_script_docs.py
@@ -189,7 +189,7 @@ def translate_type(c_type, name):
     if res is not None:
         return VariadicType(translate_type(res.group(1).strip(), name))
 
-    if c_type in ('EAlertLevel', 'ECrewPosition', 'EMissileSizes', 'EMissileWeapons', 'EScannedState', 'ESystem', 'EMainScreenSetting', 'EMainScreenOverlay', 'EDockingState', 'ScriptSimpleCallback'):
+    if c_type in ('EAlertLevel', 'ECrewPosition', 'EFactionVsFactionState', 'EMissileSizes', 'EMissileWeapons', 'EScannedState', 'ESystem', 'EMainScreenSetting', 'EMainScreenOverlay', 'EDockingState', 'ScriptSimpleCallback'):
         return EnumType(c_type)
 
     if c_type in ('int', 'float', 'double', 'int32_t', 'int8_t', 'uint32_t', 'uint8_t'):
@@ -508,6 +508,7 @@ rel="stylesheet"
         stream.write('<li><a name="enum_EAlertLevel">EAlertLevel<a/>: sets "normal", "yellow", "red" (<code>playerSpaceship.hpp</code>), returns "Normal", "YELLOW ALERT", "RED ALERT" (<code>playerSpaceship.cpp</code>)</li>\n')
         stream.write('<li><a name="enum_ECrewPosition">ECrewPosition</a>: "Helms", "Weapons", "Engineering", "Science", "Relay", "Tactical", "Engineering+", "Operations", "Single", "DamageControl", "PowerManagement", "Database", "AltRelay", "CommsOnly", "ShipLog" (<code>playerInfo.cpp</code>)</li>\n')
         stream.write('<li><a name="enum_EDockingState">EDockingState</a>: 0 (not docking), 1 (docking), 2 (docked) (<code>spaceship.h</code>)</li>\n')
+        stream.write('<li><a name="enum_EFactionVsFactionState">EFactionVsFactionState</a>: "friendly", "neutral", "enemy" (<code>factionInfo.cpp</code>)</li>\n')
         stream.write('<li><a name="enum_EMainScreenOverlay">EMainScreenOverlay</a>: "hidecomms", "showcomms" (<code>spaceship.hpp</code>)</li>\n')
         stream.write('<li><a name="enum_EMainScreenSetting">EMainScreenSetting</a>: "front", "back", "left", "right", "target", "tactical", "longrange" (<code>spaceship.hpp</code>)</li>\n')
         stream.write('<li><a name="enum_EMissileSizes">EMissileSizes</a>: "small", "medium", "large" (<code>missileWeaponData.hpp</code>)</li>\n')

--- a/src/factionInfo.cpp
+++ b/src/factionInfo.cpp
@@ -138,7 +138,7 @@ void FactionInfo::setFriendly(P<FactionInfo> other)
     other->enemy_mask &=~(1 << index);
 }
 
-EFactionVsFactionState FactionInfo::getState(P<FactionInfo> other)
+EFactionVsFactionState FactionInfo::getRelationshipWith(P<FactionInfo> other)
 {
     if (!other) return FVF_Neutral;
     if (enemy_mask & (1 << other->index)) return FVF_Enemy;
@@ -146,12 +146,12 @@ EFactionVsFactionState FactionInfo::getState(P<FactionInfo> other)
     return FVF_Neutral;
 }
 
-EFactionVsFactionState FactionInfo::getState(uint8_t idx0, uint8_t idx1)
+EFactionVsFactionState FactionInfo::getRelationshipBetween(uint8_t idx0, uint8_t idx1)
 {
     if (idx0 >= factionInfo.size()) return FVF_Neutral;
     if (idx1 >= factionInfo.size()) return FVF_Neutral;
     if (!factionInfo[idx0] || !factionInfo[idx1]) return FVF_Neutral;
-    return factionInfo[idx0]->getState(factionInfo[idx1]);
+    return factionInfo[idx0]->getRelationshipWith(factionInfo[idx1]);
 }
 
 unsigned int FactionInfo::findFactionId(string name)

--- a/src/factionInfo.cpp
+++ b/src/factionInfo.cpp
@@ -39,6 +39,10 @@ REGISTER_SCRIPT_CLASS(FactionInfo)
     /// Wrap the string in the _() function to make it available for translation.
     /// Example: faction:setDescription(_("The United Stellar Navy, or USN...")) -- sets a translatable description for this faction
     REGISTER_SCRIPT_CLASS_FUNCTION(FactionInfo, setDescription);
+    /// Returns this faction's relationship with the given faction.
+    /// Valid values are "friendly", "neutral", and "enemy".
+    /// Example: faction:getRelationshipWith(exuari) -- returns "enemy"
+    REGISTER_SCRIPT_CLASS_FUNCTION(FactionInfo, getRelationshipWith);
     /// Sets the given faction to appear as hostile to SpaceObjects of this faction.
     /// For example, Spaceships of this faction can target and fire at SpaceShips of the given faction.
     /// Defaults to no hostile factions.

--- a/src/factionInfo.cpp
+++ b/src/factionInfo.cpp
@@ -169,3 +169,31 @@ void FactionInfo::reset()
         if (factionInfo[n])
             factionInfo[n]->destroy();
 }
+
+template<> void convert<EFactionVsFactionState>::param(lua_State* L, int& idx, EFactionVsFactionState& state)
+{
+    string str = string(luaL_checkstring(L, idx++)).lower();
+
+    if (str == "friendly") { state = FVF_Friendly; }
+    else if (str == "neutral") { state = FVF_Neutral; }
+    else if (str == "enemy") { state = FVF_Enemy; }
+    else { state = FVF_Neutral; }
+}
+
+template<> int convert<EFactionVsFactionState>::returnType(lua_State* L, EFactionVsFactionState state)
+{
+    switch (state)
+    {
+    case FVF_Friendly:
+        lua_pushstring(L, "friendly");
+        return 1;
+    case FVF_Neutral:
+        lua_pushstring(L, "neutral");
+        return 1;
+    case FVF_Enemy:
+        lua_pushstring(L, "enemy");
+        return 1;
+    default:
+        return 0;
+    }
+}

--- a/src/factionInfo.h
+++ b/src/factionInfo.h
@@ -68,9 +68,8 @@ public:
      */
     void setFriendly(P<FactionInfo> other);
 
-    EFactionVsFactionState getState(P<FactionInfo> other);
-
-    static EFactionVsFactionState getState(uint8_t idx0, uint8_t idx1);
+    EFactionVsFactionState getRelationshipWith(P<FactionInfo> other);
+    static EFactionVsFactionState getRelationshipBetween(uint8_t idx0, uint8_t idx1);
     static unsigned int findFactionId(string name);
 
     static void reset(); //Destroy all FactionInfo objects

--- a/src/scienceDatabase.cpp
+++ b/src/scienceDatabase.cpp
@@ -437,7 +437,7 @@ void fillDefaultDatabaseData()
                 continue;
 
             string stance = tr("stance", "Neutral");
-            switch(FactionInfo::getState(n, m))
+            switch(FactionInfo::getRelationshipBetween(n, m))
             {
                 case FVF_Neutral: stance = tr("stance", "Neutral"); break;
                 case FVF_Enemy: stance = tr("stance", "Enemy"); break;

--- a/src/screenComponents/indicatorOverlays.cpp
+++ b/src/screenComponents/indicatorOverlays.cpp
@@ -125,7 +125,7 @@ void GuiIndicatorOverlays::onDraw(sp::RenderTarget& renderer)
             EFactionVsFactionState fvf_state = FVF_Neutral;
             if (my_spaceship)
             {
-                fvf_state = FactionInfo::getState(gameGlobalInfo->getVictoryFactionId(), my_spaceship->getFactionId());
+                fvf_state = FactionInfo::getRelationshipBetween(gameGlobalInfo->getVictoryFactionId(), my_spaceship->getFactionId());
             }
             switch(fvf_state)
             {

--- a/src/spaceObjects/spaceObject.cpp
+++ b/src/spaceObjects/spaceObject.cpp
@@ -414,7 +414,7 @@ bool SpaceObject::isEnemy(P<SpaceObject> obj)
 {
     if (obj)
     {
-        return FactionInfo::getState(faction_id, obj->faction_id) == FVF_Enemy;
+        return FactionInfo::getRelationshipBetween(faction_id, obj->faction_id) == FVF_Enemy;
     } else {
         return false;
     }
@@ -424,7 +424,7 @@ bool SpaceObject::isFriendly(P<SpaceObject> obj)
 {
     if (obj)
     {
-        return FactionInfo::getState(faction_id, obj->faction_id) == FVF_Friendly;
+        return FactionInfo::getRelationshipBetween(faction_id, obj->faction_id) == FVF_Friendly;
     } else {
         return false;
     }

--- a/src/spaceObjects/spaceship.cpp
+++ b/src/spaceObjects/spaceship.cpp
@@ -1716,24 +1716,24 @@ void SpaceShip::addBroadcast(int threshold, string message)
 
     for(int n=0; n<GameGlobalInfo::max_player_ships; n++)
     {
-        bool addtolog = 0;
+        bool addtolog = false;
         P<PlayerSpaceship> ship = gameGlobalInfo->getPlayerShip(n);
         if (ship)
         {
             if (this->isFriendly(ship))
             {
                 color = glm::u8vec4(154, 255, 154, 255); //ally = light green
-                addtolog = 1;
+                addtolog = true;
             }
-            else if ((FactionInfo::getState(this->getFactionId(), ship->getFactionId()) == FVF_Neutral) && ((threshold >= FVF_Neutral)))
+            else if ((FactionInfo::getRelationshipBetween(this->getFactionId(), ship->getFactionId()) == FVF_Neutral) && ((threshold >= FVF_Neutral)))
             {
                 color = glm::u8vec4(128,128,128, 255); //neutral = grey
-                addtolog = 1;
+                addtolog = true;
             }
             else if ((this->isEnemy(ship)) && (threshold == FVF_Enemy))
             {
                 color = glm::u8vec4(255,102,102, 255); //enemy = light red
-                addtolog = 1;
+                addtolog = true;
             }
 
             if (addtolog)


### PR DESCRIPTION
- Add conversion functions for EFactionVsFactionState as a parameter and return value
- Replace the overloaded `FactionInfo::getState` function with separate `getRelationshipWith` and `getRelationshipBetween` functions, and replaces usage of `FactionInfo::getState` with the equivalent `getRelationshipBetween`
- Expose `getRelationshipWith` to scripting:

  ```lua
  human_navy = getFactionInfo("Human Navy")
  kraylor = getFactionInfo("Kraylor")
  human_kraylor_relationship = kraylor:getRelationshipWith(human_navy) -- returns "enemy"
  ```
- Add `setRelationshipWith`

Towards #530.