### PR TITLE
Add non-hotkey copy action to toggle UI debug rendering in Debug builds

### DIFF
--- a/src/gui/gui2_canvas.cpp
+++ b/src/gui/gui2_canvas.cpp
@@ -105,6 +105,10 @@ void GuiCanvas::onTextInput(sp::TextInputEvent e)
         dumpGuiTree(f, this);
         fclose(f);
     }
+
+    if (e == sp::TextInputEvent::Copy) {
+        enable_debug_rendering = !enable_debug_rendering;
+    }
 #endif
     if (focus_element)
         focus_element->onTextInput(e);


### PR DESCRIPTION
Similar to how the cut `TextInputEvent` dumps the GUI tree to HTML, use the copy event to toggle the debug rendering overlay on Debug builds.

The overlay rendering code is already present. This adds only the means to toggle it in-game on Debug builds.

![image](https://github.com/user-attachments/assets/6c928908-1e05-4cf2-ac08-cdb4e169c639)
