### PR TITLE
Database back button outside of entrylist

### DIFF
--- a/src/screenComponents/databaseView.cpp
+++ b/src/screenComponents/databaseView.cpp
@@ -8,18 +8,29 @@
 #include "gui/gui2_image.h"
 #include "gui/gui2_keyvaluedisplay.h"
 #include "gui/gui2_scrolltext.h"
+#include "gui/gui2_button.h"
 
 #include "screenComponents/rotatingModelView.h"
 
 DatabaseViewComponent::DatabaseViewComponent(GuiContainer* owner)
 : GuiElement(owner, "DATABASE_VIEW")
 {
-    item_list = new GuiListbox(this, "DATABASE_ITEM_LIST", [this](int index, string value) {
+    setAttribute("layout", "horizontal");
+
+    // Setup the navigation bar
+    GuiElement* navigation_element = new GuiElement(this, "NAVIGATION_BAR");
+    navigation_element->setAttribute("layout", "vertical");
+    navigation_element->setMargins(20, 20, 20, 120)->setSize(navigation_width, GuiElement::GuiSizeMax);
+    back_button = new GuiButton(navigation_element,"BACK_BUTTON", "Back", [this](){
+        selected_entry = sp::ecs::Entity::fromString(back_entry);
+        display();
+    });
+    back_button->setSize(GuiElement::GuiSizeMax, 50)->hide()->setMargins(0, 0, 0, 20);
+    item_list = new GuiListbox(navigation_element, "DATABASE_ITEM_LIST", [this](int index, string value) {
         selected_entry = sp::ecs::Entity::fromString(value);
         display();
     });
-    setAttribute("layout", "horizontal");
-    item_list->setMargins(20, 20, 20, 120)->setSize(navigation_width, GuiElement::GuiSizeMax);
+    item_list->setSize(GuiElement::GuiSizeMax, GuiElement::GuiSizeMax);
     display();
 }
 
@@ -70,12 +81,19 @@ void DatabaseViewComponent::fillListBox()
     {
         if (children.size() != 0)
         {
-            item_list->addEntry(tr("button", "Back"), selected_database->parent.toString());
+            back_button->show();
+            back_entry = selected_database->parent.toString();
         }
         else if(parent_entry)
         {
-            item_list->addEntry(tr("button", "Back"), parent_entry->parent.toString());
+            back_button->show();
+            back_entry = parent_entry->parent.toString();
         }
+    }
+    else
+    {
+        back_button->hide();
+        back_entry = "";
     }
 
     // the indices we actually want to display

--- a/src/screenComponents/databaseView.h
+++ b/src/screenComponents/databaseView.h
@@ -5,6 +5,7 @@
 #include "ecs/entity.h"
 
 class GuiListbox;
+class GuiButton;
 
 class DatabaseViewComponent : public GuiElement
 {
@@ -20,6 +21,8 @@ private:
     void display();
 
     sp::ecs::Entity selected_entry;
+    string back_entry;
+    GuiButton* back_button = nullptr;
     GuiListbox* item_list = nullptr;
     GuiElement* keyvalue_container = nullptr;
     GuiElement* details_container = nullptr;


### PR DESCRIPTION
Removed the button from the list and added a margin to make it stand out.

<img width="345" alt="Screenshot 2025-06-28 at 00 00 37" src="https://github.com/user-attachments/assets/65b33d2f-f4de-425f-98d5-3a31d4092f9c" />
