### PR TITLE
ECS: re-implement mesh rendering in database entries

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -329,6 +329,7 @@ set(MAIN_SOURCES
     src/components/radar.h
     src/components/hull.h
     src/components/rendering.h
+    src/components/rendering.cpp
     src/components/docking.h
     src/components/coolant.h
     src/components/shipsystem.h

--- a/src/components/rendering.cpp
+++ b/src/components/rendering.cpp
@@ -1,0 +1,32 @@
+#include "mesh.h"
+#include "textureManager.h"
+#include "rendering.h"
+
+Mesh* MeshRenderComponent::getMesh()
+{
+    if (!mesh.ptr && !mesh.name.empty())
+        mesh.ptr = Mesh::getMesh(mesh.name);
+    return mesh.ptr;
+}
+
+sp::Texture* MeshRenderComponent::getTexture()
+{
+    if (!texture.ptr && !texture.name.empty())
+        texture.ptr = textureManager.getTexture(texture.name);
+    return texture.ptr;
+}
+
+sp::Texture* MeshRenderComponent::getSpecularTexture()
+{
+    if (!specular_texture.ptr && !specular_texture.name.empty())
+        specular_texture.ptr = textureManager.getTexture(specular_texture.name);
+    return specular_texture.ptr;
+}
+
+sp::Texture* MeshRenderComponent::getIlluminationTexture()
+{
+    if (!illumination_texture.ptr && !illumination_texture.name.empty())
+        illumination_texture.ptr = textureManager.getTexture(illumination_texture.name);
+    return illumination_texture.ptr;
+}
+

--- a/src/components/rendering.h
+++ b/src/components/rendering.h
@@ -1,7 +1,7 @@
 #pragma once
+#include <memory>
 
 #include "io/dataBuffer.h"
-
 #include "graphics/texture.h"
 #include "mesh.h"
 #include "shaderRegistry.h"

--- a/src/components/rendering.h
+++ b/src/components/rendering.h
@@ -26,7 +26,11 @@ public:
     TextureRef illumination_texture;
     glm::vec3 mesh_offset{};
     float scale = 1.0;
-    bool ensureLoaded();
+
+    Mesh* getMesh();
+    sp::Texture* getTexture();
+    sp::Texture* getSpecularTexture();
+    sp::Texture* getIlluminationTexture();
 };
 
 class EngineEmitter

--- a/src/components/rendering.h
+++ b/src/components/rendering.h
@@ -26,6 +26,7 @@ public:
     TextureRef illumination_texture;
     glm::vec3 mesh_offset{};
     float scale = 1.0;
+    bool ensureLoaded();
 };
 
 class EngineEmitter

--- a/src/mesh.cpp
+++ b/src/mesh.cpp
@@ -144,28 +144,14 @@ uint32_t Mesh::greatestDistanceFromCenter(std::vector<MeshVertex>& vertices)
         return 0;
     }
 
+    glm::vec3 sum{};
+    for(auto vertex : vertices) sum += glm::vec3{vertex.position[0], vertex.position[1], vertex.position[2]};
+    auto average = sum / float(vertices.size());
 
-    float sum_x = 0.f;
-    float sum_y = 0.f;
-    float sum_z = 0.f;
-    for(auto vertex : vertices)
-    {
-        auto [px, py, pz] = vertex.position;
-        sum_x += px;
-        sum_y += py;
-        sum_z += pz;
-    }
-
-    auto vertex_count = vertices.size();
-    auto average_x = sum_x / vertex_count;
-    auto average_y = sum_y / vertex_count;
-    auto average_z = sum_z / vertex_count;
     auto greatest_distance = 0.f;
-
     for(auto vertex : vertices)
     {
-        auto [px, py, pz] = vertex.position;
-        float distance = sqrt(pow(px - average_x, 2) + pow(py - average_y, 2) + pow(pz - average_z, 2));
+        float distance = glm::distance(average, glm::vec3{vertex.position[0], vertex.position[1], vertex.position[2]});
         if(distance > greatest_distance) {
             greatest_distance = distance;
         }

--- a/src/mesh.h
+++ b/src/mesh.h
@@ -21,10 +21,16 @@ class Mesh : sp::NonCopyable
     gl::Buffers<2> vbo_ibo{ gl::Unitialized{} };
     uint32_t face_count{};
 public:
+    float greatest_distance_from_center{};
     explicit Mesh(std::vector<MeshVertex>&& vertices);
 
     void render(int32_t position_attrib, int32_t texcoords_attrib, int32_t normal_attrib);
     glm::vec3 randomPoint();
+
+    // Calculate the center all vertices in this mesh, and return the distance
+    // of the point farthest from that center.
+
+    uint32_t greatestDistanceFromCenter(std::vector<MeshVertex>& vertices);
 
     static Mesh* getMesh(const string& filename);
 };

--- a/src/mesh.h
+++ b/src/mesh.h
@@ -29,7 +29,6 @@ public:
 
     // Calculate the center all vertices in this mesh, and return the distance
     // of the point farthest from that center.
-
     uint32_t greatestDistanceFromCenter(std::vector<MeshVertex>& vertices);
 
     static Mesh* getMesh(const string& filename);

--- a/src/screenComponents/databaseView.cpp
+++ b/src/screenComponents/databaseView.cpp
@@ -126,7 +126,7 @@ void DatabaseViewComponent::display()
 
         if (mrc)
         {
-            (new GuiRotatingModelView(visual, "DATABASE_MODEL_VIEW", mrc))
+            (new GuiRotatingModelView(visual, "DATABASE_MODEL_VIEW", selected_entry))
                 ->setSize(GuiElement::GuiSizeMax, GuiElement::GuiSizeMax);
             if(database->image != "")
             {

--- a/src/screenComponents/databaseView.cpp
+++ b/src/screenComponents/databaseView.cpp
@@ -126,7 +126,8 @@ void DatabaseViewComponent::display()
 
         if (mrc)
         {
-            //TODO: (new GuiRotatingModelView(visual, "DATABASE_MODEL_VIEW", selected_entry))->setSize(GuiElement::GuiSizeMax, GuiElement::GuiSizeMax);
+            (new GuiRotatingModelView(visual, "DATABASE_MODEL_VIEW", mrc))
+                ->setSize(GuiElement::GuiSizeMax, GuiElement::GuiSizeMax);
             if(database->image != "")
             {
                 (new GuiImage(visual, "DATABASE_IMAGE", database->image))->setMargins(0)->setSize(32, 32);

--- a/src/screenComponents/rotatingModelView.cpp
+++ b/src/screenComponents/rotatingModelView.cpp
@@ -17,8 +17,9 @@
 #include <glm/ext/matrix_clip_space.hpp>
 #include <glm/gtc/type_ptr.hpp>
 
-GuiRotatingModelView::GuiRotatingModelView(GuiContainer* owner, string id, MeshRenderComponent* mesh)
-: GuiElement(owner, id), mesh(mesh)
+GuiRotatingModelView::GuiRotatingModelView(GuiContainer* owner, string id, sp::ecs::Entity& entity)
+
+: GuiElement(owner, id), entity(entity)
 {
 }
 
@@ -31,6 +32,8 @@ void GuiRotatingModelView::onDraw(sp::RenderTarget& renderer)
     if (rect.size.y <= 0) {
         return;
     }
+
+    auto mesh = entity.getComponent<MeshRenderComponent>();
     if (!mesh) {
         return;
     }

--- a/src/screenComponents/rotatingModelView.cpp
+++ b/src/screenComponents/rotatingModelView.cpp
@@ -33,8 +33,8 @@ void GuiRotatingModelView::onDraw(sp::RenderTarget& renderer)
         return;
     }
 
-    auto mesh = entity.getComponent<MeshRenderComponent>();
-    if (!mesh) {
+    auto mrc = entity.getComponent<MeshRenderComponent>();
+    if (!mrc) {
         return;
     }
 
@@ -62,7 +62,7 @@ void GuiRotatingModelView::onDraw(sp::RenderTarget& renderer)
         return;
     }
 
-    auto mesh_radius = mesh->mesh.ptr->greatest_distance_from_center;
+    auto mesh_radius = mrc->mesh.ptr->greatest_distance_from_center;
     float mesh_diameter = mesh_radius * 2.f;
     float near_clip_boundary = 1.f;
 
@@ -83,9 +83,9 @@ void GuiRotatingModelView::onDraw(sp::RenderTarget& renderer)
 
     ShaderRegistry::updateProjectionView(projection_matrix, view_matrix);
 
-    auto model_matrix = calculateModelMatrix(glm::vec2{}, 0.f, *mesh, scale);
+    auto model_matrix = calculateModelMatrix(glm::vec2{}, 0.f, *mrc, scale);
 
-    auto shader = lookUpShader(*mesh);
+    auto shader = lookUpShader(*mrc);
     glUniformMatrix4fv(shader.get().uniform(ShaderRegistry::Uniforms::Model), 1, GL_FALSE, glm::value_ptr(model_matrix));
 
     auto modeldata_matrix = glm::rotate(model_matrix, glm::radians(180.f), {0.f, 0.f, 1.f});
@@ -95,10 +95,9 @@ void GuiRotatingModelView::onDraw(sp::RenderTarget& renderer)
     ShaderRegistry::setupLights(shader.get(), modeldata_matrix);
 
     // Textures
-    activateAndBindMeshTextures(*mesh);
+    activateAndBindMeshTextures(*mrc);
 
     // Draw
-    drawMesh(*mesh, shader);
 
 //     {
 // #ifdef DEBUG
@@ -168,6 +167,7 @@ void GuiRotatingModelView::onDraw(sp::RenderTarget& renderer)
 //         }
 // #endif
 //     }
+    drawMesh(*mrc, shader);
 
     glDisable(GL_CULL_FACE);
     glDisable(GL_DEPTH_TEST);

--- a/src/screenComponents/rotatingModelView.cpp
+++ b/src/screenComponents/rotatingModelView.cpp
@@ -85,6 +85,7 @@ void GuiRotatingModelView::onDraw(sp::RenderTarget& renderer)
     glUniformMatrix4fv(shader.get().uniform(ShaderRegistry::Uniforms::Model), 1, GL_FALSE, glm::value_ptr(modeldata_matrix));
 
     // Lights setup.
+    // FIX!!: temporarily using flipped matrix here.
     ShaderRegistry::setupLights(shader.get(), modeldata_matrix);
 
     // Textures

--- a/src/screenComponents/rotatingModelView.cpp
+++ b/src/screenComponents/rotatingModelView.cpp
@@ -94,73 +94,74 @@ void GuiRotatingModelView::onDraw(sp::RenderTarget& renderer)
     // Draw
     drawMesh(*mesh, shader);
 
-    {
-#ifdef DEBUG
-        ShaderRegistry::ScopedShader shader(ShaderRegistry::Shaders::BasicColor);
-        {
-            // Common state - matrices.
-            glUniformMatrix4fv(shader.get().uniform(ShaderRegistry::Uniforms::Projection), 1, GL_FALSE, glm::value_ptr(projection));
-            glUniformMatrix4fv(shader.get().uniform(ShaderRegistry::Uniforms::View), 1, GL_FALSE, glm::value_ptr(view_matrix));
-            glUniformMatrix4fv(shader.get().uniform(ShaderRegistry::Uniforms::Model), 1, GL_FALSE, glm::value_ptr(model_matrix));
-
-            // Vertex attrib
-            gl::ScopedVertexAttribArray positions(shader.get().attribute(ShaderRegistry::Attributes::Position));
-
-            for (const EngineEmitterData& ee : model->engine_emitters)
-            {
-                glm::vec3 offset = ee.position * model->scale;
-                float r = model->scale * ee.scale * 0.5f;
-
-                glUniform4f(shader.get().uniform(ShaderRegistry::Uniforms::Color), ee.color.x, ee.color.y, ee.color.z, 1.f);
-                auto vertices = {
-                    glm::vec3{offset.x + r, offset.y, offset.z},
-                    glm::vec3{offset.x - r, offset.y, offset.z},
-                    glm::vec3{offset.x, offset.y + r, offset.z},
-                    glm::vec3{offset.x, offset.y - r, offset.z},
-                    glm::vec3{offset.x, offset.y, offset.z + r},
-                    glm::vec3{offset.x, offset.y, offset.z - r}
-                };
-                glVertexAttribPointer(positions.get(), 3, GL_FLOAT, GL_FALSE, sizeof(glm::vec3), std::begin(vertices));
-                glDrawArrays(GL_LINES, 0, vertices.size());
-            }
-            float r = model->getRadius() * 0.1f;
-
-            glUniform4f(shader.get().uniform(ShaderRegistry::Uniforms::Color), 1.f, 1.f, 1.f, 1.f);
-
-            for (const glm::vec3& position : model->beam_position)
-            {
-                glm::vec3 offset = position * model->scale;
-
-                auto vertices = {
-                    glm::vec3{offset.x + r, offset.y, offset.z},
-                    glm::vec3{offset.x - r, offset.y, offset.z},
-                    glm::vec3{offset.x, offset.y + r, offset.z},
-                    glm::vec3{offset.x, offset.y - r, offset.z},
-                    glm::vec3{offset.x, offset.y, offset.z + r},
-                    glm::vec3{offset.x, offset.y, offset.z - r}
-                };
-                glVertexAttribPointer(positions.get(), 3, GL_FLOAT, GL_FALSE, sizeof(glm::vec3), std::begin(vertices));
-                glDrawArrays(GL_LINES, 0, vertices.size());
-            }
-
-            for (const glm::vec3& position : model->tube_position)
-            {
-                glm::vec3 offset = position * model->scale;
-
-                auto vertices = {
-                    glm::vec3{offset.x + r * 3, offset.y, offset.z},
-                    glm::vec3{offset.x - r, offset.y, offset.z},
-                    glm::vec3{offset.x, offset.y + r, offset.z},
-                    glm::vec3{offset.x, offset.y - r, offset.z},
-                    glm::vec3{offset.x, offset.y, offset.z + r},
-                    glm::vec3{offset.x, offset.y, offset.z - r}
-                };
-                glVertexAttribPointer(positions.get(), 3, GL_FLOAT, GL_FALSE, sizeof(glm::vec3), std::begin(vertices));
-                glDrawArrays(GL_LINES, 0, vertices.size());
-            }
-        }
-#endif
-    }
+//     {
+// #ifdef DEBUG
+//         ShaderRegistry::ScopedShader shader(ShaderRegistry::Shaders::BasicColor);
+//         {
+//             // Common state - matrices.
+//             glUniformMatrix4fv(shader.get().uniform(ShaderRegistry::Uniforms::Projection), 1, GL_FALSE, glm::value_ptr(projection_matrix));
+//             glUniformMatrix4fv(shader.get().uniform(ShaderRegistry::Uniforms::View), 1, GL_FALSE, glm::value_ptr(view_matrix));
+//             glUniformMatrix4fv(shader.get().uniform(ShaderRegistry::Uniforms::Model), 1, GL_FALSE, glm::value_ptr(model_matrix));
+//
+//             // Vertex attrib
+//             gl::ScopedVertexAttribArray positions(shader.get().attribute(ShaderRegistry::Attributes::Position));
+//
+//             // for (const EngineEmitterData& ee : model->engine_emitters)
+//             // {
+//             //     glm::vec3 offset = ee.position * model->scale;
+//             //     float r = model->scale * ee.scale * 0.5f;
+//             //
+//             //     glUniform4f(shader.get().uniform(ShaderRegistry::Uniforms::Color), ee.color.x, ee.color.y, ee.color.z, 1.f);
+//             //     auto vertices = {
+//             //         glm::vec3{offset.x + r, offset.y, offset.z},
+//             //         glm::vec3{offset.x - r, offset.y, offset.z},
+//             //         glm::vec3{offset.x, offset.y + r, offset.z},
+//             //         glm::vec3{offset.x, offset.y - r, offset.z},
+//             //         glm::vec3{offset.x, offset.y, offset.z + r},
+//             //         glm::vec3{offset.x, offset.y, offset.z - r}
+//             //     };
+//             //     glVertexAttribPointer(positions.get(), 3, GL_FLOAT, GL_FALSE, sizeof(glm::vec3), std::begin(vertices));
+//             //     glDrawArrays(GL_LINES, 0, vertices.size());
+//             // }
+//             auto r = mesh_radius * 0.1f;
+//             // float r = model->getRadius() * 0.1f;
+//
+//             glUniform4f(shader.get().uniform(ShaderRegistry::Uniforms::Color), 1.f, 1.f, 1.f, 1.f);
+//
+//             // for (const glm::vec3& position : model->beam_position)
+//             // {
+//             //     glm::vec3 offset = position * model->scale;
+//             //
+//             //     auto vertices = {
+//             //         glm::vec3{offset.x + r, offset.y, offset.z},
+//             //         glm::vec3{offset.x - r, offset.y, offset.z},
+//             //         glm::vec3{offset.x, offset.y + r, offset.z},
+//             //         glm::vec3{offset.x, offset.y - r, offset.z},
+//             //         glm::vec3{offset.x, offset.y, offset.z + r},
+//             //         glm::vec3{offset.x, offset.y, offset.z - r}
+//             //     };
+//             //     glVertexAttribPointer(positions.get(), 3, GL_FLOAT, GL_FALSE, sizeof(glm::vec3), std::begin(vertices));
+//             //     glDrawArrays(GL_LINES, 0, vertices.size());
+//             // }
+//
+//             // for (const glm::vec3& position : model->tube_position)
+//             // {
+//             //     glm::vec3 offset = position * model->scale;
+//             //
+//             //     auto vertices = {
+//             //         glm::vec3{offset.x + r * 3, offset.y, offset.z},
+//             //         glm::vec3{offset.x - r, offset.y, offset.z},
+//             //         glm::vec3{offset.x, offset.y + r, offset.z},
+//             //         glm::vec3{offset.x, offset.y - r, offset.z},
+//             //         glm::vec3{offset.x, offset.y, offset.z + r},
+//             //         glm::vec3{offset.x, offset.y, offset.z - r}
+//             //     };
+//             //     glVertexAttribPointer(positions.get(), 3, GL_FLOAT, GL_FALSE, sizeof(glm::vec3), std::begin(vertices));
+//             //     glDrawArrays(GL_LINES, 0, vertices.size());
+//             // }
+//         }
+// #endif
+//     }
 
     glDisable(GL_CULL_FACE);
     glDisable(GL_DEPTH_TEST);
@@ -168,69 +169,4 @@ void GuiRotatingModelView::onDraw(sp::RenderTarget& renderer)
     glBlendFunc(GL_SRC_ALPHA, GL_ONE_MINUS_SRC_ALPHA);
 
     glViewport(0, 0, renderer.getPhysicalSize().x, renderer.getPhysicalSize().y);
-#ifdef DEBUG
-        ShaderRegistry::ScopedShader shader(ShaderRegistry::Shaders::BasicColor);
-        {
-            // Common state - matrices.
-            glUniformMatrix4fv(shader.get().uniform(ShaderRegistry::Uniforms::Projection), 1, GL_FALSE, glm::value_ptr(projection));
-            glUniformMatrix4fv(shader.get().uniform(ShaderRegistry::Uniforms::View), 1, GL_FALSE, glm::value_ptr(view_matrix));
-            glUniformMatrix4fv(shader.get().uniform(ShaderRegistry::Uniforms::Model), 1, GL_FALSE, glm::value_ptr(model_matrix));
-
-            // Vertex attrib
-            gl::ScopedVertexAttribArray positions(shader.get().attribute(ShaderRegistry::Attributes::Position));
-
-            for (const EngineEmitterData& ee : model->engine_emitters)
-            {
-                glm::vec3 offset = ee.position * model->scale;
-                float r = model->scale * ee.scale * 0.5f;
-
-                glUniform4f(shader.get().uniform(ShaderRegistry::Uniforms::Color), ee.color.x, ee.color.y, ee.color.z, 1.f);
-                auto vertices = {
-                    glm::vec3{offset.x + r, offset.y, offset.z},
-                    glm::vec3{offset.x - r, offset.y, offset.z},
-                    glm::vec3{offset.x, offset.y + r, offset.z},
-                    glm::vec3{offset.x, offset.y - r, offset.z},
-                    glm::vec3{offset.x, offset.y, offset.z + r},
-                    glm::vec3{offset.x, offset.y, offset.z - r}
-                };
-                glVertexAttribPointer(positions.get(), 3, GL_FLOAT, GL_FALSE, sizeof(glm::vec3), std::begin(vertices));
-                glDrawArrays(GL_LINES, 0, vertices.size());
-            }
-            float r = model->getRadius() * 0.1f;
-
-            glUniform4f(shader.get().uniform(ShaderRegistry::Uniforms::Color), 1.f, 1.f, 1.f, 1.f);
-
-            for (const glm::vec3& position : model->beam_position)
-            {
-                glm::vec3 offset = position * model->scale;
-
-                auto vertices = {
-                    glm::vec3{offset.x + r, offset.y, offset.z},
-                    glm::vec3{offset.x - r, offset.y, offset.z},
-                    glm::vec3{offset.x, offset.y + r, offset.z},
-                    glm::vec3{offset.x, offset.y - r, offset.z},
-                    glm::vec3{offset.x, offset.y, offset.z + r},
-                    glm::vec3{offset.x, offset.y, offset.z - r}
-                };
-                glVertexAttribPointer(positions.get(), 3, GL_FLOAT, GL_FALSE, sizeof(glm::vec3), std::begin(vertices));
-                glDrawArrays(GL_LINES, 0, vertices.size());
-            }
-
-            for (const glm::vec3& position : model->tube_position)
-            {
-                glm::vec3 offset = position * model->scale;
-
-                auto vertices = {
-                    glm::vec3{offset.x + r * 3, offset.y, offset.z},
-                    glm::vec3{offset.x - r, offset.y, offset.z},
-                    glm::vec3{offset.x, offset.y + r, offset.z},
-                    glm::vec3{offset.x, offset.y - r, offset.z},
-                    glm::vec3{offset.x, offset.y, offset.z + r},
-                    glm::vec3{offset.x, offset.y, offset.z - r}
-                };
-                glVertexAttribPointer(positions.get(), 3, GL_FLOAT, GL_FALSE, sizeof(glm::vec3), std::begin(vertices));
-                glDrawArrays(GL_LINES, 0, vertices.size());
-            }
-        }
-#endif
 }

--- a/src/screenComponents/rotatingModelView.cpp
+++ b/src/screenComponents/rotatingModelView.cpp
@@ -69,9 +69,6 @@ void GuiRotatingModelView::onDraw(sp::RenderTarget& renderer)
 
     ShaderRegistry::updateProjectionView(projection_matrix, view_matrix);
 
-        // // Update view matrix in shaders.
-        // ShaderRegistry::updateProjectionView({}, view_matrix);
-
     mesh->ensureLoaded();
 
     auto transform = sp::Transform();

--- a/src/screenComponents/rotatingModelView.cpp
+++ b/src/screenComponents/rotatingModelView.cpp
@@ -50,9 +50,7 @@ void GuiRotatingModelView::onDraw(sp::RenderTarget& renderer)
     else
         glClearDepth(1.f);
 
-    glClear(GL_DEPTH_BUFFER_BIT | GL_STENCIL_BUFFER_BIT);
-    glEnable(GL_DEPTH_TEST);
-    glDepthMask(GL_TRUE);
+    glClear(GL_DEPTH_BUFFER_BIT);
     glEnable(GL_CULL_FACE);
     glCullFace(GL_BACK);
     glFrontFace(GL_CCW);

--- a/src/screenComponents/rotatingModelView.cpp
+++ b/src/screenComponents/rotatingModelView.cpp
@@ -58,7 +58,12 @@ void GuiRotatingModelView::onDraw(sp::RenderTarget& renderer)
     glFrontFace(GL_CCW);
 
 
-    mesh->ensureLoaded();
+    auto loaded = mesh->ensureLoaded();
+
+    if(!loaded) {
+        return;
+    }
+
     auto mesh_radius = mesh->mesh.ptr->greatest_distance_from_center;
     float mesh_diameter = mesh_radius * 2.f;
     float near_clip_boundary = 1.f;

--- a/src/screenComponents/rotatingModelView.cpp
+++ b/src/screenComponents/rotatingModelView.cpp
@@ -4,8 +4,11 @@
 #include "featureDefs.h"
 #include "rotatingModelView.h"
 
+#include "textureManager.h"
+
 #include "glObjects.h"
 #include "shaderRegistry.h"
+#include "systems/rendering.h"
 
 #include <array>
 
@@ -14,13 +17,215 @@
 #include <glm/ext/matrix_clip_space.hpp>
 #include <glm/gtc/type_ptr.hpp>
 
-GuiRotatingModelView::GuiRotatingModelView(GuiContainer* owner, string id/*TODO, P<ModelData> model*/)
-: GuiElement(owner, id)//, model(model)
+GuiRotatingModelView::GuiRotatingModelView(GuiContainer* owner, string id, MeshRenderComponent* mesh)
+: GuiElement(owner, id), mesh(mesh)
 {
 }
 
 void GuiRotatingModelView::onDraw(sp::RenderTarget& renderer)
 {
+
+    if (rect.size.x <= 0) {
+        LOG(INFO) << "Returning because rect.size.x <= 0 (" << rect.size.x << ")";
+        return;
+    }
+    if (rect.size.y <= 0) {
+        LOG(INFO) << "Returning because rect.size.y <= 0 (" << rect.size.y << ")";
+        return;
+    }
+    if (!mesh) {
+        LOG(INFO) << "Returning because no mesh";
+        return;
+    }
+    renderer.finish();
+
+    float camera_fov = 60.0f;
+    auto p0 = renderer.virtualToPixelPosition(rect.position);
+    auto p1 = renderer.virtualToPixelPosition(rect.position + rect.size);
+    glViewport(p0.x, renderer.getPhysicalSize().y - p1.y, p1.x - p0.x, p1.y - p0.y);
+
+    if (GLAD_GL_ES_VERSION_2_0)
+        glClearDepthf(1.f);
+    else
+        glClearDepth(1.f);
+
+    glClear(GL_DEPTH_BUFFER_BIT | GL_STENCIL_BUFFER_BIT);
+    glEnable(GL_DEPTH_TEST);
+    glDepthMask(GL_TRUE);
+    glEnable(GL_CULL_FACE);
+    glCullFace(GL_BACK);
+    glFrontFace(GL_CCW);
+
+    auto projection_matrix = glm::perspective(glm::radians(camera_fov), rect.size.x / rect.size.y, 1.f, 25000.f);
+
+    // OpenGL standard: X across (left-to-right), Y up, Z "towards".
+    auto view_matrix = glm::rotate(glm::identity<glm::mat4>(), glm::radians(90.f), glm::vec3(1.f, 0.f, 0.f)); // -> X across (l-t-r), Y "towards", Z down
+    view_matrix = glm::scale(view_matrix, glm::vec3(1.f, 1.f, -1.f)); // -> X across (l-t-r), Y "towards", Z up
+    view_matrix = glm::translate(view_matrix, glm::vec3(0.f, -200.f, 0.f));
+    view_matrix = glm::rotate(view_matrix, glm::radians(-30.f), glm::vec3(1.f, 0.f, 0.f));
+    view_matrix = glm::rotate(view_matrix, glm::radians(engine->getElapsedTime() * 360.0f / 10.0f), glm::vec3(0.f, 0.f, 1.f));
+
+    glDisable(GL_BLEND);
+    glBindTexture(GL_TEXTURE_2D, 0);
+    glEnable(GL_DEPTH_TEST);
+
+    ShaderRegistry::updateProjectionView(projection_matrix, view_matrix);
+
+        // // Update view matrix in shaders.
+        // ShaderRegistry::updateProjectionView({}, view_matrix);
+
+    if (!mesh->mesh.ptr && !mesh->mesh.name.empty())
+        mesh->mesh.ptr = Mesh::getMesh(mesh->mesh.name);
+    if (!mesh->mesh.ptr)
+        return;
+    if (!mesh->texture.ptr && !mesh->texture.name.empty())
+        mesh->texture.ptr = textureManager.getTexture(mesh->texture.name);
+    if (!mesh->specular_texture.ptr && !mesh->specular_texture.name.empty())
+        mesh->specular_texture.ptr = textureManager.getTexture(mesh->specular_texture.name);
+    if (!mesh->illumination_texture.ptr && !mesh->illumination_texture.name.empty())
+        mesh->illumination_texture.ptr = textureManager.getTexture(mesh->illumination_texture.name);
+
+    auto transform = sp::Transform();
+    transform.setPosition(glm::vec2(0,0));
+    auto position = transform.getPosition();
+    auto rotation = transform.getRotation();
+
+    auto model_matrix = glm::translate(glm::identity<glm::mat4>(), glm::vec3{ position.x, position.y, 0.f });
+    model_matrix = glm::rotate(model_matrix, glm::radians(rotation), glm::vec3{ 0.f, 0.f, 1.f });
+    model_matrix = glm::translate(model_matrix, mesh->mesh_offset);
+
+    // EE's coordinate flips to a Z-up left hand.
+    // To account for that, flip the model around 180deg.
+    auto modeldata_matrix = glm::rotate(model_matrix, glm::radians(180.f), {0.f, 0.f, 1.f});
+    modeldata_matrix = glm::scale(modeldata_matrix, glm::vec3{mesh->scale});
+    //modeldata_matrix = glm::translate(modeldata_matrix, mrc.mesh_offset); // Old mesh offset
+
+    auto shader_id = ShaderRegistry::Shaders::Object;
+    if (mesh->texture.ptr && mesh->specular_texture.ptr && mesh->illumination_texture.ptr)
+        shader_id = ShaderRegistry::Shaders::ObjectSpecularIllumination;
+    else if (mesh->texture.ptr && mesh->specular_texture.ptr)
+        shader_id = ShaderRegistry::Shaders::ObjectSpecular;
+    else if (mesh->texture.ptr && mesh->illumination_texture.ptr)
+        shader_id = ShaderRegistry::Shaders::ObjectIllumination;
+
+    ShaderRegistry::ScopedShader shader(shader_id);
+    glUniformMatrix4fv(shader.get().uniform(ShaderRegistry::Uniforms::Model), 1, GL_FALSE, glm::value_ptr(modeldata_matrix));
+
+    // Lights setup.
+    ShaderRegistry::setupLights(shader.get(), model_matrix);
+
+    // Textures
+    if (mesh->texture.ptr)
+        mesh->texture.ptr->bind();
+
+    if (mesh->specular_texture.ptr)
+    {
+        glActiveTexture(GL_TEXTURE0 + ShaderRegistry::textureIndex(ShaderRegistry::Textures::SpecularMap));
+        mesh->specular_texture.ptr->bind();
+    }
+
+    if (mesh->illumination_texture.ptr)
+    {
+        glActiveTexture(GL_TEXTURE0 + ShaderRegistry::textureIndex(ShaderRegistry::Textures::IlluminationMap));
+        mesh->illumination_texture.ptr->bind();
+    }
+
+    // Draw
+    gl::ScopedVertexAttribArray positions(shader.get().attribute(ShaderRegistry::Attributes::Position));
+    gl::ScopedVertexAttribArray texcoords(shader.get().attribute(ShaderRegistry::Attributes::Texcoords));
+    gl::ScopedVertexAttribArray normals(shader.get().attribute(ShaderRegistry::Attributes::Normal));
+
+    mesh->mesh.ptr->render(positions.get(), texcoords.get(), normals.get());
+
+    if (mesh->specular_texture.ptr || mesh->illumination_texture.ptr)
+        glActiveTexture(GL_TEXTURE0);
+
+    // render_system.render3D(rect.size.x / rect.size.y, camera_fov);
+
+    {
+        // float scale = 100.0f;// / mesh->getRadius(); // mesh->getScale() ?
+        // auto model_matrix = glm::scale(glm::identity<glm::mat4>(), glm::vec3(scale));
+        // auto texture = mesh->texture;
+        // auto illum_texture = mesh->illumination_texture;
+        // auto specular_texture = mesh->specular_texture;
+
+
+        // renderer.drawTexturedQuad(texture);
+        // model->render(model_matrix);
+#ifdef DEBUG
+        ShaderRegistry::ScopedShader shader(ShaderRegistry::Shaders::BasicColor);
+        {
+            // Common state - matrices.
+            glUniformMatrix4fv(shader.get().uniform(ShaderRegistry::Uniforms::Projection), 1, GL_FALSE, glm::value_ptr(projection));
+            glUniformMatrix4fv(shader.get().uniform(ShaderRegistry::Uniforms::View), 1, GL_FALSE, glm::value_ptr(view_matrix));
+            glUniformMatrix4fv(shader.get().uniform(ShaderRegistry::Uniforms::Model), 1, GL_FALSE, glm::value_ptr(model_matrix));
+
+            // Vertex attrib
+            gl::ScopedVertexAttribArray positions(shader.get().attribute(ShaderRegistry::Attributes::Position));
+
+            for (const EngineEmitterData& ee : model->engine_emitters)
+            {
+                glm::vec3 offset = ee.position * model->scale;
+                float r = model->scale * ee.scale * 0.5f;
+
+                glUniform4f(shader.get().uniform(ShaderRegistry::Uniforms::Color), ee.color.x, ee.color.y, ee.color.z, 1.f);
+                auto vertices = {
+                    glm::vec3{offset.x + r, offset.y, offset.z},
+                    glm::vec3{offset.x - r, offset.y, offset.z},
+                    glm::vec3{offset.x, offset.y + r, offset.z},
+                    glm::vec3{offset.x, offset.y - r, offset.z},
+                    glm::vec3{offset.x, offset.y, offset.z + r},
+                    glm::vec3{offset.x, offset.y, offset.z - r}
+                };
+                glVertexAttribPointer(positions.get(), 3, GL_FLOAT, GL_FALSE, sizeof(glm::vec3), std::begin(vertices));
+                glDrawArrays(GL_LINES, 0, vertices.size());
+            }
+            float r = model->getRadius() * 0.1f;
+
+            glUniform4f(shader.get().uniform(ShaderRegistry::Uniforms::Color), 1.f, 1.f, 1.f, 1.f);
+
+            for (const glm::vec3& position : model->beam_position)
+            {
+                glm::vec3 offset = position * model->scale;
+
+                auto vertices = {
+                    glm::vec3{offset.x + r, offset.y, offset.z},
+                    glm::vec3{offset.x - r, offset.y, offset.z},
+                    glm::vec3{offset.x, offset.y + r, offset.z},
+                    glm::vec3{offset.x, offset.y - r, offset.z},
+                    glm::vec3{offset.x, offset.y, offset.z + r},
+                    glm::vec3{offset.x, offset.y, offset.z - r}
+                };
+                glVertexAttribPointer(positions.get(), 3, GL_FLOAT, GL_FALSE, sizeof(glm::vec3), std::begin(vertices));
+                glDrawArrays(GL_LINES, 0, vertices.size());
+            }
+
+            for (const glm::vec3& position : model->tube_position)
+            {
+                glm::vec3 offset = position * model->scale;
+
+                auto vertices = {
+                    glm::vec3{offset.x + r * 3, offset.y, offset.z},
+                    glm::vec3{offset.x - r, offset.y, offset.z},
+                    glm::vec3{offset.x, offset.y + r, offset.z},
+                    glm::vec3{offset.x, offset.y - r, offset.z},
+                    glm::vec3{offset.x, offset.y, offset.z + r},
+                    glm::vec3{offset.x, offset.y, offset.z - r}
+                };
+                glVertexAttribPointer(positions.get(), 3, GL_FLOAT, GL_FALSE, sizeof(glm::vec3), std::begin(vertices));
+                glDrawArrays(GL_LINES, 0, vertices.size());
+            }
+        }
+#endif
+    }
+
+    glDisable(GL_CULL_FACE);
+    glDisable(GL_DEPTH_TEST);
+    glEnable(GL_BLEND);
+    glBlendFunc(GL_SRC_ALPHA, GL_ONE_MINUS_SRC_ALPHA);
+
+    glViewport(0, 0, renderer.getPhysicalSize().x, renderer.getPhysicalSize().y);
+
     /*TODO
     if (rect.size.x <= 0) return;
     if (rect.size.y <= 0) return;
@@ -89,7 +294,7 @@ void GuiRotatingModelView::onDraw(sp::RenderTarget& renderer)
                 glDrawArrays(GL_LINES, 0, vertices.size());
             }
             float r = model->getRadius() * 0.1f;
-            
+
             glUniform4f(shader.get().uniform(ShaderRegistry::Uniforms::Color), 1.f, 1.f, 1.f, 1.f);
 
             for (const glm::vec3& position : model->beam_position)
@@ -107,7 +312,7 @@ void GuiRotatingModelView::onDraw(sp::RenderTarget& renderer)
                 glVertexAttribPointer(positions.get(), 3, GL_FLOAT, GL_FALSE, sizeof(glm::vec3), std::begin(vertices));
                 glDrawArrays(GL_LINES, 0, vertices.size());
             }
-            
+
             for (const glm::vec3& position : model->tube_position)
             {
                 glm::vec3 offset = position * model->scale;

--- a/src/screenComponents/rotatingModelView.cpp
+++ b/src/screenComponents/rotatingModelView.cpp
@@ -97,7 +97,8 @@ void GuiRotatingModelView::onDraw(sp::RenderTarget& renderer)
     // EE's coordinate flips to a Z-up left hand.
     // To account for that, flip the model around 180deg.
     auto modeldata_matrix = glm::rotate(model_matrix, glm::radians(180.f), {0.f, 0.f, 1.f});
-    modeldata_matrix = glm::scale(modeldata_matrix, glm::vec3{mesh->scale});
+    float scale = 100.0f / mesh->mesh.ptr->greatest_distance_from_center;
+    modeldata_matrix = glm::scale(modeldata_matrix, glm::vec3{scale});
     //modeldata_matrix = glm::translate(modeldata_matrix, mrc.mesh_offset); // Old mesh offset
 
     auto shader_id = ShaderRegistry::Shaders::Object;

--- a/src/screenComponents/rotatingModelView.cpp
+++ b/src/screenComponents/rotatingModelView.cpp
@@ -26,17 +26,15 @@ void GuiRotatingModelView::onDraw(sp::RenderTarget& renderer)
 {
 
     if (rect.size.x <= 0) {
-        LOG(INFO) << "Returning because rect.size.x <= 0 (" << rect.size.x << ")";
         return;
     }
     if (rect.size.y <= 0) {
-        LOG(INFO) << "Returning because rect.size.y <= 0 (" << rect.size.y << ")";
         return;
     }
     if (!mesh) {
-        LOG(INFO) << "Returning because no mesh";
         return;
     }
+
     renderer.finish();
 
     float camera_fov = 60.0f;
@@ -116,15 +114,6 @@ void GuiRotatingModelView::onDraw(sp::RenderTarget& renderer)
         glActiveTexture(GL_TEXTURE0);
 
     {
-        // float scale = 100.0f;// / mesh->getRadius(); // mesh->getScale() ?
-        // auto model_matrix = glm::scale(glm::identity<glm::mat4>(), glm::vec3(scale));
-        // auto texture = mesh->texture;
-        // auto illum_texture = mesh->illumination_texture;
-        // auto specular_texture = mesh->specular_texture;
-
-
-        // renderer.drawTexturedQuad(texture);
-        // model->render(model_matrix);
 #ifdef DEBUG
         ShaderRegistry::ScopedShader shader(ShaderRegistry::Shaders::BasicColor);
         {
@@ -198,46 +187,6 @@ void GuiRotatingModelView::onDraw(sp::RenderTarget& renderer)
     glBlendFunc(GL_SRC_ALPHA, GL_ONE_MINUS_SRC_ALPHA);
 
     glViewport(0, 0, renderer.getPhysicalSize().x, renderer.getPhysicalSize().y);
-
-    /*TODO
-    if (rect.size.x <= 0) return;
-    if (rect.size.y <= 0) return;
-    if (!model) return;
-    renderer.finish();
-
-    float camera_fov = 60.0f;
-    auto p0 = renderer.virtualToPixelPosition(rect.position);
-    auto p1 = renderer.virtualToPixelPosition(rect.position + rect.size);
-    glViewport(p0.x, renderer.getPhysicalSize().y - p1.y, p1.x - p0.x, p1.y - p0.y);
-
-    if (GLAD_GL_ES_VERSION_2_0)
-        glClearDepthf(1.f);
-    else
-        glClearDepth(1.f);
-
-    glClear(GL_DEPTH_BUFFER_BIT);
-    glDepthMask(GL_TRUE);
-    glEnable(GL_CULL_FACE);
-
-    auto projection = glm::perspective(glm::radians(camera_fov), rect.size.x / rect.size.y, 1.f, 25000.f);
-    auto view_matrix = glm::rotate(glm::identity<glm::mat4>(), glm::radians(90.f), glm::vec3(1.f, 0.f, 0.f));
-    view_matrix = glm::scale(view_matrix, glm::vec3(1.f, 1.f, -1.f));
-    view_matrix = glm::translate(view_matrix, glm::vec3(0.f, -200.f, 0.f));
-    view_matrix = glm::rotate(view_matrix, glm::radians(-30.f), glm::vec3(1.f, 0.f, 0.f));
-    view_matrix = glm::rotate(view_matrix, glm::radians(engine->getElapsedTime() * 360.0f / 10.0f), glm::vec3(0.f, 0.f, 1.f));
-
-    glDisable(GL_BLEND);
-    glBindTexture(GL_TEXTURE_2D, 0);
-    glDepthMask(true);
-    glEnable(GL_DEPTH_TEST);
-
-
-    ShaderRegistry::updateProjectionView(projection, view_matrix);
-
-    {
-        float scale = 100.0f / model->getRadius();
-        auto model_matrix = glm::scale(glm::identity<glm::mat4>(), glm::vec3(scale));
-        model->render(model_matrix);
 #ifdef DEBUG
         ShaderRegistry::ScopedShader shader(ShaderRegistry::Shaders::BasicColor);
         {
@@ -303,10 +252,4 @@ void GuiRotatingModelView::onDraw(sp::RenderTarget& renderer)
             }
         }
 #endif
-    }
-    glDisable(GL_CULL_FACE);
-    glDisable(GL_DEPTH_TEST);
-    glEnable(GL_BLEND);
-    glViewport(0, 0, renderer.getPhysicalSize().x, renderer.getPhysicalSize().y);
-    */
 }

--- a/src/screenComponents/rotatingModelView.cpp
+++ b/src/screenComponents/rotatingModelView.cpp
@@ -56,13 +56,7 @@ void GuiRotatingModelView::onDraw(sp::RenderTarget& renderer)
     glFrontFace(GL_CCW);
 
 
-    auto loaded = mesh->ensureLoaded();
-
-    if(!loaded) {
-        return;
-    }
-
-    auto mesh_radius = mrc->mesh.ptr->greatest_distance_from_center;
+    auto mesh_radius = mrc->getMesh()->greatest_distance_from_center;
     float mesh_diameter = mesh_radius * 2.f;
     float near_clip_boundary = 1.f;
 
@@ -83,7 +77,7 @@ void GuiRotatingModelView::onDraw(sp::RenderTarget& renderer)
 
     ShaderRegistry::updateProjectionView(projection_matrix, view_matrix);
 
-    auto model_matrix = calculateModelMatrix(glm::vec2{}, 0.f, *mrc, scale);
+    auto model_matrix = calculateModelMatrix(glm::vec2{}, 0.f, mrc->mesh_offset, scale);
 
     auto shader = lookUpShader(*mrc);
     glUniformMatrix4fv(shader.get().uniform(ShaderRegistry::Uniforms::Model), 1, GL_FALSE, glm::value_ptr(model_matrix));

--- a/src/screenComponents/rotatingModelView.cpp
+++ b/src/screenComponents/rotatingModelView.cpp
@@ -26,17 +26,11 @@ GuiRotatingModelView::GuiRotatingModelView(GuiContainer* owner, string id, sp::e
 void GuiRotatingModelView::onDraw(sp::RenderTarget& renderer)
 {
 
-    if (rect.size.x <= 0) {
-        return;
-    }
-    if (rect.size.y <= 0) {
-        return;
-    }
+    if (rect.size.x <= 0) return;
+    if (rect.size.y <= 0) return;
 
     auto mrc = entity.getComponent<MeshRenderComponent>();
-    if (!mrc) {
-        return;
-    }
+    if (!mrc) return;
 
     renderer.finish();
 

--- a/src/screenComponents/rotatingModelView.cpp
+++ b/src/screenComponents/rotatingModelView.cpp
@@ -54,19 +54,20 @@ void GuiRotatingModelView::onDraw(sp::RenderTarget& renderer)
     glCullFace(GL_BACK);
     glFrontFace(GL_CCW);
 
-    auto projection_matrix = glm::perspective(glm::radians(camera_fov), rect.size.x / rect.size.y, 1.f, 25000.f);
 
     mesh->ensureLoaded();
     auto mesh_radius = mesh->mesh.ptr->greatest_distance_from_center;
     float mesh_diameter = mesh_radius * 2.f;
+    float near_clip_boundary = 1.f;
 
+    auto projection_matrix = glm::perspective(glm::radians(camera_fov), rect.size.x / rect.size.y, near_clip_boundary, 25000.f);
     float max_size = mesh_diameter * glm::tan(glm::radians(camera_fov / 2.f));
     float scale = max_size / mesh_diameter;
 
     // OpenGL standard: X across (left-to-right), Y up, Z "towards".
     auto view_matrix = glm::rotate(glm::identity<glm::mat4>(), glm::radians(90.f), glm::vec3(1.f, 0.f, 0.f)); // -> X across (l-t-r), Y "towards", Z down
     view_matrix = glm::scale(view_matrix, glm::vec3(1.f, 1.f, -1.f)); // -> X across (l-t-r), Y "towards", Z up
-    view_matrix = glm::translate(view_matrix, glm::vec3(0.f, -1.f * max_size , 0.f));
+    view_matrix = glm::translate(view_matrix, glm::vec3(0.f, -1.f * max_size - near_clip_boundary, 0.f));
     view_matrix = glm::rotate(view_matrix, glm::radians(-30.f), glm::vec3(1.f, 0.f, 0.f));
     view_matrix = glm::rotate(view_matrix, glm::radians(engine->getElapsedTime() * 360.0f / 10.0f), glm::vec3(0.f, 0.f, 1.f));
 

--- a/src/screenComponents/rotatingModelView.h
+++ b/src/screenComponents/rotatingModelView.h
@@ -2,13 +2,14 @@
 #define ROTATING_MODEL_VIEW_H
 
 #include "gui/gui2_element.h"
+#include "components/rendering.h"
 
 class GuiRotatingModelView : public GuiElement
 {
 private:
-    //TODO: P<ModelData> model;
+    MeshRenderComponent *mesh;
 public:
-    GuiRotatingModelView(GuiContainer* owner, string id /*TODO, P<ModelData> model*/);
+    GuiRotatingModelView(GuiContainer* owner, string id, MeshRenderComponent *mesh);
 
     virtual void onDraw(sp::RenderTarget& target) override;
 };

--- a/src/screenComponents/rotatingModelView.h
+++ b/src/screenComponents/rotatingModelView.h
@@ -7,9 +7,9 @@
 class GuiRotatingModelView : public GuiElement
 {
 private:
-    MeshRenderComponent *mesh;
+    sp::ecs::Entity &entity;
 public:
-    GuiRotatingModelView(GuiContainer* owner, string id, MeshRenderComponent *mesh);
+    GuiRotatingModelView(GuiContainer* owner, string id, sp::ecs::Entity& entity);
 
     virtual void onDraw(sp::RenderTarget& target) override;
 };

--- a/src/systems/rendering.cpp
+++ b/src/systems/rendering.cpp
@@ -105,6 +105,7 @@ void MeshRenderSystem::render3D(sp::ecs::Entity e, sp::Transform& transform, Mes
     glUniformMatrix4fv(shader.get().uniform(ShaderRegistry::Uniforms::Model), 1, GL_FALSE, glm::value_ptr(modeldata_matrix));
 
     // Lights setup.
+    // FIX!!: temporarily using flipped matrix here.
     ShaderRegistry::setupLights(shader.get(), modeldata_matrix);
 
     // Textures

--- a/src/systems/rendering.cpp
+++ b/src/systems/rendering.cpp
@@ -61,8 +61,11 @@ void RenderSystem::render3D(float aspect, float camera_fov)
     }
 }
 
-glm::mat4 calculateModelMatrix(glm::vec2 position, float rotation, MeshRenderComponent& mrc, float scale_override = -1.) {
-    float scale = scale_override > 0 ? scale_override : mrc.scale;
+glm::mat4 calculateModelMatrix(glm::vec2 position, float rotation, MeshRenderComponent& mrc) {
+    return calculateModelMatrix(position, rotation, mrc, mrc.scale);
+}
+
+glm::mat4 calculateModelMatrix(glm::vec2 position, float rotation, MeshRenderComponent& mrc, float scale) {
     auto model_matrix = glm::translate(glm::identity<glm::mat4>(), glm::vec3{ position.x, position.y, 0.f });
     model_matrix = glm::rotate(model_matrix, glm::radians(rotation), glm::vec3{ 0.f, 0.f, 1.f });
     model_matrix = glm::translate(model_matrix, mrc.mesh_offset);

--- a/src/systems/rendering.cpp
+++ b/src/systems/rendering.cpp
@@ -11,6 +11,12 @@
 
 std::vector<RenderSystem::RenderHandler> RenderSystem::render_handlers;
 
+/**
+ * Ensure mesh, texture, specular texture and illumation texture
+ * are cached and available.
+ * return `true` if there is at least a mesh and rendering is possible, even if no textures are found.
+ * return `false` if there is no mesh, and rendering is not possible.
+ */
 bool MeshRenderComponent::ensureLoaded()
 {
     if (!mesh.ptr && !mesh.name.empty())
@@ -124,7 +130,11 @@ void MeshRenderSystem::update(float delta)
 
 void MeshRenderSystem::render3D(sp::ecs::Entity e, sp::Transform& transform, MeshRenderComponent& mrc)
 {
-    mrc.ensureLoaded();
+    auto loaded = mrc.ensureLoaded();
+
+    if(!loaded) {
+        return;
+    }
 
     auto model_matrix = calculateModelMatrix(
             transform.getPosition(),

--- a/src/systems/rendering.cpp
+++ b/src/systems/rendering.cpp
@@ -69,13 +69,9 @@ glm::mat4 calculateModelMatrix(glm::vec2 position, float rotation, MeshRenderCom
     auto model_matrix = glm::translate(glm::identity<glm::mat4>(), glm::vec3{ position.x, position.y, 0.f });
     model_matrix = glm::rotate(model_matrix, glm::radians(rotation), glm::vec3{ 0.f, 0.f, 1.f });
     model_matrix = glm::translate(model_matrix, mrc.mesh_offset);
+    model_matrix = glm::scale(model_matrix, glm::vec3{scale});
 
-    // EE's coordinate flips to a Z-up left hand.
-    // To account for that, flip the model around 180deg.
-    auto modeldata_matrix = glm::rotate(model_matrix, glm::radians(180.f), {0.f, 0.f, 1.f});
-    modeldata_matrix = glm::scale(modeldata_matrix, glm::vec3{scale});
-    //modeldata_matrix = glm::translate(modeldata_matrix, mrc.mesh_offset); // Old mesh offset
-    return modeldata_matrix;
+    return model_matrix;
 }
 
 ShaderRegistry::ScopedShader lookUpShader(MeshRenderComponent& mrc)

--- a/src/systems/rendering.h
+++ b/src/systems/rendering.h
@@ -70,7 +70,7 @@ private:
 
 template<typename COMPONENT, bool TRANSPARENT> Render3DInterface<COMPONENT, TRANSPARENT>::Render3DInterface() { RenderSystem::add3DHandler(this); }
 
-// FIX: This is obviously a very inelegant way to share behavior
+// FIX: This is obviously not the right place to define these utility functions
 glm::mat4 calculateModelMatrix(glm::vec2 position, float rotation, glm::vec3 mesh_offset, float scale);
 ShaderRegistry::ScopedShader lookUpShader(MeshRenderComponent& mrc);
 void activateAndBindMeshTextures(MeshRenderComponent& mrc);

--- a/src/systems/rendering.h
+++ b/src/systems/rendering.h
@@ -67,7 +67,12 @@ private:
     };
     static std::vector<RenderHandler> render_handlers;
 };
+
 template<typename COMPONENT, bool TRANSPARENT> Render3DInterface<COMPONENT, TRANSPARENT>::Render3DInterface() { RenderSystem::add3DHandler(this); }
+
+// FIX: This is obviously a very inelegant way to share behavior
+glm::mat4 calculateModelMatrix(glm::vec2 position, float rotation, MeshRenderComponent& mrc, float scale_override);
+ShaderRegistry::ScopedShader lookUpShader(MeshRenderComponent& mrc);
 
 class MeshRenderSystem : public sp::ecs::System, public Render3DInterface<MeshRenderComponent, false>
 {

--- a/src/systems/rendering.h
+++ b/src/systems/rendering.h
@@ -73,6 +73,8 @@ template<typename COMPONENT, bool TRANSPARENT> Render3DInterface<COMPONENT, TRAN
 // FIX: This is obviously a very inelegant way to share behavior
 glm::mat4 calculateModelMatrix(glm::vec2 position, float rotation, MeshRenderComponent& mrc, float scale_override);
 ShaderRegistry::ScopedShader lookUpShader(MeshRenderComponent& mrc);
+void activateAndBindMeshTextures(MeshRenderComponent& mrc);
+void drawMesh(MeshRenderComponent& mrc, ShaderRegistry::ScopedShader& shader);
 
 class MeshRenderSystem : public sp::ecs::System, public Render3DInterface<MeshRenderComponent, false>
 {

--- a/src/systems/rendering.h
+++ b/src/systems/rendering.h
@@ -71,7 +71,8 @@ private:
 template<typename COMPONENT, bool TRANSPARENT> Render3DInterface<COMPONENT, TRANSPARENT>::Render3DInterface() { RenderSystem::add3DHandler(this); }
 
 // FIX: This is obviously a very inelegant way to share behavior
-glm::mat4 calculateModelMatrix(glm::vec2 position, float rotation, MeshRenderComponent& mrc, float scale_override);
+glm::mat4 calculateModelMatrix(glm::vec2 position, float rotation, MeshRenderComponent& mrc);
+glm::mat4 calculateModelMatrix(glm::vec2 position, float rotation, MeshRenderComponent& mrc, float scale);
 ShaderRegistry::ScopedShader lookUpShader(MeshRenderComponent& mrc);
 void activateAndBindMeshTextures(MeshRenderComponent& mrc);
 void drawMesh(MeshRenderComponent& mrc, ShaderRegistry::ScopedShader& shader);

--- a/src/systems/rendering.h
+++ b/src/systems/rendering.h
@@ -71,8 +71,7 @@ private:
 template<typename COMPONENT, bool TRANSPARENT> Render3DInterface<COMPONENT, TRANSPARENT>::Render3DInterface() { RenderSystem::add3DHandler(this); }
 
 // FIX: This is obviously a very inelegant way to share behavior
-glm::mat4 calculateModelMatrix(glm::vec2 position, float rotation, MeshRenderComponent& mrc);
-glm::mat4 calculateModelMatrix(glm::vec2 position, float rotation, MeshRenderComponent& mrc, float scale);
+glm::mat4 calculateModelMatrix(glm::vec2 position, float rotation, glm::vec3 mesh_offset, float scale);
 ShaderRegistry::ScopedShader lookUpShader(MeshRenderComponent& mrc);
 void activateAndBindMeshTextures(MeshRenderComponent& mrc);
 void drawMesh(MeshRenderComponent& mrc, ShaderRegistry::ScopedShader& shader);


### PR DESCRIPTION
In the first few commits, this was close to a copy/paste from `MeshRenderSystem::render3D` to `GuiRotatingModelView::onDraw`.  If duplicating the rendering pipeline in these two places is sufficient, I'm happy to simplify this PR back down to that.

That said, the rest of the work is an attempt at re-using some of the code between `render3D` and `onDraw` without compromising the clarity of the render system to serve the one-off needs of `onDraw`.  I will admit that the likelihood of render code changing often is pretty low, so maybe this kind of re-use isn't that critical here.

Aside: Again, I'm pretty new to C++, so I'm open to thoughtful feedback on language features I'm misusing, or weaknesses I might be inadvertently introducing, or patterns that make more sense than what I've put in. 

I've opted to save the debug work for a separate PR to keep this one a bit smaller, but I did leave one piece from my exploration there in this series of commits https://github.com/daid/EmptyEpsilon/pull/2140/commits/2d0405c3a9cf62d1ec288e346359e9aa3e45aadf.  I think it'll be useful to have an entity in order to enumerate and render emitters.