### PR TITLE
Fix duplicated text in comms log

### DIFF
--- a/src/gui/gui2_scrolltext.cpp
+++ b/src/gui/gui2_scrolltext.cpp
@@ -107,6 +107,8 @@ void GuiScrollFormattedText::onDraw(sp::RenderTarget& renderer)
             } else {
                 last_end = tag_start;
             }
+        } else {
+            last_end = tag_start;
         }
     }
     prepared.append(text.substr(last_end), text_size, current_color);


### PR DESCRIPTION
Fixes #2458

Before:
![](https://gn32.uk/i/2025-06-25_20-17-16.png)

After:
![](https://gn32.uk/i/2025-06-25_20-17-32.png)