### PR TITLE
Make cross-type templates behave more sensibly, like legacy

### DIFF
--- a/scripts/api/entity/cpuship.lua
+++ b/scripts/api/entity/cpuship.lua
@@ -18,6 +18,7 @@ function CpuShip()
         ai_controller = {new_name="default", orders="roaming"},
         scan_state = {allow_simple_scan=true},
         callsign = {callsign=generateRandomCallSign()},
+        comms_receiver = {script="comms_ship.lua"},
     }
     e:setFaction(__default_cpu_ship_faction)
     return e

--- a/scripts/api/entity/playerspaceship.lua
+++ b/scripts/api/entity/playerspaceship.lua
@@ -21,6 +21,14 @@ function PlayerSpaceship()
         transform = {rotation=random(0, 360)},
         callsign = {callsign=generateRandomCallSign()},
         scan_state = scan_state,
+        reactor = {},
+        coolant = {},
+        self_destruct = {},
+        science_scanner = {},
+        scan_probe_launcher = {},
+        hacking_device = {},
+        long_range_radar = {},
+        comms_transmitter = {},
     }
     e:setFaction(__default_player_ship_faction)
     return e

--- a/scripts/api/entity/shiptemplatebasedobject.lua
+++ b/scripts/api/entity/shiptemplatebasedobject.lua
@@ -26,10 +26,19 @@ function Entity:setTemplate(template_name)
             comp[key] = value
         end
     end
-    if template.__type == "station" then
+    if not comp.ai_controller and not comp.player_control then
+        -- no AI or player control, this is a station
         comp.physics.type = "static"
-    elseif template.__type == "playership" then
-        if comp.shields then comp.shields.active = false end
+    elseif comp.shields then
+        -- otherwise, set a shield frequency and turn player shields off by default
+        comp.shields.frequency = irandom(0, 20)
+        if comp.player_control then
+            comp.shields.active = false
+        end
+    end
+
+    if comp.ai_controller then
+        comp.ai_controller.new_name = template.__default_ai
     end
 
     if comp.reactor then
@@ -52,9 +61,6 @@ function Entity:setTemplate(template_name)
             crew.components.internal_crew = {ship=self}
             crew.components.internal_repair_crew = {}
         end
-    end
-    if comp.shields and template.__type ~= "station" then
-        comp.shields.frequency = irandom(0, 20)
     end
     if comp.internal_rooms == nil then -- No internal rooms, so auto-repair
         if comp.beam_weapons then comp.beam_weapons.auto_repair_per_second = 0.005; end

--- a/scripts/api/entity/shiptemplatebasedobject.lua
+++ b/scripts/api/entity/shiptemplatebasedobject.lua
@@ -42,6 +42,11 @@ function Entity:setTemplate(template_name)
     end
 
     if comp.reactor then
+        if template.__energy_storage then
+            comp.reactor.max_energy = template.__energy_storage
+            comp.reactor.energy = template.__energy_storage
+        end
+
         local reactor_power_factor = 0
         if comp.beam_weapons then comp.beam_weapons.power_factor = 3.0; reactor_power_factor = reactor_power_factor - 3.0 end
         if comp.missile_tubes then comp.missile_tubes.power_factor = 1.0; reactor_power_factor = reactor_power_factor - 1.0 end

--- a/scripts/api/entity/spacestation.lua
+++ b/scripts/api/entity/spacestation.lua
@@ -13,6 +13,7 @@ function SpaceStation()
     e.components = {
         transform = {rotation=random(0, 360)},
         callsign = {callsign=generateRandomCallSign("DS")},
+        comms_receiver = {script="comms_station.lua"},
     }
     e:setFaction(__default_station_faction)
     return e

--- a/scripts/api/shipTemplate.lua
+++ b/scripts/api/shipTemplate.lua
@@ -191,7 +191,7 @@ end
 --- Defaults to 1000.
 --- Example: template:setEnergyStorage(500)
 function ShipTemplate:setEnergyStorage(amount)
-    self.reactor = {max_energy=amount, energy=amount}
+    self.__energy_storage = amount
     return self
 end
 --- Sets the default number of repair crew for PlayerSpaceships created from this ShipTemplate.

--- a/scripts/api/shipTemplate.lua
+++ b/scripts/api/shipTemplate.lua
@@ -48,9 +48,10 @@ function ShipTemplate:__init__()
         color_by_faction=true,
         arrow_if_not_scanned=true,
     }
+    self.__default_ai = "default"
     self.__repair_crew_count = 3
+    self.long_range_radar = {}
     self.share_short_range_radar = {}
-    self.comms_receiver = {script="comms_ship.lua"}
 end
 
 --- Sets this ShipTemplate's unique reference name.
@@ -105,16 +106,6 @@ function ShipTemplate:setType(template_type)
     if template_type == "playership" then
         __player_ship_templates[#__player_ship_templates + 1] = self
         --Add some default player ship components.
-        self.reactor = {}
-        self.coolant = {}
-        self.self_destruct = {}
-        self.science_scanner = {}
-        self.scan_probe_launcher = {}
-        self.hacking_device = {}
-        self.long_range_radar = {}
-        self.comms_transmitter = {}
-        self.comms_receiver = nil
-        self.ai_controller = nil
         if self.docking_port then
             self.docking_port.auto_reload_missiles = false
         end
@@ -126,7 +117,6 @@ function ShipTemplate:setType(template_type)
         if self.radar_trace.icon == "radar/ship.png" then
             self.radar_trace.icon = "radar/blip.png"
         end
-        self.comms_receiver = {script="comms_station.lua"}
     end
     return self
 end
@@ -147,7 +137,7 @@ end
 --- - "missilevolley" prefers lining up missile attacks from long range
 --- Example: template:setAI("fighter") -- default to the "fighter" combat AI state
 function ShipTemplate:setDefaultAI(default_ai)
-    self.ai_controller = {new_name=default_ai}
+    self.__default_ai = default_ai
     return self
 end
 --- Sets the 3D appearance, by ModelData name, of ShipTemplateBasedObjects created from this ShipTemplate.
@@ -531,7 +521,7 @@ end
 --- Defaults to 30000.0 (30U).
 --- Example: template:setLongRangeRadarRange(20000) -- sets the long-range radar range to 20U
 function ShipTemplate:setLongRangeRadarRange(range)
-    if self.long_range_radar then self.long_range_radar.long_range = range end
+    self.long_range_radar.long_range = range
     return self
 end
 --- Sets the short-range radar range of SpaceShips created from this ShipTemplate.
@@ -541,7 +531,7 @@ end
 --- Defaults to 5000.0 (5U).
 --- Example: template:setShortRangeRadarRange(4000) -- sets the short-range radar range to 4U
 function ShipTemplate:setShortRangeRadarRange(range)
-    if self.long_range_radar then self.long_range_radar.short_range = range end
+    self.long_range_radar.short_range = range
     return self
 end
 --- Sets the sound file used for the impulse drive sounds on SpaceShips created from this ShipTemplate.


### PR DESCRIPTION
Two example cases:
- `PlayerSpaceship():setTemplate("MT52 Hornet")` ("Player"), a player ship with a "CPU ship" template
- `CpuShip():setTemplate("MP52 Hornet")` ("CPU"), a CPU ship with a "player ship" template

| Component           | Current | New    | Notes |
|---------------------|---------|--------|-------|
| ai_controller       | Both    | CPU    | If the template does not set AI, then CPU/CPU. |
| comms_receiver      | Player  | CPU    | |
| comms_transmitter   | CPU     | Player | |
| long_range_radar    | CPU     | Both   | The AI system expects CPU ships to have radar ranges. |
| coolant             | CPU     | Player | |
| hacking_device      | CPU     | Player | |
| reactor             | CPU     | Player | |
| scan_probe_launcher | CPU     | Player | |
| science_scanner     | CPU     | Player | |
| self_destruct       | CPU     | Player | |