### PR TITLE
Removed action on click release

### DIFF
--- a/src/screens/crew6/helmsScreen.cpp
+++ b/src/screens/crew6/helmsScreen.cpp
@@ -93,8 +93,6 @@ HelmsScreen::HelmsScreen(GuiContainer* owner)
             }
         },
         [this](glm::vec2 position) {
-            if (auto transform = my_spaceship.getComponent<sp::Transform>())
-                my_player_info->commandTargetRotation(vec2ToAngle(position - transform->getPosition()));
             heading_hint->hide();
         }
     );


### PR DESCRIPTION
Fixes #2392.

The bug was due to a second bearing select when letting go of the mouse left clic. Uniformized the movement following tactical and single pilot.
 