### PR TITLE
Fix for loop populating science DB faction relationships

### DIFF
--- a/scripts/science_db.lua
+++ b/scripts/science_db.lua
@@ -182,7 +182,7 @@ function __fillDefaultDatabaseData()
 		for name2, info2 in pairs(__faction_info) do
             if info ~= info2 then
 				local stance = _("stance", "Neutral");
-				for idx, relation in ipairs(info) do
+				for idx, relation in ipairs(info.components.faction_info) do
 					if relation.other_faction == info2 then
 						if relation.relation == "neutral" then stance = _("stance", "Neutral") end
 						if relation.relation == "enemy" then stance = _("stance", "Enemy") end


### PR DESCRIPTION
A for loop in `science_db.lua`, intended to populate faction info in the science DB, incorrectly attempts to iterate over the grandparent faction_info entity instead of its table of relationships. Fix the loop.

Before:

![image](https://github.com/user-attachments/assets/4a14cd19-eeaa-4e83-ba10-8a871164834c)

After:

![image](https://github.com/user-attachments/assets/635a8abb-93a2-459d-9e50-c4cadfa076f6)
