### PR TITLE
fix internal docking for util_random_transports.lua

### DIFF
--- a/scripts/util_random_transports.lua
+++ b/scripts/util_random_transports.lua
@@ -34,6 +34,7 @@ function update(delta)
                 if obj.undock_delay > 0 then
                     obj.undock_delay = obj.undock_delay - delta
                 else
+                    if not obj.components.transform then obj.components.transform = {} end
                     obj.target = randomStation()
                     obj.undock_delay = random(5, 30)
                     obj:orderDock(obj.target)


### PR DESCRIPTION
If a dockable object has internal ports for the transports, they will never undock after  docking.
This fixes the issue by recreating a transform component before ordering to leave the port.

_There is still the issue that large transports never dock in the first place, but that is a general issue that can't be solved in this script - other than excluding size-5- freighters from the list_