### PR TITLE
ECS: fix getReputationPoints()

### DIFF
--- a/scripts/api/entity/spaceobject.lua
+++ b/scripts/api/entity/spaceobject.lua
@@ -239,7 +239,7 @@ end
 --- Returns this SpaceObject's faction reputation points.
 --- Example: obj:getReputationPoints()
 function Entity:getReputationPoints()
-    if self.components.faction and self.components.faction.entity and self.components.faction.entity.faction_info then
+    if self.components.faction and self.components.faction.entity and self.components.faction.entity.components.faction_info then
         return self.components.faction.entity.components.faction_info.reputation_points
     end
 end


### PR DESCRIPTION
Currently, setReputationPoints() works, but getReputationPoints() returns nil.
This fixes that behavior.