### PR TITLE
Fix some issues in ECS API bindings

### DIFF
--- a/scripts/api/entity/cpuship.lua
+++ b/scripts/api/entity/cpuship.lua
@@ -135,7 +135,7 @@ end
 --- Returns the order's x,y coordinates, or 0,0 if not defined.
 --- Example: x,y = ship:getOrderTargetLocation()
 function Entity:getOrderTargetLocation()
-    if self.components.ai_controller then return unpack(e.ai_controller.order_target_location) end
+    if self.components.ai_controller then return table.unpack(self.components.ai_controller.order_target_location) end
 end
 --- Returns the target SpaceObject for this CpuShip's orders.
 --- If the orders target coordinates instead of an object, use CpuShip:getOrderTargetLocation().

--- a/scripts/api/entity/shiptemplatebasedobject.lua
+++ b/scripts/api/entity/shiptemplatebasedobject.lua
@@ -66,6 +66,7 @@ end
 --- Example: stbo:setTypeName("Prototype")
 function Entity:setTypeName(type_name)
     self.components.typename = {type_name=type_name}
+    return self
 end
 --- Returns this STBO's vessel classification name.
 --- Example:

--- a/src/script/components.cpp
+++ b/src/script/components.cpp
@@ -333,6 +333,7 @@ void initComponentScriptBindings()
     BIND_MEMBER(Hull, current);
     BIND_MEMBER(Hull, max);
     BIND_MEMBER(Hull, allow_destruction);
+    BIND_MEMBER(Hull, on_destruction);
     BIND_MEMBER_FLAG(Hull, damaged_by_flags, "damaged_by_energy", (1 << int(DamageType::Energy)));
     BIND_MEMBER_FLAG(Hull, damaged_by_flags, "damaged_by_kinetic", (1 << int(DamageType::Kinetic)));
     BIND_MEMBER_FLAG(Hull, damaged_by_flags, "damaged_by_emp", (1 << int(DamageType::EMP)));


### PR DESCRIPTION
- `getOrderTargetLocation` had broken code
- `setTypeName` didn't return `self`
- `components.hull.on_destruction` was used in the API but not bound