### PR TITLE
Fix rotation behavior in tactical and single pilot (classic version)

### DIFF
--- a/src/screens/crew1/singlePilotScreen.h
+++ b/src/screens/crew1/singlePilotScreen.h
@@ -31,6 +31,7 @@ private:
     GuiRotationDial* missile_aim;
     GuiMissileTubeControls* tube_controls;
     GuiToggleButton* lock_aim;
+    bool drag_rotate;
 public:
     SinglePilotScreen(GuiContainer* owner);
 

--- a/src/screens/crew4/tacticalScreen.cpp
+++ b/src/screens/crew4/tacticalScreen.cpp
@@ -45,19 +45,22 @@ TacticalScreen::TacticalScreen(GuiContainer* owner)
     // Control targeting and piloting with radar interactions.
     radar->setCallbacks(
         [this](sp::io::Pointer::Button button, glm::vec2 position) {
+            auto last_target = targets.get();
             targets.setToClosestTo(position, 250, TargetsContainer::Targetable);
-            if (my_spaceship && targets.get())
+            if (my_spaceship && targets.get() && (targets.get() != last_target))
                 my_spaceship->commandSetTarget(targets.get());
             else if (my_spaceship)
                 my_spaceship->commandTargetRotation(vec2ToAngle(position - my_spaceship->getPosition()));
         },
         [this](glm::vec2 position) {
-            if (my_spaceship)
+            targets.setToClosestTo(position, 250, TargetsContainer::Targetable);
+            if (my_spaceship && !targets.get())
+                drag_rotate=true;
+            if (drag_rotate)
                 my_spaceship->commandTargetRotation(vec2ToAngle(position - my_spaceship->getPosition()));
         },
         [this](glm::vec2 position) {
-            if (my_spaceship)
-                my_spaceship->commandTargetRotation(vec2ToAngle(position - my_spaceship->getPosition()));
+            drag_rotate=false;
         }
     );
     radar->setAutoRotating(PreferencesManager::get("tactical_radar_lock","0")=="1");

--- a/src/screens/crew4/tacticalScreen.h
+++ b/src/screens/crew4/tacticalScreen.h
@@ -28,6 +28,7 @@ private:
     GuiRotationDial* missile_aim;
     GuiMissileTubeControls* tube_controls;
     GuiToggleButton* lock_aim;
+    bool drag_rotate;
 public:
     TacticalScreen(GuiContainer* owner);
 


### PR DESCRIPTION
Currently, selecting a target also rotates the ship in the direction of the target. While the old code differs between targeting and rotation on mousedown, the mouse up callback always makes the ship rotate anyways. Which is especially annoying on broadside ships.

New behavior:
Click on a targetable obect: select that target
click anywhere else: rotate.
Click on a target that is already selected: rotate
Drag, as long as the dragging does not start on an object: rotate