### PR TITLE
Responsive custom function layout - revised, ECS edition

### DIFF
--- a/src/screens/crew4/operationsScreen.cpp
+++ b/src/screens/crew4/operationsScreen.cpp
@@ -87,15 +87,16 @@ OperationScreen::OperationScreen(GuiContainer* owner)
     delete_waypoint_button->setPosition(-270, -120, sp::Alignment::BottomRight)->setSize(200, 50);
 
     auto stats = new GuiElement(this, "OPERATIONS_STATS");
-    stats->setPosition(20, 100, sp::Alignment::TopLeft)->setSize(240, 80)->setAttribute("layout", "vertical");
+    stats->setPosition(20, 60, sp::Alignment::TopLeft)->setSize(240, 80)->setAttribute("layout", "vertical");
 
     // Reputation display.
-    info_reputation = new GuiKeyValueDisplay(stats, "INFO_REPUTATION", 0.45f, tr("Reputation") + ":", "");
-    info_reputation->setTextSize(20)->setSize(240, 40);
+    info_reputation = new GuiKeyValueDisplay(stats, "INFO_REPUTATION", 0.55f, tr("Reputation") + ":", "");
+    info_reputation->setTextSize(20)->setSize(200, 40);
 
     // Scenario clock display.
-    info_clock = new GuiKeyValueDisplay(stats, "INFO_CLOCK", 0.45f, tr("Clock") + ":", "");
-    info_clock->setTextSize(20)->setSize(240, 40);
+
+    info_clock = new GuiKeyValueDisplay(stats, "INFO_CLOCK", 0.55f, tr("Clock") + ":", "");
+    info_clock->setTextSize(20)->setSize(200, 40);
 
     mode = TargetSelection;
 

--- a/src/screens/crew6/scienceScreen.cpp
+++ b/src/screens/crew6/scienceScreen.cpp
@@ -41,7 +41,7 @@ ScienceScreen::ScienceScreen(GuiContainer* owner, CrewPosition crew_position)
 
     // Render the radar shadow and background decorations.
     background_gradient = new GuiImage(this, "BACKGROUND_GRADIENT", "gui/background/gradientOffset.png");
-    background_gradient->setPosition(glm::vec2(0, 0), sp::Alignment::Center)->setSize(1200, 900);
+    background_gradient->setPosition(glm::vec2(105, 0), sp::Alignment::CenterLeft)->setSize(1200, 900);
 
     background_crosses = new GuiOverlay(this, "BACKGROUND_CROSSES", glm::u8vec4{255,255,255,255});
     background_crosses->setTextureTiled("gui/background/crosses.png");
@@ -55,7 +55,7 @@ ScienceScreen::ScienceScreen(GuiContainer* owner, CrewPosition crew_position)
 
     // Draw the science radar.
     science_radar = new GuiRadarView(radar_view, "SCIENCE_RADAR", lrr ? lrr->long_range : 30000.0f, &targets);
-    science_radar->setPosition(-270, 0, sp::Alignment::CenterRight)->setSize(GuiElement::GuiSizeMax, GuiElement::GuiSizeMax);
+    science_radar->setPosition(120, 0, sp::Alignment::CenterLeft)->setSize(900,GuiElement::GuiSizeMax);
     science_radar->setRangeIndicatorStepSize(5000.0)->longRange()->enableWaypoints()->enableCallsigns()->enableHeadingIndicators()->setStyle(GuiRadarView::Circular)->setFogOfWarStyle(GuiRadarView::NebulaFogOfWar);
     science_radar->setCallbacks(
         [this](sp::io::Pointer::Button button, glm::vec2 position) {
@@ -71,7 +71,7 @@ ScienceScreen::ScienceScreen(GuiContainer* owner, CrewPosition crew_position)
 
     // Draw and hide the probe radar.
     probe_radar = new GuiRadarView(radar_view, "PROBE_RADAR", 5000, &targets);
-    probe_radar->setPosition(-270, 0, sp::Alignment::CenterRight)->setSize(GuiElement::GuiSizeMax, GuiElement::GuiSizeMax)->hide();
+    probe_radar->setPosition(120, 0, sp::Alignment::CenterLeft)->setSize(850, 850)->hide();
     probe_radar->setAutoCentering(false)->longRange()->enableWaypoints()->enableCallsigns()->enableHeadingIndicators()->setStyle(GuiRadarView::Circular)->setFogOfWarStyle(GuiRadarView::NoFogOfWar);
     probe_radar->setCallbacks(
         [this](sp::io::Pointer::Button button, glm::vec2 position) {
@@ -98,7 +98,7 @@ ScienceScreen::ScienceScreen(GuiContainer* owner, CrewPosition crew_position)
     info_sidebar->setPosition(-20, 170, sp::Alignment::TopRight)->setSize(250, GuiElement::GuiSizeMax)->setAttribute("layout", "vertical");
 
     custom_function_sidebar = new GuiCustomShipFunctions(radar_view, crew_position, "");
-    custom_function_sidebar->setPosition(-20, 170, sp::Alignment::TopRight)->setSize(250, GuiElement::GuiSizeMax)->hide();
+    custom_function_sidebar->setPosition(-15, 210, sp::Alignment::TopRight)->setSize(250, GuiElement::GuiSizeMax)->hide();
 
     // Scan button.
     scan_button = new GuiScanTargetButton(info_sidebar, "SCAN_BUTTON", &targets);
@@ -269,7 +269,26 @@ void ScienceScreen::onDraw(sp::RenderTarget& renderer)
             targets.clear();
     }
 
-    sidebar_selector->setVisible(sidebar_selector->getSelectionIndex() > 0 || custom_function_sidebar->hasEntries());
+    // Responsive layout for custom button sidebar. 1440x900 vpixels is 16:10, so this would roughly be the threshold.
+
+    int current_width = getRect().size.x;
+    sidebar_selector->setVisible(current_width < 1435 && (sidebar_selector->getSelectionIndex() > 0 || custom_function_sidebar->hasEntries()));
+    if (current_width < 1435 || !custom_function_sidebar->hasEntries())
+    {
+        info_sidebar->setPosition(-20, 170, sp::Alignment::TopRight);
+        sidebar_selector->setPosition(-20, 120, sp::Alignment::TopRight);
+        custom_function_sidebar->setVisible(sidebar_selector->getSelectionIndex() == 1);
+        custom_function_sidebar->setPosition(-20, 210, sp::Alignment::TopRight);
+        info_sidebar->setVisible(sidebar_selector->getSelectionIndex() == 0);
+    }
+    else
+    {
+        info_sidebar->setPosition(-280, 170, sp::Alignment::TopRight);
+        sidebar_selector->setPosition(-280, 120, sp::Alignment::TopRight);
+        custom_function_sidebar->setPosition(-20, 170, sp::Alignment::TopRight);
+        custom_function_sidebar->show();
+        info_sidebar->show();
+    }
 
     info_callsign->setValue("-");
     info_distance->setValue("-");


### PR DESCRIPTION
This let the custom buttons on science/ops have an extra sidebar, if the screen is wide enough. That way, those buttons/labels won't be as easy to miss as before, at least on 16:10 and wider.

As the ECS merge happened since #2120, I decided to redo this PR on a clean base.

I also addressed the concern that the science radar should not become smaller, so both radars keep their original size.

https://github.com/user-attachments/assets/f6208947-f6f9-49d5-93b7-9980749c2f0a

