### PR TITLE
[Planet] Update collision size on setPlanetRadius, setDistanceFromMovementPlane

### DIFF
--- a/src/spaceObjects/planet.cpp
+++ b/src/spaceObjects/planet.cpp
@@ -201,6 +201,7 @@ Planet::Planet()
     registerMemberReplication(&orbit_target_id);
     registerMemberReplication(&orbit_time);
     registerMemberReplication(&orbit_distance);
+    registerMemberReplication(&collision_size);
 }
 
 void Planet::setPlanetAtmosphereColor(float r, float g, float b)
@@ -425,14 +426,18 @@ void Planet::collide(Collisionable* target, float collision_force)
 
 void Planet::updateCollisionSize()
 {
-    setRadius(planet_size);
-    if (std::abs(distance_from_movement_plane) >= planet_size)
+    // collision_size is replicated, so update it only on the server.
+    if (game_server)
     {
-        collision_size = -1.0;
-    }else{
-        collision_size = sqrt((planet_size * planet_size) - (distance_from_movement_plane * distance_from_movement_plane)) * 1.1f;
-        setCollisionRadius(collision_size);
-        setCollisionPhysics(true, true);
+        setRadius(planet_size);
+        if (std::abs(distance_from_movement_plane) >= planet_size)
+        {
+            collision_size = -1.0f;
+        }else{
+            collision_size = sqrt((planet_size * planet_size) - (distance_from_movement_plane * distance_from_movement_plane)) * 1.1f;
+            setCollisionRadius(collision_size);
+            setCollisionPhysics(true, true);
+        }
     }
 }
 

--- a/src/spaceObjects/planet.cpp
+++ b/src/spaceObjects/planet.cpp
@@ -238,6 +238,7 @@ void Planet::setPlanetRadius(float size)
     this->planet_size = size;
     this->cloud_size = size * 1.05f;
     this->atmosphere_size = size * 1.2f;
+    updateCollisionSize();
 }
 
 void Planet::setPlanetCloudRadius(float size)

--- a/src/spaceObjects/planet.cpp
+++ b/src/spaceObjects/planet.cpp
@@ -249,6 +249,7 @@ void Planet::setPlanetCloudRadius(float size)
 void Planet::setDistanceFromMovementPlane(float distance_from_movement_plane)
 {
     this->distance_from_movement_plane = distance_from_movement_plane;
+    updateCollisionSize();
 }
 
 void Planet::setAxialRotationTime(float time)


### PR DESCRIPTION
When changing the planet radius with setPlanetRadius or z-coordinate with setDistanceFromMovementPlane, the planet's collision radius doesn't change. This updates the collision radius in setPlanetRadius and setDistanceFromMovementPlane.

Fixes #1957.