### PR TITLE
Add noninteractive server ports

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -198,7 +198,6 @@ int main(int argc, char** argv)
 
     string tutorial = PreferencesManager::get("tutorial");   // use "00_all.lua" for all tutorials
     string server_scenario = PreferencesManager::get("server_scenario");
-    int server_port = PreferencesManager::get("server_port").toInt();
 
     if (!tutorial.empty())
     {
@@ -216,16 +215,16 @@ int main(int argc, char** argv)
         // Create the server to listen on the assigned port.
         // Use the default port if server_port isn't set or has an invalid
         // value (toInt returns 0 if empty or not an int).
+        int server_port = PreferencesManager::get("server_port").toInt();
+
         if (server_port < 10 || server_port > 65535)
         {
-            new EpsilonServer(defaultServerPort);
-            LOG(WARNING) << "Invalid server_port " << server_port << ". Launching server_scenario " << server_scenario << " on default port " << defaultServerPort;
+            LOG(Warning, "Invalid server_port " + server_port);
+            server_port = defaultServerPort;
         }
-        else
-        {
-            new EpsilonServer(server_port);
-            LOG(INFO) << "Launching server_scenario " << server_scenario << " on custom port " << server_port;
-        }
+
+        LOG(Info, "Launching server_scenario " + server_scenario + " on port " + server_port);
+        new EpsilonServer(server_port);
 
         if(!gameGlobalInfo) // => failed to start server
             return 1;
@@ -294,14 +293,12 @@ void returnToMainMenu(RenderLayer* render_layer)
         // This is the same process as server_port and could be made DRY.
         if (headless_port < 10 || headless_port > 65535)
         {
-            new EpsilonServer(defaultServerPort);
-            LOG(WARNING) << "Invalid server_port " << headless_port << ". Launching headless scenario " << headless << " on default port " << defaultServerPort;
+            LOG(Warning, "Invalid server_port: " + headless_port);
+            headless_port = defaultServerPort;
         }
-        else
-        {
-            new EpsilonServer(headless_port);
-            LOG(INFO) << "Launching headless scenario " << headless << " on custom server_port " << headless_port;
-        }
+
+        LOG(Info, "Launching headless scenario " + headless + " on port " + headless_port);
+        new EpsilonServer(headless_port);
 
         if (PreferencesManager::get("headless_name") != "") game_server->setServerName(PreferencesManager::get("headless_name"));
         if (PreferencesManager::get("headless_password") != "") game_server->setPassword(PreferencesManager::get("headless_password").upper());

--- a/src/menus/autoConnectScreen.cpp
+++ b/src/menus/autoConnectScreen.cpp
@@ -72,16 +72,19 @@ void AutoConnectScreen::update(float delta)
             // use that. Otherwise, use defaultServerPort.
             autoconnect_address = autoconnect_address.strip();
             int autoconnect_port = defaultServerPort;
+
             if (autoconnect_address.find(":") != -1)
             {
-                autoconnect_port = autoconnect_address.substr(autoconnect_address.find(":") + 1).toInt();
                 autoconnect_address = autoconnect_address.substr(0, autoconnect_address.find(":"));
+                autoconnect_port = autoconnect_address.substr(autoconnect_address.find(":") + 1).toInt();
+
                 if (autoconnect_port < 10 || autoconnect_port > 65535)
                 {
                     LOG(WARNING) << "Invalid autoconnect port " << autoconnect_port << ". Using default port " << defaultServerPort;
                     autoconnect_port = defaultServerPort;
                 }
             }
+
             status_label->setText("Using autoconnect server " + autoconnect_address + ":" + std::to_string(autoconnect_port));
             connect_to_address = autoconnect_address;
             connect_to_port = autoconnect_port;

--- a/src/menus/autoConnectScreen.cpp
+++ b/src/menus/autoConnectScreen.cpp
@@ -66,11 +66,27 @@ void AutoConnectScreen::update(float delta)
         std::vector<ServerScanner::ServerInfo> serverList = scanner->getServerList();
         string autoconnect_address = PreferencesManager::get("autoconnect_address", "");
 
-        if (autoconnect_address != "") {
-            status_label->setText("Using autoconnect server " + autoconnect_address);
+        if (!autoconnect_address.empty())
+        {
+            // Set autoconnect_port. If autoconnect_address specifies a port,
+            // use that. Otherwise, use defaultServerPort.
+            autoconnect_address = autoconnect_address.strip();
+            int autoconnect_port = defaultServerPort;
+            if (autoconnect_address.find(":") != -1)
+            {
+                autoconnect_port = autoconnect_address.substr(autoconnect_address.find(":") + 1).toInt();
+                autoconnect_address = autoconnect_address.substr(0, autoconnect_address.find(":"));
+                if (autoconnect_port < 10 || autoconnect_port > 65535)
+                {
+                    LOG(WARNING) << "Invalid autoconnect port " << autoconnect_port << ". Using default port " << defaultServerPort;
+                    autoconnect_port = defaultServerPort;
+                }
+            }
+            status_label->setText("Using autoconnect server " + autoconnect_address + ":" + std::to_string(autoconnect_port));
             connect_to_address = autoconnect_address;
+            connect_to_port = autoconnect_port;
             tried_password = false;
-            new GameClient(VERSION_NUMBER, autoconnect_address);
+            new GameClient(VERSION_NUMBER, connect_to_address, connect_to_port);
             scanner->destroy();
         } else {
             auto name_filter = PreferencesManager::get("autoconnect_servername", "");
@@ -80,15 +96,16 @@ void AutoConnectScreen::update(float delta)
 
                 status_label->setText("Found server " + server.name);
                 connect_to_address = server.address;
+                connect_to_port = defaultServerPort;
                 tried_password = false;
-                new GameClient(VERSION_NUMBER, server.address);
+                new GameClient(VERSION_NUMBER, connect_to_address, connect_to_port);
                 scanner->destroy();
                 return;
             }
 
             status_label->setText("Searching for server...");
         }
-    }else{
+    } else {
         switch(game_client->getStatus())
         {
         case GameClient::Connecting:

--- a/src/menus/autoConnectScreen.h
+++ b/src/menus/autoConnectScreen.h
@@ -26,6 +26,7 @@ class AutoConnectScreen : public GuiCanvas, public Updatable
 {
     P<ServerScanner> scanner;
     sp::io::network::Address connect_to_address;
+    int connect_to_port;
     std::vector<AutoConnectPosition> positions;
     bool control_main_screen;
     std::map<string, string> ship_filters;


### PR DESCRIPTION
The server creation menu provides a field for setting a port, and the server browser allows the port to be specified in a manually entered IP or domain.

When running a server via `server_scenario` or `headless`, there's no way to set the server's port. Likewise, when running a client via `autoconnect`, there's no way to specify a port to connect to.

This PR:

- Adds a `server_port` PreferencesFile setting. This is used when either `headless` or `server_scenario` is set.
- Allows the `autoconnect_address` PreferencesFile setting to optionally specify a custom port delineated by a colon (`server.example.com:35669`).
- Adds INFO-level log lines that output the server's IP and port, or the IP and port that the autoconnect client is attempting to connect to.
- Adds WARNING-level log lines if the port number is out of valid range (< 10 or > 65535).
- Displays the port number on the autoconnect connection screen.

For example, one can launch a server with IP 192.168.1.50 and port 35669 with

```
EmptyEpsilon headless=scenario_00_basic.lua server_port=35669
```

or

```
EmptyEpsilon server_scenario=scenario_00_basic.lua server_port=35669
```

and then autoconnect weapons to that server on a different client by running

```
EmptyEpsilon autoconnect=1 autoconnect_address=192.168.1.50:35669
```

Both take advantage of port parameters in SeriousProton's server and client classes/functions that EmptyEpsilon doesn't appear to use.

If left undefined, these preferences should default to port 35666, leaving the default behavior of existing installs unchanged. Invalid values, such as non-numeric strings or port numbers under 10 or over 65535, also revert to the default port.

This is a naive implementation that doesn't attempt to check for port usage (including by the HTTP API). 