### PR TITLE
Add various preferences to improve autoconnect server selection

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -216,6 +216,10 @@ int main(int argc, char** argv)
         if(!gameGlobalInfo) // => failed to start server
             return 1;
 
+        if (PreferencesManager::get("server_name") != "") game_server->setServerName(PreferencesManager::get("server_name"));
+        if (PreferencesManager::get("server_password") != "") game_server->setPassword(PreferencesManager::get("server_password").upper());
+        if (PreferencesManager::get("server_internet") == "1") game_server->registerOnMasterServer(PreferencesManager::get("registry_registration_url", "http://daid.eu/ee/register.php"));
+
         // Load the scenario and open the ship selection screen.
         gameGlobalInfo->startScenario(PreferencesManager::get("server_scenario"), loadScenarioSettingsFromPrefs());
         new ShipSelectionScreen();

--- a/src/menus/autoConnectScreen.cpp
+++ b/src/menus/autoConnectScreen.cpp
@@ -72,6 +72,7 @@ void AutoConnectScreen::update(float delta)
         if (autoconnect_address != "") {
             status_label->setText("Using autoconnect server " + autoconnect_address);
             connect_to_address = autoconnect_address;
+            tried_password = false;
             new GameClient(VERSION_NUMBER, autoconnect_address);
             scanner->destroy();
         } else {
@@ -82,6 +83,7 @@ void AutoConnectScreen::update(float delta)
 
                 status_label->setText("Found server " + server.name);
                 connect_to_address = server.address;
+                tried_password = false;
                 new GameClient(VERSION_NUMBER, server.address);
                 scanner->destroy();
                 return;

--- a/src/menus/autoConnectScreen.cpp
+++ b/src/menus/autoConnectScreen.cpp
@@ -74,12 +74,19 @@ void AutoConnectScreen::update(float delta)
             connect_to_address = autoconnect_address;
             new GameClient(VERSION_NUMBER, autoconnect_address);
             scanner->destroy();
-        } else if (serverList.size() > 0) {
-            status_label->setText("Found server " + serverList[0].name);
-            connect_to_address = serverList[0].address;
-            new GameClient(VERSION_NUMBER, serverList[0].address);
-            scanner->destroy();
         } else {
+            auto name_filter = PreferencesManager::get("autoconnect_servername", "");
+            for (auto server : serverList) {
+                if (name_filter != "" && name_filter != server.name)
+                    continue;
+
+                status_label->setText("Found server " + server.name);
+                connect_to_address = server.address;
+                new GameClient(VERSION_NUMBER, server.address);
+                scanner->destroy();
+                return;
+            }
+
             status_label->setText("Searching for server...");
         }
     }else{

--- a/src/menus/autoConnectScreen.cpp
+++ b/src/menus/autoConnectScreen.cpp
@@ -99,7 +99,17 @@ void AutoConnectScreen::update(float delta)
             else
                 status_label->setText("Connecting...");
             break;
-        case GameClient::WaitingForPassword: //For now, just disconnect when we found a password protected server.
+        case GameClient::WaitingForPassword:
+            if (!tried_password) {
+                auto password = PreferencesManager::get("autoconnect_password");
+                if (password != "") {
+                    game_client->sendPassword(password.upper());
+                    tried_password = true;
+                    return;
+                }
+            }
+            // if we don't have a password or we already tried it and it didn't work,
+            // fallthrough
         case GameClient::Disconnected:
             disconnectFromServer();
             scanner = new ServerScanner(VERSION_NUMBER);

--- a/src/menus/autoConnectScreen.h
+++ b/src/menus/autoConnectScreen.h
@@ -16,6 +16,7 @@ class AutoConnectScreen : public GuiCanvas, public Updatable
     CrewPosition crew_position;
     bool control_main_screen;
     std::map<string, string> ship_filters;
+    bool tried_password = false;
 
     GuiLabel* status_label;
     int crew_position_raw = (PreferencesManager::get("autoconnect").toInt());


### PR DESCRIPTION
`server_name`, `server_password`, `server_internet` are for `server_scenario=...` what the corresponding `headless_*` are for `headless=...`

`autoconnect_servername` prevents the autoconnect screen from connecting to any server whose name is not the preference value.

`autoconnect_password` allows specifying a password for the autoconnected server. Likely mostly (only?) useful in combination with `autoconnect_servername`.