### PR TITLE
Add Wormhole Shader with Inward Movement Effect

### DIFF
--- a/resources/shaders/wormhole.shader
+++ b/resources/shaders/wormhole.shader
@@ -23,17 +23,37 @@ uniform float time;
 varying vec4 fragcolor;
 varying vec2 fragtexcoords;
 
+// Adjusted parameters
+const float spiralIntensity = 0.08;
+const float spiralFrequency = 5.0;
+const float spiralSpeed = 0.3;
+const float inwardIntensity = 0.15;
+const float inwardFrequency = 3.0;
+const float inwardSpeed = 0.1;
+const float colorShiftIntensity = 0.05;
+const float colorShiftFrequency = 1.0;
+const float effectSize = 0.6; // Adjust this value to control how large the effect grows
+
 void main()
 {
-    float wobbleAmount = 0.1;
-    float wobbleSpeed = 3.0;
-
-    vec2 wobble = vec2(
-        sin(time * wobbleSpeed + fragtexcoords.y * 10.0) * wobbleAmount,
-        cos(time * wobbleSpeed + fragtexcoords.x * 10.0) * wobbleAmount
-    );
-
-    vec2 wobbledTexCoords = fragtexcoords + wobble;
-
-    gl_FragColor = texture2D(textureMap, wobbledTexCoords) * fragcolor;
+    vec2 center = vec2(0.5, 0.5);
+    vec2 toCenter = center - fragtexcoords;
+    float dist = length(toCenter);
+    
+    // Limit the effect to a certain radius
+    float normalizedDist = smoothstep(0.0, effectSize, dist);
+    float effectStrength = 1.0 - normalizedDist;
+    
+    float angle = atan(toCenter.y, toCenter.x);
+    float spiral = sin(dist * spiralFrequency - time * spiralSpeed + angle) * spiralIntensity;
+    
+    float inward = sin(dist * inwardFrequency - time * inwardSpeed) * inwardIntensity;
+    
+    vec2 distortion = normalize(toCenter) * (spiral + inward) * effectStrength;
+    vec2 distortedCoords = fragtexcoords + distortion;
+    
+    gl_FragColor = texture2D(textureMap, distortedCoords) * fragcolor;
+    
+    float colorShift = sin(dist * colorShiftFrequency - time) * colorShiftIntensity + 1.0;
+    gl_FragColor.rgb *= vec3(colorShift, 1.0, 1.0/colorShift);
 }

--- a/resources/shaders/wormhole.shader
+++ b/resources/shaders/wormhole.shader
@@ -1,0 +1,39 @@
+[vertex]
+uniform vec4 color;
+uniform mat4 view;
+uniform mat4 projection;
+uniform mat4 model;
+
+attribute vec3 position;
+attribute vec2 texcoords;
+
+varying vec2 fragtexcoords;
+varying vec4 fragcolor;
+
+void main()
+{
+    fragtexcoords = texcoords;
+    gl_Position = projection * ((view * model * vec4(position, 1.0)) + vec4((texcoords.x - 0.5) * color.a, (texcoords.y - 0.5) * color.a, 0.0, 0.0));
+    fragcolor = vec4(color.rgb, 1.0);
+}
+
+[fragment]
+uniform sampler2D textureMap;
+uniform float time;
+varying vec4 fragcolor;
+varying vec2 fragtexcoords;
+
+void main()
+{
+    float wobbleAmount = 0.1;
+    float wobbleSpeed = 3.0;
+
+    vec2 wobble = vec2(
+        sin(time * wobbleSpeed + fragtexcoords.y * 10.0) * wobbleAmount,
+        cos(time * wobbleSpeed + fragtexcoords.x * 10.0) * wobbleAmount
+    );
+
+    vec2 wobbledTexCoords = fragtexcoords + wobble;
+
+    gl_FragColor = texture2D(textureMap, wobbledTexCoords) * fragcolor;
+}

--- a/src/shaderRegistry.cpp
+++ b/src/shaderRegistry.cpp
@@ -30,7 +30,8 @@ namespace ShaderRegistry
             "shaders/objectShader:ILLUMINATION",
             "shaders/objectShader:SPECULAR",
             "shaders/objectShader:ILLUMINATION:SPECULAR",
-            "shaders/planet"
+            "shaders/planet",
+            "shaders/wormhole",
         };
 
         std::array<const char*, Uniforms_t(Uniforms::Count)> uniform_names{
@@ -39,6 +40,7 @@ namespace ShaderRegistry
             "projection",
             "model",
             "view",
+            "time",
             "camera_position",
             "atmosphereColor",
             

--- a/src/shaderRegistry.h
+++ b/src/shaderRegistry.h
@@ -34,6 +34,7 @@ namespace ShaderRegistry
 		ObjectSpecular,
 		ObjectSpecularIllumination,
 		Planet,
+		Wormhole,
 
 		Count
 	};
@@ -47,6 +48,7 @@ namespace ShaderRegistry
 		Projection,
 		Model,
 		View,
+		Time,
 		CameraPosition,
 		AtmosphereColor,
 

--- a/src/spaceObjects/wormHole.cpp
+++ b/src/spaceObjects/wormHole.cpp
@@ -2,6 +2,7 @@
 #include <glm/gtc/type_ptr.hpp>
 
 #include "main.h"
+#include "engine.h"
 #include "random.h"
 #include "wormHole.h"
 #include "spaceship.h"
@@ -66,16 +67,16 @@ void WormHole::draw3DTransparent()
     };
 
     textureManager.getTexture("wormHole3d.png")->bind();
-    ShaderRegistry::ScopedShader shader(ShaderRegistry::Shaders::Billboard);
+    ShaderRegistry::ScopedShader shader(ShaderRegistry::Shaders::Wormhole);
 
     auto model_matrix = getModelMatrix();
     auto modeldata_matrix = glm::rotate(model_matrix, glm::radians(120.f), {1.f, 0.f, 0.f});
 
     glUniformMatrix4fv(shader.get().uniform(ShaderRegistry::Uniforms::Model), 1, GL_FALSE, glm::value_ptr(modeldata_matrix));
     glUniform4f(shader.get().uniform(ShaderRegistry::Uniforms::Color), 1.f, 1.f, 1.f, 5000.f);
+    glUniform1f(shader.get().uniform(ShaderRegistry::Uniforms::Time), engine->getElapsedTime());
     gl::ScopedVertexAttribArray positions(shader.get().attribute(ShaderRegistry::Attributes::Position));
     gl::ScopedVertexAttribArray texcoords(shader.get().attribute(ShaderRegistry::Attributes::Texcoords));
-
 
 
     glBlendFunc(GL_SRC_ALPHA, GL_ONE_MINUS_SRC_ALPHA);


### PR DESCRIPTION
**Summary**

This PR introduces a new shader for the awesome wormhole graphic created by @aBlueShadow.
The shader adds minor movement to the texture, simulating an inward pulling effect, as seen below.

![wormhole-shader](https://github.com/user-attachments/assets/81febe42-7a30-420c-89bf-7bdba54dcc25)


**Changes Made**

- Shader file:
  - Created a new shader file (`wormhole.shader`) specifically for the wormhole graphic.
  - Implemented the logic to animate the texture with a pull-inward effect.
- ShaderRegistry:
  - Added a time uniform to the ShaderRegistry to support the new shader's animation needs.
- Wormhole SpaceObject:
  - Included the `engine` header to enable `engine->getElapsedTime()` for the uniform.