### PR TITLE
[FactionInfo] Add setNeutral

### DIFF
--- a/src/factionInfo.cpp
+++ b/src/factionInfo.cpp
@@ -50,6 +50,9 @@ REGISTER_SCRIPT_CLASS(FactionInfo)
     /// Defaults to no friendly factions.
     /// Example: faction:setFriendly("Human Navy") -- sets the Human Navy to appear as friendly to this faction
     REGISTER_SCRIPT_CLASS_FUNCTION(FactionInfo, setFriendly);
+    /// Sets the given faction to appear as neutral to SpaceObjects of this faction.
+    /// Example: faction:setNeutral("Human Navy") -- sets the Human Navy to appear as neutral to this faction
+    REGISTER_SCRIPT_CLASS_FUNCTION(FactionInfo, setFriendly);
 }
 
 std::array<P<FactionInfo>, 32> factionInfo;
@@ -134,6 +137,20 @@ void FactionInfo::setFriendly(P<FactionInfo> other)
 
     friend_mask |= (1U << other->index);
     other->friend_mask |= (1U << index);
+    enemy_mask &=~(1 << other->index);
+    other->enemy_mask &=~(1 << index);
+}
+
+void FactionInfo::setNeutral(P<FactionInfo> other)
+{
+    if (!other)
+    {
+        LOG(WARNING) << "Tried to set an undefined faction to be neutral with " << name;
+        return;
+    }
+
+    friend_mask &=~(1 << other->index);
+    other->friend_mask &=~(1 << index);
     enemy_mask &=~(1 << other->index);
     other->enemy_mask &=~(1 << index);
 }

--- a/src/factionInfo.cpp
+++ b/src/factionInfo.cpp
@@ -51,8 +51,9 @@ REGISTER_SCRIPT_CLASS(FactionInfo)
     /// Example: faction:setFriendly("Human Navy") -- sets the Human Navy to appear as friendly to this faction
     REGISTER_SCRIPT_CLASS_FUNCTION(FactionInfo, setFriendly);
     /// Sets the given faction to appear as neutral to SpaceObjects of this faction.
-    /// Example: faction:setNeutral("Human Navy") -- sets the Human Navy to appear as neutral to this faction
-    REGISTER_SCRIPT_CLASS_FUNCTION(FactionInfo, setFriendly);
+    /// This removes any existing faction relationships between the two factions.
+    /// Example: faction:setNeutral(human_navy) -- sets the Human Navy to appear as neutral to this faction
+    REGISTER_SCRIPT_CLASS_FUNCTION(FactionInfo, setNeutral);
 }
 
 std::array<P<FactionInfo>, 32> factionInfo;

--- a/src/factionInfo.h
+++ b/src/factionInfo.h
@@ -67,6 +67,7 @@ public:
      * \param faction info object.
      */
     void setFriendly(P<FactionInfo> other);
+    void setNeutral(P<FactionInfo> other);
 
     EFactionVsFactionState getState(P<FactionInfo> other);
 


### PR DESCRIPTION
Add a function to set a faction's relationship with another faction to neutral.

Towards #530.

If this is merged, uncomment the corresponding [setRelationshipWith line in #1951](https://github.com/daid/EmptyEpsilon/pull/1951/files#r1148048762).