### PR TITLE
Swap info and custom buttons bar

### DIFF
--- a/src/screens/crew6/scienceScreen.cpp
+++ b/src/screens/crew6/scienceScreen.cpp
@@ -283,9 +283,9 @@ void ScienceScreen::onDraw(sp::RenderTarget& renderer)
     }
     else
     {
-        info_sidebar->setPosition(-280, 170, sp::Alignment::TopRight);
-        sidebar_selector->setPosition(-280, 120, sp::Alignment::TopRight);
-        custom_function_sidebar->setPosition(-20, 170, sp::Alignment::TopRight);
+        info_sidebar->setPosition(-20, 170, sp::Alignment::TopRight);
+        sidebar_selector->setPosition(-20, 120, sp::Alignment::TopRight);
+        custom_function_sidebar->setPosition(-280, 170, sp::Alignment::TopRight);
         custom_function_sidebar->show();
         info_sidebar->show();
     }


### PR DESCRIPTION
Swaps the custom buttons with for the normal info sidebar so the science description and deep scan info do not overlap with the waypoint and comms buttons on the left.

I originally placed the custom sidebar intentionally to the right, as I had ideas for a compromise of the old glass cockpit idea, where the smaller bar would reach into the main screen section. However, readability has to be prioritised, of course.