### PR TITLE
Reduce nonsquare rectangular radar trace size to closer match hitbox size

### DIFF
--- a/scripts/api/shipTemplate.lua
+++ b/scripts/api/shipTemplate.lua
@@ -162,7 +162,7 @@ function ShipTemplate:setModel(model_data_name)
     end
     if self.physics and self.radar_trace then
         if type(self.physics.size) == "table" then
-            self.radar_trace.radius = self.physics.size[1] * 0.8
+            self.radar_trace.radius = math.sqrt(self.physics.size[1]^2 + self.physics.size[2]^2) * 0.5
         else
             self.radar_trace.radius = self.physics.size * 0.8
         end


### PR DESCRIPTION
before:
![](https://gn32.uk/i/2025-06-19_05-02-26.png)

after:
![](https://gn32.uk/i/2025-06-19_05-02-36.png)