### PR TITLE
Explain and clarify the keybinding menu

### DIFF
--- a/src/gui/hotkeyBinder.cpp
+++ b/src/gui/hotkeyBinder.cpp
@@ -1,3 +1,4 @@
+#include <i18n.h>
 #include "engine.h"
 #include "hotkeyConfig.h"
 #include "hotkeyBinder.h"
@@ -32,6 +33,6 @@ void GuiHotkeyBinder::onDraw(sp::RenderTarget& renderer)
     for(int n=1; key->getKeyType(n) != sp::io::Keybinding::Type::None; n++)
         text += "," + key->getHumanReadableKeyName(n);
     if (key->isUserRebinding())
-        text = "[Press new key]";
+        text = tr("[New input]");
     renderer.drawText(sp::Rect(rect.position.x + 16, rect.position.y, rect.size.x, rect.size.y), text, sp::Alignment::CenterLeft, front.size, front.font, front.color);
 }

--- a/src/menus/hotkeyMenu.cpp
+++ b/src/menus/hotkeyMenu.cpp
@@ -19,14 +19,15 @@ HotkeyMenu::HotkeyMenu()
 
     // TODO: Figure out how to make this an AutoLayout.
     container = new GuiElement(this, "HOTKEY_CONFIG_CONTAINER");
-    container->setSize(GuiElement::GuiSizeMax, GuiElement::GuiSizeMax)->setPosition(0, 0, sp::Alignment::TopLeft)->setMargins(FRAME_MARGIN);
+    container->setSize(GuiElement::GuiSizeMax, GuiElement::GuiSizeMax)->setPosition(0, 0, sp::Alignment::TopLeft)->setMargins(FRAME_MARGIN / 2);
 
     top_row = new GuiElement(container, "TOP_ROW_CONTAINER");
     top_row->setSize(GuiElement::GuiSizeMax, ROW_HEIGHT)->setPosition(0, 0, sp::Alignment::TopLeft);
 
     rebinding_ui = new GuiPanel(container, "REBINDING_UI_CONTAINER");
     rebinding_ui->setSize(GuiElement::GuiSizeMax, KEY_COLUMN_HEIGHT)->setPosition(0, KEY_COLUMN_TOP, sp::Alignment::TopLeft);
-
+    info_container = new GuiElement(container, "info_container_CONTAINER");
+    info_container->setSize(GuiElement::GuiSizeMax, ROW_HEIGHT)->setPosition(0, KEY_COLUMN_TOP+KEY_COLUMN_HEIGHT, sp::Alignment::TopLeft);
     bottom_row = new GuiElement(container, "BOTTOM_ROW_CONTAINER");
     bottom_row->setSize(GuiElement::GuiSizeMax, ROW_HEIGHT)->setPosition(0, 0, sp::Alignment::BottomLeft);
 
@@ -34,7 +35,7 @@ HotkeyMenu::HotkeyMenu()
     // Top: Title and category navigation
 
     // Title label
-    (new GuiLabel(top_row, "CONFIGURE_KEYBOARD_LABEL", tr("Configure Keyboard"), 30))->addBackground()->setPosition(0, 0, sp::Alignment::TopLeft)->setSize(300, GuiElement::GuiSizeMax);
+    (new GuiLabel(top_row, "CONFIGURE_KEYBOARD_LABEL", tr("Configure Keyboard/Joystick"), 30))->addBackground()->setPosition(0, 0, sp::Alignment::TopLeft)->setSize(350, GuiElement::GuiSizeMax);
 
     // Category selector
     // Get a list of hotkey categories
@@ -66,6 +67,7 @@ HotkeyMenu::HotkeyMenu()
 
     // Bottom: Menu navigation
     // Back button to return to the Options menu
+    (new GuiScrollText(info_container, "INFO_LABEL", tr("Left Click: Assign input. Middle Click: Add input. Right Click: Delete inputs.\nPossible inputs: Keyboard keys, joystick buttons, joystick axes.")))->setPosition(10, 0, sp::Alignment::TopCenter)->setSize(GuiElement::GuiSizeMax, ROW_HEIGHT*3);
     (new GuiButton(bottom_row, "BACK", tr("button", "Back"), [this]()
     {
         // Close this menu, stop the music, and return to the main menu.

--- a/src/menus/hotkeyMenu.h
+++ b/src/menus/hotkeyMenu.h
@@ -5,6 +5,7 @@
 #include "gui/gui2_entrylist.h"
 #include "gui/gui2_canvas.h"
 #include "gui/gui2_scrollbar.h"
+#include "gui/gui2_scrolltext.h"
 #include "gui/hotkeyBinder.h"
 #include "Updatable.h"
 
@@ -25,18 +26,20 @@ private:
     const int KEY_LABEL_WIDTH = 375;
     const int KEY_FIELD_WIDTH = 150;
     const int KEY_LABEL_MARGIN = 25;
-    const int KEY_COLUMN_TOP = ROW_HEIGHT * 2;
+    const int KEY_COLUMN_TOP = ROW_HEIGHT * 1.5;
     const int KEY_ROW_COUNT = 10;
     const int KEY_COLUMN_WIDTH = KEY_LABEL_WIDTH + KEY_LABEL_MARGIN + KEY_FIELD_WIDTH;
     const int KEY_COLUMN_HEIGHT = ROW_HEIGHT * KEY_ROW_COUNT + FRAME_MARGIN * 2;
     const int PAGER_BREAKPOINT = KEY_COLUMN_WIDTH * 2 + FRAME_MARGIN * 2;
 
+    GuiScrollText* help_text;
     GuiElement* container;
     GuiElement* top_row;
     GuiPanel* rebinding_ui;
     GuiElement* bottom_row;
 
     GuiElement* rebinding_container;
+    GuiElement* info_container;
     std::vector<GuiElement*> rebinding_columns;
     std::vector<GuiElement*> rebinding_rows;
     std::vector<GuiHotkeyBinder*> text_entries;

--- a/src/menus/optionsMenu.cpp
+++ b/src/menus/optionsMenu.cpp
@@ -97,7 +97,7 @@ OptionsMenu::OptionsMenu()
     (new GuiLabel(interface_page, "CONTROL_OPTIONS_LABEL", tr("Control Options"), 30))->addBackground()->setSize(GuiElement::GuiSizeMax, 50)->layout.margin.top = 20;
 
     // Keyboard config (hotkeys/keybindings)
-    (new GuiButton(interface_page, "CONFIGURE_KEYBOARD", tr("Configure Keyboard"), [this]()
+    (new GuiButton(interface_page, "CONFIGURE_KEYBOARD", tr("Configure Keyboard/Joystick"), [this]()
     {
         new HotkeyMenu();
         destroy();


### PR DESCRIPTION
Many players are not aware that you can "keybind" joystick buttons and axes, not just keys. Another rarely known feature is that you can assign multiple inputs to one action.

This PR adds an explanatory text to tackle this problem.