### PR TITLE
Increase contrast in Science colored bands

### DIFF
--- a/src/screenComponents/rawScannerDataRadarOverlay.cpp
+++ b/src/screenComponents/rawScannerDataRadarOverlay.cpp
@@ -171,7 +171,7 @@ void RawScannerDataRadarOverlay::onDraw(sp::RenderTarget& renderer)
     a_b.push_back(a_b.front());
 
     // Draw each band as a line.
-    renderer.drawLineBlendAdd(a_r, glm::u8vec4(255, 0, 0, 255));
-    renderer.drawLineBlendAdd(a_g, glm::u8vec4(0, 255, 0, 255));
-    renderer.drawLineBlendAdd(a_b, glm::u8vec4(0, 0, 255, 255));
+    renderer.drawLineBlendAdd(a_r, glm::u8vec4(255, 45, 84, 255)); // red
+    renderer.drawLineBlendAdd(a_g, glm::u8vec4(65, 255, 81, 255)); // green
+    renderer.drawLineBlendAdd(a_b, glm::u8vec4(70, 120, 255, 255)); // blue
 }

--- a/src/screenComponents/rawScannerDataRadarOverlay.h
+++ b/src/screenComponents/rawScannerDataRadarOverlay.h
@@ -5,6 +5,7 @@
 
 class GuiRadarView;
 
+// Class for drawing the Science Bands (red, green, blue) around the Radar for the Science Station
 class RawScannerDataRadarOverlay : public GuiElement
 {
 public:

--- a/src/screenComponents/signalQualityIndicator.cpp
+++ b/src/screenComponents/signalQualityIndicator.cpp
@@ -45,7 +45,7 @@ void GuiSignalQualityIndicator::onDraw(sp::RenderTarget& renderer)
         f = (1.0f - noise[2]) * f + noise[2] * random(-1.0, 1.0);
         b.emplace_back(rect.position.x + 4.0f + n * 4, rect.position.y + rect.size.y / 2.0f + f * amp);
     }
-    renderer.drawLineBlendAdd(r, glm::u8vec4(255, 0, 0, 255));
-    renderer.drawLineBlendAdd(g, glm::u8vec4(0, 255, 0, 255));
-    renderer.drawLineBlendAdd(b, glm::u8vec4(0, 0, 255, 255));
+    renderer.drawLineBlendAdd(r, glm::u8vec4(255, 45, 84, 255)); // red
+    renderer.drawLineBlendAdd(g, glm::u8vec4(65, 255, 81, 255)); // green
+    renderer.drawLineBlendAdd(b, glm::u8vec4(70, 120, 255, 255)); // blue
 }

--- a/src/screenComponents/signalQualityIndicator.h
+++ b/src/screenComponents/signalQualityIndicator.h
@@ -6,7 +6,7 @@
 #include "gui/gui2_element.h"
 #include "timer.h"
 
-
+// Class for drawing bands in the Science Station's "Scanning" mini-game
 class GuiSignalQualityIndicator : public GuiElement
 {
     sp::SystemStopwatch clock;


### PR DESCRIPTION
Use lighter version of Red, Green, Blue for better accessibility

Aims to fix #2064 (Colored Bands for the Science station has poor accessibility)

# Before
![original_sci_bands_rgb](https://github.com/daid/EmptyEpsilon/assets/157658450/fdd21c82-ea8f-4b68-b7a5-1354882e4ab8)

# After
![modified_sci_bands_rgb](https://github.com/daid/EmptyEpsilon/assets/157658450/e0aac323-d98c-49ad-841e-69c4750eae6a)

# Accessibility for new colors
## Red
![Accessibility for Red](https://github.com/daid/EmptyEpsilon/assets/157658450/e7a7893b-5d22-44eb-b4dc-5b12112de9f5)
## Green
![Accessibility for Green](https://github.com/daid/EmptyEpsilon/assets/157658450/29675cd0-4e7a-4445-9366-63f6540712fc)
## Blue
![Accessibility for Blue](https://github.com/daid/EmptyEpsilon/assets/157658450/7ec422ce-324e-475f-b037-a62962133d38)
