### PR TITLE
Make diagnostic state translatable in scenario_50_gaps

### DIFF
--- a/scripts/scenario_50_gaps.lua
+++ b/scripts/scenario_50_gaps.lua
@@ -218,7 +218,12 @@ function setGlobals()
 end
 function mainGMButtons()
 	clearGMFunctions()
-	addGMFunction(string.format(_("buttonGM","Diagnostic %s"),diagnostic),function()
+    if diagnostic then
+        diagnostic_string=_("diagnosticState","true")
+    else
+        diagnostic_string=_("diagnosticState","false")
+    end
+    addGMFunction(string.format(_("buttonGM","Diagnostic %s"),diagnostic_string),function()
 		if diagnostic then
 			diagnostic = false
 			mainGMButtons()


### PR DESCRIPTION
This assigns a string value the the values of the boolean _diagnostic_, so it can be translated.