### PR TITLE
Fix scanning synchronisation

### DIFF
--- a/src/components/scanning.cpp
+++ b/src/components/scanning.cpp
@@ -27,6 +27,7 @@ void ScanState::setStateForFaction(sp::ecs::Entity faction_entity, ScanState::St
     for(auto& it : per_faction) {
         if (it.faction == faction_entity) {
             it.state = state;
+            per_faction_dirty = true;
             return;
         }
     }

--- a/src/multiplayer/scanning.cpp
+++ b/src/multiplayer/scanning.cpp
@@ -29,4 +29,5 @@ BASIC_REPLICATION_IMPL(ScienceDescriptionReplication, ScienceDescription)
 BASIC_REPLICATION_IMPL(ScienceScannerReplication, ScienceScanner)
     BASIC_REPLICATION_FIELD(delay);
     BASIC_REPLICATION_FIELD(max_scanning_delay);
+    BASIC_REPLICATION_FIELD(target);
 }


### PR DESCRIPTION
Currently, when a client starts a scan, the scanning ui only appears on the host. Then when the scan is completed, only the host is able to see the results.

This is due to incomplete synchronisation. After this PR, scanning works normally for clients.