### PR TITLE
Server scenario improvements

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -420,7 +420,7 @@ int main(int argc, char** argv)
             return 1;
 
         // Load the scenario and open the ship selection screen.
-        gameGlobalInfo->startScenario(PreferencesManager::get("server_scenario"));
+        gameGlobalInfo->startScenario(PreferencesManager::get("server_scenario"), loadScenarioSettingsFromPrefs());
         new ShipSelectionScreen();
     }
 
@@ -475,7 +475,7 @@ void returnToMainMenu(RenderLayer* render_layer)
         if (PreferencesManager::get("headless_name") != "") game_server->setServerName(PreferencesManager::get("headless_name"));
         if (PreferencesManager::get("headless_password") != "") game_server->setPassword(PreferencesManager::get("headless_password").upper());
         if (PreferencesManager::get("headless_internet") == "1") game_server->registerOnMasterServer(PreferencesManager::get("registry_registration_url", "http://daid.eu/ee/register.php"));
-        gameGlobalInfo->startScenario(PreferencesManager::get("headless"));
+        gameGlobalInfo->startScenario(PreferencesManager::get("headless"), loadScenarioSettingsFromPrefs());
 
         if (PreferencesManager::get("startpaused") != "1")
             engine->setGameSpeed(1.0);
@@ -518,4 +518,26 @@ void returnToShipSelection(RenderLayer* render_layer)
 void returnToOptionMenu()
 {
     new OptionsMenu();
+}
+
+std::unordered_map<string, string> loadScenarioSettingsFromPrefs()
+{
+    string preferenceValue = PreferencesManager::get("scenario_settings");
+
+    std::unordered_map<string, string> settings = {};
+    if (preferenceValue == "")
+        return settings;
+
+    for(string setting : preferenceValue.split(";"))
+    {
+        std::vector<string> key_value = setting.split("=", 1);
+        string key = key_value[0].strip();
+        if (key.length() < 1)
+            continue;
+
+        if (key_value.size() == 2)
+            settings[key] = key_value[1];
+    }
+
+    return settings;
 }

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -416,6 +416,9 @@ int main(int argc, char** argv)
         // Create the server.
         new EpsilonServer(defaultServerPort);
 
+        if(!gameGlobalInfo) // => failed to start server
+            return 1;
+
         // Load the scenario and open the ship selection screen.
         gameGlobalInfo->startScenario(PreferencesManager::get("server_scenario"));
         new ShipSelectionScreen();

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -530,13 +530,9 @@ std::unordered_map<string, string> loadScenarioSettingsFromPrefs()
 
     for(string setting : preferenceValue.split(";"))
     {
-        std::vector<string> key_value = setting.split("=", 1);
-        string key = key_value[0].strip();
-        if (key.length() < 1)
-            continue;
-
-        if (key_value.size() == 2)
-            settings[key] = key_value[1];
+        auto [key, value] = setting.partition("=");
+        if (!key.empty() && !value.empty())
+            settings[key.strip()] = value.strip();
     }
 
     return settings;

--- a/src/main.h
+++ b/src/main.h
@@ -22,5 +22,6 @@ extern std::vector<RenderLayer*> window_render_layers;
 void returnToMainMenu(RenderLayer*);
 void returnToShipSelection(RenderLayer*);
 void returnToOptionMenu();
+std::unordered_map<string, string> loadScenarioSettingsFromPrefs();
 
 #endif//MAIN_H

--- a/src/scenarioInfo.cpp
+++ b/src/scenarioInfo.cpp
@@ -29,13 +29,13 @@ ScenarioInfo::ScenarioInfo(string filename)
             line = line.substr(3).strip();
             value = value + "\n" + line;
         }else{
+            addKeyValue(key, value);
             line = line.substr(2).strip();
             if (line.find(":") < 0)
             {
                 key = "";
                 continue;
             }
-            addKeyValue(key, value);
             key = line.substr(0, line.find(":")).strip();
             value = line.substr(line.find(":") + 1).strip();
         }


### PR DESCRIPTION
- Don't crash if the server fails to start with `server_scenario` set, just exit nonzero instead.
- Don't ignore scenario options specified just before an empty comment line, to allow breaking up blocks of settings for ease of reading.
- Add `scenario_settings` option, to set scenario settings when using `server_scenario` or `headless`.