### PR TITLE
Enable outlineRect on GuiContainer::drawDebugElements

### DIFF
--- a/src/gui/gui2_container.cpp
+++ b/src/gui/gui2_container.cpp
@@ -50,7 +50,7 @@ void GuiContainer::drawDebugElements(sp::Rect parent_rect, sp::RenderTarget& ren
         if (element->visible)
         {
             renderer.fillRect(element->rect, glm::u8vec4(255, 255, 255, 5));
-            //TODO_GFX: renderer.outlineRect(element->rect, glm::u8vec4(255, 0, 255, 255));
+            renderer.outlineRect(element->rect, glm::u8vec4(255, 0, 255, 255));
 
             element->drawDebugElements(element->rect, renderer);
 


### PR DESCRIPTION
Enable `outlineRect` on UI debug elements. Requires an `outlineRect` implementation in SeriousProton, such as daid/SeriousProton#269.

![image](https://github.com/user-attachments/assets/025d524b-3d8b-4fb5-ae8e-ef7653721c52)
