### PR TITLE
Website: Move version warning message to the top

### DIFF
--- a/index.html
+++ b/index.html
@@ -848,8 +848,8 @@ end
 			</ul>
 			<div id="download-tabs-0">
 	        	<h2>Download</h2>
-    		    <p id="downloads-info-stable">Downloads for Windows and Android are available at: <a href="https://github.com/daid/EmptyEpsilon/releases">[download list]</a></p>
         		<p>You need to use the same version number for all users or else the game will not work correctly. Mixing different version numbers is not supported.</p>
+    		    <p id="downloads-info-stable">Downloads for Windows and Android are available at: <a href="https://github.com/daid/EmptyEpsilon/releases">[download list]</a></p>
 		        <h2>Source</h2>
            		<p>The sourcecode is up on github at:</p>
         		<p><a href="https://github.com/daid/EmptyEpsilon">https://github.com/daid/EmptyEpsilon</a> (Game source code)</p>
@@ -857,8 +857,8 @@ end
         	</div>
 			<div id="download-tabs-1">
 	        	<h2>Download [PRERELEASE]</h2>
-    		    <p id="downloads-info-prerelease">Downloads for Windows and Android are available at: <a href="https://github.com/daid/EmptyEpsilon/releases">[download list]</a></p>
         		<p>You need to use the same version number for all users or else the game will not work correctly. Mixing different version numbers is not supported.</p>
+    		    <p id="downloads-info-prerelease">Downloads for Windows and Android are available at: <a href="https://github.com/daid/EmptyEpsilon/releases">[download list]</a></p>
 		        <h2>Source</h2>
            		<p>The sourcecode is up on github at:</p>
         		<p><a href="https://github.com/daid/EmptyEpsilon">https://github.com/daid/EmptyEpsilon</a> (Game source code)</p>


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/7bcb2bee-c103-4d99-b004-a95851cb0b0b)

> You need to use the same version number for all users or else the game will not work correctly. Mixing different version numbers is not supported.

This message was previously at the bottom of the game-download links, so it was easy to miss.