### PR TITLE
Add radar signature to artifacts and suggest using probes in scenario "Birth of the Atlantis"

### DIFF
--- a/scripts/scenario_08_atlantis.lua
+++ b/scripts/scenario_08_atlantis.lua
@@ -147,7 +147,7 @@ function init()
 
     nebula = table.remove(b20_nebula_list, math.random(#b20_nebula_list))
     x, y = nebula:getPosition()
-    b20_artifact = Artifact():setPosition(x + random(-1000, 1000), y + random(-1000, 1000)):setRadarTraceColor(250, 79, 255)
+    b20_artifact = Artifact():setPosition(x + random(-1000, 1000), y + random(-1000, 1000)):setRadarTraceColor(250, 79, 255):setRadarSignatureInfo(0.25, 0, 0)
     b20_artifact:setScanningParameters(3, 1)
     b20_artifact.nebula = nebula
     b20_artifact.beta_radiation = irandom(1, 10)
@@ -171,11 +171,11 @@ Doppler instability: %i]]),
     )
 
     x, y = table.remove(b20_nebula_list, math.random(#b20_nebula_list)):getPosition()
-    b20_dummy_artifact_1 = Artifact():setPosition(x + random(-1000, 1000), y + random(-1000, 1000)):setRadarTraceColor(250, 79, 255):setDescriptions(_("scienceDescription-artifact", "An odd object floating in space."), _("scienceDescription-artifact", "This object seems to be inert, and not giving any readings on your sensors. The actual object must be somewhere else."))
+    b20_dummy_artifact_1 = Artifact():setPosition(x + random(-1000, 1000), y + random(-1000, 1000)):setRadarTraceColor(250, 79, 255):setDescriptions(_("scienceDescription-artifact", "An odd object floating in space."), _("scienceDescription-artifact", "This object seems to be inert, and not giving any interesting readings on your sensors. The actual object must be somewhere else.")):setRadarSignatureInfo(0.25, 0, 0)
     b20_dummy_artifact_1:setScanningParameters(3, 1)
 
     x, y = table.remove(b20_nebula_list, math.random(#b20_nebula_list)):getPosition()
-    b20_dummy_artifact_2 = Artifact():setPosition(x + random(-1000, 1000), y + random(-1000, 1000)):setRadarTraceColor(250, 79, 255):setDescriptions(_("scienceDescription-artifact", "An odd object floating in space."), _("scienceDescription-artifact", "This object seems to be inert, and not giving any readings on your sensors. The actual object must be somewhere else."))
+    b20_dummy_artifact_2 = Artifact():setPosition(x + random(-1000, 1000), y + random(-1000, 1000)):setRadarTraceColor(250, 79, 255):setDescriptions(_("scienceDescription-artifact", "An odd object floating in space."), _("scienceDescription-artifact", "This object seems to be inert, and not giving any interesting readings on your sensors. The actual object must be somewhere else.")):setRadarSignatureInfo(0.25, 0, 0)
     b20_dummy_artifact_2:setScanningParameters(3, 1)
 
     x, y = table.remove(b20_nebula_list, math.random(#b20_nebula_list)):getPosition()
@@ -422,7 +422,7 @@ Here we are, sector B20. Looks like there are some lingering Kraylor here.
 
 We are outside of the no-fire zone and at war with the Kraylor, so you are clear to engage.
 
-Report back when you have found the source of the odd sensor readings.]])
+Report back when you have found the source of the odd sensor readings. This should be a good opportunity to make use of your ship's probes, or your Science Officer might be able to track it down based on its radar signature.]])
         )
         mission_state = phase2SeekArtifact
     end
@@ -885,7 +885,7 @@ Can you move closer to the object to see if you can improve those readings? The 
     addCommsReply(
         _("artifact-comms", "No."),
         function()
-            setCommsMessage(_("artifact-comms", [[Then continue looking for it.]]))
+            setCommsMessage(_("artifact-comms", [[Then continue looking for it. Try launching some probes or asking the Science Officer if they notice any odd radar signatures.]]))
         end
     )
 end

--- a/scripts/scenario_08_atlantis.lua
+++ b/scripts/scenario_08_atlantis.lua
@@ -778,7 +778,7 @@ function shipyardGammaComms()
         addCommsReply(
             _("station-comms", "Yes."),
             function()
-                setCommsMessage(_("station-comms", [[Good. Your first mission is to identify odd readings coming from the nebula cloud in sector B20.
+                setCommsMessage(_("station-comms", [[Good. Your first mission is to identify odd readings coming from the nebula cloud near sector B20.
 
 Your ship is not equipped to travel this distance by itself, so we have tasked jump carrier JC-88 to take you there.
 

--- a/scripts/scenario_08_atlantis.lua
+++ b/scripts/scenario_08_atlantis.lua
@@ -448,7 +448,7 @@ end
 function phase2WaitTillAwayFromObject(delta)
     if distance(player, b20_artifact) > 2200 then
         setCommsMessage(_("artifact-comms", [[It seems like the artifact is stabilizing.
-It would be good to get some more reading a bit closer, as the nebula causes our sensor ]]))
+It would be good to get some more readings close to the object, as the nebula may be causing issues for your sensors.]]))
         mission_state = phase2WaitTillNearObject
     elseif distance(player, b20_artifact) > 2000 then
         phase2SpawnWormhole()
@@ -862,7 +862,7 @@ These readings indicate it is very unstable! Please move away from it.]]))
                                                                 else
                                                                     setCommsMessage(_("artifact-comms", [[Are you sure? Those readings are really off the normal scale.
 
-Can you move closer to the object to see if you can improve those readings? The nebula might be interfering with your sensors.]]))
+Can you move close to the object and get a second readings? The nebula might be interfering with your sensors.]]))
                                                                     mission_state = phase2WaitTillNearObject
                                                                 end
                                                             else

--- a/scripts/scenario_08_atlantis.lua
+++ b/scripts/scenario_08_atlantis.lua
@@ -447,7 +447,7 @@ end
 
 function phase2WaitTillAwayFromObject(delta)
     if distance(player, b20_artifact) > 2200 then
-        setCommsMessage(_("artifact-comms", [[It seems like the artifact is stablizing.
+        setCommsMessage(_("artifact-comms", [[It seems like the artifact is stabilizing.
 It would be good to get some more reading a bit closer, as the nebula causes our sensor ]]))
         mission_state = phase2WaitTillNearObject
     elseif distance(player, b20_artifact) > 2000 then

--- a/scripts/scenario_08_atlantis.lua
+++ b/scripts/scenario_08_atlantis.lua
@@ -147,7 +147,7 @@ function init()
 
     nebula = table.remove(b20_nebula_list, math.random(#b20_nebula_list))
     x, y = nebula:getPosition()
-    b20_artifact = Artifact():setPosition(x + random(-1000, 1000), y + random(-1000, 1000))
+    b20_artifact = Artifact():setPosition(x + random(-1000, 1000), y + random(-1000, 1000)):setRadarTraceColor(250, 79, 255)
     b20_artifact:setScanningParameters(3, 1)
     b20_artifact.nebula = nebula
     b20_artifact.beta_radiation = irandom(1, 10)
@@ -171,11 +171,11 @@ Doppler instability: %i]]),
     )
 
     x, y = table.remove(b20_nebula_list, math.random(#b20_nebula_list)):getPosition()
-    b20_dummy_artifact_1 = Artifact():setPosition(x + random(-1000, 1000), y + random(-1000, 1000)):setDescriptions(_("scienceDescription-artifact", "An odd object floating in space."), _("scienceDescription-artifact", "This object seems to be inert, and not giving any readings on your sensors. The actual object must be somewhere else."))
+    b20_dummy_artifact_1 = Artifact():setPosition(x + random(-1000, 1000), y + random(-1000, 1000)):setRadarTraceColor(250, 79, 255):setDescriptions(_("scienceDescription-artifact", "An odd object floating in space."), _("scienceDescription-artifact", "This object seems to be inert, and not giving any readings on your sensors. The actual object must be somewhere else."))
     b20_dummy_artifact_1:setScanningParameters(3, 1)
 
     x, y = table.remove(b20_nebula_list, math.random(#b20_nebula_list)):getPosition()
-    b20_dummy_artifact_2 = Artifact():setPosition(x + random(-1000, 1000), y + random(-1000, 1000)):setDescriptions(_("scienceDescription-artifact", "An odd object floating in space."), _("scienceDescription-artifact", "This object seems to be inert, and not giving any readings on your sensors. The actual object must be somewhere else."))
+    b20_dummy_artifact_2 = Artifact():setPosition(x + random(-1000, 1000), y + random(-1000, 1000)):setRadarTraceColor(250, 79, 255):setDescriptions(_("scienceDescription-artifact", "An odd object floating in space."), _("scienceDescription-artifact", "This object seems to be inert, and not giving any readings on your sensors. The actual object must be somewhere else."))
     b20_dummy_artifact_2:setScanningParameters(3, 1)
 
     x, y = table.remove(b20_nebula_list, math.random(#b20_nebula_list)):getPosition()


### PR DESCRIPTION
I played this scenario with some new players, and it took over an hour for them to complete Phase 2 (of 5 phases).

They felt that there was too much time "blindly wandering around" the nebula looking for the artifact. When they did come near one of the artifacts, it appeared on the edge of the radar, so they missed it and then got distracted with one of the Ghosts. I swapped to the GM screen to tell them to go back since we had already been searching for a while at that point. This was kind of discouraging to them (flying through a nebula isn't what makes EmptyEpsilon interesting) and they didn't get to do much combat since we had to stop playing right after that.

I've removed some of the nebula from 8 to 6 so there's less players have to search through. I also spaced them out to encourage players to jump between nebula (rather than flying slowly with impulse), and so that its easier to keep track of which nebula they've searched (it used to appear like one massive nebula on the player's screen).

## Before:
![Before](https://github.com/user-attachments/assets/eeeb1883-8efb-4cfd-aa4d-84042053357d)

## After:
![After](https://github.com/user-attachments/assets/82828b24-de03-420d-9039-7deb17982240)

