### PR TITLE
Fix combat maneuver generating heat without firing any thrusters

### DIFF
--- a/src/spaceObjects/spaceship.cpp
+++ b/src/spaceObjects/spaceship.cpp
@@ -1153,6 +1153,19 @@ void SpaceShip::update(float delta)
             combat_maneuver_strafe_active = combat_maneuver_strafe_request;
     }
 
+    // If the ship doesn't have thrusters in a given direction, don't try to fire them.
+    if (combat_maneuver_boost_speed == 0)
+    {
+        combat_maneuver_boost_active = 0.0;
+        combat_maneuver_boost_request = 0.0;
+    }
+
+    if (combat_maneuver_strafe_speed == 0)
+    {
+        combat_maneuver_strafe_active = 0.0;
+        combat_maneuver_strafe_request = 0.0;
+    }
+
     // If the ship is making a combat maneuver ...
     if (combat_maneuver_boost_active != 0.0f || combat_maneuver_strafe_active != 0.0f)
     {
@@ -1170,6 +1183,10 @@ void SpaceShip::update(float delta)
         {
             setVelocity(getVelocity() + forward * combat_maneuver_boost_speed * combat_maneuver_boost_active);
             setVelocity(getVelocity() + vec2FromAngle(getRotation() + 90) * combat_maneuver_strafe_speed * combat_maneuver_strafe_active);
+
+            // Add heat to systems consuming combat maneuver boost.
+            addHeat(SYS_Impulse, fabs(combat_maneuver_boost_active) * delta * heat_per_combat_maneuver_boost);
+            addHeat(SYS_Maneuver, fabs(combat_maneuver_strafe_active) * delta * heat_per_combat_maneuver_strafe);
         }
     // If the ship isn't making a combat maneuver, recharge its boost.
     }else if (combat_maneuver_charge < 1.0f)
@@ -1178,10 +1195,6 @@ void SpaceShip::update(float delta)
         if (combat_maneuver_charge > 1.0f)
             combat_maneuver_charge = 1.0f;
     }
-
-    // Add heat to systems consuming combat maneuver boost.
-    addHeat(SYS_Impulse, fabs(combat_maneuver_boost_active) * delta * heat_per_combat_maneuver_boost);
-    addHeat(SYS_Maneuver, fabs(combat_maneuver_strafe_active) * delta * heat_per_combat_maneuver_strafe);
 
     for(int n = 0; n < max_beam_weapons; n++)
     {


### PR DESCRIPTION
- Attempting to maneuver in a direction the ship can't maneuver does nothing. No heat, no thrust, no inhibiting recharge.
- Attempting to maneuver in a direction the ship _can_ maneuver, but without charge results in little to no heat and thrust, and no combat maneuver recharge.

Pre-PR behaviour is that both of these situations result in full heating to the relevant ship system, making it _very_ easy for Helms to damage/break a system without realising it.