### PR TITLE
Fix duplicate default keybind for Science and Relay

### DIFF
--- a/src/gui/hotkeyConfig.cpp
+++ b/src/gui/hotkeyConfig.cpp
@@ -88,7 +88,7 @@ Keys::Keys() :
     station_weapons("STATION_WEAPONS", "F3"),
     station_engineering("STATION_ENGINEERING", "F4"),
     station_science("STATION_SCIENCE", "F5"),
-    station_relay("STATION_RELAY", "F5"),
+    station_relay("STATION_RELAY", "F6"),
 
     //Main screen
     mainscreen_forward("MAINSCREEN_FORWARD", "Up"),


### PR DESCRIPTION
Both Science and Relay stations use `F5` as the keybind to switch to that station. Pressing `F5` repeatedly doesn't toggle between the two stations and `F6` is unused, so I set Science to `F5` and Relay to `F6` (which follows the order of the stations in the "choose your stations" screen and else where in the game)

Testing Plan:

- From Helm (or some other station), pressing `F5` should switch to Science
- From Relay, pressing `F5` should switch to Science
- From Helm (or some other station), pressing `F6` should switch to Relay
- From Science, pressing `F6` should switch to Relay
