### PR TITLE
allow saving options with $EE_CONF_DIR set

### DIFF
--- a/src/menus/optionsMenu.cpp
+++ b/src/menus/optionsMenu.cpp
@@ -201,7 +201,9 @@ OptionsMenu::OptionsMenu()
     // Save options button.
     (new GuiButton(this, "SAVE_OPTIONS", tr("options", "Save"), []()
     {
-        if (getenv("HOME"))
+        if (getenv("EE_CONF_DIR"))
+            PreferencesManager::save(string(getenv("EE_CONF_DIR")) + "/options.ini");
+        else if (getenv("HOME"))
             PreferencesManager::save(string(getenv("HOME")) + "/.emptyepsilon/options.ini");
         else
             PreferencesManager::save("options.ini");


### PR DESCRIPTION
Back in #2047 I overlooked that the configuration path is re-calculated when the options.ini is saved with the button in the Options menu, this makes the same change there.