### PR TITLE
[GuiAdvancedScrollText] Performance improvements

### DIFF
--- a/src/gui/gui2_advancedscrolltext.cpp
+++ b/src/gui/gui2_advancedscrolltext.cpp
@@ -24,16 +24,16 @@ unsigned int GuiAdvancedScrollText::getEntryCount() const
     return entries.size();
 }
 
-string GuiAdvancedScrollText::getEntryText(int index) const
+string GuiAdvancedScrollText::getEntryText(unsigned int index) const
 {
-    if (index < 0 || index >= int(getEntryCount()))
+    if (index >= getEntryCount())
         return "";
     return entries[index].text;
 }
 
-GuiAdvancedScrollText* GuiAdvancedScrollText::removeEntry(int index)
+GuiAdvancedScrollText* GuiAdvancedScrollText::removeEntry(unsigned int index)
 {
-    if (index < 0 || index > int(getEntryCount()))
+    if (index > getEntryCount())
         return this;
     entries.erase(entries.begin() + index);
     return this;
@@ -68,12 +68,12 @@ void GuiAdvancedScrollText::onDraw(sp::RenderTarget& renderer)
     }
 
     //Calculate how many lines we have to display in total.
-    int line_count = draw_offset + scrollbar->getValue();
+    const int line_count = draw_offset + scrollbar->getValue();
 
     //Check if we need to update the scroll bar.
     if (scrollbar->getMax() != line_count)
     {
-        int diff = line_count - scrollbar->getMax();
+        const int diff = line_count - scrollbar->getMax();
         scrollbar->setRange(0, line_count);
         scrollbar->setValueSize(rect.size.y);
         if (auto_scroll_down)

--- a/src/gui/gui2_advancedscrolltext.cpp
+++ b/src/gui/gui2_advancedscrolltext.cpp
@@ -41,7 +41,7 @@ GuiAdvancedScrollText::Entry GuiAdvancedScrollText::prepEntry(GuiAdvancedScrollT
 
 GuiAdvancedScrollText* GuiAdvancedScrollText::removeEntry(unsigned int index)
 {
-    if (index > getEntryCount())
+    if (index >= getEntryCount())
         return this;
 
     // Find new max prefix if entry was the last one with the current max

--- a/src/gui/gui2_advancedscrolltext.cpp
+++ b/src/gui/gui2_advancedscrolltext.cpp
@@ -54,7 +54,8 @@ void GuiAdvancedScrollText::onDraw(sp::RenderTarget& renderer)
         auto prepared_prefix = sp::RenderTarget::getDefaultFont()->prepare(e.prefix, 32, text_size, rect.size, sp::Alignment::TopLeft);
         auto prepared_text = sp::RenderTarget::getDefaultFont()->prepare(e.text, 32, text_size, {rect.size.x - max_prefix_width - 50, rect.size.y}, sp::Alignment::TopLeft, sp::Font::FlagLineWrap | sp::Font::FlagClip);
         auto height = prepared_text.getUsedAreaSize().y;
-        if (draw_offset + height > 0)
+        if (draw_offset + height > 0
+            && draw_offset < rect.size.y)
         {
             for(auto& g : prepared_prefix.data)
                 g.position.y += draw_offset;

--- a/src/gui/gui2_advancedscrolltext.cpp
+++ b/src/gui/gui2_advancedscrolltext.cpp
@@ -1,7 +1,7 @@
 #include "gui2_advancedscrolltext.h"
 
 GuiAdvancedScrollText::GuiAdvancedScrollText(GuiContainer* owner, string id)
-: GuiElement(owner, id), text_size(30.0f), max_prefix_width(0.0f)
+: GuiElement(owner, id), text_size(30.0f), rect_width(rect.size.x), max_prefix_width(0.0f)
 {
     scrollbar = new GuiScrollbar(this, id + "_SCROLL", 0, 1, 0, nullptr);
     scrollbar->setPosition(0, 0, sp::Alignment::TopRight)->setSize(50, GuiElement::GuiSizeMax);
@@ -48,11 +48,22 @@ GuiAdvancedScrollText* GuiAdvancedScrollText::clearEntries()
 
 void GuiAdvancedScrollText::onDraw(sp::RenderTarget& renderer)
 {
+    const bool is_resized = rect_width != rect.size.x;
+    if (is_resized) { rect_width = rect.size.x; }
+
     //Draw the visible entries
     float draw_offset = -scrollbar->getValue() + text_size + 12.0f;
 
     for(Entry& e : entries)
     {
+        if (is_resized)
+        {
+            // Window width has changed. Re-prep fonts.
+            e.prepared_prefix = sp::RenderTarget::getDefaultFont()->prepare(e.prefix, 32, text_size, rect.size, sp::Alignment::TopLeft);
+            max_prefix_width = std::max(max_prefix_width, e.prepared_prefix.getUsedAreaSize().x);
+            e.prepared_text = sp::RenderTarget::getDefaultFont()->prepare(e.text, 32, text_size, {rect.size.x - max_prefix_width - 50.0f, rect.size.y}, sp::Alignment::TopLeft, sp::Font::FlagLineWrap | sp::Font::FlagClip);
+        }
+
         const float height = e.prepared_text.getUsedAreaSize().y;
 
         if (draw_offset + height > 0

--- a/src/gui/gui2_advancedscrolltext.cpp
+++ b/src/gui/gui2_advancedscrolltext.cpp
@@ -108,7 +108,7 @@ void GuiAdvancedScrollText::onDraw(sp::RenderTarget& renderer)
     }
 
     //Calculate how many lines we have to display in total.
-    const int line_count = draw_offset + scrollbar->getValue();
+    const int line_count = (draw_offset - text_size - 12.0f) + scrollbar->getValue();
 
     //Check if we need to update the scroll bar.
     if (scrollbar->getMax() != line_count)

--- a/src/gui/gui2_advancedscrolltext.cpp
+++ b/src/gui/gui2_advancedscrolltext.cpp
@@ -23,9 +23,9 @@ unsigned int GuiAdvancedScrollText::getEntryCount() const
     return entries.size();
 }
 
-string GuiAdvancedScrollText::getEntryText(unsigned int index) const
+string GuiAdvancedScrollText::getEntryText(int index) const
 {
-    if (index >= getEntryCount())
+    if (index < 0 || index >= static_cast<int>(getEntryCount()))
         return "";
     return entries[index].text;
 }
@@ -39,9 +39,9 @@ GuiAdvancedScrollText::Entry GuiAdvancedScrollText::prepEntry(GuiAdvancedScrollT
     return e;
 }
 
-GuiAdvancedScrollText* GuiAdvancedScrollText::removeEntry(unsigned int index)
+GuiAdvancedScrollText* GuiAdvancedScrollText::removeEntry(int index)
 {
-    if (index >= getEntryCount())
+    if (index < 0 || index >= static_cast<int>(getEntryCount()))
         return this;
 
     // Find new max prefix if entry was the last one with the current max

--- a/src/gui/gui2_advancedscrolltext.h
+++ b/src/gui/gui2_advancedscrolltext.h
@@ -22,7 +22,10 @@ protected:
     float text_size;
     float rect_width;
     float max_prefix_width;
+    std::map<float, int> prefix_widths;
     bool auto_scroll_down;
+    GuiAdvancedScrollText::Entry prepEntry(GuiAdvancedScrollText::Entry& e);
+
 public:
     GuiAdvancedScrollText(GuiContainer* owner, string id);
 

--- a/src/gui/gui2_advancedscrolltext.h
+++ b/src/gui/gui2_advancedscrolltext.h
@@ -24,7 +24,7 @@ protected:
     float max_prefix_width;
     std::map<float, int> prefix_widths;
     bool auto_scroll_down;
-    GuiAdvancedScrollText::Entry prepEntry(GuiAdvancedScrollText::Entry& e);
+    Entry prepEntry(Entry& e);
 
 public:
     GuiAdvancedScrollText(GuiContainer* owner, string id);

--- a/src/gui/gui2_advancedscrolltext.h
+++ b/src/gui/gui2_advancedscrolltext.h
@@ -11,6 +11,7 @@ protected:
     {
     public:
         string prefix;
+        float prefix_width;
         string text;
         glm::u8vec4 color;
     };
@@ -18,6 +19,7 @@ protected:
     std::vector<Entry> entries;
     GuiScrollbar* scrollbar;
     float text_size;
+    float max_prefix_width;
     bool auto_scroll_down;
 public:
     GuiAdvancedScrollText(GuiContainer* owner, string id);

--- a/src/gui/gui2_advancedscrolltext.h
+++ b/src/gui/gui2_advancedscrolltext.h
@@ -36,8 +36,8 @@ public:
     GuiAdvancedScrollText* setTextSize(float text_size) { this->text_size = text_size; return this; }
 
     unsigned int getEntryCount() const;
-    string getEntryText(unsigned int index) const;
-    GuiAdvancedScrollText* removeEntry(unsigned int index);
+    string getEntryText(int index) const;
+    GuiAdvancedScrollText* removeEntry(int index);
     GuiAdvancedScrollText* clearEntries();
 
     virtual void onDraw(sp::RenderTarget& renderer) override;

--- a/src/gui/gui2_advancedscrolltext.h
+++ b/src/gui/gui2_advancedscrolltext.h
@@ -31,8 +31,8 @@ public:
     GuiAdvancedScrollText* setTextSize(float text_size) { this->text_size = text_size; return this; }
 
     unsigned int getEntryCount() const;
-    string getEntryText(int index) const;
-    GuiAdvancedScrollText* removeEntry(int index);
+    string getEntryText(unsigned int index) const;
+    GuiAdvancedScrollText* removeEntry(unsigned int index);
     GuiAdvancedScrollText* clearEntries();
 
     virtual void onDraw(sp::RenderTarget& renderer) override;

--- a/src/gui/gui2_advancedscrolltext.h
+++ b/src/gui/gui2_advancedscrolltext.h
@@ -20,6 +20,7 @@ protected:
     std::vector<Entry> entries;
     GuiScrollbar* scrollbar;
     float text_size;
+    float rect_width;
     float max_prefix_width;
     bool auto_scroll_down;
 public:

--- a/src/gui/gui2_advancedscrolltext.h
+++ b/src/gui/gui2_advancedscrolltext.h
@@ -11,8 +11,9 @@ protected:
     {
     public:
         string prefix;
-        float prefix_width;
+        sp::Font::PreparedFontString prepared_prefix;
         string text;
+        sp::Font::PreparedFontString prepared_text;
         glm::u8vec4 color;
     };
 


### PR DESCRIPTION
Fixes Issue #1939

Most of the work is from @oznogon , I just added some finishing touches. 

This refactors GuiAdvancedScrollText to improve render performance.

- Font prep is moved to addEntry, and FontPreparedStrings are stored in the entries. This means fonts for an entry are prepared once upon the entry's addition, not each frame. This improves render performance, especially with large texts.
- Font prep is repeated across all entries only if the window width changes.
- Content outside the bottom of the scroll rect is ignored on the text-rendering step, rather than rendered and then clipped. This improves render performance when scrolling to the top of the text.
- max_prefix_width is calculated upon entry addition/removal rather than each frame.

Testing on a variety of systems with a 10,000-entry log, this maintains:

- 20fps on a 12th-gen/16-thread i5 on Intel graphics, with power-saving enabled (previously: 2.8)
- 40fps on a 12th-gen/16-thread i5 on Intel graphics (previously: 4)
- 51fps on a 16-thread Ryzen 9/RTX 3060 (previously: 9)

Known issues:

- Resizing the window with a large text is as expensive as before this PR, since this is now the only time the entire entries list is prepared at once.
