### PR TITLE
Remove combat maneuvers from helms tutorial

### DIFF
--- a/scripts/tutorial/00_all.lua
+++ b/scripts/tutorial/00_all.lua
@@ -69,6 +69,7 @@ addToSequence(helmsTutorial, function()
     resetPlayerShip()
     player:setJumpDrive(false)
     player:setWarpDrive(false)
+    player:setCanCombatManeuver(false)
     player:setImpulseMaxSpeed(0);
     player:setRotationMaxSpeed(0);
 end)


### PR DESCRIPTION
I recently noticed that you can softlock the helms tutorial by excessively using combat maneuvers.(overheating and damaging the system with no way to repair or cooling down).
One way would to avoid this would be auto coolant, but given that combat maneuvering is not even part of the tutorial lesson, I figured the easiest fix would be to just disable it.