### PR TITLE
makes scenario_20_training1 playable again for non-english-languages

### DIFF
--- a/scripts/locale/scenario_20_training1.de.po
+++ b/scripts/locale/scenario_20_training1.de.po
@@ -10,7 +10,7 @@ msgstr ""
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
-"X-Generator: Poedit 3.0.1\n"
+"X-Generator: Poedit 3.4.2\n"
 
 # Scenario name
 msgid "Training: Cruiser"
@@ -38,12 +38,27 @@ msgstr ""
 "Während dieses Trainings lernt ihr, die Aktionen eurer Crew zu koordinieren "
 "und ein Exuari-Übungsgelände zu zerstören.\n"
 "\n"
-"Ihr Schiff ist ein leichter Phobos-Kreuzer - das häufigste Schiff der "
-"Marine.\n"
+"Euer Schiff ist ein leichter Phobos-Kreuzer - das häufigste Schiff der "
+"Navy.\n"
 "\n"
 "Dies ist eine kurze Mission für eine unerfahrene Crew."
 
-#: scripts/scenario_20_training1.lua:130
+#: scripts/scenario_20_training1.lua:36
+msgctxt "scienceDescription-shipname"
+msgid "Exuari transport"
+msgstr "Ein Exuari-Transportschiff"
+
+#: scripts/scenario_20_training1.lua:40
+msgctxt "scienceDescription-shipname"
+msgid "Exuari freighter"
+msgstr "Ein Exuari-Frachter"
+
+#: scripts/scenario_20_training1.lua:44
+msgctxt "scienceDescription-shipname"
+msgid "Exuari shuttle"
+msgstr "Ein Shuttle der Exuari"
+
+#: scripts/scenario_20_training1.lua:79
 msgctxt "goal-incCall"
 msgid ""
 "This is Commander Saberhagen.\n"
@@ -62,25 +77,25 @@ msgstr ""
 "\n"
 "In dieser Trainingsmission üben Sie die grundlegende Steuerung der Phobos, "
 "eines leichten Kreuzers.\n"
-"Da es sich nicht um ein Tutorial handelt, entscheiden Sie selbst, wie Sie "
-"alle feindlichen Ziele auf einem Exuari-Übungsgelände zerstören.\n"
-"Es wird nicht viel Widerstand geben, so dass Sie in aller Ruhe verschiedene "
-"Ansätze und Taktiken ausprobieren können.\n"
+"Da es sich nicht um ein Tutorial handelt, entscheidet ihr selbst, wie ihr "
+"alle feindlichen Ziele auf einem Exuari-Übungsgelände zerstört.\n"
+"Es wird nicht viel Widerstand geben, so dass ihr in aller Ruhe verschiedene "
+"Ansätze und Taktiken ausprobieren könnt.\n"
 "\n"
-"Hier ist Ihre Chance, ein paar hilflose Gegner zu verprügeln.\n"
+"Hier ist eure Chance, ein paar hilflose Gegner zu verprügeln.\n"
 "Commander Saberhagen Ende."
 
-#: scripts/scenario_20_training1.lua:148
+#: scripts/scenario_20_training1.lua:98
 msgctxt "msgMainscreen-bonusTarget"
 msgid "escaped."
 msgstr "geflohen."
 
-#: scripts/scenario_20_training1.lua:150
+#: scripts/scenario_20_training1.lua:100
 msgctxt "msgMainscreen-bonusTarget"
 msgid "destroyed."
 msgstr "zerstört."
 
-#: scripts/scenario_20_training1.lua:152
+#: scripts/scenario_20_training1.lua:102
 #, lua-format
 msgctxt "msgMainscreen"
 msgid ""

--- a/scripts/scenario_20_training1.lua
+++ b/scripts/scenario_20_training1.lua
@@ -84,7 +84,6 @@ There will be not much resistance, so you can try different approaches and tacti
 
 Here's your chance to beat up some helpless opponents.
 Commander Saberhagen out.]]))
-    globalMessage("Test")
     end
 end
 

--- a/scripts/scenario_20_training1.lua
+++ b/scripts/scenario_20_training1.lua
@@ -20,37 +20,6 @@ function createExuariWeakInterceptor()
 	return CpuShip():setFaction("Exuari"):setTemplate("Dagger"):setBeamWeapon(0, 0, 0, 0, 0.1, 0.1)
 end
 
-function copyShipDBEntry(base_ship_template,new_ship)
-  ship_db = queryScienceDatabase("Ships")
-
-  -- Search each Ships class's entry for the base ship
-  for k,entry in ipairs(ship_db:getEntries())
-  do
-    base_ship_entry = entry:getEntryByName(base_ship_template)
-    if base_ship_entry ~= nil
-    then
-      break;
-    end
-  end
-
-  -- Create a new Exuari DB entry for the new ship
-  exuari_ship_db = ship_db:getEntryByName("Exuari")
-  new_ship_entry = exuari_ship_db:addEntry(new_ship:getTypeName())
-
-  -- Copy base ship data to the new entry
-  for k,v in pairs(base_ship_entry:getKeyValues())
-  do
-    new_ship_entry:setKeyValue(k,v)
-  end
-
-  new_ship_entry:setImage(base_ship_entry:getImage())
-  new_ship_entry:setLongDescription(base_ship_entry:getLongDescription())
-  -- Impossible without a getModelName() function
-  -- new_ship_entry:setModelName(base_ship_entry:getModelName())
-
-  return new_ship_entry
-end
-
 function createExuariWeakBomber()
 	return CpuShip():setFaction("Exuari"):setTemplate("Gunner"):setWeaponTubeCount(0):setWeaponStorageMax("HVLI", 0):setWeaponStorage("HVLI", 0):setBeamWeapon(0, 0, 0, 0, 0.1, 0.1)
 end
@@ -64,37 +33,17 @@ function createExuariBomber()
 end
 
 function createExuariTransport()
-	return CpuShip():setFaction("Exuari"):setTemplate("Personnel Freighter 1"):setTypeName("Exuari transport")
+	return CpuShip():setFaction("Exuari"):setTemplate("Personnel Freighter 1"):setDescriptionForScanState("simple",_("scienceDescription-shipname","Exuari transport"))
 end
-
--- Create a dummy ship to populate the ScienceDatabase entry, then destroy it
-init_transport = createExuariTransport()
-init_transport_entry = copyShipDBEntry("Personnel Freighter 1", init_transport)
--- init_transport_entry:setLongDescription("The Exuari transport transports Exuari")
-init_transport_entry:setModelDataName("transport_1_1") -- manually entered from finding Personnel Freighter in shiptemplates
-init_transport:destroy()
 
 function createExuariFreighter()
-	return CpuShip():setFaction("Exuari"):setTemplate("Goods Freighter 5"):setTypeName("Exuari freighter")
+	return CpuShip():setFaction("Exuari"):setTemplate("Goods Freighter 5"):setDescriptionForScanState("simple",_("scienceDescription-shipname","Exuari freighter"))
 end
-
--- Create a dummy ship to populate the ScienceDatabase entry, then destroy it
-init_transport = createExuariFreighter()
-init_transport_entry = copyShipDBEntry("Goods Freighter 5", init_transport)
--- init_transport_entry:setLongDescription("The Exuari transport transports Exuari")
-init_transport_entry:setModelDataName("transport_2_5") -- manually entered from finding Goods Freighter in shiptemplates
-init_transport:destroy()
 
 function createExuariShuttle()
-	return CpuShip():setFaction("Exuari"):setTemplate("Racer"):setTypeName("Exuari shuttle"):setWarpDrive(false):setBeamWeapon(0, 0, 355, 0, 0.1, 0.1):setBeamWeapon(1, 0, 355, 0, 0.1, 0.1)
+	return CpuShip():setFaction("Exuari"):setTemplate("Racer"):setDescriptionForScanState("simple",_("scienceDescription-shipname","Exuari shuttle")):setWarpDrive(false):setBeamWeapon(0, 0, 355, 0, 0.1, 0.1):setBeamWeapon(1, 0, 355, 0, 0.1, 0.1)
 end
 
--- Create a dummy ship to populate the ScienceDatabase entry, then destroy it
-init_transport = createExuariShuttle()
-init_transport_entry = copyShipDBEntry("Racer", init_transport)
--- init_transport_entry:setLongDescription("The Exuari transport transports Exuari")
-init_transport_entry:setModelDataName("small_frigate_1") -- manually entered from finding Racer in shiptemplates
-init_transport:destroy()
 
 -- init
 function init()
@@ -135,6 +84,7 @@ There will be not much resistance, so you can try different approaches and tacti
 
 Here's your chance to beat up some helpless opponents.
 Commander Saberhagen out.]]))
+    globalMessage("Test")
     end
 end
 
@@ -196,4 +146,3 @@ function update(delta)
 
     commsInstr()
 end
-


### PR DESCRIPTION
This addresses https://github.com/daid/EmptyEpsilon/issues/1686 and especially https://github.com/daid/EmptyEpsilon/issues/1686#issuecomment-1666091533 , as that scenario became unplayable for non-english languages.

This PR does not try to fix the actual issue (which seems to be very persistent) but offers a workaround, to make it at least playable again. 
- Deletes all database references, notably the ones that copy the ship names and cause the issue.
- The custom ship name is transferred to the ship description for simple scan. So it now can be considered a description of how this particular ship is used, rather than an custom model name. Positive side effect: Other than ship names, this can safely be translated.