### PR TITLE
Scenario Carrier update

### DIFF
--- a/scripts/scenario_56_carrierTurret.lua
+++ b/scripts/scenario_56_carrierTurret.lua
@@ -68,6 +68,10 @@ require("place_station_scenario_utility.lua")
 require("generate_call_sign_scenario_utility.lua")
 
 function init()
+	ECS = false
+	if createEntity then
+		ECS = true
+	end
 	mission_diagnostic = false
 	diagnostic = false
 	fleet_id_diagnostic = false
@@ -606,7 +610,17 @@ function GMSpawnsEnemies()
 	gmSelected = false
 	gmSelect = getGMSelection()
 	for idx, obj in ipairs(gmSelect) do
-		if obj.typeName == "PlayerSpaceship" then
+		local player_spaceship = false
+		if ECS then
+			if obj.components.player_control then
+				player_spaceship = true
+			end
+		else
+			if obj.typeName == "PlayerSpaceship" then
+				player_spaceship = true
+			end
+		end
+		if player_spaceship then
 			gmPlayer = obj
 			break
 		end
@@ -3197,7 +3211,17 @@ function friendlyComms()
 			addCommsReply(_("Back"), commsShip)
 		end)
 		for idx, obj in ipairs(comms_target:getObjectsInRange(5000)) do
-			if obj.typeName == "SpaceStation" and not comms_target:isEnemy(obj) then
+			local space_station = false
+			if ECS then
+				if obj.components.space_station then
+					space_station = true
+				end
+			else
+				if obj.typeName == "SpaceStation" then
+					space_station = true
+				end
+			end
+			if space_station and not comms_target:isEnemy(obj) then
 				addCommsReply(string.format(_("shipAssist-comms", "Dock at %s"), obj:getCallSign()), function()
 					setCommsMessage(string.format(_("shipAssist-comms", "Docking at %s."), obj:getCallSign()));
 					comms_target:orderDock(obj)

--- a/scripts/scenario_56_carrierTurret.lua
+++ b/scripts/scenario_56_carrierTurret.lua
@@ -3213,7 +3213,7 @@ function friendlyComms()
 		for idx, obj in ipairs(comms_target:getObjectsInRange(5000)) do
 			local space_station = false
 			if ECS then
-				if obj.components.space_station then
+				if obj.components.docking_bay and obj.components.physics and obj.components.physics.type == "static" then
 					space_station = true
 				end
 			else


### PR DESCRIPTION
Renamed from Carriers and turrets to Carrier and Fighters. 
Added Discord server info.
Changed configuration.
- Divided difficulty into enemies and Murphy.
- More timed options: none, 30 minutes, 60 minutes, 90 minutes.
- Added carrier and fighter selection options (default is to select at random). 

Switched to using the place station scenario utility. 
Added the generate call sign utility for NPC ship names. 
Split up init code where applicable to setConstants and setGlobals functions. 
Updated goods handling.
Updated GM button handling.
Simplified function naming in update function.
Changed timers to use getScenarioTime() instead of a flavor of delta. 
Add loop limiters for repeat until loops.
Include Saipan amongst the possible carriers.
Removed non-starfighter types from possible fighters and added new player fighter types (Formax, Foil, Red Jacket). 
Add shield button to tactical console for fighters. 
Enable auto coolant and auto repair for fighters.
Set Striker max impulse speed to 90.
Shorten fighters' long range radar range to 10 units. 
Add applicable translation contexts including ones for goods. 
Add automated defense for friendly and neutral stations. 
Use hail messages for mission plot points in addition to ship log. 
Save mission critical messages in command log and set up a command log read button for Relay. 
Switch to using getActivePlayerShips().
Add ability for players to use reputation to get a replacement fighter or carrier. 
Switch from using player to using comms_source.
Create and use a common mission related comms function for docked and undocked states. 
Add buttons to transfer cargo from carrier to fighter. 
Add inventory button for players on Relay.
Add reputation points for completing a number of different mini mission milestones. 
Adjust final statistics screen to include the number of completed mini mission milestones.