### PR TITLE
GH Pages: Suggest VS Code instead of Atom

### DIFF
--- a/index.html
+++ b/index.html
@@ -267,7 +267,7 @@
 				<ul>
 					<li><a href="http://www.pnotepad.org/">Programmer's Notepad</a> (Windows)</li>
 					<li><a href="http://www.sublimetext.com/">Sublime Text</a> (Windows, OS X, Linux)</li>
-					<li><a href="https://atom.io/">Atom</a> (Windows, OS X, Linux)</li>
+					<li><a href="https://code.visualstudio.com/">Visual Studio Code</a> (Windows, OS X, Linux)</li>
 					<li><a href="https://notepad-plus-plus.org/">Notepad++</a> (Windows)</li>
 				</ul>
 				<p>I use Programmer's Notepad, but any of these editors will do.</p>


### PR DESCRIPTION
Atom was sunset at the end of 2022, so it probably shouldn't be listed as a suggestion anymore.

https://atom.io/ redirects to this blog post: https://github.blog/news-insights/product-news/sunsetting-atom/.

I've added Visual Studio Code as an alternative suggestion.

![image](https://github.com/user-attachments/assets/ffe4c46b-4dd4-46e0-89da-7f1f2bf6e006)
