### PR TITLE
Make mouse cursor sprite variable

### DIFF
--- a/src/gui/mouseRenderer.cpp
+++ b/src/gui/mouseRenderer.cpp
@@ -11,7 +11,7 @@ void MouseRenderer::render(sp::RenderTarget& renderer)
 {
     if (!visible) return;
 
-    renderer.drawSprite("mouse.png", position, 32.0);
+    renderer.drawSprite(sprite, position, 32.0);
 }
 
 bool MouseRenderer::onPointerMove(glm::vec2 position, sp::io::Pointer::ID id)

--- a/src/gui/mouseRenderer.h
+++ b/src/gui/mouseRenderer.h
@@ -15,8 +15,10 @@ public:
     virtual void onPointerLeave(sp::io::Pointer::ID id) override;
     virtual void onPointerDrag(glm::vec2 position, sp::io::Pointer::ID id) override;
 
+    void setSpriteImage(string sprite_image) { sprite = sprite_image; }
 private:
     glm::vec2 position;
+    string sprite = "mouse.png";
 };
 
 #endif//MOUSE_RENDERER_H


### PR DESCRIPTION
Use a variable to define the `MouseRenderer` cursor sprite for potential modal replacement.