### PR TITLE
show playership descriptions on ship selection screen (server side)

### DIFF
--- a/scripts/locale/shiptemplates/OLD.de.po
+++ b/scripts/locale/shiptemplates/OLD.de.po
@@ -10,23 +10,28 @@ msgstr ""
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
-"X-Generator: Poedit 3.0.1\n"
+"X-Generator: Poedit 3.1.1\n"
+
 #: scripts/shiptemplates/OLD.lua:6
 msgctxt "playerShip"
 msgid "Player Cruiser"
 msgstr ""
+
 #: scripts/shiptemplates/OLD.lua:63
 msgctxt "playerShip"
 msgid "Player Missile Cr."
 msgstr ""
+
 #: scripts/shiptemplates/OLD.lua:118
 msgctxt "playerShip"
 msgid "Player Fighter"
 msgstr ""
+
 #: scripts/shiptemplates/OLD.lua:159
 msgctxt "ship"
 msgid "Tug"
 msgstr ""
+
 #: scripts/shiptemplates/OLD.lua:168
 msgid ""
 "The tugboat is a reliable, but small and un-armed transport ship. Due to "
@@ -37,28 +42,34 @@ msgstr ""
 "Transportschiff. Aufgrund seiner niedrigen Kosten wird das gerne genutzt um "
 "neue Captains einzuweisen - Ohne das Risiko, durch versehentliches "
 "Waffenfeuer eine Katastrophe anzurichten."
+
 #: scripts/shiptemplates/OLD.lua:176
 msgctxt "playerShip"
 msgid "Nautilus"
 msgstr ""
+
 #: scripts/shiptemplates/OLD.lua:176 scripts/shiptemplates/OLD.lua:239
 #: scripts/shiptemplates/OLD.lua:264 scripts/shiptemplates/OLD.lua:275
-#: scripts/shiptemplates/OLD.lua:387 scripts/shiptemplates/OLD.lua:474
+#: scripts/shiptemplates/OLD.lua:387 scripts/shiptemplates/OLD.lua:475
 msgctxt "class"
 msgid "Frigate"
 msgstr "Fregatte"
+
 #: scripts/shiptemplates/OLD.lua:176
 msgctxt "subclass"
 msgid "Mine Layer"
 msgstr "Minenleger"
+
 #: scripts/shiptemplates/OLD.lua:177
 msgid "Small mine laying vessel with minimal armament, shields and hull"
 msgstr ""
 "Kleines Minen-legendes Schiff mit minimaler Bewaffnung, Schilden und Hülle"
+
 #: scripts/shiptemplates/OLD.lua:223
 msgctxt "ship"
 msgid "Fighter"
 msgstr ""
+
 #: scripts/shiptemplates/OLD.lua:226
 msgid ""
 "Fighters are quick agile ships that do not do a lot of damage, but usually "
@@ -68,14 +79,17 @@ msgstr ""
 "Jäger sind schnelle und wendige Schiffe, die nicht viel Schaden verursachen, "
 "aber üblicherweise in großen Gruppen unterwegs sind. Sie sind leicht "
 "auszuschalten, sollten aber nicht unterschätzt werden."
+
 #: scripts/shiptemplates/OLD.lua:239
 msgctxt "ship"
 msgid "Karnack"
 msgstr ""
+
 #: scripts/shiptemplates/OLD.lua:239
 msgctxt "subclass"
 msgid "Cruiser"
 msgstr "Kreuzer"
+
 #: scripts/shiptemplates/OLD.lua:241
 msgid ""
 "Fabricated by: Repulse shipyards. Due to it's versatility, this ship has "
@@ -93,10 +107,12 @@ msgstr ""
 "ausgeschlachtete Modelle. Dadurch wurde es schnell zu einem beliebten Modell "
 "für Schmuggler und andere Zivilen Gruppierungen. Die leichte Anpassbarkeit "
 "wurde auch dazu genutzt, es mit (illegalen) Waffen aufzurüsten."
+
 #: scripts/shiptemplates/OLD.lua:253
 msgctxt "ship"
 msgid "Karnack MK2"
 msgstr "Karnack MK2"
+
 #: scripts/shiptemplates/OLD.lua:254
 msgid ""
 "Fabricated by: Repulse shipyards. The successor to the widely successful "
@@ -112,14 +128,17 @@ msgstr ""
 "und spezielle Anpassungen durch die Schiffswerft. Letzteres wurde von vielen "
 "Fraktionen stark nachgefragt, nachdem sie bemerkten, dass die alte MK1 für "
 "weniger redliche Zwecke genutzt wurde."
+
 #: scripts/shiptemplates/OLD.lua:264
 msgctxt "ship"
 msgid "Missile Cruiser"
 msgstr ""
+
 #: scripts/shiptemplates/OLD.lua:264
 msgctxt "subclass"
 msgid "Cruiser: Missile"
 msgstr "Kreuzer: Raketenkreuzer"
+
 #: scripts/shiptemplates/OLD.lua:266
 msgid ""
 "Polaris missile cruiser mark I. Fabricated by: Repulse shipyards. This "
@@ -129,14 +148,17 @@ msgstr ""
 "Polaris-Raketenkreuzer MK1 Hergestellt von Repulse shipyards. Dieser "
 "Raketenkreuzer ist eine Langstrecken-Raketenplattform. Er hält nicht allzu "
 "viel  Schaden aus, aber kann sehr viel Schaden anrichten."
+
 #: scripts/shiptemplates/OLD.lua:275
 msgctxt "ship"
 msgid "Gunship"
 msgstr ""
+
 #: scripts/shiptemplates/OLD.lua:275
 msgctxt "subclass"
 msgid "Gunship"
 msgstr "Kanonenboot"
+
 #: scripts/shiptemplates/OLD.lua:277
 msgid ""
 "The gunship is a ship equipped with a homing missile tube to do initial "
@@ -147,10 +169,12 @@ msgstr ""
 "vorbereitend Schaden zu verursachen, und dann dann mit den beiden Lasern "
 "auszuschalten. Es wurde dazu entwickelt, um schnell Schiffe auszuschalten, "
 "die kleiner sind als es selbst."
+
 #: scripts/shiptemplates/OLD.lua:288
 msgctxt "ship"
 msgid "Adv. Gunship"
 msgstr ""
+
 #: scripts/shiptemplates/OLD.lua:289
 msgid ""
 "The advanced gunship is a ship equipped with 2 homing missiles to do initial "
@@ -161,19 +185,23 @@ msgstr ""
 "ausgestattet, um vorbereitend Schaden zu verursachen, und dann dann mit den "
 "beiden Lasern auszuschalten. Es wurde dazu entwickelt, um schnell Schiffe "
 "auszuschalten, die kleiner sind als es selbst."
+
 #: scripts/shiptemplates/OLD.lua:293
 msgctxt "ship"
 msgid "Strikeship"
 msgstr ""
+
 #: scripts/shiptemplates/OLD.lua:293 scripts/shiptemplates/OLD.lua:305
 #: scripts/shiptemplates/OLD.lua:387
 msgctxt "class"
 msgid "Starfighter"
 msgstr "Raumjäger"
+
 #: scripts/shiptemplates/OLD.lua:293
 msgctxt "subclass"
 msgid "Strike"
 msgstr "Angriffs-schiff"
+
 #: scripts/shiptemplates/OLD.lua:295
 msgid ""
 "The Strikeship is a warp-drive equipped fighter build for quick strikes, "
@@ -183,14 +211,17 @@ msgstr ""
 "Das Strikeship ist ein Raumjäger, der mit einem Warpantrieb ausgestattet ist "
 "und für schnelle Angriffe konzipiert ist. Es ist wendig, aber verursacht "
 "nicht all zu viel Schaden. Außerdem sind die Heckschilde sehr schwach."
+
 #: scripts/shiptemplates/OLD.lua:305
 msgctxt "ship"
 msgid "Adv. Striker"
 msgstr ""
+
 #: scripts/shiptemplates/OLD.lua:305
 msgctxt "subclass"
 msgid "Patrol"
 msgstr "Patroulle"
+
 #: scripts/shiptemplates/OLD.lua:307
 msgid ""
 "The Advanced Striker is a jump-drive equipped fighter build for quick "
@@ -202,10 +233,12 @@ msgstr ""
 "ausgestatteter Jäger für schnelle Angriffe. Er ist langsam aber sehr wendig, "
 "er macht nicht viel Schaden, und hat nur schwache Schilde. Durch seinen "
 "Sprungantrieb kann er allerdings schnell ins Geschehen eingreifen."
+
 #: scripts/shiptemplates/OLD.lua:316
 msgctxt "playerShip"
 msgid "Striker"
 msgstr ""
+
 #: scripts/shiptemplates/OLD.lua:317
 msgid ""
 "The Striker is the predecessor to the advanced striker, slow but agile, but "
@@ -213,18 +246,22 @@ msgid ""
 msgstr ""
 "Die Striker ist das Vorgängermodell der verbesserten Striker, langsam aber "
 "wendig, verursacht wenig Schaden, und verfügt nur über schwache Schilde."
+
 #: scripts/shiptemplates/OLD.lua:352
 msgctxt "ship"
 msgid "Dreadnought"
 msgstr "Dreadnought"
+
 #: scripts/shiptemplates/OLD.lua:352 scripts/shiptemplates/OLD.lua:367
 msgctxt "class"
 msgid "Dreadnought"
 msgstr "Schlachtschiff"
+
 #: scripts/shiptemplates/OLD.lua:352
 msgctxt "subclass"
 msgid "Assault"
 msgstr "Dreadnought"
+
 #: scripts/shiptemplates/OLD.lua:354
 msgid ""
 "The Dreadnought is a flying fortress, it's slow, slow to turn, but packs a "
@@ -233,14 +270,17 @@ msgstr ""
 "Die Dreadnaught ist eine fliegende Festung. Sie ist langsam, kann sich nur "
 "langsam drehen, aber besitzt eine große Anzahl an Laserwaffen am Bug. Sie "
 "frontal anzugreifen grenzt an Selbstmord."
+
 #: scripts/shiptemplates/OLD.lua:367
 msgctxt "ship"
 msgid "Battlestation"
 msgstr ""
+
 #: scripts/shiptemplates/OLD.lua:367
 msgctxt "subclass"
 msgid "Battlecruiser"
 msgstr "Schlachtkreuzer"
+
 #: scripts/shiptemplates/OLD.lua:369
 msgid ""
 "The battle station is a huge ship with many defensive features. It can be "
@@ -248,19 +288,31 @@ msgid ""
 msgstr ""
 "Die \"battle station\" ist ein großes Schiff mit vielen defensiven "
 "Merkmalen. Kleinere Schiffe können an sie andocken."
+
 #: scripts/shiptemplates/OLD.lua:387
 msgctxt "class"
 msgid "Corvette"
 msgstr "Korvette"
-#: scripts/shiptemplates/OLD.lua:390
-msgctxt "playerShip"
-msgid "Ender"
+
+#: scripts/shiptemplates/OLD.lua:391
+msgid ""
+"Player version of the battle station. Only half es much shield strength, but "
+"more speed and maneuverability, so it is surprisingly agile - for a capital "
+"ship, of course. Piloting this colossus still feels very different compared "
+"to other ships. It also has two additional missile tubes."
 msgstr ""
-#: scripts/shiptemplates/OLD.lua:459
+"Spielbare Variante der \"Battlestation\". Nur halb so starke Schilde, dafür "
+"aber schneller und wengier, so dass sie erstaunlich beweglich ist - für ein "
+"Großkampfschiff. Diesen Koloss zu steuern fühlt sich immer noch ganz anders "
+"an als bei anderen Schiffen. Außerdem verfügt die Ender über zwei "
+"zusätzliche Raketenschächte."
+
+#: scripts/shiptemplates/OLD.lua:460
 msgctxt "ship"
 msgid "Weapons platform"
 msgstr ""
-#: scripts/shiptemplates/OLD.lua:461
+
+#: scripts/shiptemplates/OLD.lua:462
 msgid ""
 "The weapons-platform is a stationary platform with beam-weapons. It's "
 "extremely slow to turn, but it's beam weapons do a huge amount of damage."
@@ -268,15 +320,18 @@ msgstr ""
 "Diese Waffenplattform ist eine stationäre Plattform mit Laserwaffen. Sie "
 "dreht sich nur extrem langsam, aber ihre Laserwaffen verursachen extrem viel "
 "Schaden."
-#: scripts/shiptemplates/OLD.lua:474
+
+#: scripts/shiptemplates/OLD.lua:475
 msgctxt "ship"
 msgid "Blockade Runner"
 msgstr ""
-#: scripts/shiptemplates/OLD.lua:474
+
+#: scripts/shiptemplates/OLD.lua:475
 msgctxt "subclass"
 msgid "High Punch"
 msgstr ""
-#: scripts/shiptemplates/OLD.lua:476
+
+#: scripts/shiptemplates/OLD.lua:477
 msgid ""
 "Blockade runner is a reasonably fast, high shield, slow on weapons ship "
 "designed to break through defense lines and deliver goods."
@@ -284,4 +339,3 @@ msgstr ""
 "Die Blockade Runner ist ein relativ schnelles Schiff mit starken Schilden "
 "und langsamen Waffen, das entwickelt wurde um durch Verteidigungslinien u "
 "brechen und Versorgungsgüter zu liefern."
-#, fuzzy

--- a/scripts/locale/shiptemplates/corvette.de.po
+++ b/scripts/locale/shiptemplates/corvette.de.po
@@ -10,11 +10,13 @@ msgstr ""
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
-"X-Generator: Poedit 3.0.1\n"
+"X-Generator: Poedit 3.1.1\n"
+
 #: scripts/shiptemplates/corvette.lua:14
 msgctxt "ship"
 msgid "Atlantis X23"
 msgstr ""
+
 #: scripts/shiptemplates/corvette.lua:14 scripts/shiptemplates/corvette.lua:83
 #: scripts/shiptemplates/corvette.lua:101
 #: scripts/shiptemplates/corvette.lua:157
@@ -30,10 +32,12 @@ msgstr ""
 msgctxt "class"
 msgid "Corvette"
 msgstr "Korvette"
+
 #: scripts/shiptemplates/corvette.lua:14 scripts/shiptemplates/corvette.lua:83
 msgctxt "subclass"
 msgid "Destroyer"
 msgstr "Zerstörer"
+
 #: scripts/shiptemplates/corvette.lua:15
 msgid ""
 "The Atlantis X23 is the smallest model of destroyer, and its combination of "
@@ -48,10 +52,12 @@ msgstr ""
 "mehrere kleinere Feinde zu verteidigen. Da die Atlantis außerdem über einen "
 "Springantrieb verfügt, kann sie auch als Patrouillenschiff zwischen Systemen "
 "eingesetzt werden."
+
 #: scripts/shiptemplates/corvette.lua:33
 msgctxt "playerShip"
 msgid "Atlantis"
 msgstr ""
+
 #: scripts/shiptemplates/corvette.lua:34
 msgid ""
 "A refitted Atlantis X23 for more general tasks. The large shield system has "
@@ -59,15 +65,18 @@ msgid ""
 "impulse engines. Its missile loadout is also more diverse. Mistaking the "
 "modified Atlantis for an Atlantis X23 would be a deadly mistake."
 msgstr ""
-"Eine umgerüstete Atlantis, welche dadurch noch mehr zu einem Vielzweckschiff "
-"wird. Das große Schildsystem wurde durch ein hochentwickeltes "
-"Ausweichmanöver-system und zusätzliche Impulstriebwerke ersetzt. Seine "
-"Waffenvorräte sind ebenfalls vielfältiger. Die modifizierte Atlantis mit "
-"einer Atlantis X23 zu verwechseln, kann ein tödlicher Fehler sein."
+"Eine umgerüstete Atlantis, welche dadurch noch vielseitiger einsetzbar ist. "
+"Das große Schildsystem wurde durch ein hochentwickeltes "
+"Ausweichmanöversystem und verbesserte Impulstriebwerke ersetzt. Die "
+"Waffenvorräte sind ebenfalls breiter aufgestellt. Die modifizierte Atlantis "
+"mit einer Atlantis X23 zu verwechseln, kann schnell zu einem tödlichen "
+"Fehler werden."
+
 #: scripts/shiptemplates/corvette.lua:83
 msgctxt "ship"
 msgid "Starhammer II"
 msgstr ""
+
 #: scripts/shiptemplates/corvette.lua:84
 msgid ""
 "Contrary to its predecessor, the Starhammer II lives up to its name. By "
@@ -83,14 +92,17 @@ msgstr ""
 "dar. Seine geringe Geschwindigkeit erschwert es, in Position zu kommen, aber "
 "sobald er sich zur richtigen Zeit am richtigen Ort befindet, können selbst "
 "die stärksten Schilde dem Angriff eines Starhammer nicht lange widerstehen."
+
 #: scripts/shiptemplates/corvette.lua:101
 msgctxt "playerShip"
 msgid "Crucible"
 msgstr ""
+
 #: scripts/shiptemplates/corvette.lua:101
 msgctxt "subclass"
 msgid "Popper"
 msgstr ""
+
 #: scripts/shiptemplates/corvette.lua:102
 msgid ""
 "A number of missile tubes range around this ship. Beams were deemed lower "
@@ -100,31 +112,37 @@ msgstr ""
 "Eine grosse Zahl an Raketenwerfern befinden sich rund um das Schiff. Laser "
 "waren zweitrangig, sind aber immer noch vorhanden. Stärkere Verteidigung als "
 "eine Fregatte, aber nicht so stark wie die Atlantis"
+
 #: scripts/shiptemplates/corvette.lua:157
 msgctxt "playerShip"
 msgid "Maverick"
 msgstr ""
+
 #: scripts/shiptemplates/corvette.lua:157
 msgctxt "subclass"
 msgid "Gunner"
 msgstr ""
+
 #: scripts/shiptemplates/corvette.lua:158
 msgid ""
 "A number of beams bristle from various points on this gunner. Missiles were "
 "deemed lower priority, though they are still present. Stronger defenses than "
 "a frigate, but not as strong as the Atlantis"
 msgstr ""
-"Eine große Zahl an Lasern befinden sich rund um das Schiff. Raketenwerfer "
-"waren zweitrangig, sind aber immer noch vorhanden. Stärkere Verteidigung als "
-"eine Fregatte, aber nicht so stark wie die Atlantis"
+"Eine große Zahl an Lasern befinden sich rund um das Schiff. Raketen waren "
+"zweitrangig, sind aber immer noch vorhanden. Stärkere Verteidigung als eine "
+"Fregatte, aber nicht so stark wie die Atlantis."
+
 #: scripts/shiptemplates/corvette.lua:217
 msgctxt "ship"
 msgid "Defense platform"
 msgstr ""
+
 #: scripts/shiptemplates/corvette.lua:217
 msgctxt "subclass"
 msgid "Support"
 msgstr "Support"
+
 #: scripts/shiptemplates/corvette.lua:218
 msgid ""
 "This stationary defense platform operates like a station, with docking and "
@@ -136,21 +154,25 @@ msgstr ""
 "Laserwaffen ausgestattet, und ist in der Lage, sich langsam zu drehen. "
 "Größere Systeme nutzen diese Plattformen oft, um Patrouillenschiffe zu "
 "versorgen."
+
 #: scripts/shiptemplates/corvette.lua:223
 #: scripts/shiptemplates/corvette.lua:311
 msgctxt "class"
 msgid "Starfighter"
 msgstr "Raumjäger"
+
 #: scripts/shiptemplates/corvette.lua:223
 #: scripts/shiptemplates/corvette.lua:310
 msgctxt "class"
 msgid "Frigate"
 msgstr "Fregatte"
+
 #: scripts/shiptemplates/corvette.lua:235
 #, lua-format
 msgctxt "ship"
 msgid "Personnel Freighter %d"
 msgstr ""
+
 #: scripts/shiptemplates/corvette.lua:235
 #: scripts/shiptemplates/corvette.lua:248
 #: scripts/shiptemplates/corvette.lua:261
@@ -160,6 +182,7 @@ msgstr ""
 msgctxt "subclass"
 msgid "Freighter"
 msgstr "Frachter"
+
 #: scripts/shiptemplates/corvette.lua:236
 msgid ""
 "These freighters are designed to transport armed troops, military support "
@@ -168,16 +191,19 @@ msgstr ""
 "Diese Transportschiffe sind konzipiert um bewaffnete Truppen, "
 "militaristisches Unterstützungspersonal und Kampfausrüstung zu "
 "transportieren.."
+
 #: scripts/shiptemplates/corvette.lua:244
 #, lua-format
 msgctxt "ship"
 msgid "Personnel Jump Freighter %d"
 msgstr ""
+
 #: scripts/shiptemplates/corvette.lua:248
 #, lua-format
 msgctxt "ship"
 msgid "Goods Freighter %d"
 msgstr ""
+
 #: scripts/shiptemplates/corvette.lua:249
 msgid ""
 "Cargo freighters haul large loads of cargo across long distances on impulse "
@@ -187,16 +213,19 @@ msgstr ""
 "Frachtschiffe transportieren per Impulsantrieb große Mengen an Ladung über "
 "lange Distanzen. Ihre Frachträume verfügen über Klimakontrolle und "
 "Stabilisierungssysteme, und die Fracht in einem guten Zustand zu halten."
+
 #: scripts/shiptemplates/corvette.lua:257
 #, lua-format
 msgctxt "ship"
 msgid "Goods Jump Freighter %d"
 msgstr ""
+
 #: scripts/shiptemplates/corvette.lua:261
 #, lua-format
 msgctxt "ship"
 msgid "Garbage Freighter %d"
 msgstr ""
+
 #: scripts/shiptemplates/corvette.lua:262
 msgid ""
 "These freighters are specially designed to haul garbage and waste. They are "
@@ -206,16 +235,19 @@ msgstr ""
 "Diese Müllfrachter sind speziell dazu gebaut um Abfälle zu transportieren. "
 "Sie sich mit einer Müllpresse ausgestattet und besitzen weniger "
 "Stabillisierungssysteme als normale Frachtschiffe."
+
 #: scripts/shiptemplates/corvette.lua:270
 #, lua-format
 msgctxt "ship"
 msgid "Garbage Jump Freighter %d"
 msgstr ""
+
 #: scripts/shiptemplates/corvette.lua:274
 #, lua-format
 msgctxt "ship"
 msgid "Equipment Freighter %d"
 msgstr ""
+
 #: scripts/shiptemplates/corvette.lua:275
 msgid ""
 "Equipment freighters have specialized environmental and stabilization "
@@ -223,16 +255,19 @@ msgid ""
 msgstr ""
 "Gerätefrachter besitzen spezialisierte Umwelt- und Stabilisierungssysteme, "
 "um empfindliche Maschinen und komplexe Instrumente sicher zu transportieren.]"
+
 #: scripts/shiptemplates/corvette.lua:283
 #, lua-format
 msgctxt "ship"
 msgid "Equipment Jump Freighter %d"
 msgstr ""
+
 #: scripts/shiptemplates/corvette.lua:287
 #, lua-format
 msgctxt "ship"
 msgid "Fuel Freighter %d"
 msgstr ""
+
 #: scripts/shiptemplates/corvette.lua:288
 msgid ""
 "Fuel freighters have massive tanks for hauling fuel, and delicate internal "
@@ -241,15 +276,18 @@ msgid ""
 msgstr ""
 "Treibstoff-Frachter besitzen massive Tanks und hochempfindliche interne "
 "Sensoren, um jede Änderung des Zustands der Fracht zu überwachen."
+
 #: scripts/shiptemplates/corvette.lua:296
 #, lua-format
 msgctxt "ship"
 msgid "Fuel Jump Freighter %d"
 msgstr ""
+
 #: scripts/shiptemplates/corvette.lua:301
 msgctxt "ship"
 msgid "Jump Carrier"
 msgstr ""
+
 #: scripts/shiptemplates/corvette.lua:302
 msgid ""
 "The Jump Carrier is a specialized Freighter. It does not carry any cargo, as "
@@ -264,23 +302,27 @@ msgstr ""
 "für diesen Antrieb bereit stellen.\n"
 "Er wurde entwickelt um andere Schiffe über immense Strecken zu "
 "transportieren. Daher besitzt er spezielle Andockbuchten für andere Schiffe."
+
 #: scripts/shiptemplates/corvette.lua:315
 msgctxt "playerShip"
 msgid "Benedict"
 msgstr ""
+
 #: scripts/shiptemplates/corvette.lua:315
 msgctxt "subclass"
 msgid "Freighter/Carrier"
 msgstr "Frachter/Trägerschiff"
+
 #: scripts/shiptemplates/corvette.lua:316
 msgid "Benedict is an improved version of the Jump Carrier"
 msgstr "Die Benedict ist eine verbesserte Version des Sprung-Trägers"
+
 #: scripts/shiptemplates/corvette.lua:349
 msgctxt "playerShip"
 msgid "Kiriya"
 msgstr ""
+
 #: scripts/shiptemplates/corvette.lua:350
 msgid "Kiriya is an improved warp drive version of the Jump Carrier"
 msgstr ""
 "Die Kiriya ist eine verbesserte Version des Sprung-Trägers mit Warp-Antrieb"
-#, fuzzy

--- a/scripts/locale/shiptemplates/frigates.de.po
+++ b/scripts/locale/shiptemplates/frigates.de.po
@@ -10,11 +10,13 @@ msgstr ""
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
-"X-Generator: Poedit 3.0.1\n"
+"X-Generator: Poedit 3.1.1\n"
+
 #: scripts/shiptemplates/frigates.lua:14
 msgctxt "ship"
 msgid "Phobos T3"
 msgstr ""
+
 #: scripts/shiptemplates/frigates.lua:14 scripts/shiptemplates/frigates.lua:87
 #: scripts/shiptemplates/frigates.lua:116
 #: scripts/shiptemplates/frigates.lua:133
@@ -27,10 +29,12 @@ msgstr ""
 msgctxt "class"
 msgid "Frigate"
 msgstr "Fregatte"
+
 #: scripts/shiptemplates/frigates.lua:14
 msgctxt "subclass"
 msgid "Cruiser"
 msgstr "Kreuzer"
+
 #: scripts/shiptemplates/frigates.lua:16
 msgid ""
 "The Phobos T3, just like the Atlantis, is the workhorse of almost any navy. "
@@ -43,10 +47,12 @@ msgstr ""
 "den jeweiligen Zweck extrem einfach macht Die technischen Daten sind nicht "
 "sonderlich beeindruckend, aber durch ihren modularen Aufbau lässt sie sich "
 "leicht in großen Stückzahlen herstellen."
+
 #: scripts/shiptemplates/frigates.lua:28
 msgctxt "ship"
 msgid "Elara P2"
 msgstr ""
+
 #: scripts/shiptemplates/frigates.lua:29
 msgid ""
 "Inspired by the Phobos T3 design, the Elara P2 is nearly identical. With the "
@@ -56,10 +62,12 @@ msgstr ""
 "Inspiriert vom Design der Phobos T3, ist die Elara P2 nahezu identisch. "
 "Ausgestattet mit einen zusätzlichen Warpantrieb und stärkeren Frontschilden, "
 "ist die Elara P2 noch gefährlicher als die Phobos."
+
 #: scripts/shiptemplates/frigates.lua:33
 msgctxt "ship"
 msgid "Phobos M3"
 msgstr ""
+
 #: scripts/shiptemplates/frigates.lua:34
 msgid ""
 "The Phobos M3 is one of the most common variants of the Phobos T3. It adds a "
@@ -69,26 +77,31 @@ msgstr ""
 "Die Phobos M3 ist eine der gebräuchlichsten Varianten der Phobos T3. Im "
 "Vergleich dazu verfügt die M3 über einen zusätzlichen Minenschacht, die "
 "dadurch bedingte höhere Masse macht sie allerdings ein wenig langsamer."
+
 #: scripts/shiptemplates/frigates.lua:41
 msgctxt "playerShip"
 msgid "Phobos M3P"
 msgstr ""
+
 #: scripts/shiptemplates/frigates.lua:42
 msgid ""
 "Player variant of the Phobos M3, not as strong as the atlantis, but has "
 "front firing tubes, making it an easier to use ship in some scenarios."
 msgstr ""
-"Spielervariante der Phobos M3. Nicht so stark wie die Atlantis, allerdings "
-"mit nach vorne gerichteten Waffenschächten, wodurch das Schiff in manchen "
-"Szenarios einfacher handzuhaben ist."
+"Spielbare Variante der Phobos M3. Nicht so stark wie die Atlantis, "
+"allerdings mit nach vorne gerichteten Waffenschächten, wodurch das Schiff in "
+"manchen Szenarios einfacher handzuhaben ist."
+
 #: scripts/shiptemplates/frigates.lua:87
 msgctxt "ship"
 msgid "Nirvana R5"
 msgstr ""
+
 #: scripts/shiptemplates/frigates.lua:87
 msgctxt "subclass"
 msgid "Cruiser: Anti-fighter"
 msgstr "Kreuzer: Anti-Jäger"
+
 #: scripts/shiptemplates/frigates.lua:89
 msgid ""
 "The Nirvana R5 is an anti-fighter cruiser. It has several rapid-firing, low-"
@@ -96,10 +109,12 @@ msgid ""
 msgstr ""
 "Die Nirvana R5 ist ein Anti-Jäger-Kreuzer. Sie verfügt über mehrere leichte, "
 "schnell feuernde Nahbereichs-Verteidigungswaffen, um Jäger abzuwehren."
+
 #: scripts/shiptemplates/frigates.lua:98
 msgctxt "ship"
 msgid "Nirvana R5A"
 msgstr ""
+
 #: scripts/shiptemplates/frigates.lua:99
 msgid ""
 "An improved version of the Nirvana R5 with faster turning speed and firing "
@@ -107,10 +122,12 @@ msgid ""
 msgstr ""
 "Eine verbesserte Version der Nirvana R5A mit besserer Manövrierbarkeit und "
 "höherer Feuerrate."
+
 #: scripts/shiptemplates/frigates.lua:106
 msgctxt "ship"
 msgid "Nirvana R3"
 msgstr ""
+
 #: scripts/shiptemplates/frigates.lua:107
 msgid ""
 "One of the earliest mass produced Nirvana models, the Nirvana R3 is designed "
@@ -123,14 +140,17 @@ msgstr ""
 "mehrere schnelle und schwache Abwehrlaser. Verglichen mit der späteren, "
 "weiter verbreiteten Nirvana R5 haben die Laser eine kürzere Reichweite, "
 "außerdem sind Schilde und Impulsantrieb schwächer."
+
 #: scripts/shiptemplates/frigates.lua:116
 msgctxt "ship"
 msgid "Storm"
 msgstr ""
+
 #: scripts/shiptemplates/frigates.lua:116
 msgctxt "subclass"
 msgid "Cruiser: Heavy Artillery"
 msgstr "Kreuzer:Schwere Artillerie"
+
 #: scripts/shiptemplates/frigates.lua:118
 msgid ""
 "A heavy artillery cruiser, the Storm fires bunches of missiles from forward "
@@ -138,15 +158,18 @@ msgid ""
 msgstr ""
 "Als schwerer Artillerie-Kreuzer kann die Storm mehrere Raketen aus am Heck "
 "angebrachten Werfern abfeuern."
+
 #: scripts/shiptemplates/frigates.lua:133
 msgctxt "playerShip"
 msgid "Hathcock"
 msgstr ""
+
 #: scripts/shiptemplates/frigates.lua:133
 #: scripts/shiptemplates/frigates.lua:299
 msgctxt "subclass"
 msgid "Cruiser: Sniper"
 msgstr "Kreuzer: Sniper"
+
 #: scripts/shiptemplates/frigates.lua:135
 msgid ""
 "Long range narrow beam and some point defense beams, broadside missiles. "
@@ -154,14 +177,17 @@ msgid ""
 msgstr ""
 "Ein schmaler Langstreckenlaser und einige Abwehrlaser, sowie "
 "Breitseitenraketen. Sehr wendig für eine Fregatte."
+
 #: scripts/shiptemplates/frigates.lua:179
 msgctxt "ship"
 msgid "Piranha F12"
 msgstr ""
+
 #: scripts/shiptemplates/frigates.lua:179
 msgctxt "subclass"
 msgid "Cruiser: Light Artillery"
 msgstr "Kreuzer: Leichte Artillerie"
+
 #: scripts/shiptemplates/frigates.lua:181
 msgid ""
 "A light artillery cruiser, the Piranha F12 is the smallest ship to "
@@ -169,10 +195,12 @@ msgid ""
 msgstr ""
 "Als leichter Artilleriekreuzer ist die Piranha F12 das kleinste Schiff, das "
 "ausschließlich über Breitseitenwaffen verfügt."
+
 #: scripts/shiptemplates/frigates.lua:201
 msgctxt "ship"
 msgid "Piranha F12.M"
 msgstr ""
+
 #: scripts/shiptemplates/frigates.lua:202
 msgid ""
 "This modified Piranha F12 is in all respects the same vessel except for "
@@ -185,10 +213,12 @@ msgstr ""
 "zur normalen Konfiguration erlaubt, auch Nukes zu verwenden. Allerdings "
 "verringert sich durch diese Veränderung auch die Gesamtkapazität der "
 "Munition."
+
 #: scripts/shiptemplates/frigates.lua:207
 msgctxt "ship"
 msgid "Piranha F8"
 msgstr ""
+
 #: scripts/shiptemplates/frigates.lua:208
 msgid ""
 "The first version of the Piranha was not popular due to its meager firepower "
@@ -197,10 +227,12 @@ msgstr ""
 "Aufgrund der mageren Feuerkraft und der seltsamen Anordnung der "
 "Waffenschächte war diese erste Version der Piranha nicht gerade beliebt. Das "
 "Ergebnis war ein großer finanzieller Rückschlag."
+
 #: scripts/shiptemplates/frigates.lua:216
 msgctxt "playerShip"
 msgid "Piranha"
 msgstr ""
+
 #: scripts/shiptemplates/frigates.lua:217
 msgid ""
 "This combat-specialized Piranha F12 adds mine-laying tubes, combat "
@@ -208,14 +240,17 @@ msgid ""
 msgstr ""
 "Diese auf den Kampf spezialisierte Piranha besitzt zusätzliche "
 "Minenschächte, ein Ausweichmanöver-system und einen Sprungantrieb."
+
 #: scripts/shiptemplates/frigates.lua:272
 msgctxt "ship"
 msgid "Stalker Q7"
 msgstr ""
+
 #: scripts/shiptemplates/frigates.lua:272
 msgctxt "subclass"
 msgid "Cruiser: Strike ship"
 msgstr "Kreuzer: Angriffsschiff"
+
 #: scripts/shiptemplates/frigates.lua:274
 msgid ""
 "The Stalker is a strike ship designed to swoop into battle, deal damage "
@@ -225,10 +260,12 @@ msgstr ""
 "die Schlacht einzugreifen, schnell viel Schaden zu verursachen, und das "
 "Kampfgeschehen schnell wieder zu verlassen. Das Modell Q7 ist mit einem "
 "Warpantrieb ausgestattet."
+
 #: scripts/shiptemplates/frigates.lua:282
 msgctxt "ship"
 msgid "Stalker Q5"
 msgstr ""
+
 #: scripts/shiptemplates/frigates.lua:283
 msgid ""
 "The stalker Q5 predates the Stalker Q7. Like the Q7, the Q5 is designed to "
@@ -240,10 +277,12 @@ msgstr ""
 "Schaden zu verursachen, und das Kampfgeschehen schnell wieder zu verlassen. "
 "Verglichen mit der Q7 hat die Q5 schwächere Schilde und Hüllenstärke, aber "
 "eine höhere Wendigkeit."
+
 #: scripts/shiptemplates/frigates.lua:288
 msgctxt "ship"
 msgid "Stalker R7"
 msgstr ""
+
 #: scripts/shiptemplates/frigates.lua:289
 msgid ""
 "The Stalker is a strike ship designed to swoop into battle, deal damage "
@@ -253,10 +292,12 @@ msgstr ""
 "Schlacht einzugreifen, schnell viel Schaden zu verursachen, und das "
 "Kampfgeschehen schnell wieder zu verlassen. TDas Modell R7 ist mit einem "
 "Sprungantrieb ausgestattet."
+
 #: scripts/shiptemplates/frigates.lua:293
 msgctxt "ship"
 msgid "Stalker R5"
 msgstr ""
+
 #: scripts/shiptemplates/frigates.lua:294
 msgid ""
 "The stalker R5 predates the Stalker R7. Like the R7, the R5 is designed to "
@@ -268,10 +309,12 @@ msgstr ""
 "Schaden zu verursachen, und das Kampfgeschehen schnell wieder zu verlassen. "
 "Verglichen mit der R7 hat die R5 schwächere Schilde und Hüllenstärke, aber "
 "eine höhere Wendigkeit."
+
 #: scripts/shiptemplates/frigates.lua:299
 msgctxt "ship"
 msgid "Ranus U"
 msgstr ""
+
 #: scripts/shiptemplates/frigates.lua:301
 msgid ""
 "The Ranus U sniper is built to deal a large amounts of damage quickly and "
@@ -283,14 +326,17 @@ msgstr ""
 "zu verursachen und sich dann zurückzuziehen. Es ist die einzige Basis-"
 "Fregatte welche über Nuklearwaffen verfügt, obwohl es sich generell um die "
 "kleinste Fregatte handelt."
+
 #: scripts/shiptemplates/frigates.lua:312
 msgctxt "ship"
 msgid "Flavia"
 msgstr ""
+
 #: scripts/shiptemplates/frigates.lua:312
 msgctxt "subclass"
 msgid "Light transport"
 msgstr "Leichter Transporter"
+
 #: scripts/shiptemplates/frigates.lua:314
 msgid ""
 "Popular among traders and smugglers, the Flavia is a small cargo and "
@@ -301,10 +347,12 @@ msgstr ""
 "Händlern als auch Schmugglern beliebt. Bei kleinerer Ladung und kuerzeren "
 "Strecken ist es günstiger als ein ein Frachter und wird oft genutzt um "
 "hochwertige Ware diskret zu transportieren."
+
 #: scripts/shiptemplates/frigates.lua:319
 msgctxt "ship"
 msgid "Flavia Falcon"
 msgstr ""
+
 #: scripts/shiptemplates/frigates.lua:320
 msgid ""
 "The Flavia Falcon is a Flavia transport modified for faster flight, and adds "
@@ -313,10 +361,12 @@ msgstr ""
 "Die Flavia Falcon ist ein Flavia-Transporter welcher für höhere "
 "Geschwindigkeit optimiert wurde und besitzt zusätzlich zwei rueckwärtige "
 "Laser um den Rücken von Feinden frei zu halten."
+
 #: scripts/shiptemplates/frigates.lua:325
 msgctxt "playerShip"
 msgid "Flavia P.Falcon"
 msgstr ""
+
 #: scripts/shiptemplates/frigates.lua:326
 msgid ""
 "The Flavia P.Falcon has a nuclear-capable rear-facing weapon tube and a warp "
@@ -324,25 +374,31 @@ msgid ""
 msgstr ""
 "Die Flavia P.Falcon besitzt einen rueckwärtigen Raketenschacht welcher Nukes "
 "einsetzen kann, sowie einen Warpantrieb."
+
 #: scripts/shiptemplates/frigates.lua:369
 msgctxt "playerShip"
 msgid "Repulse"
 msgstr ""
+
 #: scripts/shiptemplates/frigates.lua:369
 msgctxt "subclass"
 msgid "Armored Transport"
-msgstr "Armored Transport"
+msgstr "Gepanzerter Transporter"
+
 #: scripts/shiptemplates/frigates.lua:371
 msgid "Jump/Turret version of Flavia Falcon"
 msgstr "Sprung/Geschützturm-Version der Flavia Falcon"
+
 #: scripts/shiptemplates/frigates.lua:414
 msgctxt "ship"
 msgid "Fiend G3"
 msgstr ""
+
 #: scripts/shiptemplates/frigates.lua:414
 msgctxt "subclass"
 msgid "Gunship"
 msgstr "Kanonenboot"
+
 #: scripts/shiptemplates/frigates.lua:416
 msgid ""
 "The Fiend G3 was the first model produced by Conversions R Us. They got a "
@@ -358,10 +414,12 @@ msgstr ""
 "über Zielsuchraketen und Laser um schwächere Schiffe auszuschalten. In "
 "Verbindung mit dem Sprungantrieb ist es im Vergleich zum normalen "
 "Kanonenboot das wesentlich gefährlichere Schiff."
+
 #: scripts/shiptemplates/frigates.lua:428
 msgctxt "ship"
 msgid "Fiend G4"
 msgstr ""
+
 #: scripts/shiptemplates/frigates.lua:429
 msgid ""
 "The Fiend G4 was among the first models produced by Conversions R Us. They "
@@ -377,10 +435,12 @@ msgstr ""
 "hat verfügt es über Zielsuchraketen und Laser um schwächere Schiffe "
 "auszuschalten. In Verbindung mit dem Warpantrieb ist es im Vergleich zum "
 "normalen Kanonenboot das wesentlich gefährlichere Schiff."
+
 #: scripts/shiptemplates/frigates.lua:433
 msgctxt "ship"
 msgid "Fiend G6"
 msgstr ""
+
 #: scripts/shiptemplates/frigates.lua:434
 msgid ""
 "With the success of the Fiend G3 and G4 models, Conversions R Us continued "
@@ -395,10 +455,12 @@ msgstr ""
 "Wie das verbesserte Kanonenboot verfügt dieses Modell über zwei Raketenrohre "
 "und Laser um schwächere Schiffe auszuschalten. Ihr Sprungantrieb macht sie "
 "jedoch nochmals um einiges gefährlicher."
+
 #: scripts/shiptemplates/frigates.lua:437
 msgctxt "ship"
 msgid "Fiend G5"
 msgstr ""
+
 #: scripts/shiptemplates/frigates.lua:438
 msgid ""
 "With the success of the Fiend G3 and G4 models, Conversions R Us continued "
@@ -413,4 +475,3 @@ msgstr ""
 "Wie das verbesserte Kanonenboot verfügt dieses Modell über zwei Raketenrohre "
 "und Laser um schwächere Schiffe auszuschalten. Ihr Sprungantrieb macht sie "
 "jedoch nochmals um einiges gefährlicher."
-#, fuzzy

--- a/scripts/locale/shiptemplates/starFighters.de.po
+++ b/scripts/locale/shiptemplates/starFighters.de.po
@@ -10,21 +10,25 @@ msgstr ""
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
-"X-Generator: Poedit 3.0.1\n"
+"X-Generator: Poedit 3.1.1\n"
+
 #: scripts/shiptemplates/starFighters.lua:13
 msgctxt "ship"
 msgid "MT52 Hornet"
 msgstr ""
+
 #: scripts/shiptemplates/starFighters.lua:13
 #: scripts/shiptemplates/starFighters.lua:65
 #: scripts/shiptemplates/starFighters.lua:121
 msgctxt "class"
 msgid "Starfighter"
 msgstr "Raumjäger"
+
 #: scripts/shiptemplates/starFighters.lua:13
 msgctxt "subclass"
 msgid "Interceptor"
 msgstr "Abfangjäger"
+
 #: scripts/shiptemplates/starFighters.lua:15
 msgid ""
 "The MT52 Hornet is a basic interceptor found in many corners of the galaxy. "
@@ -35,10 +39,12 @@ msgstr ""
 "Galaxie gefunden werden kann.  Es ist einfach Ersatzteile für MT52er zu "
 "finden, nicht nur weil sie in großer Stückzahl produziert werden, sondern "
 "auch weil sie im Kampf schnell zerstört werden."
+
 #: scripts/shiptemplates/starFighters.lua:23
 msgctxt "ship"
 msgid "MU52 Hornet"
 msgstr ""
+
 #: scripts/shiptemplates/starFighters.lua:25
 msgid ""
 "The MU52 Hornet is a new, upgraded version of the MT52. All of its systems "
@@ -46,10 +52,12 @@ msgid ""
 msgstr ""
 "Die MU52 Hornet ist eine neue, modifizierte Version der MT52. Alle Systeme "
 "sind im Vergleich zur MT52 leicht verbessert."
+
 #: scripts/shiptemplates/starFighters.lua:31
 msgctxt "playerShip"
 msgid "MP52 Hornet"
 msgstr ""
+
 #: scripts/shiptemplates/starFighters.lua:32
 msgid ""
 "The MP52 Hornet is a significantly upgraded version of MU52 Hornet, with "
@@ -59,14 +67,17 @@ msgstr ""
 "Die MP52 Hornet ist eine stark erweiterte Version der MU52, mit nahezu "
 "doppelter Hüllenstärke, fast dreimal so leistungsfähigen Schilden, besserer "
 "Beschleunigung, Impulsbooster und einer zweiten Laserkanone."
+
 #: scripts/shiptemplates/starFighters.lua:65
 msgctxt "ship"
 msgid "Adder MK5"
 msgstr ""
+
 #: scripts/shiptemplates/starFighters.lua:65
 msgctxt "subclass"
 msgid "Gunship"
 msgstr "Kanonenboot"
+
 #: scripts/shiptemplates/starFighters.lua:67
 msgid ""
 "The Adder line's fifth iteration proved to be a great success among pirates "
@@ -77,10 +88,12 @@ msgstr ""
 "Erfolgsgeschichte erwiesen und ist sowohl unter Piraten als auch "
 "Sicherheitskräften sehr beliebt. Es ist billig, schnell, einfach zu warten, "
 "und verfügt über ordentliche Feuerkraft."
+
 #: scripts/shiptemplates/starFighters.lua:78
 msgctxt "ship"
 msgid "Adder MK4"
 msgstr ""
+
 #: scripts/shiptemplates/starFighters.lua:80
 msgid ""
 "The mark 4 Adder is a rare sight these days due to the success its "
@@ -93,10 +106,12 @@ msgstr ""
 "ersetzt. die ähnliche Form sorgt allerdings dafür, dass sorglose Käufer "
 "manchmal Betrügern zum Opfer fallen, welche eine MK4 tarnen und als MK5 "
 "ausgeben."
+
 #: scripts/shiptemplates/starFighters.lua:88
 msgctxt "ship"
 msgid "Adder MK3"
 msgstr ""
+
 #: scripts/shiptemplates/starFighters.lua:89
 msgid ""
 "The Adder MK3 is one of the first of the Adder line to meet with some "
@@ -113,10 +128,12 @@ msgstr ""
 "und der hohen Ähnlichkeit mit späteren Modellen. Verglichen mit der Adder "
 "MK4 sind die Schilde und die Hülle der MK3 schwächer, allerdings ist die "
 "Wendigkeit höher."
+
 #: scripts/shiptemplates/starFighters.lua:94
 msgctxt "ship"
 msgid "Adder MK6"
 msgstr ""
+
 #: scripts/shiptemplates/starFighters.lua:96
 msgid ""
 "The mark 6 Adder is a small upgrade compared to the highly successful mark 5 "
@@ -126,10 +143,12 @@ msgstr ""
 "Im Vergleich zur Mark 5 stellt die Adder Mark 6 nur ein kleines Upgrade dar. "
 "Da viele Leute immer noch die vertrautere und zuverlässige MK5 bevorzugen, "
 "ist die Mark 6 weit weniger erfolgreich."
+
 #: scripts/shiptemplates/starFighters.lua:100
 msgctxt "ship"
 msgid "Adder MK7"
 msgstr ""
+
 #: scripts/shiptemplates/starFighters.lua:102
 msgid ""
 "The release of the Adder Mark 7 sent the manufacturer into a second "
@@ -143,10 +162,12 @@ msgstr ""
 "Laserreichweite, aber aufgrund der Beliebtheit der Vorgänger, vor allem der "
 "MK5, konnte der Kaufpreis nicht hoch genug angesetzt werden, um die "
 "Entwicklungs- und Herstellungskosten der MK7 wieder hereinzubekommen."
+
 #: scripts/shiptemplates/starFighters.lua:106
 msgctxt "ship"
 msgid "Adder MK8"
 msgstr ""
+
 #: scripts/shiptemplates/starFighters.lua:108
 msgid ""
 "New management after bankruptcy revisited their most popular Adder Mark 5 "
@@ -160,10 +181,12 @@ msgstr ""
 "verbesserte die Wendigkeit: Die Adder MK8 war geboren. Zielgruppe sind "
 "pragmatische, aber nostalgische Käufer einen Ersatz für ihre Adder Mk5-"
 "Flotte brauchen."
+
 #: scripts/shiptemplates/starFighters.lua:113
 msgctxt "ship"
 msgid "Adder MK9"
 msgstr ""
+
 #: scripts/shiptemplates/starFighters.lua:115
 msgid ""
 "Hot on the heels of the Adder Mark 8 comes the Adder Mark 9. Still using the "
@@ -178,14 +201,17 @@ msgstr ""
 "Schilde, sowie einer höheren Wendigkeit - und, als kbesonderes Extra, zwei "
 "Nuklearraketen. Wie ihre Werbung sagt: \"In einer Adder Mark 9 fühlen sich "
 "einfach besser.\""
+
 #: scripts/shiptemplates/starFighters.lua:121
 msgctxt "ship"
 msgid "WX-Lindworm"
 msgstr ""
+
 #: scripts/shiptemplates/starFighters.lua:121
 msgctxt "subclass"
 msgid "Bomber"
 msgstr "Bomber"
+
 #: scripts/shiptemplates/starFighters.lua:123
 msgid ""
 "The WX-Lindworm, or \"Worm\" as it's often called, is a bomber-class "
@@ -199,8 +225,16 @@ msgstr ""
 "ordentliche Feuerkraft. Sein Konzept ist wie folgt: Schneller Anflug, Ziel "
 "zerstören, schnelle Flucht - und dabei möglichst nicht selbst zerstört "
 "werden."
+
 #: scripts/shiptemplates/starFighters.lua:136
 msgctxt "playerShip"
 msgid "ZX-Lindworm"
 msgstr ""
-#, fuzzy
+
+#: scripts/shiptemplates/starFighters.lua:137
+msgid ""
+"The ZX-Lindworm is a vastly improved version of the WX-Lindworm. Additional "
+"beam weapon, more missiles, tougher, faster and more agile."
+msgstr ""
+"Der ZX-Lindworm ist eine stark verbesserte Version der WX-Lindworm. "
+"Zusätzliche Laser, mehr Raketen, robuster, schneller und wendiger."

--- a/scripts/shiptemplates/OLD.lua
+++ b/scripts/shiptemplates/OLD.lua
@@ -387,7 +387,8 @@ template:setJumpDrive(true)
 template:setDockClasses(_("class", "Starfighter"), _("class", "Frigate"), _("class", "Corvette"))
 template:setSharesEnergyWithDocked(true)
 
-variation = template:copy("Ender"):setType("playership"):setLocaleName(_("playerShip", "Ender"))
+variation = template:copy("Ender")--:setType("playership"):setLocaleName(_("playerShip", "Ender"))
+template:setDescription(_("Player version of the battle station. Only half es much shield strength, but more speed and maneuverability, so it is surprisingly agile - for a capital ship, of course. Piloting this colossus still feels very different compared to other ships. It also has two additional missile tubes."))
 --                  Arc, Dir, Range, CycleTime, Dmg
 variation:setBeam(0, 10, -90, 2500.0, 6.1, 4)
 variation:setBeam(1, 10, -90, 2500.0, 6.0, 4)

--- a/scripts/shiptemplates/OLD.lua
+++ b/scripts/shiptemplates/OLD.lua
@@ -387,7 +387,7 @@ template:setJumpDrive(true)
 template:setDockClasses(_("class", "Starfighter"), _("class", "Frigate"), _("class", "Corvette"))
 template:setSharesEnergyWithDocked(true)
 
-variation = template:copy("Ender")--:setType("playership"):setLocaleName(_("playerShip", "Ender"))
+variation = template:copy("Ender"):setType("playership"):setLocaleName(_("playerShip", "Ender"))
 template:setDescription(_("Player version of the battle station. Only half es much shield strength, but more speed and maneuverability, so it is surprisingly agile - for a capital ship, of course. Piloting this colossus still feels very different compared to other ships. It also has two additional missile tubes."))
 --                  Arc, Dir, Range, CycleTime, Dmg
 variation:setBeam(0, 10, -90, 2500.0, 6.1, 4)

--- a/scripts/shiptemplates/starFighters.lua
+++ b/scripts/shiptemplates/starFighters.lua
@@ -134,6 +134,7 @@ template:setTubeDirection(1, 1):setWeaponTubeExclusiveFor(1, "HVLI")
 template:setTubeDirection(2,-1):setWeaponTubeExclusiveFor(2, "HVLI")
 
 variation = template:copy("ZX-Lindworm"):setLocaleName(_("playerShip", "ZX-Lindworm")):setModel("LindwurmFighterBlue"):setType("playership")
+variation:setDescription(_([[The ZX-Lindworm is a vastly improved version of the WX-Lindworm. Additional beam weapon, more missiles, tougher, faster and more agile.]]))
 variation:setHull(75)
 variation:setShields(40)
 variation:setSpeed(70, 15, 25)

--- a/src/menus/shipSelectionScreen.h
+++ b/src/menus/shipSelectionScreen.h
@@ -5,6 +5,7 @@
 #include "gui/gui2_canvas.h"
 #include "gui/gui2_panel.h"
 
+class GuiScrollText;
 class GuiLabel;
 class GuiListbox;
 class GuiOverlay;
@@ -20,6 +21,7 @@ class PasswordDialog;
 class ShipSelectionScreen : public GuiCanvas, public Updatable
 {
 private:
+    GuiScrollText* playership_info;
     GuiElement* container;
     GuiElement* left_container;
     GuiElement* right_container;


### PR DESCRIPTION
While not having the descriptions of playerships in the database is intentional, having them available outgame might still be a good idea.
And with the "new", leaner layout of the ship selection screen, there is enough empty space to show some additional text:
![eedescription](https://github.com/daid/EmptyEpsilon/assets/25465934/c66f302f-fcb7-427a-addc-bd0cdd2167f3)
It shows always the text of the ship that is currently selected on the ship spawn selector, so it is only visible on the server.