### PR TITLE
Fix large/small missile lifetime being backwards (plus other minor fixes)

### DIFF
--- a/scripts/api/entity/scanprobe.lua
+++ b/scripts/api/entity/scanprobe.lua
@@ -8,6 +8,7 @@
 function ScanProbe()
     local e = createEntity()
     e.components = {
+        transform = {},
         lifetime = {lifetime=60*10},
         radar_trace = {
             icon="radar/probe.png",

--- a/src/components/zone.cpp
+++ b/src/components/zone.cpp
@@ -5,6 +5,12 @@
 
 void Zone::updateTriangles()
 {
+    if (outline.empty()) {
+        radius = 1;
+        triangles.clear();
+        return;
+    }
+
     label_offset = centerOfMass(outline);
     radius = 1;
     for(auto p : outline) {

--- a/src/systems/missilesystem.cpp
+++ b/src/systems/missilesystem.cpp
@@ -348,7 +348,7 @@ void MissileSystem::spawnProjectile(sp::ecs::Entity source, MissileTubes::MountP
         }
 
         if (tube.type_loaded != MW_Mine)
-            missile.addComponent<LifeTime>().lifetime = mwd.lifetime / category_modifier;
+            missile.addComponent<LifeTime>().lifetime = mwd.lifetime * category_modifier;
 
         if (tube.type_loaded != MW_Mine) {
             auto& dbad = missile.addComponent<DestroyedByAreaDamage>();


### PR DESCRIPTION
before:
small HVLI lasts 27s at a speed of 1U/s, travelling **27U**
medium HVLI lasts 13.5s at a speed of 0.5U/s, travelling 6.75U
large HVLI lasts 6.75s at a speed of 0.25U/s, travelling **~1.7U**

after:
small HVLI lasts 6.75s at a speed of 1U/s, travelling 6.75U
medium HVLI lasts 13.5s at a speed of 0.5U/s, travelling 6.75U
large HVLI lasts 27s at a speed of 0.25U/s, travelling 6.75U