### PR TITLE
Make planets never_radar_blocked like legacy

### DIFF
--- a/scripts/api/entity/planet.lua
+++ b/scripts/api/entity/planet.lua
@@ -19,6 +19,7 @@ function Planet()
             cloud_size = 5200,
         },
         physics = {type="static", size=5000},
+        never_radar_blocked = {}
     }
     return e
 end


### PR DESCRIPTION
On legacy builds Relay can see all planets from the start, but on master branch, planets are not visible without a probe or exploration. This restores the old behavior.