### PR TITLE
Show energy production/consumption on Engineering Screen

### DIFF
--- a/src/screens/crew6/engineeringScreen.cpp
+++ b/src/screens/crew6/engineeringScreen.cpp
@@ -79,6 +79,8 @@ EngineeringScreen::EngineeringScreen(GuiContainer* owner, ECrewPosition crew_pos
                 my_spaceship->commandSetSystemPowerRequest(ESystem(n), value);
         });
         info.power_bar->setColor(glm::u8vec4(192, 192, 32, 128))->setSize(column_width, GuiElement::GuiSizeMax);
+        info.power_label = new GuiLabel(info.power_bar, id + "_POWER_LABEL", "...", 20); 
+        info.power_label->setSize(GuiElement::GuiSizeMax, GuiElement::GuiSizeMax);
         info.coolant_bar = new GuiProgressSlider(info.row, id + "_COOLANT", 0.0f, 10.0f, 0.0f, [this,n](float value){
             if (my_spaceship)
                 my_spaceship->commandSetSystemCoolantRequest(ESystem(n), value);
@@ -252,6 +254,8 @@ void EngineeringScreen::onDraw(sp::RenderTarget& renderer)
                 info.heat_icon->hide();
 
             info.power_bar->setValue(system.power_level);
+            info.power_label->setText(toNearbyIntString(my_spaceship->getNetSubsystemEnergyUsage(ESystem(n)) * -60.0f) + "/min");
+
             info.coolant_bar->setValue(system.coolant_level);
             if (system.coolant_request > 0.0f) {
                 float f = system.coolant_request / 10.f;

--- a/src/screens/crew6/engineeringScreen.h
+++ b/src/screens/crew6/engineeringScreen.h
@@ -44,6 +44,7 @@ private:
         GuiArrow* heat_arrow;
         GuiImage* heat_icon;
         GuiProgressSlider* power_bar;
+        GuiLabel* power_label;
         GuiProgressSlider* coolant_bar;
         GuiImage* coolant_max_indicator;
     };

--- a/src/spaceObjects/playerSpaceship.h
+++ b/src/spaceObjects/playerSpaceship.h
@@ -315,6 +315,7 @@ public:
     // Call on the server to play a sound on the main screen.
     void playSoundOnMainScreen(string sound_name);
 
+    float getNetSubsystemEnergyUsage(ESystem system);
     float getNetSystemEnergyUsage();
 
     // Ship's log functions


### PR DESCRIPTION
This is a proposal to slightly change the UI of the Engineering screen to add the power consumption of each system of the player's ship. This information is crucial for new players who want to understand energy distribution.

![image](https://github.com/daid/EmptyEpsilon/assets/7481485/9b97a867-afd1-4183-837e-9b4477511803)
