### PR TITLE
Add handling of headless_port, server_port, autoconnect_port

### DIFF
--- a/src/epsilonServer.cpp
+++ b/src/epsilonServer.cpp
@@ -9,7 +9,7 @@
 #include "config.h"
 
 
-EpsilonServer::EpsilonServer(int server_port)
+EpsilonServer::EpsilonServer(uint16_t server_port)
 : GameServer("Server", VERSION_NUMBER, server_port)
 {
     if (game_server)

--- a/src/epsilonServer.h
+++ b/src/epsilonServer.h
@@ -6,7 +6,7 @@
 class EpsilonServer : public GameServer
 {
 public:
-    EpsilonServer(int server_port);
+    EpsilonServer(uint16_t server_port);
     virtual ~EpsilonServer() = default;
 
     virtual void onNewClient(int32_t client_id) override;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -197,12 +197,15 @@ int main(int argc, char** argv)
 #endif //STEAMSDK
 
     string tutorial = PreferencesManager::get("tutorial");   // use "00_all.lua" for all tutorials
-    if (tutorial != "")
+    string server_scenario = PreferencesManager::get("server_scenario");
+    int server_port = PreferencesManager::get("server_port").toInt();
+
+    if (!tutorial.empty())
     {
         LOG(DEBUG) << "Starting tutorial: " << tutorial;
         new TutorialGame(false, tutorial);
     }
-    else if (PreferencesManager::get("server_scenario") == "")
+    else if (server_scenario.empty())
         returnToMainMenu(defaultRenderLayer);
     else
     {
@@ -210,18 +213,33 @@ int main(int argc, char** argv)
         // using its defined default settings, and launches directly into
         // the ship selection screen instead of the main menu.
 
-        // Create the server.
-        new EpsilonServer(defaultServerPort);
+        // Create the server to listen on the assigned port.
+        // Use the default port if server_port isn't set or has an invalid
+        // value (toInt returns 0 if empty or not an int), or is too large.
+        if (server_port < 10 || server_port > 65535)
+        {
+            new EpsilonServer(defaultServerPort);
+            LOG(INFO) << "Launching server_scenario " << server_scenario << " on default port " << defaultServerPort;
+        }
+        else
+        {
+            // toInt/strtol returns a long integer. Recast it after the range
+            // check, because casting an int > 65535 wraps around using modulo,
+            // which would produce unexpected results in this case.
+            uint16_t recast_port = static_cast<uint16_t>(server_port);
+            new EpsilonServer(static_cast<uint16_t>(recast_port));
+            LOG(INFO) << "Launching server_scenario " << server_scenario << " on custom port " << recast_port;
+        }
 
         if(!gameGlobalInfo) // => failed to start server
             return 1;
 
-        if (PreferencesManager::get("server_name") != "") game_server->setServerName(PreferencesManager::get("server_name"));
-        if (PreferencesManager::get("server_password") != "") game_server->setPassword(PreferencesManager::get("server_password").upper());
+        if (!PreferencesManager::get("server_name").empty()) game_server->setServerName(PreferencesManager::get("server_name"));
+        if (!PreferencesManager::get("server_password").empty()) game_server->setPassword(PreferencesManager::get("server_password").upper());
         if (PreferencesManager::get("server_internet") == "1") game_server->registerOnMasterServer(PreferencesManager::get("registry_registration_url", "http://daid.eu/ee/register.php"));
 
         // Load the scenario and open the ship selection screen.
-        gameGlobalInfo->startScenario(PreferencesManager::get("server_scenario"), loadScenarioSettingsFromPrefs());
+        gameGlobalInfo->startScenario(server_scenario, loadScenarioSettingsFromPrefs());
         new ShipSelectionScreen();
     }
 
@@ -246,7 +264,7 @@ int main(int argc, char** argv)
     if (PreferencesManager::get("engine_enabled").empty())
         PreferencesManager::set("engine_enabled", "2");
 
-    if (PreferencesManager::get("headless") == "")
+    if (PreferencesManager::get("headless").empty())
     {
 #ifdef _WIN32
         mkdir(configuration_path.c_str());
@@ -270,13 +288,34 @@ void returnToMainMenu(RenderLayer* render_layer)
         return;
     }
 
-    if (PreferencesManager::get("headless") != "")
+    string headless = PreferencesManager::get("headless", "");
+
+    if (!headless.empty())
     {
-        new EpsilonServer(defaultServerPort);
+        // Create the server to listen on the assigned port.
+        // Use the default port if server_port isn't set or has an invalid
+        // value (toInt returns 0), or is too large.
+        int headless_port = PreferencesManager::get("headless_port").toInt();
+        // This is the same process as server_port and could be made DRY.
+        if (headless_port < 10 || headless_port > 65535)
+        {
+            new EpsilonServer(defaultServerPort);
+            LOG(INFO) << "Launching headless scenario " << headless << " on default port " << defaultServerPort;
+        }
+        else
+        {
+            // toInt/strtol returns a long integer. Recast it after the range
+            // check, because casting an int > 65535 wraps around using modulo,
+            // which would produce unexpected results in this case.
+            uint16_t recast_port = headless_port;
+            new EpsilonServer(recast_port);
+            LOG(INFO) << "Launching headless scenario " << headless << " on custom headless_port " << recast_port;
+        }
+
         if (PreferencesManager::get("headless_name") != "") game_server->setServerName(PreferencesManager::get("headless_name"));
         if (PreferencesManager::get("headless_password") != "") game_server->setPassword(PreferencesManager::get("headless_password").upper());
         if (PreferencesManager::get("headless_internet") == "1") game_server->registerOnMasterServer(PreferencesManager::get("registry_registration_url", "http://daid.eu/ee/register.php"));
-        gameGlobalInfo->startScenario(PreferencesManager::get("headless"), loadScenarioSettingsFromPrefs());
+        gameGlobalInfo->startScenario(headless, loadScenarioSettingsFromPrefs());
 
         if (PreferencesManager::get("startpaused") != "1")
             engine->setGameSpeed(1.0);
@@ -290,7 +329,9 @@ void returnToMainMenu(RenderLayer* render_layer)
             window_positions.push_back(AutoConnectPosition(part));
 
         new AutoConnectScreen(window_positions, PreferencesManager::get("autocontrolmainscreen").toInt(), PreferencesManager::get("autoconnectship", "solo"));
-    }else{
+    }
+    else
+    {
         new MainMenu();
     }
 }

--- a/src/menus/autoConnectScreen.h
+++ b/src/menus/autoConnectScreen.h
@@ -5,6 +5,7 @@
 #include "playerInfo.h"
 #include "io/network/address.h"
 #include "preferenceManager.h"
+#include "multiplayer_server.h"
 
 class GuiLabel;
 class ServerScanner;
@@ -26,6 +27,7 @@ class AutoConnectScreen : public GuiCanvas, public Updatable
 {
     P<ServerScanner> scanner;
     sp::io::network::Address connect_to_address;
+    uint16_t connect_to_port = defaultServerPort;
     std::vector<AutoConnectPosition> positions;
     bool control_main_screen;
     std::map<string, string> ship_filters;


### PR DESCRIPTION
When running a server via `server_scenario` or `headless`, there doesn't appear to be a way to set the server's port. Likewise, when running a client via `autoconnect`, there doesn't appear to be a way to specify a port to connect to.

This attempts to add `server_port` (used only when `server_scenario` is set), `headless_port`, and `autoconnect_port` preferences that take advantage of port parameters in SeriousProton server and client classes/functions that EE doesn't appear to use.

If left undefined, these preferences should default to port 35666, leaving the default behavior of existing installs unchanged.

This is a naive implementation that doesn't attempt to check for port usage (including by the HTTP API) and allows any port from 10 to 65535. It also adds INFO-level log lines that output the server's IP and port, or the IP and port that the autoconnect client is attempting to connect to.