### PR TITLE
Label change when clicking on lock button in weapons

### DIFF
--- a/src/screenComponents/aimLock.cpp
+++ b/src/screenComponents/aimLock.cpp
@@ -10,6 +10,10 @@
 AimLockButton::AimLockButton(GuiContainer* owner, string id, GuiMissileTubeControls* tube_controls, GuiRotationDial* missile_aim)
 : GuiToggleButton(owner, id, tr("missile","Lock"), [this](bool value)
     {
+        if (value)
+            text = tr("missile","Lock");
+        else
+            text = tr("missile","Manual");
         setAimLock(value);
     })
 {

--- a/src/screens/crew1/singlePilotScreen.cpp
+++ b/src/screens/crew1/singlePilotScreen.cpp
@@ -135,7 +135,7 @@ SinglePilotScreen::SinglePilotScreen(GuiContainer* owner)
 
     // Missile lock button near top right of left panel.
     lock_aim = new AimLockButton(this, "LOCK_AIM", tube_controls, missile_aim);
-    lock_aim->setPosition(250, 70, sp::Alignment::TopCenter)->setSize(130, 50);
+    lock_aim->setPosition(250, 70, sp::Alignment::TopCenter)->setSize(145, 50);
 
     (new GuiCustomShipFunctions(this, CrewPosition::singlePilot, ""))->setPosition(-20, 120, sp::Alignment::TopRight)->setSize(250, GuiElement::GuiSizeMax);
 }

--- a/src/screens/crew4/tacticalScreen.cpp
+++ b/src/screens/crew4/tacticalScreen.cpp
@@ -112,7 +112,7 @@ TacticalScreen::TacticalScreen(GuiContainer* owner)
     });
     missile_aim->hide()->setPosition(0, 0, sp::Alignment::Center)->setSize(GuiElement::GuiSizeMatchHeight, 800);
     lock_aim = new AimLockButton(this, "LOCK_AIM", tube_controls, missile_aim);
-    lock_aim->setPosition(250, 20, sp::Alignment::TopCenter)->setSize(110, 50);
+    lock_aim->setPosition(250, 20, sp::Alignment::TopCenter)->setSize(145, 50);
 
     // Combat maneuver and propulsion controls in the bottom right corner.
     (new GuiCombatManeuver(this, "COMBAT_MANEUVER"))->setPosition(-20, -390, sp::Alignment::BottomRight)->setSize(200, 150);

--- a/src/screens/crew6/weaponsScreen.cpp
+++ b/src/screens/crew6/weaponsScreen.cpp
@@ -63,7 +63,7 @@ WeaponsScreen::WeaponsScreen(GuiContainer* owner)
     radar->enableTargetProjections(tube_controls);
 
     lock_aim = new AimLockButton(this, "LOCK_AIM", tube_controls, missile_aim);
-    lock_aim->setPosition(250, 20, sp::Alignment::TopCenter)->setSize(130, 50);
+    lock_aim->setPosition(250, 20, sp::Alignment::TopCenter)->setSize(145, 50);
 
     if (gameGlobalInfo->use_beam_shield_frequencies || gameGlobalInfo->use_system_damage)
     {


### PR DESCRIPTION
Added the dual label lock/manual on the button for clarity.
The button switches between those two states
<img width="136" alt="Screenshot 2025-06-25 at 13 30 25" src="https://github.com/user-attachments/assets/db6c9b43-4cd2-4626-9c00-314d3424f1d8" />
<img width="129" alt="Screenshot 2025-06-25 at 13 30 21" src="https://github.com/user-attachments/assets/e6d30532-f037-478b-8285-38b766cf1e62" />

This is what the button looks when in manual mode in the UI

![Screenshot 2025-06-25 at 13 30 41](https://github.com/user-attachments/assets/d67b1a62-9226-4999-b88f-eeccb1ec58be)
![Screenshot 2025-06-25 at 13 30 39](https://github.com/user-attachments/assets/8173b310-8e8b-415d-ae51-55fea379637d)
![Screenshot 2025-06-25 at 13 30 34](https://github.com/user-attachments/assets/dc2189bf-56d7-43e6-a9ef-059fd7dbe166)
