### PR TITLE
Add XDG_DATA_HOME as a directory for resources

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -180,6 +180,16 @@ int main(int argc, char** argv)
     if (PreferencesManager::get("mod") != "")
     {
         string mod = PreferencesManager::get("mod");
+        if (getenv("XDG_DATA_HOME"))
+        {
+            new DirectoryResourceProvider(string(getenv("XDG_DATA_HOME")) + "/emptyepsilon/resources/mods/" + mod);
+            PackResourceProvider::addPackResourcesForDirectory(string(getenv("XDG_DATA_HOME")) + "/emptyepsilon/resources/mods/" + mod);
+        }
+        else if (getenv("HOME"))
+        {
+            new DirectoryResourceProvider(string(getenv("HOME")) + "/.local/share/emptyepsilon/resources/mods/" + mod);
+            PackResourceProvider::addPackResourcesForDirectory(string(getenv("HOME")) + "/.local/share/emptyepsilon/resources/mods/" + mod);
+        }
         if (getenv("HOME"))
         {
             new DirectoryResourceProvider(string(getenv("HOME")) + "/.emptyepsilon/resources/mods/" + mod);
@@ -192,6 +202,18 @@ int main(int argc, char** argv)
     new DirectoryResourceProvider("resources/");
     new DirectoryResourceProvider("scripts/");
     PackResourceProvider::addPackResourcesForDirectory("packs/");
+    if (getenv("XDG_DATA_HOME"))
+    {
+        new DirectoryResourceProvider(string(getenv("XDG_DATA_HOME")) + "/emptyepsilon/resources/");
+        new DirectoryResourceProvider(string(getenv("XDG_DATA_HOME")) + "/emptyepsilon/scripts/");
+        PackResourceProvider::addPackResourcesForDirectory(string(getenv("XDG_DATA_HOME")) + "/emptyepsilon/packs/");
+    }
+    else if (getenv("HOME"))
+    {
+        new DirectoryResourceProvider(string(getenv("HOME")) + "/.local/share/emptyepsilon/resources/");
+        new DirectoryResourceProvider(string(getenv("HOME")) + "/.local/share/emptyepsilon/scripts/");
+        PackResourceProvider::addPackResourcesForDirectory(string(getenv("HOME")) + "/.local/share/emptyepsilon/packs/");
+    }
     if (getenv("HOME"))
     {
         new DirectoryResourceProvider(string(getenv("HOME")) + "/.emptyepsilon/resources/");


### PR DESCRIPTION
The builtin resources are installed into `/usr/share/emptyepsilon` on linux by default.

The user equivalent of that directory is `~/.local/share/emptyepsilon` (or `$XDG_DATA_HOME/emptyepsilon` if `$XDG_DATA_HOME` is set). So it would make sense to also pick up resources in that directory.

the structure is on purpose
```
if $XDG_DATA_HOME
    $XDG_DATA_HOME/emptyepsilon
else if $HOME
    $HOME/.local/share/emptyepsilon
if $HOME
    $HOME/.emptyepsilon
```
so that `~/.emptyepsilon` is still picked up no matter if `$XDG_DATA_HOME` is set or not