### PR TITLE
enter callback for Server password

### DIFF
--- a/src/menus/joinServerMenu.cpp
+++ b/src/menus/joinServerMenu.cpp
@@ -28,6 +28,12 @@ JoinServerScreen::JoinServerScreen(const ServerScanner::ServerInfo& target)
     password_entry = new GuiTextEntry(password_entry_box, "PASSWORD_ENTRY", "");
     password_entry->setPosition(20, 0, sp::Alignment::CenterLeft)->setSize(400, 50);
     password_entry->setHidePassword();
+    password_entry->enterCallback([this](string entry)
+    {
+        password_entry_box->hide();
+        password_focused = false;
+        game_client->sendPassword(entry.upper());
+    });
     (new GuiButton(password_entry_box, "PASSWORD_ENTRY_OK", "Ok", [this]()
     {
         password_entry_box->hide();


### PR DESCRIPTION
When entering a server password on a client trying to connect, pressing enter now does the same as pressing ok.