### PR TITLE
Fix shield synchronisation

### DIFF
--- a/src/multiplayer/basic.h
+++ b/src/multiplayer/basic.h
@@ -24,7 +24,7 @@ enum class BasicReplicationRequest {
         void receive(sp::ecs::Entity entity, sp::io::DataBuffer& packet) override; \
         void remove(sp::ecs::Entity entity) override; \
         template<BasicReplicationRequest> bool impl(sp::ecs::Entity entity, sp::io::DataBuffer& packet, COMPONENT& c, COMPONENT* backup); \
-        template<BasicReplicationRequest> void field_impl(sp::ecs::Entity entity, sp::io::DataBuffer& packet, COMPONENT& c, COMPONENT* backup, sp::io::DataBuffer& tmp, uint32_t& flags); \
+        template<BasicReplicationRequest> void field_impl(sp::ecs::Entity entity, sp::io::DataBuffer& packet, COMPONENT& c, COMPONENT* backup, sp::io::DataBuffer& tmp, uint64_t& flags); \
     };
 #define BASIC_REPLICATION_CLASS(CLASS, COMPONENT) \
     BASIC_REPLICATION_CLASS_RATE(CLASS, COMPONENT, 60.0f);
@@ -63,14 +63,14 @@ enum class BasicReplicationRequest {
     void CLASS::remove(sp::ecs::Entity entity) { entity.removeComponent<COMPONENT>(); } \
     template<BasicReplicationRequest BRR> bool CLASS::impl(sp::ecs::Entity entity, sp::io::DataBuffer& packet, COMPONENT& target, COMPONENT* backup) { \
         sp::io::DataBuffer tmp; \
-        uint32_t flags = 0; \
+        uint64_t flags = 0; \
         if (BRR == BasicReplicationRequest::Receive) packet >> flags; \
         field_impl<BRR>(entity, packet, target, backup, tmp, flags); \
         if (tmp.getDataSize() > 0) packet.write(CMD_ECS_SET_COMPONENT, component_index, entity.getIndex(), flags, tmp); \
         return tmp.getDataSize() > 0; \
     } \
-    template<BasicReplicationRequest BRR> void CLASS::field_impl(sp::ecs::Entity entity, sp::io::DataBuffer& packet, COMPONENT& target, COMPONENT* backup, sp::io::DataBuffer& tmp, uint32_t& flags) { \
-        uint32_t flag = 1;
+    template<BasicReplicationRequest BRR> void CLASS::field_impl(sp::ecs::Entity entity, sp::io::DataBuffer& packet, COMPONENT& target, COMPONENT* backup, sp::io::DataBuffer& tmp, uint64_t& flags) { \
+        uint64_t flag = 1;
 
 #define BASIC_REPLICATION_FIELD(FIELD) \
     switch(BRR) { \

--- a/src/multiplayer/shields.cpp
+++ b/src/multiplayer/shields.cpp
@@ -2,6 +2,8 @@
 #include "multiplayer.h"
 
 BASIC_REPLICATION_IMPL(ShieldsReplication, Shields)
+    BASIC_REPLICATION_FIELD(active);
+
     BASIC_REPLICATION_FIELD(front_system.health);
     BASIC_REPLICATION_FIELD(front_system.health_max);
     BASIC_REPLICATION_FIELD(front_system.power_level);
@@ -32,7 +34,7 @@ BASIC_REPLICATION_IMPL(ShieldsReplication, Shields)
     BASIC_REPLICATION_FIELD(rear_system.power_change_rate_per_second);
     BASIC_REPLICATION_FIELD(rear_system.auto_repair_per_second);
 
-    //BASIC_REPLICATION_FIELD(calibration_time); TODO: With this we have 33 fields, while basic replication is limited to 32 fields.
+    BASIC_REPLICATION_FIELD(calibration_time);
     BASIC_REPLICATION_FIELD(calibration_delay);
     BASIC_REPLICATION_FIELD(frequency);
 


### PR DESCRIPTION
While testing locally I noticed that the power levels between the host and a client were out of sync. Eventually this turned out to be caused by the shields being on for the client, but off for the server, which is caused by the `active` field of the shield component not being synchronised.

The shield component was already synchronising 32 fields, so I increased the basic replication size to 64 bits. I've done some brief local testing and the shields are now fully in sync, and other things like movement are continuing to work as expected. This doesn't increase the bandwidth used unless needed, since the underlying `sp::io::dataBuffer` implementation does variable width encoding of the u64, and flags are allocated LSB first.