### PR TITLE
hardware: fix blink effect on and off

### DIFF
--- a/src/hardware/hardwareMappingEffects.cpp
+++ b/src/hardware/hardwareMappingEffects.cpp
@@ -75,9 +75,9 @@ float HardwareMappingEffectBlink::onActive()
         timer.start(on ? on_time : off_time);
     }
     if (on)
-        return off_value;
-    else
         return on_value;
+    else
+        return off_value;
 }
 
 void HardwareMappingEffectBlink::onInactive()


### PR DESCRIPTION
on_time and off_time were switched.

This caused new blink effects to start with on_time seconds switched off followed by off_time seconds switched on.