### PR TITLE
[ShipsLogControl] Fix update failure with duplicate text

### DIFF
--- a/src/gui/gui2_advancedscrolltext.cpp
+++ b/src/gui/gui2_advancedscrolltext.cpp
@@ -7,12 +7,13 @@ GuiAdvancedScrollText::GuiAdvancedScrollText(GuiContainer* owner, string id)
     scrollbar->setPosition(0, 0, sp::Alignment::TopRight)->setSize(50, GuiElement::GuiSizeMax);
 }
 
-GuiAdvancedScrollText* GuiAdvancedScrollText::addEntry(string prefix, string text, glm::u8vec4 color)
+GuiAdvancedScrollText* GuiAdvancedScrollText::addEntry(string prefix, string text, glm::u8vec4 color, unsigned int seq)
 {
     entries.emplace_back();
     entries.back().prefix = prefix;
     entries.back().text = text;
     entries.back().color = color;
+    entries.back().seq = seq;
     return this;
 }
 
@@ -26,6 +27,13 @@ string GuiAdvancedScrollText::getEntryText(int index) const
     if (index < 0 || index >= int(getEntryCount()))
         return "";
     return entries[index].text;
+}
+
+unsigned int GuiAdvancedScrollText::getEntrySeq(unsigned int index) const
+{
+    if (index >= getEntryCount())
+        return 0;
+    return entries[index].seq;
 }
 
 GuiAdvancedScrollText* GuiAdvancedScrollText::removeEntry(int index)

--- a/src/gui/gui2_advancedscrolltext.h
+++ b/src/gui/gui2_advancedscrolltext.h
@@ -13,6 +13,7 @@ protected:
         string prefix;
         string text;
         glm::u8vec4 color;
+        unsigned int seq;
     };
 
     std::vector<Entry> entries;
@@ -25,11 +26,12 @@ public:
     GuiAdvancedScrollText* enableAutoScrollDown() { auto_scroll_down = true; return this; }
     GuiAdvancedScrollText* disableAutoScrollDown() { auto_scroll_down = false; return this; }
 
-    GuiAdvancedScrollText* addEntry(string prefix, string text, glm::u8vec4 color);
+    GuiAdvancedScrollText* addEntry(string prefix, string text, glm::u8vec4 color, unsigned int seq);
     GuiAdvancedScrollText* setTextSize(float text_size) { this->text_size = text_size; return this; }
 
     unsigned int getEntryCount() const;
     string getEntryText(int index) const;
+    unsigned int getEntrySeq(unsigned int index) const;
     GuiAdvancedScrollText* removeEntry(int index);
     GuiAdvancedScrollText* clearEntries();
 

--- a/src/screenComponents/shipsLogControl.cpp
+++ b/src/screenComponents/shipsLogControl.cpp
@@ -39,12 +39,12 @@ void ShipsLog::onDraw(sp::RenderTarget& renderer)
             log_text->removeEntry(0);
         }
 
-        if (log_text->getEntryCount() > 0 && logs.size() > 0 && log_text->getEntryText(0) != logs[0].text)
+        if (log_text->getEntryCount() > 0 && logs.size() > 0 && log_text->getEntrySeq(0) != logs[0].seq)
         {
             bool updated = false;
             for(unsigned int n=1; n<log_text->getEntryCount(); n++)
             {
-                if (log_text->getEntryText(n) == logs[0].text)
+                if (log_text->getEntrySeq(n) == logs[0].seq)
                 {
                     for(unsigned int m=0; m<n; m++)
                         log_text->removeEntry(0);
@@ -59,7 +59,7 @@ void ShipsLog::onDraw(sp::RenderTarget& renderer)
         while(log_text->getEntryCount() < logs.size())
         {
             int n = log_text->getEntryCount();
-            log_text->addEntry(logs[n].prefix, logs[n].text, logs[n].color);
+            log_text->addEntry(logs[n].prefix, logs[n].text, logs[n].color, logs[n].seq);
         }
     }else{
         if (log_text->getEntryCount() > 0 && logs.size() == 0)
@@ -70,7 +70,7 @@ void ShipsLog::onDraw(sp::RenderTarget& renderer)
                 log_text->clearEntries();
         }
         if (log_text->getEntryCount() == 0 && logs.size() > 0)
-            log_text->addEntry(logs.back().prefix, logs.back().text, logs.back().color);
+            log_text->addEntry(logs.back().prefix, logs.back().text, logs.back().color, logs.back().seq);
     }
 }
 

--- a/src/screens/extra/shipLogScreen.cpp
+++ b/src/screens/extra/shipLogScreen.cpp
@@ -40,12 +40,12 @@ void ShipLogScreen::onDraw(sp::RenderTarget& renderer)
             log_text->removeEntry(0);
         }
 
-        if (log_text->getEntryCount() > 0 && logs.size() > 0 && log_text->getEntryText(0) != logs[0].text)
+        if (log_text->getEntryCount() > 0 && logs.size() > 0 && log_text->getEntrySeq(0) != logs[0].seq)
         {
             bool updated = false;
             for(unsigned int n=1; n<log_text->getEntryCount(); n++)
             {
-                if (log_text->getEntryText(n) == logs[0].text)
+                if (log_text->getEntrySeq(n) == logs[0].seq)
                 {
                     for(unsigned int m=0; m<n; m++)
                         log_text->removeEntry(0);
@@ -60,7 +60,7 @@ void ShipLogScreen::onDraw(sp::RenderTarget& renderer)
         while(log_text->getEntryCount() < logs.size())
         {
             int n = log_text->getEntryCount();
-            log_text->addEntry(logs[n].prefix, logs[n].text, logs[n].color);
+            log_text->addEntry(logs[n].prefix, logs[n].text, logs[n].color, logs[n].seq);
         }
     }
 }

--- a/src/spaceObjects/playerSpaceship.cpp
+++ b/src/spaceObjects/playerSpaceship.cpp
@@ -520,8 +520,8 @@ string alertLevelToLocaleString(EAlertLevel level)
 }
 
 // Configure ship's log packets.
-static inline sp::io::DataBuffer& operator << (sp::io::DataBuffer& packet, const PlayerSpaceship::ShipLogEntry& e) { return packet << e.prefix << e.text << e.color.r << e.color.g << e.color.b << e.color.a; }
-static inline sp::io::DataBuffer& operator >> (sp::io::DataBuffer& packet, PlayerSpaceship::ShipLogEntry& e) { packet >> e.prefix >> e.text >> e.color.r >> e.color.g >> e.color.b >> e.color.a; return packet; }
+static inline sp::io::DataBuffer& operator << (sp::io::DataBuffer& packet, const PlayerSpaceship::ShipLogEntry& e) { return packet << e.prefix << e.text << e.color.r << e.color.g << e.color.b << e.color.a << e.seq; }
+static inline sp::io::DataBuffer& operator >> (sp::io::DataBuffer& packet, PlayerSpaceship::ShipLogEntry& e) { packet >> e.prefix >> e.text >> e.color.r >> e.color.g >> e.color.b >> e.color.a >> e.seq; return packet; }
 
 REGISTER_MULTIPLAYER_CLASS(PlayerSpaceship, "PlayerSpaceship");
 PlayerSpaceship::PlayerSpaceship()
@@ -1123,7 +1123,7 @@ void PlayerSpaceship::addToShipLog(string message, glm::u8vec4 color)
         ships_log.erase(ships_log.begin());
 
     // Timestamp a log entry, color it, and add it to the end of the log.
-    ships_log.emplace_back(gameGlobalInfo->getMissionTime() + string(": "), message, color);
+    ships_log.emplace_back(gameGlobalInfo->getMissionTime() + string(": "), message, color, last_log_seq++);
 }
 
 void PlayerSpaceship::addToShipLogBy(string message, P<SpaceObject> target)

--- a/src/spaceObjects/playerSpaceship.h
+++ b/src/spaceObjects/playerSpaceship.h
@@ -59,10 +59,11 @@ public:
         string prefix;
         string text;
         glm::u8vec4 color;
+        unsigned int seq;
 
         ShipLogEntry() {}
-        ShipLogEntry(string prefix, string text, glm::u8vec4 color)
-        : prefix(prefix), text(text), color(color) {}
+        ShipLogEntry(string prefix, string text, glm::u8vec4 color, unsigned int seq)
+        : prefix(prefix), text(text), color(color), seq(seq) {}
 
         bool operator!=(const ShipLogEntry& e) { return prefix != e.prefix || text != e.text || color != e.color; }
     };
@@ -114,6 +115,7 @@ private:
     std::vector<ShipLogEntry> ships_log;
     float energy_shield_use_per_second = default_energy_shield_use_per_second;
     float energy_warp_per_second = default_energy_warp_per_second;
+    unsigned int last_log_seq = 0;
 public:
     std::vector<CustomShipFunction> custom_functions;
 


### PR DESCRIPTION
* Add a sequence # to log messages
* Store seq in GuiAdvancedScrollText along with rest of log data
* Compare seq instead of text when sync'ing ScrollText to log
* Fixes Issue #1947

I'm hoping this sequence # will also come in useful when I look at optimizing the network sync of the ship's log.