### PR TITLE
Add __pycache__ to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -48,3 +48,4 @@ build*/
 _build*/
 cmake/_win32/
 cmake/android/
+script_docs/__pycache__/


### PR DESCRIPTION
Small annoyance, whenever the build has run, a .pyc file in __pycache__ is shown as a new file and is not ignored.

Since __pycache__ is the equivalent of a C++ build folder this should not be in the repo.