### PR TITLE
Fix avoid-object only working near origin

### DIFF
--- a/src/systems/pathfinding.cpp
+++ b/src/systems/pathfinding.cpp
@@ -216,11 +216,11 @@ bool PathPlanner::checkToAvoid(glm::vec2 start, glm::vec2 end, glm::vec2& new_po
             uint32_t hash;
             if(steep)
             {
-                hash = hashPosition({y, x});
+                hash = hashPosition({y * small_object_grid_size, x * small_object_grid_size});
             }
             else
             {
-                hash = hashPosition({x, y});
+                hash = hashPosition({x * small_object_grid_size, y * small_object_grid_size});
             }
 
             for(auto e : path_finding_system->small_entities[hash])


### PR DESCRIPTION
(images contain other fixes & custom pathfinding debug)

before: ![](https://gn32.uk/i/2025-06-15_00-18-53.png)

after: ![](https://gn32.uk/i/2025-06-15_00-18-16.png)