### PR TITLE
Fix ShipLog replication

### DIFF
--- a/src/multiplayer/shiplog.cpp
+++ b/src/multiplayer/shiplog.cpp
@@ -31,6 +31,7 @@ void ShipLogReplication::update(sp::io::DataBuffer& packet)
                 const auto& e = log.get(n);
                 packet << e.prefix << e.text << e.color;
             }
+            log.new_entry_count = 0;
         }
         info.set(entity.getIndex(), {entity.getVersion()});
     }


### PR DESCRIPTION
* Entire ship log was replicating on every tick
* Using 17.5kb/s after filled to 100 entries
* Now uses 0.2kb/s (I'm sending bursts of messages at 10/s)
* Tested that back-replication still works to a new client