### PR TITLE
restockMissile on playerships

### DIFF
--- a/scripts/shiptemplates/exuari.lua
+++ b/scripts/shiptemplates/exuari.lua
@@ -270,7 +270,7 @@ template:setSpeed(20, 1.5, 3)
 template:setDockClasses(_("class", "Exuari"))
 template:setSharesEnergyWithDocked(true)
 template:setRepairDocked(true)
-template:setRestocksMissilesDocked(true)
+template:setRestocksMissilesDocked("all")
 template:setRestocksScanProbes(true)
 
 variation = template:copy("Fortress")

--- a/src/ai/ai.cpp
+++ b/src/ai/ai.cpp
@@ -449,7 +449,7 @@ void ShipAI::runOrders()
         {
             P<ShipTemplateBasedObject> target = owner->getOrderTarget();
             bool allow_undock = true;
-            if (target->restocks_missiles_docked)
+            if (target->canRestockMissiles(owner))
             {
                 for(int n = 0; n < MW_Count; n++)
                 {
@@ -829,7 +829,10 @@ P<SpaceObject> ShipAI::findBestMissileRestockTarget(glm::vec2 position, float ra
         P<SpaceObject> space_object = obj;
         if (!space_object || !owner->isFriendly(space_object) || space_object == target)
             continue;
-        if (space_object->canBeDockedBy(owner) == DockStyle::None || !space_object->canRestockMissiles())
+        if (space_object->canBeDockedBy(owner) == DockStyle::None)
+            continue;
+        P<ShipTemplateBasedObject> stbo = space_object;
+        if (stbo && !stbo->canRestockMissiles(owner))
             continue;
         //calculate score
         auto position_difference = space_object->getPosition() - owner_position;

--- a/src/screenComponents/missileTubeControls.cpp
+++ b/src/screenComponents/missileTubeControls.cpp
@@ -62,7 +62,6 @@ GuiMissileTubeControls::GuiMissileTubeControls(GuiContainer* owner, string id)
         rows[n] = row;
     }
 
-
     for (int n = MW_Count-1; n >= 0; n--)
     {
         load_type_rows[n].layout = new GuiElement(this, id + "_ROW_" + string(n));
@@ -83,6 +82,12 @@ GuiMissileTubeControls::GuiMissileTubeControls(GuiContainer* owner, string id)
     load_type_rows[MW_EMP].button->setIcon("gui/icons/weapon-emp.png");
     load_type_rows[MW_Nuke].button->setIcon("gui/icons/weapon-nuke.png");
     load_type_rows[MW_HVLI].button->setIcon("gui/icons/weapon-hvli.png");
+
+    docked_loading_bar= new GuiProgressbar(this, id + "_DOCKED_LOADING_PROGRESS", 0, 1.0, 0);
+    docked_loading_bar->setColor(glm::u8vec4(128, 128, 128, 255))->setSize(200, 50);
+    docked_loading_label = new GuiLabel(docked_loading_bar, id + "_DOCKED_LOADING_PROGRESS_LABEL", "Loading", 35);
+    docked_loading_label->setSize(GuiElement::GuiSizeMax, GuiElement::GuiSizeMax)->hide();
+
 }
 
 void GuiMissileTubeControls::onUpdate()
@@ -151,6 +156,15 @@ void GuiMissileTubeControls::onUpdate()
     }
     for(int n=my_spaceship->weapon_tube_count; n<max_weapon_tubes; n++)
         rows[n].layout->hide();
+
+    if (my_spaceship->missile_resupply_delay < my_spaceship->missile_resupply_time){
+        docked_loading_bar->show();
+        docked_loading_label->show();
+        docked_loading_bar->setValue((my_spaceship->missile_resupply_time-my_spaceship->missile_resupply_delay) / my_spaceship->missile_resupply_time);
+    } else {
+        docked_loading_bar->hide();
+        docked_loading_label->hide();
+    }
 
     if (keys.weapons_select_homing.getDown())
         selectMissileWeapon(MW_Homing);

--- a/src/screenComponents/missileTubeControls.h
+++ b/src/screenComponents/missileTubeControls.h
@@ -29,6 +29,8 @@ private:
     EMissileWeapons load_type;
     bool manual_aim;
     float missile_target_angle;
+    GuiProgressbar* docked_loading_bar;
+    GuiLabel* docked_loading_label;
 public:
     GuiMissileTubeControls(GuiContainer* owner, string id);
 

--- a/src/screens/crew6/engineeringScreen.cpp
+++ b/src/screens/crew6/engineeringScreen.cpp
@@ -300,7 +300,12 @@ void EngineeringScreen::onDraw(sp::RenderTarget& renderer)
                 }
                 break;
             case SYS_MissileSystem:
-                addSystemEffect(tr("missile","Reload rate"), toNearbyIntString(effectiveness * 100) + "%");
+                if (my_spaceship->weapon_tube_count > 0)
+                    addSystemEffect(tr("missile","Reload rate"), toNearbyIntString(effectiveness * 100) + "%");
+                if (my_spaceship->restocks_missiles_docked == R_Fighters)
+                    addSystemEffect(tr("fighter missile","Fighter missile reload rate"), toNearbyIntString(effectiveness * 100) + "%");
+                else if (my_spaceship->restocks_missiles_docked != R_None)
+                    addSystemEffect(tr("fighter missile","Docked missile reload rate"), toNearbyIntString(effectiveness * 100) + "%");
                 break;
             case SYS_Maneuver:
                 addSystemEffect(tr("Turning speed"), toNearbyIntString(effectiveness * 100) + "%");

--- a/src/screens/gm/tweak.cpp
+++ b/src/screens/gm/tweak.cpp
@@ -158,11 +158,17 @@ GuiTweakShipTemplateBasedObject::GuiTweakShipTemplateBasedObject(GuiContainer* o
     });
     restocks_scan_probes_toggle->setSize(GuiElement::GuiSizeMax, 40);
 
-    // Restocks cpuship weapons bool
-    restocks_cpuship_weapons_toggle = new GuiToggleButton(left_col, "", tr("Restocks cpuship missiles"), [this](bool value) {
-        target->setRestocksMissilesDocked(value);
+    // Restocks missiles selector 
+    restocks_cpuship_weapons_selector= new GuiSelector(left_col, "", [this](int index, string value) {
+        target->setRestocksMissilesDocked(ERestockMissileBehaviour(index));
     });
-    restocks_cpuship_weapons_toggle->setSize(GuiElement::GuiSizeMax, 40);
+    restocks_cpuship_weapons_selector->setSize(GuiElement::GuiSizeMax, 40);
+    restocks_cpuship_weapons_selector->addEntry(tr("Does not restock missiles"),R_None);
+    restocks_cpuship_weapons_selector->addEntry(tr("Restocks cpuship missiles"),R_CpuShips);
+    restocks_cpuship_weapons_selector->addEntry(tr("Restocks fighter missiles"),R_Fighters);
+    restocks_cpuship_weapons_selector->addEntry(tr("Restocks player missiles"),R_PlayerShips);
+    restocks_cpuship_weapons_selector->addEntry(tr("Restocks missiles for all"),R_All);
+    restocks_cpuship_weapons_selector->setSelectionIndex(R_None);
 
     // Right column
     // Hull max and state sliders
@@ -205,7 +211,7 @@ void GuiTweakShipTemplateBasedObject::onDraw(sp::RenderTarget& renderer)
     shares_energy_with_docked_toggle->setValue(target->getSharesEnergyWithDocked());
     repairs_docked_toggle->setValue(target->getRepairDocked());
     restocks_scan_probes_toggle->setValue(target->getRestocksScanProbes());
-    restocks_cpuship_weapons_toggle->setValue(target->getRestocksMissilesDocked());
+    restocks_cpuship_weapons_selector->setSelectionIndex(target->getRestocksMissilesDocked());
     hull_slider->setValue(target->hull_strength);
     hull_max_slider->setValue(target->hull_max);
     can_be_destroyed_toggle->setValue(target->getCanBeDestroyed());

--- a/src/screens/gm/tweak.h
+++ b/src/screens/gm/tweak.h
@@ -57,7 +57,7 @@ private:
     GuiToggleButton* shares_energy_with_docked_toggle;
     GuiToggleButton* repairs_docked_toggle;
     GuiToggleButton* restocks_scan_probes_toggle;
-    GuiToggleButton* restocks_cpuship_weapons_toggle;
+    GuiSelector* restocks_cpuship_weapons_selector;
     GuiSlider* hull_max_slider;
     GuiSlider* hull_slider;
     GuiToggleButton* can_be_destroyed_toggle;

--- a/src/shipTemplate.cpp
+++ b/src/shipTemplate.cpp
@@ -319,7 +319,7 @@ ShipTemplate::ShipTemplate()
     shares_energy_with_docked = true;
     repair_docked = false;
     restocks_scan_probes = false;
-    restocks_missiles_docked = false;
+    restocks_missiles_docked = R_None;
     energy_storage_amount = 1000;
     repair_crew_count = 3;
     weapon_tube_count = 0;
@@ -653,9 +653,9 @@ void ShipTemplate::setRestocksScanProbes(bool enabled)
     restocks_scan_probes = enabled;
 }
 
-void ShipTemplate::setRestocksMissilesDocked(bool enabled)
+void ShipTemplate::setRestocksMissilesDocked(ERestockMissileBehaviour behaviour)
 {
-    restocks_missiles_docked = enabled;
+    restocks_missiles_docked = behaviour;
 }
 
 void ShipTemplate::setJumpDrive(bool enabled)

--- a/src/shipTemplate.h
+++ b/src/shipTemplate.h
@@ -33,6 +33,18 @@ enum ESystem
 /* Define script conversion function for the ESystem enum. */
 template<> void convert<ESystem>::param(lua_State* L, int& idx, ESystem& es);
 
+enum ERestockMissileBehaviour
+{
+    R_None = 0,
+    R_CpuShips,
+    R_Fighters,
+    R_PlayerShips,
+    R_All
+};
+
+/* Define script conversion function for the ERestockMissileBehaviour enum. */
+template<> void convert<ERestockMissileBehaviour>::param(lua_State* L, int& idx, ERestockMissileBehaviour& er);
+
 class ShipRoomTemplate
 {
 public:
@@ -97,7 +109,7 @@ public:
     bool shares_energy_with_docked;
     bool repair_docked;
     bool restocks_scan_probes;
-    bool restocks_missiles_docked;
+    ERestockMissileBehaviour restocks_missiles_docked;
     bool can_scan = true;
     bool can_hack = true;
     bool can_dock = true;
@@ -146,7 +158,7 @@ public:
     void setSharesEnergyWithDocked(bool enabled);
     void setRepairDocked(bool enabled);
     void setRestocksScanProbes(bool enabled);
-    void setRestocksMissilesDocked(bool enabled);
+    void setRestocksMissilesDocked(ERestockMissileBehaviour behaviour);
     void setCanScan(bool enabled) { can_scan = enabled; }
     void setCanHack(bool enabled) { can_hack = enabled; }
     void setCanDock(bool enabled) { can_dock = enabled; }
@@ -207,6 +219,7 @@ public:
 string getSystemName(ESystem system);
 string getLocaleSystemName(ESystem system);
 REGISTER_MULTIPLAYER_ENUM(ESystem);
+REGISTER_MULTIPLAYER_ENUM(ERestockMissileBehaviour);
 
 /* Define script conversion function for the ShipTemplate::TemplateType enum. */
 template<> void convert<ShipTemplate::TemplateType>::param(lua_State* L, int& idx, ShipTemplate::TemplateType& tt);

--- a/src/shipTemplate.hpp
+++ b/src/shipTemplate.hpp
@@ -41,4 +41,19 @@ template<> void convert<ShipTemplate::TemplateType>::param(lua_State* L, int& id
         tt = ShipTemplate::Ship;
 }
 
+/* Define script conversion function for the ERestockMissileBehaviour enum. */
+template<> void convert<ERestockMissileBehaviour>::param(lua_State* L, int& idx, ERestockMissileBehaviour& er)
+{
+    string str = string(luaL_checkstring(L, idx++)).lower();
+    if (str == "all")
+        er = R_All;
+    else if (str == "cpuships")
+        er = R_CpuShips;
+    else if (str == "fighters")
+        er = R_Fighters;
+    else if (str == "playerships")
+        er = R_PlayerShips;
+    else
+        er = R_None;
+}
 #endif /* _SHIPTEMPLATE_HPP_ */

--- a/src/spaceObjects/cpuShip.cpp
+++ b/src/spaceObjects/cpuShip.cpp
@@ -112,10 +112,8 @@ CpuShip::CpuShip()
     setRotation(random(0, 360));
     target_rotation = getRotation();
 
-    restocks_missiles_docked = true;
+    restocks_missiles_docked = R_CpuShips;
     comms_script_name = "comms_ship.lua";
-
-    missile_resupply = 0.0;
 
     new_ai_name = "default";
     ai = nullptr;
@@ -146,36 +144,6 @@ void CpuShip::update(float delta)
     }
     if (ai)
         ai->run(delta);
-
-    //recharge missiles of CPU ships docked to station. Can be disabled setting the restocks_missiles_docked flag to false.
-    if (docking_state == DS_Docked)
-    {
-        P<ShipTemplateBasedObject> docked_with_template_based = docking_target;
-        P<SpaceShip> docked_with_ship = docking_target;
-
-        if (docked_with_template_based && docked_with_template_based->restocks_missiles_docked)
-        {
-            bool needs_missile = 0;
-
-            for(int n=0; n<MW_Count; n++)
-            {
-                if  (weapon_storage[n] < weapon_storage_max[n])
-                {
-                    if (missile_resupply >= missile_resupply_time)
-                    {
-                        weapon_storage[n] += 1;
-                        missile_resupply = 0.0;
-                        break;
-                    }
-                    else
-                        needs_missile = 1;
-                }
-            }
-
-            if (needs_missile)
-                missile_resupply += delta;
-        }
-    }
 }
 
 void CpuShip::applyTemplateValues()

--- a/src/spaceObjects/cpuShip.h
+++ b/src/spaceObjects/cpuShip.h
@@ -24,7 +24,6 @@ class ShipAI;
 class CpuShip : public SpaceShip
 {
     static constexpr float auto_system_repair_per_second = 0.005f;
-    static constexpr float missile_resupply_time = 10.0f;
 
     EAIOrder orders;                    //Server only
     glm::vec2 order_target_location{};  //Server only
@@ -61,8 +60,6 @@ public:
     virtual std::unordered_map<string, string> getGMInfo() override;
 
     virtual string getExportLine() override;
-
-    float missile_resupply;
 };
 string getAIOrderString(EAIOrder order);
 string getLocaleAIOrderString(EAIOrder order);

--- a/src/spaceObjects/shipTemplateBasedObject.h
+++ b/src/spaceObjects/shipTemplateBasedObject.h
@@ -5,6 +5,8 @@
 #include "spaceObject.h"
 #include "shipTemplate.h"
 
+class SpaceShip;
+
 /**
     An object which is based on a ship template. Contains generic behaviour for:
     * Hull damage
@@ -34,7 +36,7 @@ public:
     bool shares_energy_with_docked;       //[config]
     bool repair_docked;                   //[config]
     bool restocks_scan_probes;
-    bool restocks_missiles_docked;        //only restocks cpuships; playerships should use comms
+    ERestockMissileBehaviour restocks_missiles_docked;
 
     ScriptSimpleCallback on_destruction;
     ScriptSimpleCallback on_taking_damage;
@@ -46,7 +48,7 @@ public:
     virtual void update(float delta) override;
 
     virtual std::unordered_map<string, string> getGMInfo() override;
-    virtual bool canRestockMissiles() override { return restocks_missiles_docked; }
+    bool canRestockMissiles(P<SpaceShip> receiver);
     virtual bool canBeTargetedBy(P<SpaceObject> other) override { return true; }
     virtual bool hasShield() override;
     virtual string getCallSign() override { return callsign; }
@@ -107,8 +109,8 @@ public:
     void setRepairDocked(bool enabled) { repair_docked = enabled; }
     bool getRestocksScanProbes() { return restocks_scan_probes; }
     void setRestocksScanProbes(bool enabled) { restocks_scan_probes = enabled; }
-    bool getRestocksMissilesDocked() { return restocks_missiles_docked; }
-    void setRestocksMissilesDocked(bool enabled) { restocks_missiles_docked = enabled; }
+    ERestockMissileBehaviour getRestocksMissilesDocked() { return restocks_missiles_docked; }
+    void setRestocksMissilesDocked(ERestockMissileBehaviour behaviour) { restocks_missiles_docked = behaviour; }
 
     void onTakingDamage(ScriptSimpleCallback callback);
     void onDestruction(ScriptSimpleCallback callback);

--- a/src/spaceObjects/spaceObject.h
+++ b/src/spaceObjects/spaceObject.h
@@ -202,7 +202,6 @@ public:
     virtual string getCallSign() { return callsign; }
     virtual DockStyle canBeDockedBy(P<SpaceObject> obj) { return DockStyle::None; }
     virtual DockStyle getDockedStyle() { return DockStyle::None; }
-    virtual bool canRestockMissiles() { return false; }
     virtual bool hasShield() { return false; }
     virtual bool canHideInNebula() { return true; }
     virtual bool canBeTargetedBy(P<SpaceObject> other);

--- a/src/spaceObjects/spaceStation.cpp
+++ b/src/spaceObjects/spaceStation.cpp
@@ -27,7 +27,7 @@ SpaceStation::SpaceStation()
 : ShipTemplateBasedObject(300, "SpaceStation")
 {
     restocks_scan_probes = true;
-    restocks_missiles_docked = true;
+    restocks_missiles_docked = R_CpuShips;
     comms_script_name = "comms_station.lua";
     setRadarSignatureInfo(0.2, 0.5, 0.5);
 

--- a/src/spaceObjects/spaceship.h
+++ b/src/spaceObjects/spaceship.h
@@ -93,6 +93,7 @@ public:
     constexpr static float heat_per_combat_maneuver_strafe = 0.2f;
     constexpr static float heat_per_warp = 0.02f;
     constexpr static float unhack_time = 180.0f; //It takes this amount of time to go from 100% hacked to 0% hacked for systems.
+    constexpr static float missile_resupply_time = 10.0f;
 
     float energy_level;
     float max_energy_level;
@@ -211,6 +212,8 @@ public:
     DockStyle docked_style = DockStyle::None;
     P<SpaceObject> docking_target; //Server only
     glm::vec2 docking_offset{0, 0}; //Server only
+
+    float missile_resupply_delay = missile_resupply_time;
 
     SpaceShip(string multiplayerClassName, float multiplayer_significant_range=-1);
     virtual ~SpaceShip();


### PR DESCRIPTION
* Option to grant stations or ships the ability to automatically restock missiles on player ships.
* Previously it was only possible to restock missiles of cpuships.
* Change setRestockMissilesDockes from bool to enum that specifies who can restock missiles: None, cpuships, playerships, fighters, all.
* The 'fighters'-option automatically restocks missiles on internally docked ships. This is an easy way to provide missiles for player fighters from a carrier without the need for the fighters to dock on a station.
* New loading bar on the weapons screen indicates that restocking of missiles is in progress.
* If a playership provides missiles, the power of the missile-system in engineering determines the speed of the restocking.
* If a playership does not have missiles and does not provide missiles to docked ships, the missile-system in engineering is hidden.
* GM can select what type of docked ships will be provided with missiles (cpuships, playerships, fighters).
* Scenarios can set the option via a lua-function.