### PR TITLE
Extract comments for translators

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -642,7 +642,7 @@ if(PYTHONINTERP_FOUND)
 endif()
 
 add_custom_target(update_locale
-    COMMAND xgettext --keyword=tr:1c,2 --keyword=tr:1 --keyword=trMark:1c,2 --keyword=trMark:1 --omit-header -d resources/locale/main.en ${MAIN_SOURCES} ${GUI_LIB_SOURCES}
+    COMMAND xgettext --keyword=tr:1c,2 --keyword=tr:1 --keyword=trMark:1c,2 --keyword=trMark:1 --add-comments=TRANSLATORS --omit-header -d resources/locale/main.en ${MAIN_SOURCES} ${GUI_LIB_SOURCES}
     COMMAND python3 update_locale.py
     WORKING_DIRECTORY ${PROJECT_SOURCE_DIR})
 

--- a/update_locale.py
+++ b/update_locale.py
@@ -71,7 +71,7 @@ for script in glob.glob("scripts/**/*.lua", recursive=True):
     cmd = ["xgettext", "--keyword=_:1c,2", "--keyword=_:1", "--omit-header", "-j", "-d", output[:-3], "-C", "-"]
     subprocess.run(cmd, check=True, input=b"")
     pre = open(output, "rt").read()
-    cmd = ["xgettext", "--keyword=_:1c,2", "--keyword=_:1", "--omit-header", "-j", "-d", output[:-3], script]
+    cmd = ["xgettext", "--keyword=_:1c,2", "--keyword=_:1", "--add-comments=TRANSLATORS", "--omit-header", "-j", "-d" , output[:-3], script]
     subprocess.run(cmd, check=True)
     post = open(output, "rt").read()
     if pre == post and "name" not in info:


### PR DESCRIPTION
This enables the add-comment option in gettext, that allows scenario writers and c++ coders to give translators detailed information about a given text.

Example how it works:

Right before the line that contains a translation string, add a comment that contains the TRANSLATORS keyword (case matters)
```
-- TRANSLATORS: F is formation spacing of the drones, S is their scan range
addGMFunction(string.format(_("buttonGM", "+Distance F%.1fU S%.1fU"),drone_formation_spacing/1000,drone_scan_range_for_flags/1000),setDroneDistances)
```

After the update/creation of the base translation files, that comment now got added to the .po file, which will look like this in Poedit:

![poedit-snippet](https://github.com/user-attachments/assets/05df700d-9381-434c-9277-b919b37af7d0)
