### PR TITLE
convert window angle input from slider to textentry

### DIFF
--- a/src/menus/shipSelectionScreen.cpp
+++ b/src/menus/shipSelectionScreen.cpp
@@ -525,14 +525,14 @@ CrewPositionSelection::CrewPositionSelection(GuiContainer* owner, string id, int
     window_button = new GuiToggleButton(window_button_row, "WINDOW_BUTTON", tr("Ship window"), [this](bool value) {
         disableAllExcept(window_button);
     });
-    window_button->setSize(175, 50);
+    window_button->setSize(GuiElement::GuiSizeMax, 50);
 
-    window_angle = new GuiSlider(window_button_row, "WINDOW_ANGLE", 0.0, 359.0, 0.0, [this](float value) {
-        window_angle_label->setText(string("{angle}°").format({{"angle", string(int(window_angle->getValue()))}}));
-    });
-    window_angle->setSize(GuiElement::GuiSizeMax, 50);
-    window_angle_label = new GuiLabel(window_angle, "WINDOW_ANGLE_LABEL", "0°", 30);
-    window_angle_label->setSize(GuiElement::GuiSizeMax, GuiElement::GuiSizeMax);
+    window_angle = new GuiTextEntry(window_button_row, "WINDOW_ANGLE","0");
+    window_angle->setSize(75, 50);
+    window_angle->setSelectOnFocus();
+
+    window_angle_label = new GuiLabel(window_button_row, "WINDOW_ANGLE_LABEL", "°", 30);
+    window_angle_label->setSize(12, GuiElement::GuiSizeMax);
 
     // Top-down view button
     topdown_button = new GuiToggleButton(layout, "TOP_DOWN_3D_BUTTON", tr("Top-down 3D view"), [this](bool value) {
@@ -621,7 +621,7 @@ void CrewPositionSelection::spawnUI(RenderLayer* render_layer)
     {
         destroy();
         uint8_t window_flags = PreferencesManager::get("ship_window_flags", "1").toInt();
-        new WindowScreen(render_layer, int(window_angle->getValue()), window_flags);
+        new WindowScreen(render_layer, window_angle->getText().toInt(), window_flags);
     }else if(topdown_button->getValue())
     {
         my_player_info->commandSetShipId(-1);

--- a/src/menus/shipSelectionScreen.h
+++ b/src/menus/shipSelectionScreen.h
@@ -56,7 +56,7 @@ private:
     GuiToggleButton* crew_position_button[max_crew_positions];
     GuiToggleButton* main_screen_controls_button;
     GuiToggleButton* window_button;
-    GuiSlider* window_angle;
+    GuiTextEntry* window_angle;
     GuiLabel* window_angle_label;
     GuiToggleButton* topdown_button;
 };


### PR DESCRIPTION
The current solution for ship window angles has a big problem: Precise settings are virtually impossible. The possible steps depend on the current aspect ratio, but even on ultra wide screen it is very fiddly. This is especially an issue if you want to have two windows next to each other. Or on a rear window that feels slightly off because you can't set it to exactly 180°.
So I replaced the slider with a text input. 
![windowangle](https://github.com/daid/EmptyEpsilon/assets/25465934/0539936b-5b3b-4f1c-9b19-3823dc605f32)

Downside of this solution is that you need a keyboard, but I don't think this is a big issue. On machines without a keyboard, you might want to set up auto connect anyway. And on android, the on-screen-keyboard works just fine.