### PR TITLE
Add slider controls to GM tweaks

### DIFF
--- a/src/gui/gui2_slider.cpp
+++ b/src/gui/gui2_slider.cpp
@@ -150,7 +150,7 @@ void GuiSlider::onDraw(sp::RenderTarget& renderer)
 
     if (overlay_label)
     {
-        overlay_label->setText(string(value, 0));
+        overlay_label->setText(string(value, int(overlay_label_precision)));
     }
 }
 
@@ -214,12 +214,13 @@ GuiSlider* GuiSlider::addSnapValue(float value, float range)
     return this;
 }
 
-GuiSlider* GuiSlider::addOverlay()
+GuiSlider* GuiSlider::addOverlay(unsigned int precision, float font_size)
 {
     if (!overlay_label)
     {
-        overlay_label = new GuiLabel(this, "", "", 30);
+        overlay_label = new GuiLabel(this, "", "", font_size);
         overlay_label->setSize(GuiElement::GuiSizeMax, GuiElement::GuiSizeMax);
+        overlay_label_precision = precision;
     }
     return this;
 }

--- a/src/gui/gui2_slider.h
+++ b/src/gui/gui2_slider.h
@@ -44,6 +44,7 @@ protected:
     };
     std::vector<TSnapPoint> snap_points;
     GuiLabel* overlay_label;
+    unsigned int overlay_label_precision = 0;
     const GuiThemeStyle* tick_style;
 public:
     GuiSlider(GuiContainer* owner, string id, float min_value, float max_value, float start_value, func_t func);
@@ -56,7 +57,7 @@ public:
     GuiSlider* setValueSnapped(float value);
     GuiSlider* clearSnapValues();
     GuiSlider* addSnapValue(float value, float range);
-    GuiSlider* addOverlay();
+    GuiSlider* addOverlay(unsigned int precision = 0u, float font_size = 30.0f);
 };
 
 class GuiSlider2D : public GuiElement


### PR DESCRIPTION
Add a `GuiSliderTweak` component to allow setting some GM screen tweaks with a slider instead of a text field. This implementation supports only values with a fixed range, such as arcs or directions between 0.0-360.0, values like heat always defined as 0.0-1.0, or beam/shield frequencies always defined as 0-20.

![Screenshot_20250606_171340](https://github.com/user-attachments/assets/13333347-6430-4b34-b875-ae38dcca012a)

For integer values, the `ADD_INT_SLIDER_TWEAK` macro adds snap points for each value in the range.

![Screenshot_20250606_171244](https://github.com/user-attachments/assets/9bc56e4a-8185-4930-9af6-1550166e1666)

To support these changes, this PR also extends `GuiSlider` to allow setting the decimal precision (for integer values) and font size (to match the presentation of text fields) of its built-in label.