### PR TITLE
tutorials: start specific tutorial before autoconnect

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -196,7 +196,13 @@ int main(int argc, char** argv)
     new SteamRichPresence();
 #endif //STEAMSDK
 
-    if (PreferencesManager::get("server_scenario") == "")
+    string tutorial = PreferencesManager::get("tutorial");   // use "00_all.lua" for all tutorials
+    if (tutorial != "")
+    {
+        LOG(DEBUG) << "Starting tutorial: " << tutorial;
+        new TutorialGame(false, tutorial);
+    }
+    else if (PreferencesManager::get("server_scenario") == "")
         returnToMainMenu(defaultRenderLayer);
     else
     {
@@ -277,10 +283,6 @@ void returnToMainMenu(RenderLayer* render_layer)
         if (crew_position < 0) crew_position = 0;
         if (crew_position > static_cast<int>(CrewPosition::MAX)) crew_position = static_cast<int>(CrewPosition::MAX);
         new AutoConnectScreen(CrewPosition(crew_position), PreferencesManager::get("autocontrolmainscreen").toInt(), PreferencesManager::get("autoconnectship", "solo"));
-    }
-    else if (PreferencesManager::get("tutorial").toInt())
-    {
-        new TutorialGame(true);
     }else{
         new MainMenu();
     }


### PR DESCRIPTION
Changes the behaviour of the "tutorial" preference in options.ini or as command line argument. You can now specify which tutorial is started by the name of the tutorial file (e.g. "tutorial=tutorial/00_all.lua" for all tutorials).

If the autoconnect option is defined at the same time, the tutorial is started first and the connection to the server happens after the tutorial is finished.

This allows for example to show the helms tutorial before connecting to the helms station of a running server.