### PR TITLE
Enable auto connect for ship window

### DIFF
--- a/src/menus/autoConnectScreen.cpp
+++ b/src/menus/autoConnectScreen.cpp
@@ -6,6 +6,7 @@
 #include "playerInfo.h"
 #include "multiplayer_client.h"
 #include "multiplayer_server_scanner.h"
+#include "screens/windowScreen.h"
 
 #include "gui/gui2_label.h"
 
@@ -23,6 +24,8 @@ AutoConnectScreen::AutoConnectScreen(ECrewPosition crew_position, bool control_m
     status_label->setPosition(0, 300, sp::Alignment::TopCenter)->setSize(0, 50);
 
     string position_name = "Main screen";
+    if (crew_position_raw >=1000 && crew_position_raw<=1360)
+        position_name =tr("Ship window");
     if (crew_position < max_crew_positions)
         position_name = getCrewPositionName(crew_position);
 
@@ -117,7 +120,12 @@ void AutoConnectScreen::update(float delta)
                         if (my_spaceship->getMultiplayerId() == my_player_info->ship_id && (crew_position == max_crew_positions || my_player_info->crew_position[crew_position]))
                         {
                             destroy();
-                            my_player_info->spawnUI(0, getRenderLayer());
+                            if (crew_position_raw >=1000 && crew_position_raw<=1360){
+                                uint8_t window_flags = PreferencesManager::get("ship_window_flags", "1").toInt();
+                                new WindowScreen(getRenderLayer(), crew_position_raw-1000, window_flags);
+                            } else{
+                                my_player_info->spawnUI(0, getRenderLayer());
+                            }
                         }
                     }
                 }else{

--- a/src/menus/autoConnectScreen.h
+++ b/src/menus/autoConnectScreen.h
@@ -4,6 +4,7 @@
 #include "gui/gui2_canvas.h"
 #include "playerInfo.h"
 #include "io/network/address.h"
+#include "preferenceManager.h"
 
 class GuiLabel;
 class ServerScanner;
@@ -17,6 +18,7 @@ class AutoConnectScreen : public GuiCanvas, public Updatable
     std::map<string, string> ship_filters;
 
     GuiLabel* status_label;
+    int crew_position_raw = (PreferencesManager::get("autoconnect").toInt());
 public:
     AutoConnectScreen(ECrewPosition crew_position, bool control_main_screen, string ship_filter);
     virtual ~AutoConnectScreen();


### PR DESCRIPTION
This let you setup auto connect for ship windows.
It reserves the 'autoconnect' values from 1000 to 1360 for ship windows with angles between 0° and 360°.

I opted for this way rather than adding a new ECrewPosition value, as ship windows are, like main screen, a special case and handled differently. Also we don't need an extra option just for the angle that way, and it is unlikely that we'll ever get to more than 1000 different stations :-)

