### PR TITLE
Adjust GM tweak and creation panel layouts

### DIFF
--- a/src/screens/gm/objectCreationView.cpp
+++ b/src/screens/gm/objectCreationView.cpp
@@ -27,23 +27,24 @@ GuiObjectCreationView::GuiObjectCreationView(GuiContainer* owner)
     box->setAttribute("padding", "20");
     box->setAttribute("layout", "horizontal");
 
-    auto row1 = new GuiElement(box, "row1");
-    row1->setAttribute("stretch", "true");
-    row1->setAttribute("layout", "vertical");
-    auto row2 = new GuiElement(box, "row2");
-    row2->setAttribute("stretch", "true");
-    row2->setAttribute("layout", "vertical");
-    auto row3 = new GuiElement(box, "row3");
-    row3->setAttribute("stretch", "true");
-    row3->setAttribute("layout", "vertical");
+    auto col1 = new GuiElement(box, "COLUMN_1");
+    col1->setAttribute("stretch", "true");
+    col1->setAttribute("layout", "vertical");
+    auto col2 = new GuiElement(box, "COLUMN_2");
+    col2->setAttribute("stretch", "true");
+    col2->setAttribute("margin", "20,0");
+    col2->setAttribute("layout", "vertical");
+    auto col3 = new GuiElement(box, "COLUMN_3");
+    col3->setAttribute("stretch", "true");
+    col3->setAttribute("layout", "vertical");
 
-    faction_selector = new GuiSelector(row1, "FACTION_SELECTOR", nullptr);
+    faction_selector = new GuiSelector(col1, "FACTION_SELECTOR", nullptr);
     for(auto [entity, info] : sp::ecs::Query<FactionInfo>())
         faction_selector->addEntry(info.locale_name, info.name);
     faction_selector->setSelectionIndex(0);
-    faction_selector->setSize(300, 50);
+    faction_selector->setSize(GuiElement::GuiSizeMax, 50);
 
-    category_selector = new GuiListbox(row1, "CATEGORY_SELECTOR", [this](int index, string)
+    category_selector = new GuiListbox(col1, "CATEGORY_SELECTOR", [this](int index, string)
     {
         last_selection_index = -1;
         object_list->clear();
@@ -64,8 +65,8 @@ GuiObjectCreationView::GuiObjectCreationView(GuiContainer* owner)
     category_selector->setSelectionIndex(0);
     category_selector->setAttribute("stretch", "true");
 
-    object_filter = new GuiTextEntry(row2, "OBJECT_FILTER", "");
-    object_filter->setTextSize(20)->setSize(300, 30)->setAttribute("fill_width", "true");
+    object_filter = new GuiTextEntry(col2, "OBJECT_FILTER", "");
+    object_filter->setTextSize(20)->setSize(GuiElement::GuiSizeMax, 30)->setAttribute("fill_width", "true");
     object_filter->callback([this](string value) {
         value = value.lower();
         last_selection_index = -1;
@@ -76,7 +77,7 @@ GuiObjectCreationView::GuiObjectCreationView(GuiContainer* owner)
             }
         }
     });
-    object_list = new GuiListbox(row2, "OBJECT_LIST", [this](int index, string value) {
+    object_list = new GuiListbox(col2, "OBJECT_LIST", [this](int index, string value) {
         for(auto& info : spawn_list) {
             if (info.category == category_selector->getSelectionValue() && info.label == value) {
                 if (last_selection_index == index) {
@@ -111,10 +112,10 @@ GuiObjectCreationView::GuiObjectCreationView(GuiContainer* owner)
         }
     }
 
-    description = new GuiScrollText(row3, "DESCRIPTION", "-");
+    description = new GuiScrollText(col3, "DESCRIPTION", "");
     description->setAttribute("stretch", "true");
 
-    (new GuiButton(row1, "CLOSE_BUTTON", tr("button", "Cancel"), [this]() {
+    (new GuiButton(col1, "CLOSE_BUTTON", tr("button", "Cancel"), [this]() {
         this->hide();
     }))->setSize(300, 50);
 }

--- a/src/screens/gm/tweak.cpp
+++ b/src/screens/gm/tweak.cpp
@@ -119,20 +119,20 @@ public:
 
 
 #define ADD_PAGE(LABEL, COMPONENT) \
-    new_page = new GuiTweakPage(this); \
+    new_page = new GuiTweakPage(content); \
     new_page->has_component = [](sp::ecs::Entity e) { return e.hasComponent<COMPONENT>(); }; \
     new_page->add_component = [](sp::ecs::Entity e) { e.addComponent<COMPONENT>(); }; \
     new_page->remove_component = [](sp::ecs::Entity e) { e.removeComponent<COMPONENT>(); }; \
     pages.push_back(new_page); \
     list->addEntry(LABEL, "");
 #define ADD_LABEL(LABEL) do { \
-        auto row = new GuiElement(new_page->contents, ""); \
+        auto row = new GuiElement(new_page->tweaks, ""); \
         row->setSize(GuiElement::GuiSizeMax, 30)->setAttribute("layout", "horizontal"); \
         auto label = new GuiLabel(row, "", LABEL, 20); \
         label->setAlignment(sp::Alignment::CenterRight)->setSize(GuiElement::GuiSizeMax, 30); \
     } while(0)
 #define ADD_TEXT_TWEAK(LABEL, COMPONENT, VALUE) do { \
-        auto row = new GuiElement(new_page->contents, ""); \
+        auto row = new GuiElement(new_page->tweaks, ""); \
         row->setSize(GuiElement::GuiSizeMax, 30)->setAttribute("layout", "horizontal"); \
         auto label = new GuiLabel(row, "", LABEL, 20); \
         label->setAlignment(sp::Alignment::CenterRight)->setSize(GuiElement::GuiSizeMax, 30); \
@@ -141,7 +141,7 @@ public:
         ui->callback([this](string text) { auto v = entity.getComponent<COMPONENT>(); if (v) v->VALUE = text; }); \
     } while(0)
 #define ADD_NUM_TEXT_TWEAK(LABEL, COMPONENT, VALUE) do { \
-        auto row = new GuiElement(new_page->contents, ""); \
+        auto row = new GuiElement(new_page->tweaks, ""); \
         row->setSize(GuiElement::GuiSizeMax, 30)->setAttribute("layout", "horizontal"); \
         auto label = new GuiLabel(row, "", LABEL, 20); \
         label->setAlignment(sp::Alignment::CenterRight)->setSize(GuiElement::GuiSizeMax, 30); \
@@ -150,7 +150,7 @@ public:
         ui->callback([this](string text) { auto v = entity.getComponent<COMPONENT>(); if (v) v->VALUE = text.toFloat(); }); \
     } while(0)
 #define ADD_NUM_SLIDER_TWEAK(LABEL, COMPONENT, MIN_VALUE, MAX_VALUE, VALUE) do { \
-        auto row = new GuiElement(new_page->contents, ""); \
+        auto row = new GuiElement(new_page->tweaks, ""); \
         row->setSize(GuiElement::GuiSizeMax, 30)->setAttribute("layout", "horizontal"); \
         auto label = new GuiLabel(row, "", LABEL, 20); \
         label->setAlignment(sp::Alignment::CenterRight)->setSize(GuiElement::GuiSizeMax, 30); \
@@ -159,7 +159,7 @@ public:
         ui->update_func = [this]() -> float { auto v = entity.getComponent<COMPONENT>(); if (v) return v->VALUE; return 0.0f; }; \
     } while(0)
 #define ADD_INT_SLIDER_TWEAK(LABEL, COMPONENT, MIN_VALUE, MAX_VALUE, VALUE) do { \
-        auto row = new GuiElement(new_page->contents, ""); \
+        auto row = new GuiElement(new_page->tweaks, ""); \
         row->setSize(GuiElement::GuiSizeMax, 30)->setAttribute("layout", "horizontal"); \
         auto label = new GuiLabel(row, "", LABEL, 20); \
         label->setAlignment(sp::Alignment::CenterRight)->setSize(GuiElement::GuiSizeMax, 30); \
@@ -170,7 +170,7 @@ public:
         ui->update_func = [this]() -> float { auto v = entity.getComponent<COMPONENT>(); if (v) return v->VALUE; return 0u; }; \
     } while(0)
 #define ADD_BOOL_TWEAK(LABEL, COMPONENT, VALUE) do { \
-        auto row = new GuiElement(new_page->contents, ""); \
+        auto row = new GuiElement(new_page->tweaks, ""); \
         row->setSize(GuiElement::GuiSizeMax, 30)->setAttribute("layout", "horizontal"); \
         auto label = new GuiLabel(row, "", LABEL, 20); \
         label->setAlignment(sp::Alignment::CenterRight)->setSize(GuiElement::GuiSizeMax, 30); \
@@ -178,7 +178,7 @@ public:
         ui->update_func = [this]() -> bool { auto v = entity.getComponent<COMPONENT>(); if (v) return v->VALUE; return false; }; \
     } while(0)
 #define ADD_VECTOR(LABEL, COMPONENT, VECTOR) do { \
-        auto row = new GuiElement(new_page->contents, ""); \
+        auto row = new GuiElement(new_page->tweaks, ""); \
         row->setSize(GuiElement::GuiSizeMax, 30)->setAttribute("layout", "horizontal"); \
         auto label = new GuiLabel(row, "", LABEL, 20); \
         label->setAlignment(sp::Alignment::CenterRight)->setSize(GuiElement::GuiSizeMax, 30); \
@@ -190,7 +190,7 @@ public:
         del->setTextSize(20)->setSize(50, 30); \
     } while(0)
 #define ADD_VECTOR_NUM_TEXT_TWEAK(LABEL, COMPONENT, VECTOR, VALUE) do { \
-        auto row = new GuiElement(new_page->contents, ""); \
+        auto row = new GuiElement(new_page->tweaks, ""); \
         row->setSize(GuiElement::GuiSizeMax, 30)->setAttribute("layout", "horizontal"); \
         auto label = new GuiLabel(row, "", LABEL, 20); \
         label->setAlignment(sp::Alignment::CenterRight)->setSize(GuiElement::GuiSizeMax, 30); \
@@ -206,7 +206,7 @@ public:
         }); \
     } while(0)
 #define ADD_VECTOR_BOOL_TWEAK(LABEL, COMPONENT, VECTOR, VALUE) do { \
-        auto row = new GuiElement(new_page->contents, ""); \
+        auto row = new GuiElement(new_page->tweaks, ""); \
         row->setSize(GuiElement::GuiSizeMax, 30)->setAttribute("layout", "horizontal"); \
         auto label = new GuiLabel(row, "", LABEL, 20); \
         label->setAlignment(sp::Alignment::CenterRight)->setSize(GuiElement::GuiSizeMax, 30); \
@@ -219,7 +219,7 @@ public:
             return false; }; \
     } while(0)
 #define ADD_VECTOR_TOGGLE_MASK_TWEAK(LABEL, COMPONENT, VECTOR, VALUE, MASK) do { \
-        auto row = new GuiElement(new_page->contents, ""); \
+        auto row = new GuiElement(new_page->tweaks, ""); \
         row->setSize(GuiElement::GuiSizeMax, 30)->setAttribute("layout", "horizontal"); \
         auto label = new GuiLabel(row, "", LABEL, 20); \
         label->setAlignment(sp::Alignment::CenterRight)->setSize(GuiElement::GuiSizeMax, 30); \
@@ -233,7 +233,7 @@ public:
             return false; }; \
     } while(0)
 #define ADD_VECTOR_NUM_SLIDER_TWEAK(LABEL, COMPONENT, VECTOR, MIN_VALUE, MAX_VALUE, VALUE) do { \
-        auto row = new GuiElement(new_page->contents, ""); \
+        auto row = new GuiElement(new_page->tweaks, ""); \
         row->setSize(GuiElement::GuiSizeMax, 30)->setAttribute("layout", "horizontal"); \
         auto label = new GuiLabel(row, "", LABEL, 20); \
         label->setAlignment(sp::Alignment::CenterRight)->setSize(GuiElement::GuiSizeMax, 30); \
@@ -250,7 +250,7 @@ public:
         }; \
     } while(0)
 #define ADD_VECTOR_ENUM_TWEAK(LABEL, COMPONENT, VECTOR, VALUE, MIN_VALUE, MAX_VALUE, STRING_CONVERT_FUNCTION) do { \
-        auto row = new GuiElement(new_page->contents, ""); \
+        auto row = new GuiElement(new_page->tweaks, ""); \
         row->setSize(GuiElement::GuiSizeMax, 30)->setAttribute("layout", "horizontal"); \
         auto label = new GuiLabel(row, "", LABEL, 20); \
         label->setAlignment(sp::Alignment::CenterRight)->setSize(GuiElement::GuiSizeMax, 30); \
@@ -282,8 +282,12 @@ GuiEntityTweak::GuiEntityTweak(GuiContainer* owner)
 {
     setPosition(0, -100, sp::Alignment::BottomCenter);
     setSize(1000, 700);
+    setAttribute("padding", "20");
 
-    GuiListbox* list = new GuiListbox(this, "", [this](int index, string value)
+    content = new GuiElement(this, "GM_TWEAK_DIALOG_CONTENT");
+    content->setSize(GuiElement::GuiSizeMax,GuiElement::GuiSizeMax)->setAttribute("layout", "horizontal");
+
+    GuiListbox* list = new GuiListbox(content, "", [this](int index, string value)
     {
         for(GuiTweakPage* page : pages)
             page->hide();
@@ -291,7 +295,7 @@ GuiEntityTweak::GuiEntityTweak(GuiContainer* owner)
     });
 
     list->setSize(300, GuiElement::GuiSizeMax);
-    list->setPosition(25, 25, sp::Alignment::TopLeft);
+    list->setPosition(0, 0, sp::Alignment::TopLeft);
 
     GuiTweakPage* new_page;
     GuiVectorTweak* vector_selector;
@@ -447,7 +451,7 @@ GuiEntityTweak::GuiEntityTweak(GuiContainer* owner)
 
     for(GuiTweakPage* page : pages)
     {
-        page->setSize(700, 700)->setPosition(0, 0, sp::Alignment::BottomRight)->hide();
+        page->setSize(GuiElement::GuiSizeMax, GuiElement::GuiSizeMax)->hide();
     }
 
     pages[0]->show();
@@ -455,7 +459,7 @@ GuiEntityTweak::GuiEntityTweak(GuiContainer* owner)
 
     (new GuiButton(this, "CLOSE_BUTTON", tr("button", "Close"), [this]() {
         hide();
-    }))->setTextSize(20)->setPosition(-10, 0, sp::Alignment::TopRight)->setSize(70, 30);
+    }))->setTextSize(20)->setPosition(10, -20, sp::Alignment::TopRight)->setSize(70, 30);
 }
 
 void GuiEntityTweak::open(sp::ecs::Entity e)
@@ -475,11 +479,11 @@ GuiTweakPage::GuiTweakPage(GuiContainer* owner)
         else
             add_component(entity);
     });
-    add_remove_button->setSize(300, 50)->setPosition(0, 15, sp::Alignment::TopCenter);
+    add_remove_button->setSize(300, 50)->setAttribute("alignment", "topcenter");
 
-    contents = new GuiElement(this, "CONTENT");
-    contents->setPosition(0, 75, sp::Alignment::TopLeft)->setSize(GuiElement::GuiSizeMax, GuiElement::GuiSizeMax)->setAttribute("layout", "vertical");
-    contents->setMargins(30, 0);
+    tweaks = new GuiElement(this, "TWEAKS");
+    tweaks->setPosition(0, 75, sp::Alignment::TopLeft)->setSize(GuiElement::GuiSizeMax, GuiElement::GuiSizeMax)->setAttribute("layout", "vertical");
+    tweaks->setMargins(30, 0);
 }
 
 void GuiTweakPage::open(sp::ecs::Entity e)
@@ -491,9 +495,9 @@ void GuiTweakPage::onDraw(sp::RenderTarget& target)
 {
     if (has_component(entity)) {
         add_remove_button->setText(tr("tweak-button", "Remove component"));
-        contents->show();
+        tweaks->show();
     } else {
         add_remove_button->setText(tr("tweak-button", "Create component"));
-        contents->hide();
+        tweaks->hide();
     }
 }

--- a/src/screens/gm/tweak.h
+++ b/src/screens/gm/tweak.h
@@ -19,7 +19,7 @@ public:
     std::function<void(sp::ecs::Entity)> remove_component;
 
     GuiButton* add_remove_button;
-    GuiElement* contents;
+    GuiElement* tweaks;
 
     sp::ecs::Entity entity;
 };
@@ -33,6 +33,7 @@ public:
 
 private:
     sp::ecs::Entity entity;
+    GuiElement* content;
     std::vector<GuiTweakPage*> pages;
 };
 


### PR DESCRIPTION
- Use padding and layout attributes instead of absolute positions where helpful.
- Fix inconsistent width of faction selector in object creation view.
- Remove placeholder dash from default description in object creation view.

Before:

![Screenshot_20250710_023703](https://github.com/user-attachments/assets/f99682c9-88f5-4560-ae39-68dfb875f3e0)
![Screenshot_20250710_023638](https://github.com/user-attachments/assets/ccbeab71-60f5-40e4-8ee4-af322d9a579d)

After:

![Screenshot_20250710_023552](https://github.com/user-attachments/assets/537ba406-1553-4868-a3a6-750ced5a7320)
![Screenshot_20250710_023529](https://github.com/user-attachments/assets/756bac9e-3be7-4787-a48c-e5c3599f4d1e)
