### PR TITLE
Add focusdelete parameter to text entry fields

### DIFF
--- a/src/gui/gui2_textentry.cpp
+++ b/src/gui/gui2_textentry.cpp
@@ -3,12 +3,13 @@
 #include "clipboard.h"
 
 
-GuiTextEntry::GuiTextEntry(GuiContainer* owner, string id, string text)
+GuiTextEntry::GuiTextEntry(GuiContainer* owner, string id, string text, bool focusdelete)
 : GuiElement(owner, id), text(text), text_size(30), func(nullptr)
 {
     blink_timer.repeat(blink_rate);
     front_style = theme->getStyle("textentry.front");
     back_style = theme->getStyle("textentry.back");
+    delete_on_focus = focus;
 }
 
 GuiTextEntry::~GuiTextEntry()
@@ -338,6 +339,7 @@ void GuiTextEntry::onTextInput(sp::TextInputEvent e)
 
 void GuiTextEntry::onFocusGained()
 {
+    if (delete_on_focus) setText("");
     typing_indicator = true;
     blink_timer.repeat(blink_rate);
     SDL_StartTextInput();

--- a/src/gui/gui2_textentry.cpp
+++ b/src/gui/gui2_textentry.cpp
@@ -9,7 +9,7 @@ GuiTextEntry::GuiTextEntry(GuiContainer* owner, string id, string text, bool foc
     blink_timer.repeat(blink_rate);
     front_style = theme->getStyle("textentry.front");
     back_style = theme->getStyle("textentry.back");
-    delete_on_focus = focus;
+    delete_on_focus = focusdelete;
 }
 
 GuiTextEntry::~GuiTextEntry()

--- a/src/gui/gui2_textentry.h
+++ b/src/gui/gui2_textentry.h
@@ -13,6 +13,7 @@ public:
 
 protected:
     string text;
+    bool delete_on_focus;
     int selection_start = 0;
     int selection_end = 0;
 
@@ -31,7 +32,7 @@ protected:
 
     glm::vec2 render_offset{0, 0};
 public:
-    GuiTextEntry(GuiContainer* owner, string id, string text);
+    GuiTextEntry(GuiContainer* owner, string id, string text, bool focusdelete=false);
     virtual ~GuiTextEntry();
 
     virtual void onDraw(sp::RenderTarget& renderer) override;


### PR DESCRIPTION
This adds an optional boolean parameter to text entry fields. If true, the content of the text field is deleted when it gains focus. This is useful when it is very likely that the user wants to type in a completely new value instead of editing the old one, like numbers for example.