### PR TITLE
Station selection rearrangement and added info

### DIFF
--- a/src/menus/shipSelectionScreen.cpp
+++ b/src/menus/shipSelectionScreen.cpp
@@ -146,11 +146,11 @@ ShipSelectionScreen::ShipSelectionScreen()
     auto right_panel = new GuiPanel(right_container, "DIRECT_OPTIONS_PANEL");
     if (game_server) {
     right_panel->setPosition(0, 50, sp::Alignment::TopCenter)->setSize(550, 325);
-	}
-	else
-	{
-	right_panel->setPosition(0, 50, sp::Alignment::TopCenter)->setSize(550, 560);
-	}
+    }
+    else
+    {
+    right_panel->setPosition(0, 50, sp::Alignment::TopCenter)->setSize(550, 560);
+    }
     auto right_content = new GuiElement(right_panel, "");
     right_content->setMargins(50)->setPosition(0, 0)->setSize(GuiElement::GuiSizeMax, GuiElement::GuiSizeMax)->setAttribute("layout", "vertical");
 
@@ -334,8 +334,8 @@ ShipSelectionScreen::ShipSelectionScreen()
     {
         GuiSelector* ship_template_selector = new GuiSelector(left_container, "CREATE_SHIP_SELECTOR", [this](int index, string value)
         {
-			P<ShipTemplate> ship_template = ShipTemplate::getTemplate(value);
-			playership_info->setText(ship_template->getDescription());
+            P<ShipTemplate> ship_template = ShipTemplate::getTemplate(value);
+            playership_info->setText(ship_template->getDescription());
         });
 
         // List only ships with templates designated for player use.
@@ -484,7 +484,7 @@ CrewPositionSelection::CrewPositionSelection(GuiContainer* owner, string id, int
     right_container->setSize(GuiElement::GuiSizeMax, GuiElement::GuiSizeMax)->setAttribute("layout", "vertical");
     right_container->setMargins(25, 50, 25, 100);
 
-	// 5-6-crew panel
+    // 5-6-crew panel
     auto standard_crew_panel = new GuiPanel(left_container, "");
     standard_crew_panel->setSize(GuiElement::GuiSizeMax, 335)->setPosition(0, 0, sp::Alignment::BottomCenter)->setMargins(0, 0, 0, 25);
     (new GuiLabel(standard_crew_panel, "CREW_POSITION_SELECT_LABEL", tr("6/5 player crew"), 30))->addBackground()->setSize(GuiElement::GuiSizeMax, 50)->setMargins(15, 0);
@@ -506,7 +506,7 @@ CrewPositionSelection::CrewPositionSelection(GuiContainer* owner, string id, int
         create_crew_position_button(layout, n);
 
 
-	// 3-4-crew panel
+    // 3-4-crew panel
     auto limited_crew_panel = new GuiPanel(left_container, "");
     limited_crew_panel->setSize(GuiElement::GuiSizeMax, GuiElement::GuiSizeMax);;
     (new GuiLabel(limited_crew_panel, "CREW_POSITION_SELECT_LABEL", tr("4/3/1 player crew"), 30))->addBackground()->setSize(GuiElement::GuiSizeMax, 50)->setMargins(15, 0);
@@ -564,7 +564,7 @@ CrewPositionSelection::CrewPositionSelection(GuiContainer* owner, string id, int
     ready_button->setSize(300, 50)->setPosition(-100, -25, sp::Alignment::BottomRight);
 
 
-	// Alternative options panel
+    // Alternative options panel
     auto alternative_options_panel = new GuiPanel(center_container, "");
     alternative_options_panel->setSize(GuiElement::GuiSizeMax, GuiElement::GuiSizeMax);;
     (new GuiLabel(alternative_options_panel, "CREW_POSITION_SELECT_LABEL", tr("Alternative options"), 30))->addBackground()->setSize(GuiElement::GuiSizeMax, 50)->setMargins(15, 0);
@@ -579,13 +579,13 @@ CrewPositionSelection::CrewPositionSelection(GuiContainer* owner, string id, int
     layout->setMargins(25, 50, 25, 0)->setSize(GuiElement::GuiSizeMax, GuiElement::GuiSizeMax)->setAttribute("layout", "vertical");
     for(int n=int(singlePilot) + 1; n<int(max_crew_positions); n++)
     create_crew_position_button(layout, n);
-	// Info text panel
-	auto info_panel = new GuiPanel(right_container,"");
-	station_info_text = tr("You can select multiple stations and switch between them during the game.\nIf mainscreen is selected alongside stations, it will be shown next to the current station (if the total screen size is wide enough).");
-	info_panel->setSize(GuiElement::GuiSizeMax, GuiElement::GuiSizeMax);
+    // Info text panel
+    auto info_panel = new GuiPanel(right_container,"");
+    station_info_text = tr("You can select multiple stations and switch between them during the game.\nIf mainscreen is selected alongside stations, it will be shown next to the current station (if the total screen size is wide enough).");
+    info_panel->setSize(GuiElement::GuiSizeMax, GuiElement::GuiSizeMax);
 
-	station_info = new GuiScrollText(info_panel, "STATION_INFO", station_info_text);
-	station_info->setPosition(0, 10, sp::Alignment::TopCenter)->setSize(GuiElement::GuiSizeMax, GuiElement::GuiSizeMax)->setMargins(15, 0, 15, 10);
+    station_info = new GuiScrollText(info_panel, "STATION_INFO", station_info_text);
+    station_info->setPosition(0, 10, sp::Alignment::TopCenter)->setSize(GuiElement::GuiSizeMax, GuiElement::GuiSizeMax)->setMargins(15, 0, 15, 10);
 
 }
 

--- a/src/menus/shipSelectionScreen.cpp
+++ b/src/menus/shipSelectionScreen.cpp
@@ -593,6 +593,7 @@ void CrewPositionSelection::onUpdate()
     bool any_selected = main_screen_button->getValue() || window_button->getValue() || topdown_button->getValue();
     // If a position already has a player on the currently selected player ship,
     // indicate that on the button.
+    string crew_text = "";
     for(int n = 0; n < max_crew_positions; n++)
     {
         string button_text = getCrewPositionName(ECrewPosition(n));
@@ -611,13 +612,16 @@ void CrewPositionSelection::onUpdate()
 
             if (players.size() > 0)
             {
-                crew_position_button[n]->setText(button_text + " (" + string(", ").join(players) + ")");
+                crew_position_button[n]->setText(button_text + " [x]");
+                crew_text += "\n" + button_text + ": " + string(", ").join(players) + "";
             } else {
                 crew_position_button[n]->setText(button_text);
             }
             any_selected = any_selected || crew_position_button[n]->getValue();
         }
     }
+    if (crew_text != "") crew_text = "\n\n" + tr("--- Crew ---") + crew_text;
+    station_info->setText(station_info_text + crew_text);
 
     ready_button->setEnable(any_selected);
 }

--- a/src/menus/shipSelectionScreen.cpp
+++ b/src/menus/shipSelectionScreen.cpp
@@ -406,6 +406,7 @@ ShipSelectionScreen::ShipSelectionScreen()
 
 void ShipSelectionScreen::update(float delta)
 {
+
     // If this is a client and is disconnected from the server, destroy the
     // screen and return to the main menu.
     if (game_client && game_client->getStatus() == GameClient::Disconnected)
@@ -448,7 +449,6 @@ void ShipSelectionScreen::update(float delta)
     }
 
 
-
     // If there aren't any player ships, show a label stating so.
     if (player_ship_list->entryCount() > 0)
     {
@@ -472,17 +472,25 @@ CrewPositionSelection::CrewPositionSelection(GuiContainer* owner, string id, int
     auto container = new GuiElement(this, "");
     container->setSize(GuiElement::GuiSizeMax, GuiElement::GuiSizeMax)->setAttribute("layout", "horizontal");
 
-    auto one = new GuiPanel(container, "");
-    one->setMargins(50, 50, 25, 100)->setSize(GuiElement::GuiSizeMax, GuiElement::GuiSizeMax);
-    (new GuiLabel(one, "CREW_POSITION_SELECT_LABEL", tr("6/5 player crew"), 30))->addBackground()->setSize(GuiElement::GuiSizeMax, 50)->setMargins(15, 0);
-    auto layout = new GuiElement(one, "");
-    layout->setMargins(25, 50)->setSize(GuiElement::GuiSizeMax, GuiElement::GuiSizeMax)->setAttribute("layout", "vertical");
-    main_screen_button = new GuiToggleButton(layout, "", tr("Main screen"), [this](bool value) {
-        my_player_info->commandSetMainScreen(window_index, value);
-        unselectSingleOptions();
-    });
-    main_screen_button->setValue(my_player_info->main_screen & (1 << window_index));
-    main_screen_button->setSize(GuiElement::GuiSizeMax, 50);
+    auto left_container = new GuiElement(container, "");
+    left_container->setSize(GuiElement::GuiSizeMax, GuiElement::GuiSizeMax)->setAttribute("layout", "vertical");
+    left_container->setMargins(50, 50, 25, 100);
+
+    auto center_container = new GuiElement(container, "");
+    center_container->setSize(GuiElement::GuiSizeMax, GuiElement::GuiSizeMax)->setAttribute("layout", "vertical");
+    center_container->setMargins(25, 50, 25, 100);
+
+    auto right_container = new GuiElement(container, "");
+    right_container->setSize(GuiElement::GuiSizeMax, GuiElement::GuiSizeMax)->setAttribute("layout", "vertical");
+    right_container->setMargins(25, 50, 25, 100);
+
+	// 5-6-crew panel
+    auto standard_crew_panel = new GuiPanel(left_container, "");
+    standard_crew_panel->setSize(GuiElement::GuiSizeMax, 335)->setPosition(0, 0, sp::Alignment::BottomCenter)->setMargins(0, 0, 0, 25);
+    (new GuiLabel(standard_crew_panel, "CREW_POSITION_SELECT_LABEL", tr("6/5 player crew"), 30))->addBackground()->setSize(GuiElement::GuiSizeMax, 50)->setMargins(15, 0);
+    auto layout = new GuiElement(standard_crew_panel, "");
+    layout->setMargins(25, 50, 25, 0)->setSize(GuiElement::GuiSizeMax, GuiElement::GuiSizeMax)->setAttribute("layout", "vertical");
+
     auto create_crew_position_button = [this](GuiElement* layout, int n) {
         auto button = new GuiToggleButton(layout, "", getCrewPositionName(ECrewPosition(n)), [this, n](bool value){
             my_player_info->commandSetCrewPosition(window_index, ECrewPosition(n), value);
@@ -497,27 +505,28 @@ CrewPositionSelection::CrewPositionSelection(GuiContainer* owner, string id, int
     for(int n=0; n<=int(relayOfficer); n++)
         create_crew_position_button(layout, n);
 
-    auto two = new GuiPanel(container, "");
-    two->setMargins(25, 50, 25, 100)->setSize(GuiElement::GuiSizeMax, GuiElement::GuiSizeMax);;
-    (new GuiLabel(two, "CREW_POSITION_SELECT_LABEL", tr("4/3/1 player crew"), 30))->addBackground()->setSize(GuiElement::GuiSizeMax, 50)->setMargins(15, 0);
-    layout = new GuiElement(two, "");
+
+	// 3-4-crew panel
+    auto limited_crew_panel = new GuiPanel(left_container, "");
+    limited_crew_panel->setSize(GuiElement::GuiSizeMax, GuiElement::GuiSizeMax);;
+    (new GuiLabel(limited_crew_panel, "CREW_POSITION_SELECT_LABEL", tr("4/3/1 player crew"), 30))->addBackground()->setSize(GuiElement::GuiSizeMax, 50)->setMargins(15, 0);
+    layout = new GuiElement(limited_crew_panel, "");
     layout->setMargins(25, 50)->setSize(GuiElement::GuiSizeMax, GuiElement::GuiSizeMax)->setAttribute("layout", "vertical");
     for(int n=int(tacticalOfficer); n<=int(singlePilot); n++)
         create_crew_position_button(layout, n);
 
-    auto three = new GuiPanel(container, "");
-    three->setMargins(25, 50, 50, 100)->setSize(GuiElement::GuiSizeMax, GuiElement::GuiSizeMax);;
-    (new GuiLabel(three, "CREW_POSITION_SELECT_LABEL", tr("Alternative options"), 30))->addBackground()->setSize(GuiElement::GuiSizeMax, 50)->setMargins(15, 0);
-    layout = new GuiElement(three, "");
-    layout->setMargins(25, 50)->setSize(GuiElement::GuiSizeMax, GuiElement::GuiSizeMax)->setAttribute("layout", "vertical");
-    for(int n=int(singlePilot) + 1; n<int(max_crew_positions); n++)
-        create_crew_position_button(layout, n);
-
-    // Main screen controls button
-    main_screen_controls_button = new GuiToggleButton(layout, "MAIN_SCREEN_CONTROLS_ENABLE", tr("Main screen controls"), [this](bool value) {
-        my_player_info->commandSetMainScreenControl(window_index, value);
+    // 3d views panel
+    auto space_screens_panel= new GuiPanel(center_container,"");
+    space_screens_panel->setSize(GuiElement::GuiSizeMax, 215)->setMargins(0, 0, 0, 25);
+    (new GuiLabel(space_screens_panel, "CREW_POSITION_SELECT_LABEL", tr("3D screens"), 30))->addBackground()->setSize(GuiElement::GuiSizeMax, 50)->setMargins(15, 0);
+    layout = new GuiElement(space_screens_panel, "");
+    layout->setMargins(25, 50, 25, 0)->setSize(GuiElement::GuiSizeMax, GuiElement::GuiSizeMax)->setAttribute("layout", "vertical");
+    main_screen_button = new GuiToggleButton(layout, "", tr("Main screen"), [this](bool value) {
+        my_player_info->commandSetMainScreen(window_index, value);
+        unselectSingleOptions();
     });
-    main_screen_controls_button->setValue(my_player_info->main_screen_control)->setSize(GuiElement::GuiSizeMax, 50);
+    main_screen_button->setValue(my_player_info->main_screen & (1 << window_index));
+    main_screen_button->setSize(GuiElement::GuiSizeMax, 50);
 
     // Window
     auto window_button_row = new GuiElement(layout, "");
@@ -530,6 +539,12 @@ CrewPositionSelection::CrewPositionSelection(GuiContainer* owner, string id, int
     window_angle = new GuiTextEntry(window_button_row, "WINDOW_ANGLE","0");
     window_angle->setSize(75, 50);
     window_angle->setSelectOnFocus();
+    window_angle->callback([this](string text) { // Check validity: Only allow numbers and no more than 3 digits. Angles above 360 are fine though.
+        if (text !="" && text !="-") window_angle->setText(text.toInt());
+        if (text.length() >3 && text.toInt()>=0 ) window_angle->setText(text.substr(0,3));
+        if (text.length() >4 && text.toInt()<0 ) window_angle->setText(text.substr(0,4));
+    });
+
 
     window_angle_label = new GuiLabel(window_button_row, "WINDOW_ANGLE_LABEL", "°", 30);
     window_angle_label->setSize(12, GuiElement::GuiSizeMax);
@@ -547,6 +562,30 @@ CrewPositionSelection::CrewPositionSelection(GuiContainer* owner, string id, int
 
     ready_button = new GuiButton(this, "READY", tr("button", "Ready"), on_ready);
     ready_button->setSize(300, 50)->setPosition(-100, -25, sp::Alignment::BottomRight);
+
+
+	// Alternative options panel
+    auto alternative_options_panel = new GuiPanel(center_container, "");
+    alternative_options_panel->setSize(GuiElement::GuiSizeMax, GuiElement::GuiSizeMax);;
+    (new GuiLabel(alternative_options_panel, "CREW_POSITION_SELECT_LABEL", tr("Alternative options"), 30))->addBackground()->setSize(GuiElement::GuiSizeMax, 50)->setMargins(15, 0);
+    layout = new GuiElement(alternative_options_panel, "");
+
+    // Main screen controls button
+    main_screen_controls_button = new GuiToggleButton(layout, "MAIN_SCREEN_CONTROLS_ENABLE", tr("Main screen controls"), [this](bool value) {
+        my_player_info->commandSetMainScreenControl(window_index, value);
+    });
+    main_screen_controls_button->setValue(my_player_info->main_screen_control)->setSize(GuiElement::GuiSizeMax, 50);
+
+    layout->setMargins(25, 50, 25, 0)->setSize(GuiElement::GuiSizeMax, GuiElement::GuiSizeMax)->setAttribute("layout", "vertical");
+    for(int n=int(singlePilot) + 1; n<int(max_crew_positions); n++)
+    create_crew_position_button(layout, n);
+	// Info text panel
+	auto info_panel= new GuiPanel(right_container,"");
+	station_info_text = tr("You can select multiple stations and switch between them during the game.\nIf mainscreen is selected alongside stations, it will be shown next to the current station (if the total screen size is wide enough).");
+	info_panel->setSize(GuiElement::GuiSizeMax, GuiElement::GuiSizeMax);
+	station_info = new GuiScrollText(info_panel, "STATION_INFO", station_info_text);
+	station_info->setPosition(0, 10, sp::Alignment::TopCenter)->setSize(GuiElement::GuiSizeMax, GuiElement::GuiSizeMax)->setMargins(15, 0, 15, 10);
+
 }
 
 void CrewPositionSelection::onUpdate()

--- a/src/menus/shipSelectionScreen.cpp
+++ b/src/menus/shipSelectionScreen.cpp
@@ -580,9 +580,10 @@ CrewPositionSelection::CrewPositionSelection(GuiContainer* owner, string id, int
     for(int n=int(singlePilot) + 1; n<int(max_crew_positions); n++)
     create_crew_position_button(layout, n);
 	// Info text panel
-	auto info_panel= new GuiPanel(right_container,"");
+	auto info_panel = new GuiPanel(right_container,"");
 	station_info_text = tr("You can select multiple stations and switch between them during the game.\nIf mainscreen is selected alongside stations, it will be shown next to the current station (if the total screen size is wide enough).");
 	info_panel->setSize(GuiElement::GuiSizeMax, GuiElement::GuiSizeMax);
+
 	station_info = new GuiScrollText(info_panel, "STATION_INFO", station_info_text);
 	station_info->setPosition(0, 10, sp::Alignment::TopCenter)->setSize(GuiElement::GuiSizeMax, GuiElement::GuiSizeMax)->setMargins(15, 0, 15, 10);
 
@@ -612,7 +613,7 @@ void CrewPositionSelection::onUpdate()
 
             if (players.size() > 0)
             {
-                crew_position_button[n]->setText(button_text + " [x]");
+                crew_position_button[n]->setText(button_text + " ["+ std::to_string(players.size()) +"]");
                 crew_text += "\n" + button_text + ": " + string(", ").join(players) + "";
             } else {
                 crew_position_button[n]->setText(button_text);

--- a/src/menus/shipSelectionScreen.h
+++ b/src/menus/shipSelectionScreen.h
@@ -59,6 +59,8 @@ private:
     GuiTextEntry* window_angle;
     GuiLabel* window_angle_label;
     GuiToggleButton* topdown_button;
+    GuiScrollText* station_info;
+    string station_info_text;
 };
 
 class SecondMonitorScreen : public GuiCanvas, public Updatable


### PR DESCRIPTION
This changes basically three things for ship selection

- the buttons are rearranged, so main screen no longer seems to be part of 5-6 crew.
- the newly freed space is used to display an info text about how the main screen button work together with other stations.
- instead of the buttons, the crew names are displayed in the info panel, so there are no weird text overflows anymore. On the buttons themself, there is only an indicator if and how many people are logged into that station


![Shipselection-rearrange3](https://github.com/daid/EmptyEpsilon/assets/25465934/6ff56502-4210-41d4-bef4-9d27dca4ad6b)
