### PR TITLE
Fix speed display on helms

### DIFF
--- a/src/screens/crew6/helmsScreen.cpp
+++ b/src/screens/crew6/helmsScreen.cpp
@@ -107,7 +107,7 @@ HelmsScreen::HelmsScreen(GuiContainer* owner)
     energy_display->setPosition(20, 100, sp::Alignment::TopLeft)->setSize(240, 40);
     auto heading_display = new HeadingInfoDisplay(this, "HEADING_DISPLAY", 0.45);
     heading_display->setPosition(20, 140, sp::Alignment::TopLeft)->setSize(240, 40);
-    auto velocity_display = new GuiKeyValueDisplay(this, "VELOCITY_DISPLAY", 0.45, tr("Speed"), "");
+    auto velocity_display = new VelocityInfoDisplay(this, "VELOCITY_DISPLAY", 0.45);
     velocity_display->setPosition(20, 180, sp::Alignment::TopLeft)->setSize(240, 40);
 
     GuiElement* engine_layout = new GuiElement(this, "ENGINE_LAYOUT");


### PR DESCRIPTION
Helms key/value UI elements for ship info were all converted to `InfoDisplay` except speed. Fix this omission to restore speed displays on Helms.

Before:

![Screenshot 2025-06-10 at 9 57 02 AM](https://github.com/user-attachments/assets/f6c4bcf4-6232-48c0-ad39-a2148b2a814f)

After:

![Screenshot 2025-06-10 at 9 57 25 AM](https://github.com/user-attachments/assets/34429398-1a3c-46e0-918e-7c9ccded2103)
