### PR TITLE
Correct typo in Ender Description

### DIFF
--- a/scripts/shiptemplates/OLD.lua
+++ b/scripts/shiptemplates/OLD.lua
@@ -388,7 +388,7 @@ template:setDockClasses(_("class", "Starfighter"), _("class", "Frigate"), _("cla
 template:setSharesEnergyWithDocked(true)
 
 variation = template:copy("Ender"):setType("playership"):setLocaleName(_("playerShip", "Ender"))
-variation:setDescription(_("Player version of the battle station. Only half es much shield strength, but more speed and maneuverability, so it is surprisingly agile - for a capital ship, of course. Piloting this colossus still feels very different compared to other ships. It also has two additional missile tubes."))
+variation:setDescription(_("Player version of the battle station. Only half as much shield strength, but more speed and maneuverability, so it is surprisingly agile - for a capital ship, of course. Piloting this colossus still feels very different compared to other ships. It also has two additional missile tubes."))
 --                  Arc, Dir, Range, CycleTime, Dmg
 variation:setBeam(0, 10, -90, 2500.0, 6.1, 4)
 variation:setBeam(1, 10, -90, 2500.0, 6.0, 4)


### PR DESCRIPTION
Just fixing a tiny typo in a description.