### PR TITLE
Website: Move "Source Code" download link to a new tab

### DIFF
--- a/index.html
+++ b/index.html
@@ -845,25 +845,25 @@ end
 			<ul>
 				<li><a href="#download-tabs-0"><span class="button-text">Stable</span></a></li>
 				<li><a href="#download-tabs-1"><span class="button-text">Prerelease</span></a></li>
+				<li><a href="#download-tabs-2"><span class="button-text">Source Code</span></a></li>
 			</ul>
 			<div id="download-tabs-0">
 	        	<h2>Download</h2>
     		    <p id="downloads-info-stable">Downloads for Windows and Android are available at: <a href="https://github.com/daid/EmptyEpsilon/releases">[download list]</a></p>
         		<p>You need to use the same version number for all users or else the game will not work correctly. Mixing different version numbers is not supported.</p>
-		        <h2>Source</h2>
-           		<p>The sourcecode is up on github at:</p>
-        		<p><a href="https://github.com/daid/EmptyEpsilon">https://github.com/daid/EmptyEpsilon</a> (Game source code)</p>
-		        <p><a href="https://github.com/daid/SeriousProton">https://github.com/daid/SeriousProton</a> (Engine source code)</p>
         	</div>
 			<div id="download-tabs-1">
 	        	<h2>Download [PRERELEASE]</h2>
     		    <p id="downloads-info-prerelease">Downloads for Windows and Android are available at: <a href="https://github.com/daid/EmptyEpsilon/releases">[download list]</a></p>
         		<p>You need to use the same version number for all users or else the game will not work correctly. Mixing different version numbers is not supported.</p>
-		        <h2>Source</h2>
-           		<p>The sourcecode is up on github at:</p>
-        		<p><a href="https://github.com/daid/EmptyEpsilon">https://github.com/daid/EmptyEpsilon</a> (Game source code)</p>
-		        <p><a href="https://github.com/daid/SeriousProton">https://github.com/daid/SeriousProton</a> (Engine source code)</p>
         	</div>
+			<div id="download-tabs-2">
+				<h2>Source Code</h2>
+				<p>The sourcecode is up on GitHub at:</p>
+				<p><a href="https://github.com/daid/EmptyEpsilon">https://github.com/daid/EmptyEpsilon</a> (Game source code)</p>
+				<p><a href="https://github.com/daid/SeriousProton">https://github.com/daid/SeriousProton</a> (Engine source code)
+				</p>
+			</div>
        	</div>
    	</div>
     <div id="tabs-community">

--- a/index.html
+++ b/index.html
@@ -874,8 +874,8 @@ end
         <h2>Forums</h2>
         <p>The forums where we communicate about the game can be found at: <a href="http://bridgesim.net/categories/emptyepsilon">bridgesim.net</a>.</p>
         <h2>Issues</h2>
-        <p>You can report issues on github at <a href="https://github.com/daid/EmptyEpsilon/issues">https://github.com/daid/EmptyEpsilon/issues</a>. Remember to stay civil, and that the maintainers have no obligation to you.</p>
-        <p>(Want your link on this page? Feel free to let us know on a github issue, and we can update this list)</p>
+        <p>You can report issues on GitHub at <a href="https://github.com/daid/EmptyEpsilon/issues">https://github.com/daid/EmptyEpsilon/issues</a>. Remember to stay civil, and that the maintainers have no obligation to you.</p>
+        <p>(Want your link on this page? Feel free to let us know on a GitHub issue, and we can update this list)</p>
         <h2>Find a local game</h2>
         <p><a href="https://quantum-games.be/">Quantum Games</a> Belgian location. French language. Offers customized experiences.</p>
         <h2>Things using EmptyEpsilon</h2>


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/fccbf254-d037-46dc-a03e-509b9cb58e87)
The source code download link was previously at the bottom of the list of game download links, so it was easy to miss. It was also duplicated under both `Stable` and `Prerelease` tabs.