### PR TITLE
Add setSelectOnFocus method to textentry

### DIFF
--- a/src/gui/gui2_textentry.cpp
+++ b/src/gui/gui2_textentry.cpp
@@ -340,7 +340,7 @@ void GuiTextEntry::onFocusGained()
 {
     if (select_on_focus) {
 		selection_end = 0;
-        selection_start = text.length();
+		selection_start = text.length();
     }
     typing_indicator = true;
     blink_timer.repeat(blink_rate);

--- a/src/gui/gui2_textentry.cpp
+++ b/src/gui/gui2_textentry.cpp
@@ -338,6 +338,10 @@ void GuiTextEntry::onTextInput(sp::TextInputEvent e)
 
 void GuiTextEntry::onFocusGained()
 {
+    if (select_on_focus) {
+		selection_end = 0;
+        selection_start = text.length();
+    }
     typing_indicator = true;
     blink_timer.repeat(blink_rate);
     SDL_StartTextInput();
@@ -370,6 +374,12 @@ GuiTextEntry* GuiTextEntry::setTextSize(float size)
 GuiTextEntry* GuiTextEntry::setMultiline(bool enabled)
 {
     multiline = enabled;
+    return this;
+}
+
+GuiTextEntry* GuiTextEntry::setSelectOnFocus(bool enabled)
+{
+    select_on_focus = enabled;
     return this;
 }
 

--- a/src/gui/gui2_textentry.h
+++ b/src/gui/gui2_textentry.h
@@ -18,6 +18,7 @@ protected:
 
     float text_size;
     bool multiline = false;
+    bool select_on_focus = false;
     bool readonly = false;
     bool hide_password = false;
     const GuiThemeStyle* front_style;
@@ -46,6 +47,7 @@ public:
     GuiTextEntry* setText(string text);
     GuiTextEntry* setTextSize(float size);
     GuiTextEntry* setMultiline(bool enabled=true);
+    GuiTextEntry* setSelectOnFocus(bool enabled=true);
     GuiTextEntry* setHidePassword(bool enabled=true);
     GuiTextEntry* callback(func_t func);
     GuiTextEntry* enterCallback(func_t func);


### PR DESCRIPTION
This is a rewrite of #1991:
- Instead of deleting, the option selects all the content of the text entry field
- Instead of a parameter of the constructor,  it is now a method similar setMultiline