### PR TITLE
Improved function for calculating firing solutions (relaunched).

### DIFF
--- a/src/spaceObjects/spaceshipParts/weaponTube.cpp
+++ b/src/spaceObjects/spaceshipParts/weaponTube.cpp
@@ -332,7 +332,7 @@ float WeaponTube::calculateFiringSolution(P<SpaceObject> target)
 
         // Get target parameters in the tube centered reference frame:
         const glm::vec2 target_position = transform_global_to_tube(target->getPosition() - parent->getPosition(), tube_angle);
-        const glm::vec2 target_velocity = transform_global_to_tube(target->getVelocity() - parent->getVelocity(), tube_angle);
+        const glm::vec2 target_velocity = transform_global_to_tube(target->getVelocity(), tube_angle);
 
         const int MAX_ITER = 10;
         const float tolerance = 0.1f * target->getRadius();


### PR DESCRIPTION
Proposed improvement to the WeaponTube::calculateFiringSolution function for faster and more reliable convergence:
- Direct calculation of turning angle from aim point.
- Improved calculation of interception point / nearest approach point (from TODO).
- Harmonization of methods for moving and stationary targets.

Relaunched pull request because the previous one had a bug that made the firing solution incorrect when the parent ship is moving. Bug is now corrected. Contact Chimp on discord for more information.

Fixes #1996 