### PR TITLE
fix: prevent segfault when template does not exist

### DIFF
--- a/src/spaceObjects/shipTemplateBasedObject.cpp
+++ b/src/spaceObjects/shipTemplateBasedObject.cpp
@@ -437,6 +437,7 @@ float ShipTemplateBasedObject::getShieldRechargeRate(int shield_index)
 void ShipTemplateBasedObject::setTemplate(string template_name)
 {
     P<ShipTemplate> new_ship_template = ShipTemplate::getTemplate(template_name);
+    if (!new_ship_template) return;
     this->template_name = template_name;
     ship_template = new_ship_template;
     type_name = template_name;


### PR DESCRIPTION
setTemplate now produces an error, if the chosen template does not exist. But the game no longer crashes with a segfault.