### PR TITLE
getImpulseMaxSpeed should return both fwd & rev

### DIFF
--- a/scripts/api/entity/spaceship.lua
+++ b/scripts/api/entity/spaceship.lua
@@ -402,8 +402,8 @@ end
 --- forward,reverse = getImpulseMaxSpeed()
 --- forward = getImpulseMaxSpeed() -- forward speed only
 function Entity:getImpulseMaxSpeed()
-    if self.components.impulse_engine then return self.components.impulse_engine.max_speed_forward end
-    return 0.0
+    if self.components.impulse_engine then return self.components.impulse_engine.max_speed_forward, self.impulse_engine.max_speed_reverse end
+    return 0.0, 0.0
 end
 --- Sets this SpaceShip's maximum forward and reverse impulse speeds.
 --- The reverse maximum speed value is optional.


### PR DESCRIPTION
Used in scenario code here:
* https://github.com/daid/EmptyEpsilon/blob/master/scripts/scenario_29_surf.lua#L805
* https://github.com/daid/EmptyEpsilon/blob/master/scripts/scenario_29_surf.lua#L919
* https://github.com/daid/EmptyEpsilon/blob/master/scripts/cpu_ship_diversification_scenario_utility.lua#L2201
