### PR TITLE
[#2373] Allow JumpControl to abort a jump in progress

### DIFF
--- a/resources/gui/default.theme.txt
+++ b/resources/gui/default.theme.txt
@@ -13,6 +13,10 @@
                 color: #FF0000
                 color.disabled: #A08080
             }
+            [button.jump_abort.back] {
+                color: #FF0000
+                color.disabled: #A08080
+            }
             [button.toggle.off.back] {
             }
             [button.toggle.on.back] {
@@ -25,6 +29,11 @@
             color.disabled: #FFFFFF4D
 
             [button.selfdestruct.front] {
+                color: #FF0000
+                color.active: #120000
+                color.disabled: #FF00004D
+            }
+            [button.jump_abort.front] {
                 color: #FF0000
                 color.active: #120000
                 color.disabled: #FF00004D

--- a/scripts/api/entity/playerspaceship.lua
+++ b/scripts/api/entity/playerspaceship.lua
@@ -356,6 +356,12 @@ function Entity:commandJump(target)
     commandJump(self, target)
     return self
 end
+--- Commands this PlayerSpaceship to abort a jump in progress.
+--- Example: player:commandAbortJump() -- aborts a jump if in progress
+function Entity:commandAbortJump()
+    commandAbortJump(self)
+    return self
+end
 --- Commands this PlayerSpaceship to set its weapons target to the given SpaceObject.
 --- Example: player:commandSetTarget(enemy)
 function Entity:commandSetTarget(target)

--- a/src/gui/theme.h
+++ b/src/gui/theme.h
@@ -27,7 +27,7 @@ public:
     Themes are loaded from a text resource, and referenced from GuiElement classes.
     A single theme contains information on how to style different widget elements.
     
-    Each element describes the the following properties:
+    Each element describes the following properties:
     - texture
     - color
     - font

--- a/src/playerInfo.cpp
+++ b/src/playerInfo.cpp
@@ -103,6 +103,7 @@ static const uint16_t CMD_HACKING_FINISHED = 0x0028;
 static const uint16_t CMD_CUSTOM_FUNCTION = 0x0029;
 static const uint16_t CMD_TURN_SPEED = 0x002A;
 static const uint16_t CMD_CREW_SET_TARGET = 0x002B;
+static const uint16_t CMD_ABORT_JUMP = 0x002C;
 
 //Pre-ship commands
 static const uint16_t CMD_UPDATE_CREW_POSITION = 0x0101;
@@ -192,6 +193,13 @@ void PlayerInfo::commandJump(float distance)
 {
     sp::io::DataBuffer packet;
     packet << CMD_JUMP << distance;
+    sendClientCommand(packet);
+}
+
+void PlayerInfo::commandAbortJump()
+{
+    sp::io::DataBuffer packet;
+    packet << CMD_ABORT_JUMP;
     sendClientCommand(packet);
 }
 
@@ -618,6 +626,9 @@ void PlayerInfo::onReceiveClientCommand(int32_t client_id, sp::io::DataBuffer& p
             packet >> distance;
             JumpSystem::initializeJump(ship, distance);
         }
+        break;
+    case CMD_ABORT_JUMP:
+        JumpSystem::abortJump(ship);
         break;
     case CMD_SET_TARGET:
         {

--- a/src/playerInfo.h
+++ b/src/playerInfo.h
@@ -38,6 +38,7 @@ public:
     void commandImpulse(float target);
     void commandWarp(int target);
     void commandJump(float distance);
+    void commandAbortJump();
     void commandSetTarget(sp::ecs::Entity target);
     void commandSetScienceLink(sp::ecs::Entity probe);
     void commandClearScienceLink();

--- a/src/screenComponents/jumpControls.cpp
+++ b/src/screenComponents/jumpControls.cpp
@@ -24,7 +24,13 @@ GuiJumpControls::GuiJumpControls(GuiContainer* owner, string id)
     label->setTextSize(30)->setPosition(50, -50, sp::Alignment::BottomLeft)->setSize(40, GuiElement::GuiSizeMax);
 
     button = new GuiButton(this, id + "_BUTTON", tr("jumpcontrol", "Jump"), [this]() {
-        my_player_info->commandJump(slider->getValue());
+        auto jump = my_spaceship.getComponent<JumpDrive>();
+        if (!jump)
+            return;
+        else if (jump->delay <= 0.0f)
+            my_player_info->commandJump(slider->getValue());
+        else
+            my_player_info->commandAbortJump();
     });
     button->setPosition(0, 0, sp::Alignment::BottomLeft)->setSize(GuiElement::GuiSizeMax, 50);
 
@@ -40,21 +46,21 @@ void GuiJumpControls::onDraw(sp::RenderTarget& target)
             label->setKey("");
             label->setValue("");
             slider->disable();
-            button->disable();
+            button->setText(tr("jumpcontrol", "Jump"))->setStyle("button")->disable();
             charge_bar->hide();
         } else if (jump->delay > 0.0f)
         {
             label->setKey(tr("jumpcontrol","Jump in"));
             label->setValue(string(int(ceilf(jump->delay))));
             slider->disable();
-            button->disable();
+            button->setText(tr("jumpcontrol", "Abort"))->setStyle("button.jump_abort")->enable();
             charge_bar->hide();
         }else if (jump->charge < jump->max_distance)
         {
             label->setKey(tr("jumpcontrol", "Charging"));
             label->setValue("...");
             slider->hide();
-            button->disable();
+            button->setText(tr("jumpcontrol", "Jump"))->setStyle("button")->disable();
             charge_bar->setRange(0.0, jump->max_distance);
             charge_bar->setValue(jump->charge)->show();
         }else{
@@ -62,7 +68,7 @@ void GuiJumpControls::onDraw(sp::RenderTarget& target)
             label->setValue(string(slider->getValue() / 1000.0f, 1) + DISTANCE_UNIT_1K);
             slider->enable()->show();
             slider->setRange(jump->max_distance, jump->min_distance);
-            button->enable();
+            button->setText(tr("jumpcontrol", "Jump"))->setStyle("button")->enable();
             charge_bar->hide();
         }
     }

--- a/src/script.cpp
+++ b/src/script.cpp
@@ -844,6 +844,11 @@ void luaCommandJump(sp::ecs::Entity ship, float distance) {
     JumpSystem::initializeJump(ship, distance);
 }
 
+void luaCommandAbortJump(sp::ecs::Entity ship) {
+    if (my_player_info && my_player_info->ship == ship) { my_player_info->commandAbortJump(); return; }
+    JumpSystem::abortJump(ship);
+}
+
 void luaCommandSetTarget(sp::ecs::Entity ship, sp::ecs::Entity target) {
     if (my_player_info && my_player_info->ship == ship) { my_player_info->commandSetTarget(target); return; }
     ship.getOrAddComponent<Target>().entity = target;
@@ -1201,6 +1206,7 @@ bool setupScriptEnvironment(sp::script::Environment& env)
     env.setGlobal("commandImpulse", &luaCommandImpulse);
     env.setGlobal("commandWarp", &luaCommandWarp);
     env.setGlobal("commandJump", &luaCommandJump);
+    env.setGlobal("commandAbortJump", &luaCommandAbortJump);
     env.setGlobal("commandSetTarget", &luaCommandSetTarget);
     env.setGlobal("commandLoadTube", &luaCommandLoadTube);
     env.setGlobal("commandUnloadTube", &luaCommandUnloadTube);

--- a/src/systems/jumpsystem.cpp
+++ b/src/systems/jumpsystem.cpp
@@ -48,6 +48,7 @@ void JumpSystem::update(float delta)
                 if (entity.hasComponent<Coolant>())
                     jump.addHeat(jump.heat_per_jump);
 
+                jump.charge -= jump.distance;
                 jump.delay = 0.f;
             }
         } else {
@@ -87,6 +88,26 @@ void JumpSystem::initializeJump(sp::ecs::Entity entity, float distance)
     {
         jump->distance = distance;
         jump->delay = jump->activation_delay;
-        jump->charge -= distance;
     }
+}
+
+void JumpSystem::abortJump(sp::ecs::Entity entity)
+{
+    auto jump = entity.getComponent<JumpDrive>();
+    if (!jump) return;
+    if (jump->delay <= 0.0f) return;
+    float abort_penalty = (jump->activation_delay - jump->delay) / jump->activation_delay;
+    // Discharge the jump charge by a fraction of the completed jump.
+    // Aborting a jump quickly should consume less charge.
+    jump->charge = std::max(0.0f, jump->charge - (jump->distance * abort_penalty));
+    // Discourage frequently aborting jumps by flooding the system with heat
+    // that would've been vented into space otherwise.
+    // Aborting a jump quickly generates less system heat.
+    // Aborting a jump late generates significantly more heat than jumping.
+    if (entity.hasComponent<Coolant>())
+        jump->addHeat(abort_penalty);
+    else
+        jump->health -= abort_penalty; // If not using coolant, directly damage the system.
+    // Reset the fixed jump delay.
+    jump->delay = 0.0f;
 }

--- a/src/systems/jumpsystem.h
+++ b/src/systems/jumpsystem.h
@@ -10,4 +10,5 @@ public:
     void update(float delta) override;
 
     static void initializeJump(sp::ecs::Entity entity, float distance);
+    static void abortJump(sp::ecs::Entity entity);
 };


### PR DESCRIPTION
Instead of disabling the Jump button in `GuiJumpControls` after a jump is initiated, keep it enabled but change its theme and text to "Abort". If tap/clicked, the jump in progress is aborted.

![Screenshot 2025-06-09 at 4 43 40 PM](https://github.com/user-attachments/assets/286e9813-20db-4ca3-baeb-cc6d63eda477)

To discourage Helms from frequently aborting jumps, aborting a jump consumes a portion of the charge from a full jump, and floods the jump system with heat. Aborting a jump close to completion consumes a larger proportion of the charge, and generates more heat than allowing the jump to complete. The additional heat can also cause significant system damage to the jump drive if it isn't properly cooled before the jump is aborted. (If coolant is not in use on the ship, aborting the jump directly damages the jump drive system.)

Aborting a jump doesn't directly consume reactor energy because energy will be spent to recharge the wasted drive charge.