### PR TITLE
[#2466] Hack GuiSelector popup fix using string IDs

### DIFF
--- a/src/gui/gui2_selector.cpp
+++ b/src/gui/gui2_selector.cpp
@@ -95,3 +95,9 @@ void GuiSelector::onMouseUp(glm::vec2 position, sp::io::Pointer::ID id)
         popup->show()->moveToFront();
     }
 }
+
+void GuiSelector::onFocusLost()
+{
+    // Explicitly hide the popup when the selector loses focus.
+    popup->hide();
+}

--- a/src/gui/gui2_selector.cpp
+++ b/src/gui/gui2_selector.cpp
@@ -26,7 +26,7 @@ GuiSelector::GuiSelector(GuiContainer* owner, string id, func_t func)
     });
     right->setPosition(0, 0, sp::Alignment::TopRight)->setSize(GuiSizeMatchHeight, GuiSizeMax);
 
-    popup = new GuiPanel(getTopLevelContainer(), "");
+    popup = new GuiPanel(getTopLevelContainer(), id + "_POPUP");
     popup->hide();
 }
 

--- a/src/gui/gui2_selector.cpp
+++ b/src/gui/gui2_selector.cpp
@@ -26,7 +26,7 @@ GuiSelector::GuiSelector(GuiContainer* owner, string id, func_t func)
     });
     right->setPosition(0, 0, sp::Alignment::TopRight)->setSize(GuiSizeMatchHeight, GuiSizeMax);
 
-    popup = new GuiPanel(getTopLevelContainer(), id + "_POPUP");
+    popup = new GuiPanel(getTopLevelContainer(), "");
     popup->hide();
 }
 

--- a/src/gui/gui2_selector.h
+++ b/src/gui/gui2_selector.h
@@ -22,6 +22,7 @@ public:
     virtual void onDraw(sp::RenderTarget& renderer) override;
     virtual bool onMouseDown(sp::io::Pointer::Button button, glm::vec2 position, sp::io::Pointer::ID id) override;
     virtual void onMouseUp(glm::vec2 position, sp::io::Pointer::ID id) override;
+    virtual void onFocusLost() override;
 
     GuiSelector* setTextSize(float size);
 };

--- a/src/screens/crewStationScreen.cpp
+++ b/src/screens/crewStationScreen.cpp
@@ -412,11 +412,6 @@ void CrewStationScreen::showTab(GuiElement* element)
         else 
         {
             info.element->hide();
-            for (auto child : children)
-            {
-                if (child->getID().find("_POPUP") != -1)
-                    child->hide();
-            }
             info.button->setValue(false);
         }
     }

--- a/src/screens/crewStationScreen.cpp
+++ b/src/screens/crewStationScreen.cpp
@@ -408,7 +408,11 @@ void CrewStationScreen::showTab(GuiElement* element)
             string keyboard_category = "";
             keyboard_category = populateShortcutsList(info.position);
             keyboard_help->setText(keyboard_general + keyboard_category);
-        } 
+
+            // Explicitly reset focus after switching tabs, such as when changed
+            // via hotkey.
+            focus(main_panel);
+        }
         else 
         {
             info.element->hide();

--- a/src/screens/crewStationScreen.cpp
+++ b/src/screens/crewStationScreen.cpp
@@ -412,6 +412,11 @@ void CrewStationScreen::showTab(GuiElement* element)
         else 
         {
             info.element->hide();
+            for (auto child : children)
+            {
+                if (child->getID().find("_POPUP") != -1)
+                    child->hide();
+            }
             info.button->setValue(false);
         }
     }


### PR DESCRIPTION
Attempt to work around #2466 by assigning string IDs to popups generated by clicking a `GuiSelector`, then iterating through children of `CrewStationScreen` and hiding them when changing tabs.