### PR TITLE
Handle setting ports non-interactively

### DIFF
--- a/src/menus/autoConnectScreen.h
+++ b/src/menus/autoConnectScreen.h
@@ -26,6 +26,7 @@ class AutoConnectScreen : public GuiCanvas, public Updatable
 {
     P<ServerScanner> scanner;
     sp::io::network::Address connect_to_address;
+    int connect_to_port;
     std::vector<AutoConnectPosition> positions;
     bool control_main_screen;
     std::map<string, string> ship_filters;


### PR DESCRIPTION
- Add `server_port` preferences file option to set the server port on non-interactive launches (`server_scenario` and `headless`).
- Extend `autoconnect_address` to parse an optional colon-delimited port number.