### PR TITLE
commsOverlay: remove focus highlight of previous selection.

### DIFF
--- a/src/screenComponents/commsOverlay.cpp
+++ b/src/screenComponents/commsOverlay.cpp
@@ -176,6 +176,7 @@ void GuiCommsOverlay::onUpdate()
             script_comms_options->setOptions({});
             for(string message : my_spaceship->getCommsReplyOptions())
                 script_comms_options->addEntry(message, message);
+            script_comms_options->setSelectionIndex(-1);
             int display_options_count = std::min(5, script_comms_options->entryCount());
             script_comms_options->setSize(760, display_options_count * 50);
             script_comms_text->setSize(760, 500 - display_options_count * 50);


### PR DESCRIPTION
After selecting a comms reply option, the button with the same selection index as the previously selected option was highlighted. This commit fixed it: all the buttons are black on new comms pages.