### PR TITLE
[#2382] Accurately calculate jump timing in UI elements

### DIFF
--- a/src/components/jumpdrive.h
+++ b/src/components/jumpdrive.h
@@ -4,7 +4,7 @@
 #include "shipsystem.h"
 #include "tween.h"
 
-// Impulse engine component, indicate that this entity can move under impulse control.
+// Jump drive component indicates that this entity can teleport with a jump drive.
 class JumpDrive : public ShipSystem {
 public:
     // Config
@@ -22,4 +22,10 @@ public:
     float just_jumped = 0.0f; //[output] used for visual effect after jumping.
 
     float get_recharge_rate() { return Tween<float>::linear(getSystemEffectiveness(), 0.0, 1.0, -0.25, 1.0); }
+    int get_seconds_to_jump() {
+        if (getSystemEffectiveness() <= 0.0f)
+            return std::numeric_limits<int>::max();
+        else
+            return int(ceilf((activation_delay * (delay / activation_delay)) / getSystemEffectiveness()));
+    }
 };

--- a/src/screenComponents/jumpControls.cpp
+++ b/src/screenComponents/jumpControls.cpp
@@ -48,7 +48,8 @@ void GuiJumpControls::onDraw(sp::RenderTarget& target)
             if (jump->get_seconds_to_jump() == std::numeric_limits<int>::max())
                 label->setValue(tr("jumpcontrol", "∞ sec."));
             else
-                label->setValue(string(jump->get_seconds_to_jump()) + tr("jumpcontrol", " sec."));
+                label->setValue(tr("jumpcontrol", "{delay} sec.").format({{"delay", string(jump->get_seconds_to_jump())}}));
+
             slider->disable();
             button->disable();
             charge_bar->hide();

--- a/src/screenComponents/jumpControls.cpp
+++ b/src/screenComponents/jumpControls.cpp
@@ -44,8 +44,11 @@ void GuiJumpControls::onDraw(sp::RenderTarget& target)
             charge_bar->hide();
         } else if (jump->delay > 0.0f)
         {
-            label->setKey(tr("jumpcontrol","Jump in"));
-            label->setValue(string(int(ceilf(jump->delay))));
+            label->setKey(tr("jumpcontrol", "Jump in"));
+            if (jump->get_seconds_to_jump() == std::numeric_limits<int>::max())
+                label->setValue(tr("jumpcontrol", "∞ sec."));
+            else
+                label->setValue(string(jump->get_seconds_to_jump()) + tr("jumpcontrol", " sec."));
             slider->disable();
             button->disable();
             charge_bar->hide();

--- a/src/screenComponents/jumpIndicator.cpp
+++ b/src/screenComponents/jumpIndicator.cpp
@@ -24,7 +24,10 @@ void GuiJumpIndicator::onDraw(sp::RenderTarget& target)
         auto jump = my_spaceship.getComponent<JumpDrive>();
         if (jump && jump->delay > 0.0f) {
             box->show();
-            label->setText(tr("Jump in: {delay}").format({{"delay", string(int(ceilf(jump->delay)))}}));
+            if (jump->get_seconds_to_jump() == std::numeric_limits<int>::max())
+                label->setText(tr("jumpcontrol", "Jump delayed"));
+            else
+                label->setText(tr("Jump in: {delay}").format({{"delay", string(jump->get_seconds_to_jump()) + tr("jumpcontrol", " sec.")}}));
         } else {
             box->hide();
         }

--- a/src/screens/crew6/engineeringScreen.cpp
+++ b/src/screens/crew6/engineeringScreen.cpp
@@ -313,10 +313,13 @@ void EngineeringScreen::onDraw(sp::RenderTarget& renderer)
                     addSystemEffect(tr("Warp drive speed"), toNearbyIntString(effectiveness * 100) + "%");
                     break;
                 case ShipSystem::Type::JumpDrive:{
-                    auto jump = my_spaceship.getComponent<JumpDrive>();
-                    if (jump) {
+                    if (auto jump = my_spaceship.getComponent<JumpDrive>()) {
+                        if (jump->get_seconds_to_jump() == std::numeric_limits<int>::max()) {
+                            addSystemEffect(tr("Time to jump activation"), "∞ sec.");
+                        } else {
+                            addSystemEffect(tr("Time to jump activation"), string(jump->get_seconds_to_jump()) + " sec.");
+                        }
                         addSystemEffect(tr("Jump drive recharge rate"), toNearbyIntString(jump->get_recharge_rate() * 100) + "%");
-                        addSystemEffect(tr("Jump drive jump speed"), toNearbyIntString(effectiveness * 100) + "%");
                     }
                     }break;
                 case ShipSystem::Type::FrontShield:{

--- a/src/screens/crew6/engineeringScreen.cpp
+++ b/src/screens/crew6/engineeringScreen.cpp
@@ -314,11 +314,10 @@ void EngineeringScreen::onDraw(sp::RenderTarget& renderer)
                     break;
                 case ShipSystem::Type::JumpDrive:{
                     if (auto jump = my_spaceship.getComponent<JumpDrive>()) {
-                        if (jump->get_seconds_to_jump() == std::numeric_limits<int>::max()) {
+                        if (jump->get_seconds_to_jump() == std::numeric_limits<int>::max())
                             addSystemEffect(tr("Time to jump activation"), "∞ sec.");
-                        } else {
-                            addSystemEffect(tr("Time to jump activation"), string(jump->get_seconds_to_jump()) + " sec.");
-                        }
+                        else
+                            addSystemEffect(tr("Time to jump activation"), tr("jumpcontrol", "{delay} sec.").format({{"delay", string(jump->get_seconds_to_jump())}}));
                         addSystemEffect(tr("Jump drive recharge rate"), toNearbyIntString(jump->get_recharge_rate() * 100) + "%");
                     }
                     }break;


### PR DESCRIPTION
#2406, but with all the logic moved to a function in the JumpDrive component and UI as requested.

Resolves https://github.com/daid/EmptyEpsilon/issues/2382.