### PR TITLE
Fix broken links to other tabs

### DIFF
--- a/index.html
+++ b/index.html
@@ -977,11 +977,14 @@ $(function() {
 	$("#download-tabs li" ).removeClass("ui-corner-top").addClass("ui-corner-left");
 	$("#download-tabs div" ).removeClass("ui-corner-bottom");
 
-
 	$('[href="#tabs-stations"]').click(() => $("#tabs").tabs("option", "active", 3));
 	$('[href="#tabs-scripting"]').click(
 		() => $("#tabs").tabs("option", "active", 4)
 	);
+	$('[href="#tabs-science"]').click(() => {
+		$("#tabs").tabs("option", "active", 3);
+		$("#station-tabs").tabs("option", "active", 4);
+	});
 
 	// $.each($("img"), function(idx, element)
 	// {

--- a/index.html
+++ b/index.html
@@ -977,6 +977,8 @@ $(function() {
 	$("#download-tabs li" ).removeClass("ui-corner-top").addClass("ui-corner-left");
 	$("#download-tabs div" ).removeClass("ui-corner-bottom");
 
+
+	$('[href="#tabs-stations"]').click(() => $("#tabs").tabs("option", "active", 3));
 	$('[href="#tabs-scripting"]').click(
 		() => $("#tabs").tabs("option", "active", 4)
 	);

--- a/index.html
+++ b/index.html
@@ -977,6 +977,10 @@ $(function() {
 	$("#download-tabs li" ).removeClass("ui-corner-top").addClass("ui-corner-left");
 	$("#download-tabs div" ).removeClass("ui-corner-bottom");
 
+	$('[href="#tabs-scripting"]').click(
+		() => $("#tabs").tabs("option", "active", 4)
+	);
+
 	// $.each($("img"), function(idx, element)
 	// {
 	// 	element = $(element)


### PR DESCRIPTION
Fixes links to other tabs. However, clicking the link scrolls the window to the tab's contents, hiding the Empty Epsilon logo and tab-buttons.