### PR TITLE
Fix text scroll on player ship info box

### DIFF
--- a/src/menus/shipSelectionScreen.cpp
+++ b/src/menus/shipSelectionScreen.cpp
@@ -279,7 +279,7 @@ ShipSelectionScreen::ShipSelectionScreen()
         auto right_panel_2 = new GuiPanel(right_container, "PLAYER_SHIP_INFO_BOX");
         right_panel_2->setPosition(0, 400, sp::Alignment::TopCenter)->setSize(550, 350);
         playership_info = new GuiScrollText(right_panel_2, "PLAYERSHIP_INFO", tr("Ship info..."));
-        playership_info->setPosition(0, 10, sp::Alignment::TopCenter)->setSize(520, 400);
+        playership_info->setPosition(0, 10, sp::Alignment::TopCenter)->setSize(520, 330);
     }
 
     // Player ship selection panel


### PR DESCRIPTION
The player ship info box `GuiScrollText` element on `ShipSelectionScreen` overflows its container. Resize it to fit.

Before:

![Screenshot 2025-06-10 at 1 57 19 PM](https://github.com/user-attachments/assets/95490094-285b-49e1-a9ff-19855d2364fa)

After:

![Screenshot 2025-06-10 at 1 56 41 PM](https://github.com/user-attachments/assets/a3288479-099b-4080-82a2-b21c801ccc1d)