### PR TITLE
Fix "Scan complexity: None (delay)"

### DIFF
--- a/src/screenComponents/scanningDialog.cpp
+++ b/src/screenComponents/scanningDialog.cpp
@@ -201,6 +201,8 @@ std::pair<int, int> GuiScanningDialog::getScanComplexityDepth()
     if (complexity < 0) {
         switch(gameGlobalInfo->scanning_complexity) {
         case SC_None:
+            complexity = 0;
+            break;
         case SC_Simple:
             complexity = 1;
             break;


### PR DESCRIPTION
* Scanning window was appearing even when set to None