### PR TITLE
fix for setPlanetRadius breaks setPosition

### DIFF
--- a/scripts/api/entity/planet.lua
+++ b/scripts/api/entity/planet.lua
@@ -78,7 +78,11 @@ function Entity:setPlanetRadius(size)
         pr.atmosphere_size = size*1.2
         if (pr.size * pr.size) > (pr.distance_from_movement_plane * pr.distance_from_movement_plane) then
             local collision_size = math.sqrt((pr.size * pr.size) - (pr.distance_from_movement_plane * pr.distance_from_movement_plane)) * 1.1;
-            self.components.physics = {type="static", size=collision_size}
+            if(not self.components.physics) then
+                self.components.physics = {type="static", size=collision_size}
+            else
+                self.components.physics.size = collision_size
+            end
         else
             self.components.physics = nil
         end
@@ -113,7 +117,11 @@ function Entity:setDistanceFromMovementPlane(z)
         pr.distance_from_movement_plane = z
         if (pr.size * pr.size) > (pr.distance_from_movement_plane * pr.distance_from_movement_plane) then
             local collision_size = math.sqrt((pr.size * pr.size) - (pr.distance_from_movement_plane * pr.distance_from_movement_plane)) * 1.1;
-            self.components.physics = {type="static", size=collision_size}
+            if (not self.components.physics) then
+                self.components.physics = {type="static", size=collision_size}
+            else
+                self.components.physics.size = collision_size
+            end
         else
             self.components.physics = nil
         end


### PR DESCRIPTION
There is some unexpected interaction between setPlanetRadius() and setPosition().

The lua scenario code below works - every 10s the planet gets further from the origin and switches texture. However, if I uncomment the setPlanetRadius(), then the radius and texture update, but the position does not.

```
function init()
    P = Planet():setPosition(sectorToXY("F6")):setPlanetRadius(2500):setPlanetSurfaceTexture("planets/planet-1.png")
    player = PlayerSpaceship():setTemplate("Phobos M3P"):setPosition(0, 0):setRotation(0)
end

sectorNum = 6
lastupdate = 0
function update(delta)
    lastupdate = lastupdate + delta
    if lastupdate > 10 then
        sectorNum = sectorNum + 1
        P:setPosition(sectorToXY("F" .. sectorNum))
        P:setPlanetSurfaceTexture("planets/planet-" .. (sectorNum % 5) + 1 .. ".png")
        lastupdate = 0
    else
        --P:setPlanetRadius(sectorNum * 500)
    end
end
```

This patch fixes it. For some reason it was the first thing I tried, and it worked, but I can't yet describe why it fixes it; so not convinced it's the correct thing to do. With this patch, the radius, texture, and position all update as expected.