### PR TITLE
Avoid opening both chat and script comms at once

### DIFF
--- a/src/screenComponents/commsOverlay.cpp
+++ b/src/screenComponents/commsOverlay.cpp
@@ -166,15 +166,14 @@ void GuiCommsOverlay::onUpdate()
         broken_box->setVisible(transmitter->state == CommsTransmitter::State::ChannelBroken);
         closed_box->setVisible(transmitter->state == CommsTransmitter::State::ChannelClosed);
 
-        const bool is_open = transmitter->state == CommsTransmitter::State::ChannelOpen || transmitter->state == CommsTransmitter::State::ChannelOpenGM || transmitter->state == CommsTransmitter::State::ChannelOpenPlayer;
+        const bool is_open = transmitter->state == CommsTransmitter::State::ChannelOpenGM || transmitter->state == CommsTransmitter::State::ChannelOpenPlayer;
         chat_comms_box->setVisible(is_open);
         chat_comms_text->setText(transmitter->incomming_message);
-        if (is_open && !chat_open_last_update) {
+        if (is_open && !chat_open_last_update)
+        {
           // Chat window has just opened, let's auto-focus the text input
-          auto canvas = dynamic_cast<GuiCanvas*>(getTopLevelContainer());
-          if (canvas) {
+          if (auto canvas = dynamic_cast<GuiCanvas*>(getTopLevelContainer()))
             canvas->focus(chat_comms_message_entry);
-          }
         }
         chat_open_last_update = is_open;
 


### PR DESCRIPTION
Every time script comms are initiated with a player, `GuiCommsOverlay` opens both chat and script comms because of the inclusion of `CommsTransmitter::State::ChannelOpen` in this line:

```cpp
        const bool is_open = transmitter->state == CommsTransmitter::State::ChannelOpen || CommsTransmitter::State::ChannelOpenGM || transmitter->state == CommsTransmitter::State::ChannelOpenPlayer;
```

which is followed by:

```cpp
        chat_comms_box->setVisible(is_open);
```

The script comms panel is then rendered over the redundant chat comms panel, hiding the issue to players. This can be exposed by enabling UI debug rendering.

However, the chat comms text entry field takes keyboard focus, resulting in inconsistent hotkey behavior while comms remain open or until the player clicks on any visible element.

Render chat comms only when the `CommsTransmitter::State` supports chat (`ChannelOpenGM` and `ChannelOpenPlayer`).