### PR TITLE
Add small window camera offset in order to prevent glitches

### DIFF
--- a/src/screens/windowScreen.cpp
+++ b/src/screens/windowScreen.cpp
@@ -56,7 +56,7 @@ void WindowScreen::update(float delta)
 
         auto position = my_spaceship->getPosition() + rotateVec2(glm::vec2(my_spaceship->getRadius(), 0), camera_yaw);
 
-        camera_position.x = position.x;
+        camera_position.x = position.x + 1.0f; // small offset to prevent camera glitches on some models
         camera_position.y = position.y;
         camera_position.z = 0.0;
     }


### PR DESCRIPTION
This slightly moves the ship window camera, so that there is no camera glitch with the Phobos, where the collsion shape is significantly smaller than the model. On some angles, that issue also occurred for the maverick.
The alternative to that is obviously to increase the collision radius of the Phobos , but the difference seems too big (80 vs 110) to be an accident. So I assume the phobos' collision radius is intentionally smaller than the model length, to reduce the amount of empty space it covers.