### PR TITLE
De-const various consts and expose them to Lua

### DIFF
--- a/src/components/docking.h
+++ b/src/components/docking.h
@@ -44,7 +44,7 @@ public:
 
     bool auto_reload_missiles = false;
     float auto_reload_missile_delay = 0.0f;
-    static constexpr float auto_reload_missile_time = 10.0f;
+    float auto_reload_missile_time = 10.0f;
 
     DockingStyle canDockOn(DockingBay& bay) {
         if (bay.external_dock_classes.empty() && bay.internal_dock_classes.empty()) return DockingStyle::External;

--- a/src/components/jumpdrive.h
+++ b/src/components/jumpdrive.h
@@ -13,6 +13,7 @@ public:
     float heat_per_jump = 0.35f;
     float min_distance = 5000.0f; //[config]
     float max_distance = 50000.0f; //[config]
+    float activation_delay = 10.0f; // Time between hitting "jump" and actually jumping
 
     // Runtime
     float charge = 50000.0f; //[output]

--- a/src/components/jumpdrive.h
+++ b/src/components/jumpdrive.h
@@ -7,11 +7,10 @@
 // Impulse engine component, indicate that this entity can move under impulse control.
 class JumpDrive : public ShipSystem {
 public:
-    constexpr static float charge_time = 90.0f;   /*<Total charge time for the jump drive after a max range jump */
-    constexpr static float energy_per_km_charge = 2.0f;
-    constexpr static float heat_per_jump = 0.35f;
-
     // Config
+    float charge_time = 90.0f;   /*<Total charge time for the jump drive after a max range jump */
+    float energy_per_km_charge = 2.0f;
+    float heat_per_jump = 0.35f;
     float min_distance = 5000.0f; //[config]
     float max_distance = 50000.0f; //[config]
 

--- a/src/components/maneuveringthrusters.h
+++ b/src/components/maneuveringthrusters.h
@@ -18,12 +18,15 @@ public:
 
 class CombatManeuveringThrusters {
 public:
+    float charge_time = 20.0f; // time to charge from 0 to 100%, assuming we have both impulse and maneuver systems.
     float charge = 1.0f; // [output] How much charge there is in the combat maneuvering system (0.0-1.0)
 
     struct Thruster {
         float request = 0.0f; // [input] How much boost we want at this moment (0.0-1.0)
         float active = 0.0f;
         float speed = 0.0f; /*< [config] Speed to indicate how fast we will fly forwards/sideways with a full boost/strafe */
+        float max_time = 3.0f; // max time to boost with a fully charged system
+        float heat_per_second = 0.2f; // heat per second when fully active
     };
     Thruster boost;
     Thruster strafe;

--- a/src/components/shipsystem.cpp
+++ b/src/components/shipsystem.cpp
@@ -11,10 +11,6 @@
 #include "components/warpdrive.h"
 
 
-// Overheat subsystem damage rate
-constexpr static float damage_per_second_on_overheat = 0.08f;
-
-
 float ShipSystem::getSystemEffectiveness()
 {
     float power = power_level;

--- a/src/components/shipsystem.h
+++ b/src/components/shipsystem.h
@@ -42,6 +42,7 @@ public:
     float heat_add_rate_per_second = default_add_heat_rate_per_second;
     float power_change_rate_per_second = default_power_rate_per_second;
     float auto_repair_per_second = 0.0f;
+    float damage_per_second_on_overheat = 0.08f;
 
     float getSystemEffectiveness();
     void addHeat(float amount);

--- a/src/components/warpdrive.h
+++ b/src/components/warpdrive.h
@@ -6,11 +6,10 @@
 // Impulse engine component, indicate that this entity can move under impulse control.
 class WarpDrive : public ShipSystem {
 public:
-    constexpr static float charge_time = 4.0f;
-    constexpr static float decharge_time = 2.0f;
-    constexpr static float heat_per_warp = 0.02f;
-
     // Config
+    float charge_time = 4.0f;
+    float decharge_time = 2.0f;
+    float heat_per_warp = 0.02f;
     int max_level = 4;
     float speed_per_level = 1000;
     float energy_warp_per_second = 1.7f;

--- a/src/multiplayer/basic.h
+++ b/src/multiplayer/basic.h
@@ -79,13 +79,6 @@ enum class BasicReplicationRequest {
     case BasicReplicationRequest::Receive: if (flags & flag) packet >> target.FIELD; break; \
     } \
     flag <<= 1;
-#define BASIC_REPLICATION_PAIR(FIELD_A, FIELD_B) \
-    switch(BRR) { \
-    case BasicReplicationRequest::SendAll: flags |= flag; tmp << target.FIELD_A; tmp << target.FIELD_B; break; \
-    case BasicReplicationRequest::Update: if (target.FIELD_A != backup->FIELD_A || target.FIELD_B != backup->FIELD_B) { flags |= flag; tmp << target.FIELD_A; backup->FIELD_A = target.FIELD_A; tmp << target.FIELD_B; backup->FIELD_B = target.FIELD_B; } break; \
-    case BasicReplicationRequest::Receive: if (flags & flag) { packet >> target.FIELD_A; packet >> target.FIELD_B; }; break; \
-    } \
-    flag <<= 1;
 #define BASIC_REPLICATION_VECTOR(FIELD) \
     switch(BRR) { \
     case BasicReplicationRequest::SendAll: flags |= flag; tmp << target.FIELD.size(); break; \

--- a/src/multiplayer/basic.h
+++ b/src/multiplayer/basic.h
@@ -79,6 +79,13 @@ enum class BasicReplicationRequest {
     case BasicReplicationRequest::Receive: if (flags & flag) packet >> target.FIELD; break; \
     } \
     flag <<= 1;
+#define BASIC_REPLICATION_PAIR(FIELD_A, FIELD_B) \
+    switch(BRR) { \
+    case BasicReplicationRequest::SendAll: flags |= flag; tmp << target.FIELD_A; tmp << target.FIELD_B; break; \
+    case BasicReplicationRequest::Update: if (target.FIELD_A != backup->FIELD_A || target.FIELD_B != backup->FIELD_B) { flags |= flag; tmp << target.FIELD_A; backup->FIELD_A = target.FIELD_A; tmp << target.FIELD_B; backup->FIELD_B = target.FIELD_B; } break; \
+    case BasicReplicationRequest::Receive: if (flags & flag) { packet >> target.FIELD_A; packet >> target.FIELD_B; }; break; \
+    } \
+    flag <<= 1;
 #define BASIC_REPLICATION_VECTOR(FIELD) \
     switch(BRR) { \
     case BasicReplicationRequest::SendAll: flags |= flag; tmp << target.FIELD.size(); break; \

--- a/src/multiplayer/beamweapon.cpp
+++ b/src/multiplayer/beamweapon.cpp
@@ -16,6 +16,7 @@ BASIC_REPLICATION_IMPL(BeamWeaponSysReplication, BeamWeaponSys)
     BASIC_REPLICATION_FIELD(heat_add_rate_per_second);
     BASIC_REPLICATION_FIELD(power_change_rate_per_second);
     BASIC_REPLICATION_FIELD(auto_repair_per_second);
+    BASIC_REPLICATION_FIELD(damage_per_second_on_overheat);
 
     BASIC_REPLICATION_FIELD(frequency);
     BASIC_REPLICATION_FIELD(system_target);

--- a/src/multiplayer/impulse.cpp
+++ b/src/multiplayer/impulse.cpp
@@ -17,6 +17,7 @@ BASIC_REPLICATION_IMPL(ImpulseEngineReplication, ImpulseEngine)
     BASIC_REPLICATION_FIELD(heat_add_rate_per_second);
     BASIC_REPLICATION_FIELD(power_change_rate_per_second);
     BASIC_REPLICATION_FIELD(auto_repair_per_second);
+    BASIC_REPLICATION_FIELD(damage_per_second_on_overheat);
 
     BASIC_REPLICATION_FIELD(max_speed_forward);
     BASIC_REPLICATION_FIELD(max_speed_reverse);

--- a/src/multiplayer/jumpdrive.cpp
+++ b/src/multiplayer/jumpdrive.cpp
@@ -17,9 +17,14 @@ BASIC_REPLICATION_IMPL(JumpDriveReplication, JumpDrive)
     BASIC_REPLICATION_FIELD(heat_add_rate_per_second);
     BASIC_REPLICATION_FIELD(power_change_rate_per_second);
     BASIC_REPLICATION_FIELD(auto_repair_per_second);
+    BASIC_REPLICATION_FIELD(damage_per_second_on_overheat);
 
+    BASIC_REPLICATION_FIELD(charge_time);
+    BASIC_REPLICATION_FIELD(energy_per_km_charge);
+    BASIC_REPLICATION_FIELD(heat_per_jump);
     BASIC_REPLICATION_FIELD(min_distance);
     BASIC_REPLICATION_FIELD(max_distance);
+    BASIC_REPLICATION_FIELD(activation_delay);
     BASIC_REPLICATION_FIELD(charge);
     BASIC_REPLICATION_FIELD(distance);
     BASIC_REPLICATION_FIELD(delay);

--- a/src/multiplayer/maneuveringthrusters.cpp
+++ b/src/multiplayer/maneuveringthrusters.cpp
@@ -17,6 +17,7 @@ BASIC_REPLICATION_IMPL(ManeuveringThrustersReplication, ManeuveringThrusters)
     BASIC_REPLICATION_FIELD(heat_add_rate_per_second);
     BASIC_REPLICATION_FIELD(power_change_rate_per_second);
     BASIC_REPLICATION_FIELD(auto_repair_per_second);
+    BASIC_REPLICATION_FIELD(damage_per_second_on_overheat);
 
     BASIC_REPLICATION_FIELD(speed);
     BASIC_REPLICATION_FIELD(target);
@@ -24,11 +25,16 @@ BASIC_REPLICATION_IMPL(ManeuveringThrustersReplication, ManeuveringThrusters)
 }
 
 BASIC_REPLICATION_IMPL(CombatManeuveringThrustersReplication, CombatManeuveringThrusters)
+    BASIC_REPLICATION_FIELD(charge_time);
     BASIC_REPLICATION_FIELD(charge);
     BASIC_REPLICATION_FIELD(boost.request);
     BASIC_REPLICATION_FIELD(boost.active);
     BASIC_REPLICATION_FIELD(boost.speed);
+    BASIC_REPLICATION_FIELD(boost.max_time);
+    BASIC_REPLICATION_FIELD(boost.heat_per_second);
     BASIC_REPLICATION_FIELD(strafe.request);
     BASIC_REPLICATION_FIELD(strafe.active);
     BASIC_REPLICATION_FIELD(strafe.speed);
+    BASIC_REPLICATION_FIELD(strafe.max_time);
+    BASIC_REPLICATION_FIELD(strafe.heat_per_second);
 }

--- a/src/multiplayer/missiletubes.cpp
+++ b/src/multiplayer/missiletubes.cpp
@@ -17,6 +17,7 @@ BASIC_REPLICATION_IMPL(MissileTubesReplication, MissileTubes)
     BASIC_REPLICATION_FIELD(heat_add_rate_per_second);
     BASIC_REPLICATION_FIELD(power_change_rate_per_second);
     BASIC_REPLICATION_FIELD(auto_repair_per_second);
+    BASIC_REPLICATION_FIELD(damage_per_second_on_overheat);
 
     BASIC_REPLICATION_FIELD(storage[MW_Homing]);
     BASIC_REPLICATION_FIELD(storage[MW_Nuke]);

--- a/src/multiplayer/reactor.cpp
+++ b/src/multiplayer/reactor.cpp
@@ -17,6 +17,7 @@ BASIC_REPLICATION_IMPL(ReactorReplication, Reactor)
     BASIC_REPLICATION_FIELD(heat_add_rate_per_second);
     BASIC_REPLICATION_FIELD(power_change_rate_per_second);
     BASIC_REPLICATION_FIELD(auto_repair_per_second);
+    BASIC_REPLICATION_FIELD(damage_per_second_on_overheat);
 
     BASIC_REPLICATION_FIELD(max_energy);
     BASIC_REPLICATION_FIELD(energy);

--- a/src/multiplayer/shields.cpp
+++ b/src/multiplayer/shields.cpp
@@ -12,6 +12,11 @@ BASIC_REPLICATION_IMPL(ShieldsReplication, Shields)
     BASIC_REPLICATION_FIELD(front_system.can_be_hacked);
     BASIC_REPLICATION_FIELD(front_system.hacked_level);
     BASIC_REPLICATION_FIELD(front_system.power_factor);
+    BASIC_REPLICATION_FIELD(front_system.coolant_change_rate_per_second);
+    BASIC_REPLICATION_FIELD(front_system.heat_add_rate_per_second);
+    BASIC_REPLICATION_FIELD(front_system.power_change_rate_per_second);
+    BASIC_REPLICATION_FIELD(front_system.auto_repair_per_second);
+    BASIC_REPLICATION_FIELD(front_system.damage_per_second_on_overheat);
 
     BASIC_REPLICATION_FIELD(rear_system.health);
     BASIC_REPLICATION_FIELD(rear_system.health_max);
@@ -23,20 +28,17 @@ BASIC_REPLICATION_IMPL(ShieldsReplication, Shields)
     BASIC_REPLICATION_FIELD(rear_system.can_be_hacked);
     BASIC_REPLICATION_FIELD(rear_system.hacked_level);
     BASIC_REPLICATION_FIELD(rear_system.power_factor);
+    BASIC_REPLICATION_FIELD(rear_system.coolant_change_rate_per_second);
+    BASIC_REPLICATION_FIELD(rear_system.heat_add_rate_per_second);
+    BASIC_REPLICATION_FIELD(rear_system.power_change_rate_per_second);
+    BASIC_REPLICATION_FIELD(rear_system.auto_repair_per_second);
+    BASIC_REPLICATION_FIELD(rear_system.damage_per_second_on_overheat);
 
-    BASIC_REPLICATION_PAIR(front_system.coolant_change_rate_per_second, rear_system.coolant_change_rate_per_second);
-    BASIC_REPLICATION_PAIR(front_system.heat_add_rate_per_second,       rear_system.heat_add_rate_per_second);
-    BASIC_REPLICATION_PAIR(front_system.power_change_rate_per_second,   rear_system.power_change_rate_per_second);
-    BASIC_REPLICATION_PAIR(front_system.auto_repair_per_second,         rear_system.auto_repair_per_second);
-    BASIC_REPLICATION_PAIR(front_system.damage_per_second_on_overheat,  rear_system.damage_per_second_on_overheat);
-
-    BASIC_REPLICATION_FIELD(calibration_time);
+    //BASIC_REPLICATION_FIELD(calibration_time); TODO: With this we have 33 fields, while basic replication is limited to 32 fields.
     BASIC_REPLICATION_FIELD(calibration_delay);
     BASIC_REPLICATION_FIELD(frequency);
 
     BASIC_REPLICATION_FIELD(energy_use_per_second);
-
-    BASIC_REPLICATION_FIELD(active);
 
     BASIC_REPLICATION_VECTOR(entries)
         VECTOR_REPLICATION_FIELD(level);

--- a/src/multiplayer/shields.cpp
+++ b/src/multiplayer/shields.cpp
@@ -12,11 +12,6 @@ BASIC_REPLICATION_IMPL(ShieldsReplication, Shields)
     BASIC_REPLICATION_FIELD(front_system.can_be_hacked);
     BASIC_REPLICATION_FIELD(front_system.hacked_level);
     BASIC_REPLICATION_FIELD(front_system.power_factor);
-    BASIC_REPLICATION_FIELD(front_system.coolant_change_rate_per_second);
-    BASIC_REPLICATION_FIELD(front_system.heat_add_rate_per_second);
-    BASIC_REPLICATION_FIELD(front_system.power_change_rate_per_second);
-    BASIC_REPLICATION_FIELD(front_system.auto_repair_per_second);
-    //BASIC_REPLICATION_FIELD(front_system.damage_per_second_on_overheat); TODO: see below
 
     BASIC_REPLICATION_FIELD(rear_system.health);
     BASIC_REPLICATION_FIELD(rear_system.health_max);
@@ -28,17 +23,20 @@ BASIC_REPLICATION_IMPL(ShieldsReplication, Shields)
     BASIC_REPLICATION_FIELD(rear_system.can_be_hacked);
     BASIC_REPLICATION_FIELD(rear_system.hacked_level);
     BASIC_REPLICATION_FIELD(rear_system.power_factor);
-    BASIC_REPLICATION_FIELD(rear_system.coolant_change_rate_per_second);
-    BASIC_REPLICATION_FIELD(rear_system.heat_add_rate_per_second);
-    BASIC_REPLICATION_FIELD(rear_system.power_change_rate_per_second);
-    BASIC_REPLICATION_FIELD(rear_system.auto_repair_per_second);
-    //BASIC_REPLICATION_FIELD(rear_system.damage_per_second_on_overheat); TODO: see below
 
-    //BASIC_REPLICATION_FIELD(calibration_time); TODO: With this we have 33 fields, while basic replication is limited to 32 fields.
+    BASIC_REPLICATION_PAIR(front_system.coolant_change_rate_per_second, rear_system.coolant_change_rate_per_second);
+    BASIC_REPLICATION_PAIR(front_system.heat_add_rate_per_second,       rear_system.heat_add_rate_per_second);
+    BASIC_REPLICATION_PAIR(front_system.power_change_rate_per_second,   rear_system.power_change_rate_per_second);
+    BASIC_REPLICATION_PAIR(front_system.auto_repair_per_second,         rear_system.auto_repair_per_second);
+    BASIC_REPLICATION_PAIR(front_system.damage_per_second_on_overheat,  rear_system.damage_per_second_on_overheat);
+
+    BASIC_REPLICATION_FIELD(calibration_time);
     BASIC_REPLICATION_FIELD(calibration_delay);
     BASIC_REPLICATION_FIELD(frequency);
 
     BASIC_REPLICATION_FIELD(energy_use_per_second);
+
+    BASIC_REPLICATION_FIELD(active);
 
     BASIC_REPLICATION_VECTOR(entries)
         VECTOR_REPLICATION_FIELD(level);

--- a/src/multiplayer/shields.cpp
+++ b/src/multiplayer/shields.cpp
@@ -16,6 +16,7 @@ BASIC_REPLICATION_IMPL(ShieldsReplication, Shields)
     BASIC_REPLICATION_FIELD(front_system.heat_add_rate_per_second);
     BASIC_REPLICATION_FIELD(front_system.power_change_rate_per_second);
     BASIC_REPLICATION_FIELD(front_system.auto_repair_per_second);
+    //BASIC_REPLICATION_FIELD(front_system.damage_per_second_on_overheat); TODO: see below
 
     BASIC_REPLICATION_FIELD(rear_system.health);
     BASIC_REPLICATION_FIELD(rear_system.health_max);
@@ -31,6 +32,7 @@ BASIC_REPLICATION_IMPL(ShieldsReplication, Shields)
     BASIC_REPLICATION_FIELD(rear_system.heat_add_rate_per_second);
     BASIC_REPLICATION_FIELD(rear_system.power_change_rate_per_second);
     BASIC_REPLICATION_FIELD(rear_system.auto_repair_per_second);
+    //BASIC_REPLICATION_FIELD(rear_system.damage_per_second_on_overheat); TODO: see below
 
     //BASIC_REPLICATION_FIELD(calibration_time); TODO: With this we have 33 fields, while basic replication is limited to 32 fields.
     BASIC_REPLICATION_FIELD(calibration_delay);

--- a/src/multiplayer/warp.cpp
+++ b/src/multiplayer/warp.cpp
@@ -17,7 +17,11 @@ BASIC_REPLICATION_IMPL(WarpDriveReplication, WarpDrive)
     BASIC_REPLICATION_FIELD(heat_add_rate_per_second);
     BASIC_REPLICATION_FIELD(power_change_rate_per_second);
     BASIC_REPLICATION_FIELD(auto_repair_per_second);
+    BASIC_REPLICATION_FIELD(damage_per_second_on_overheat);
 
+    BASIC_REPLICATION_FIELD(charge_time);
+    BASIC_REPLICATION_FIELD(decharge_time);
+    BASIC_REPLICATION_FIELD(heat_per_warp);
     BASIC_REPLICATION_FIELD(max_level);
     BASIC_REPLICATION_FIELD(speed_per_level);
     BASIC_REPLICATION_FIELD(energy_warp_per_second);

--- a/src/script/components.cpp
+++ b/src/script/components.cpp
@@ -385,6 +385,7 @@ void initComponentScriptBindings()
     BIND_MEMBER(DockingPort, state);
     BIND_MEMBER(DockingPort, target);
     BIND_MEMBER(DockingPort, auto_reload_missiles);
+    BIND_MEMBER(DockingPort, auto_reload_missile_time);
 
     sp::script::ComponentHandler<DockingBay>::name("docking_bay");
     BIND_MEMBER_FLAG(DockingBay, flags, "share_energy", DockingBay::ShareEnergy);
@@ -512,6 +513,9 @@ void initComponentScriptBindings()
     BIND_MEMBER_NAMED(CombatManeuveringThrusters, strafe.active, "strafe_active");
     sp::script::ComponentHandler<WarpDrive>::name("warp_drive");
     BIND_SHIP_SYSTEM(WarpDrive);
+    BIND_MEMBER(WarpDrive, charge_time);
+    BIND_MEMBER(WarpDrive, decharge_time);
+    BIND_MEMBER(WarpDrive, heat_per_warp);
     BIND_MEMBER(WarpDrive, max_level);
     BIND_MEMBER(WarpDrive, speed_per_level);
     BIND_MEMBER(WarpDrive, energy_warp_per_second);
@@ -521,6 +525,9 @@ void initComponentScriptBindings()
     BIND_MEMBER(WarpJammer, range);
     sp::script::ComponentHandler<JumpDrive>::name("jump_drive");
     BIND_SHIP_SYSTEM(JumpDrive);
+    BIND_MEMBER(JumpDrive, charge_time);
+    BIND_MEMBER(JumpDrive, energy_per_km_charge);
+    BIND_MEMBER(JumpDrive, heat_per_jump);
     BIND_MEMBER(JumpDrive, min_distance);
     BIND_MEMBER(JumpDrive, max_distance);
     BIND_MEMBER(JumpDrive, charge);

--- a/src/script/components.cpp
+++ b/src/script/components.cpp
@@ -538,6 +538,7 @@ void initComponentScriptBindings()
     BIND_MEMBER(JumpDrive, heat_per_jump);
     BIND_MEMBER(JumpDrive, min_distance);
     BIND_MEMBER(JumpDrive, max_distance);
+    BIND_MEMBER(JumpDrive, activation_delay);
     BIND_MEMBER(JumpDrive, charge);
     BIND_MEMBER(JumpDrive, distance);
     BIND_MEMBER(JumpDrive, delay);

--- a/src/script/components.cpp
+++ b/src/script/components.cpp
@@ -508,12 +508,17 @@ void initComponentScriptBindings()
     BIND_MEMBER(ManeuveringThrusters, rotation_request);
     sp::script::ComponentHandler<CombatManeuveringThrusters>::name("combat_maneuvering_thrusters");
     BIND_MEMBER(CombatManeuveringThrusters, charge);
+    BIND_MEMBER(CombatManeuveringThrusters, charge_time);
     BIND_MEMBER_NAMED(CombatManeuveringThrusters, boost.speed, "boost_speed");
     BIND_MEMBER_NAMED(CombatManeuveringThrusters, strafe.speed, "strafe_speed");
     BIND_MEMBER_NAMED(CombatManeuveringThrusters, boost.request, "boost_request");
     BIND_MEMBER_NAMED(CombatManeuveringThrusters, strafe.request, "strafe_request");
     BIND_MEMBER_NAMED(CombatManeuveringThrusters, boost.active, "boost_active");
     BIND_MEMBER_NAMED(CombatManeuveringThrusters, strafe.active, "strafe_active");
+    BIND_MEMBER_NAMED(CombatManeuveringThrusters, boost.max_time, "boost_max_time");
+    BIND_MEMBER_NAMED(CombatManeuveringThrusters, strafe.max_time, "strafe_max_time");
+    BIND_MEMBER_NAMED(CombatManeuveringThrusters, boost.heat_per_second, "boost_heat_per_second");
+    BIND_MEMBER_NAMED(CombatManeuveringThrusters, strafe.heat_per_second, "strafe_heat_per_second");
     sp::script::ComponentHandler<WarpDrive>::name("warp_drive");
     BIND_SHIP_SYSTEM(WarpDrive);
     BIND_MEMBER(WarpDrive, charge_time);

--- a/src/script/components.cpp
+++ b/src/script/components.cpp
@@ -182,7 +182,8 @@
     BIND_MEMBER(T, coolant_change_rate_per_second); \
     BIND_MEMBER(T, heat_add_rate_per_second); \
     BIND_MEMBER(T, power_change_rate_per_second); \
-    BIND_MEMBER(T, auto_repair_per_second);
+    BIND_MEMBER(T, auto_repair_per_second); \
+    BIND_MEMBER(T, damage_per_second_on_overheat);
 
 
 void initComponentScriptBindings()
@@ -355,6 +356,7 @@ void initComponentScriptBindings()
     BIND_MEMBER_NAMED(Shields, front_system.heat_add_rate_per_second, "front_heat_add_rate_per_second");
     BIND_MEMBER_NAMED(Shields, front_system.power_change_rate_per_second, "front_power_change_rate_per_second");
     BIND_MEMBER_NAMED(Shields, front_system.auto_repair_per_second, "front_auto_repair_per_second");
+    BIND_MEMBER_NAMED(Shields, front_system.damage_per_second_on_overheat, "front_damage_per_second_on_overheat");
     BIND_MEMBER_NAMED(Shields, rear_system.health, "rear_health");
     BIND_MEMBER_NAMED(Shields, rear_system.health_max, "rear_health_max");
     BIND_MEMBER_NAMED(Shields, rear_system.power_level, "rear_power_level");
@@ -369,6 +371,7 @@ void initComponentScriptBindings()
     BIND_MEMBER_NAMED(Shields, rear_system.heat_add_rate_per_second, "rear_heat_add_rate_per_second");
     BIND_MEMBER_NAMED(Shields, rear_system.power_change_rate_per_second, "rear_power_change_rate_per_second");
     BIND_MEMBER_NAMED(Shields, rear_system.auto_repair_per_second, "rear_auto_repair_per_second");
+    BIND_MEMBER_NAMED(Shields, rear_system.damage_per_second_on_overheat, "rear_damage_per_second_on_overheat");
 
     BIND_MEMBER(Shields, active);
     BIND_MEMBER(Shields, calibration_time);

--- a/src/systems/jumpsystem.cpp
+++ b/src/systems/jumpsystem.cpp
@@ -86,7 +86,7 @@ void JumpSystem::initializeJump(sp::ecs::Entity entity, float distance)
     if (jump->delay <= 0.0f)
     {
         jump->distance = distance;
-        jump->delay = 10.f;
+        jump->delay = jump->activation_delay;
         jump->charge -= distance;
     }
 }

--- a/src/systems/maneuvering.cpp
+++ b/src/systems/maneuvering.cpp
@@ -81,10 +81,10 @@ void ManeuveringSystem::update(float delta)
                 // Add heat to systems consuming combat maneuver boost.
                 auto thrusters = entity.getComponent<ManeuveringThrusters>();
                 if (thrusters && entity.hasComponent<Coolant>())
-                    thrusters->addHeat(std::abs(combat.boost.active) * delta * heat_per_combat_maneuver_boost);
+                    thrusters->addHeat(std::abs(combat.strafe.active) * delta * heat_per_combat_maneuver_strafe);
                 auto impulse = entity.getComponent<ImpulseEngine>();
                 if (impulse && entity.hasComponent<Coolant>())
-                    impulse->addHeat(std::abs(combat.strafe.active) * delta * heat_per_combat_maneuver_strafe);
+                    impulse->addHeat(std::abs(combat.boost.active) * delta * heat_per_combat_maneuver_boost);
             }
         }else if (combat.charge < 1.0f)
         {


### PR DESCRIPTION
```
docking_port.auto_reload_missile_time
jump_drive.charge_time
jump_drive.energy_per_km_charge
jump_drive.heat_per_jump
jump_drive.activation_delay
warp_drive.charge_time
warp_drive.decharge_time
warp_drive.heat_per_warp
combat_maneuvering_thrusters.charge_time
combat_maneuvering_thrusters.boost_max_time
combat_maneuvering_thrusters.strafe_max_time
combat_maneuvering_thrusters.boost_heat_per_second
combat_maneuvering_thrusters.strafe_heat_per_second
<all systems>.damage_per_second_on_overheat
```

Also fixes combat thruster heat generation being flipped (boost to maneuver, strafe to impulse; 08e3730).