### PR TITLE
orbiting: Exception for time=0 and fixing description

### DIFF
--- a/scripts/api/entity/planet.lua
+++ b/scripts/api/entity/planet.lua
@@ -131,8 +131,11 @@ function Entity:setAxialRotationTime(rotation_time)
     end
     return self
 end
---- Sets a SpaceObject around which this Planet orbits, as well as its orbital period in orbital degrees per tick.
---- Example: moon:setOrbit(planet, 20)
+--- Sets a SpaceObject around which this SpaceObject orbits, as well as its orbital period in seconds. Setting time to 0 will stop movement, while still being locked in orbit.
+--- An orbit can be cancelled by setting the SpaceObject as its own target.
+--- Example: 
+--- moon:setOrbit(planet, 20)
+--- moon:setOrbit(moon) -- undo orbiting planet by orbiting itself
 function Entity:setOrbit(target, time)
     local x0, y0 = self:getPosition()
     local x1, y1 = target:getPosition()

--- a/scripts/api/entity/planet.lua
+++ b/scripts/api/entity/planet.lua
@@ -132,11 +132,15 @@ function Entity:setAxialRotationTime(rotation_time)
     return self
 end
 --- Sets a SpaceObject around which this SpaceObject orbits, as well as its orbital period in seconds. Setting time to 0 will stop movement, while still being locked in orbit.
---- An orbit can be cancelled by setting the SpaceObject as its own target.
---- Example: 
+--- An orbit can be cancelled by setting the target to nil
+--- Example:
 --- moon:setOrbit(planet, 20)
---- moon:setOrbit(moon) -- undo orbiting planet by orbiting itself
+--- moon:setOrbit(nil) -- undo orbiting
 function Entity:setOrbit(target, time)
+    if target == nil then
+        self.components.orbit = nil
+        return self
+    end
     local x0, y0 = self:getPosition()
     local x1, y1 = target:getPosition()
     local xd, yd = (x1 - x0), (y1 - y0)

--- a/src/systems/basicmovement.cpp
+++ b/src/systems/basicmovement.cpp
@@ -22,7 +22,8 @@ void BasicMovementSystem::update(float delta)
             orbit.center = tt->getPosition();
 
         float angle = vec2ToAngle(transform.getPosition() - orbit.center);
-        angle += delta / orbit.time * 360.0f;
+        if (orbit.time != 0)
+            angle += delta / orbit.time * 360.0f;
         transform.setPositionNoReplication(orbit.center + vec2FromAngle(angle) * orbit.distance);
     }
 


### PR DESCRIPTION
This adds a special case that stops orbital movement when time is set to 0, preventing divide by zero issues. I think it makes sense to hardcode this in C++ rather than changing it in lua.
I also updated the description of the setOrbit() function in planet.lua