### PR TITLE
Various Lua fixes

### DIFF
--- a/scripts/api/entity/scanprobe.lua
+++ b/scripts/api/entity/scanprobe.lua
@@ -68,7 +68,7 @@ end
 function Entity:setOwner(owner)
     if self.components.allow_radar_link then self.components.allow_radar_link.owner = owner end
     if owner and owner:isValid() and owner.components.faction then
-        self.components.faction.entity = owner.components.faction.entity
+        self.components.faction = {entity = owner.components.faction.entity}
     else
         self.components.faction = nil
     end

--- a/scripts/api/entity/shiptemplatebasedobject.lua
+++ b/scripts/api/entity/shiptemplatebasedobject.lua
@@ -192,7 +192,11 @@ end
 function Entity:setShieldsMax(...)
     if self.components.shields then
         for i, max in ipairs({...}) do
-            self.components.shields[i].max = max
+            if self.components.shields[i] then
+                self.components.shields[i].max = max
+            else
+                self.components.shields[i] = {max=max, level=max}
+            end
         end
         while select('#', ...) < #self.components.shields do
             self.components.shields[#self.components.shields] = nil

--- a/scripts/api/entity/shiptemplatebasedobject.lua
+++ b/scripts/api/entity/shiptemplatebasedobject.lua
@@ -81,7 +81,7 @@ end
 --- This overrides the vessel class name provided by the ShipTemplate.
 --- Example: stbo:setTypeName("Prototype")
 function Entity:setTypeName(type_name)
-    self.components.typename = {type_name=type_name}
+    self.components.typename = {type_name=type_name, localized=type_name}
     return self
 end
 --- Returns this STBO's vessel classification name.

--- a/scripts/api/entity/spaceobject.lua
+++ b/scripts/api/entity/spaceobject.lua
@@ -255,6 +255,7 @@ function Entity:setReputationPoints(amount)
     if self.components.faction and self.components.faction.entity and self.components.faction.entity.components.faction_info then
         self.components.faction.entity.components.faction_info.reputation_points = amount
     end
+    return self
 end
 --- Deducts a given number of faction reputation points from this SpaceObject.
 --- Returns true if there are enough points to deduct the specified amount, then does so.
@@ -279,6 +280,7 @@ function Entity:addReputationPoints(amount)
             self.components.faction.entity.components.faction_info.reputation_points = points + amount
         end
     end
+    return self
 end
 --- Returns the name of the map sector, such as "A4", where this SpaceObject is located.
 --- Example: obj:getSectorName()

--- a/scripts/api/entity/spaceship.lua
+++ b/scripts/api/entity/spaceship.lua
@@ -244,7 +244,7 @@ function __getSystemByName(entity, system_name)
     if system_name == "warp" then return entity.components.warp_drive end
     if system_name == "jumpdrive" then return entity.components.jump_drive end
     if system_name == "frontshield" then return entity.components.shields end
-    if system_name == "rearshield" and #entity.components.shields > 1 then return entity.components.shields end
+    if system_name == "rearshield" and entity.components.shields and #entity.components.shields > 1 then return entity.components.shields end
     return nil
 end
 

--- a/scripts/scenario_27_liberation.lua
+++ b/scripts/scenario_27_liberation.lua
@@ -2014,7 +2014,7 @@ function findClearSpot(objects,area_shape,area_point_x,area_point_y,area_distanc
 				assert(item.shape ~= nil,string.format("function findClearSpot expects an object list table where each item in the table is identified by shape, but item index %s's shape was nil",i))
 				assert(valid_table_item_shapes[item.shape] == nil,string.format("function findClearSpot expects a valid shape in the object list table item index %i, but got %s instead",i,item.shape))
 				if item.shape == "circle" then
-					assert(type(item.obj)=="table",string.format("function findClearSpot expects a space object or table as the object in the object list table item index %i, but got a %s instead",i,type(item.obj)))
+					assert(type(item.obj)=="table" or type(item.obj)=="userdata",string.format("function findClearSpot expects a space object or table as the object in the object list table item index %i, but got a %s instead",i,type(item.obj)))
 					local ix, iy = item.obj:getPosition()
 					assert(type(item.dist)=="number",string.format("function findClearSpot expects a distance number as the dist value in the object list table item index %i, but got a %s instead",i,type(item.dist)))
 					local comparison_dist = item.dist
@@ -2027,7 +2027,7 @@ function findClearSpot(objects,area_shape,area_point_x,area_point_y,area_distanc
 					end
 				end
 				if item.shape == "zone" then
-					assert(type(item.obj)=="table",string.format("function findClearSpot expects a space object or table as the object in the object list table item index %i, but got a %s instead",i,type(item.obj)))
+					assert(type(item.obj)=="table" or type(item.obj)=="userdata",string.format("function findClearSpot expects a space object or table as the object in the object list table item index %i, but got a %s instead",i,type(item.obj)))
 					local ta = Artifact():setPosition(cx,cy)
 					if item.obj:isInside(ta) then
 						far_enough = false
@@ -2055,7 +2055,7 @@ function findClearSpot(objects,area_shape,area_point_x,area_point_y,area_distanc
 				assert(item.shape ~= nil,string.format("function findClearSpot expects an object list table where each item in the table is identified by shape, but item index %s's shape was nil",i))
 				assert(valid_table_item_shapes[item.shape] == nil,string.format("function findClearSpot expects a valid shape in the object list table item index %i, but got %s instead",i,item.shape))
 				if item.shape == "circle" then
-					assert(type(item.obj)=="table",string.format("function findClearSpot expects a space object or table as the object in the object list table item index %i, but got a %s instead",i,type(item.obj)))
+					assert(type(item.obj)=="table" or type(item.obj)=="userdata",string.format("function findClearSpot expects a space object or table as the object in the object list table item index %i, but got a %s instead",i,type(item.obj)))
 					local ix, iy = item.obj:getPosition()
 					assert(type(item.dist)=="number",string.format("function findClearSpot expects a distance number as the dist value in the object list table item index %i, but got a %s instead",i,type(item.dist)))
 					local comparison_dist = item.dist
@@ -2090,7 +2090,7 @@ function findClearSpot(objects,area_shape,area_point_x,area_point_y,area_distanc
 				assert(item.shape ~= nil,string.format("function findClearSpot expects an object list table where each item in the table is identified by shape, but item index %s's shape was nil",i))
 				assert(valid_table_item_shapes[item.shape] == nil,string.format("function findClearSpot expects a valid shape in the object list table item index %i, but got %s instead",i,item.shape))
 				if item.shape == "circle" then
-					assert(type(item.obj)=="table",string.format("function findClearSpot expects a space object or table as the object in the object list table item index %i, but got a %s instead",i,type(item.obj)))
+					assert(type(item.obj)=="table" or type(item.obj)=="userdata",string.format("function findClearSpot expects a space object or table as the object in the object list table item index %i, but got a %s instead",i,type(item.obj)))
 					local ix, iy = item.obj:getPosition()
 					assert(type(item.dist)=="number",string.format("function findClearSpot expects a distance number as the dist value in the object list table item index %i, but got a %s instead",i,type(item.dist)))
 					local comparison_dist = item.dist
@@ -2125,7 +2125,7 @@ function findClearSpot(objects,area_shape,area_point_x,area_point_y,area_distanc
 				assert(item.shape ~= nil,string.format("function findClearSpot expects an object list table where each item in the table is identified by shape, but item index %s's shape was nil",i))
 				assert(valid_table_item_shapes[item.shape] == nil,string.format("function findClearSpot expects a valid shape in the object list table item index %i, but got %s instead",i,item.shape))
 				if item.shape == "circle" then
-					assert(type(item.obj)=="table",string.format("function findClearSpot expects a space object or table as the object in the object list table item index %i, but got a %s instead",i,type(item.obj)))
+					assert(type(item.obj)=="table" or type(item.obj)=="userdata",string.format("function findClearSpot expects a space object or table as the object in the object list table item index %i, but got a %s instead",i,type(item.obj)))
 					local ix, iy = item.obj:getPosition()
 					assert(type(item.dist)=="number",string.format("function findClearSpot expects a distance number as the dist value in the object list table item index %i, but got a %s instead",i,type(item.dist)))
 					local comparison_dist = item.dist

--- a/scripts/scenario_34_cadet.lua
+++ b/scripts/scenario_34_cadet.lua
@@ -961,7 +961,7 @@ function findClearSpot(objects,area_shape,area_point_x,area_point_y,area_distanc
 				assert(item.shape ~= nil,string.format("function findClearSpot expects an object list table where each item in the table is identified by shape, but item index %s's shape was nil",i))
 				assert(valid_table_item_shapes[item.shape] == nil,string.format("function findClearSpot expects a valid shape in the object list table item index %i, but got %s instead",i,item.shape))
 				if item.shape == "circle" then
-					assert(type(item.obj)=="table",string.format("function findClearSpot expects a space object or table as the object in the object list table item index %i, but got a %s instead",i,type(item.obj)))
+					assert(type(item.obj)=="table" or type(item.obj)=="userdata",string.format("function findClearSpot expects a space object or table as the object in the object list table item index %i, but got a %s instead",i,type(item.obj)))
 					local ix, iy = item.obj:getPosition()
 					assert(type(item.dist)=="number",string.format("function findClearSpot expects a distance number as the dist value in the object list table item index %i, but got a %s instead",i,type(item.dist)))
 					local comparison_dist = item.dist
@@ -974,7 +974,7 @@ function findClearSpot(objects,area_shape,area_point_x,area_point_y,area_distanc
 					end
 				end
 				if item.shape == "zone" then
-					assert(type(item.obj)=="table",string.format("function findClearSpot expects a space object or table as the object in the object list table item index %i, but got a %s instead",i,type(item.obj)))
+					assert(type(item.obj)=="table" or type(item.obj)=="userdata",string.format("function findClearSpot expects a space object or table as the object in the object list table item index %i, but got a %s instead",i,type(item.obj)))
 					local ta = Artifact():setPosition(cx,cy)
 					if item.obj:isInside(ta) then
 						far_enough = false
@@ -1008,7 +1008,7 @@ function findClearSpot(objects,area_shape,area_point_x,area_point_y,area_distanc
 				assert(item.shape ~= nil,string.format("function findClearSpot expects an object list table where each item in the table is identified by shape, but item index %s's shape was nil",i))
 				assert(valid_table_item_shapes[item.shape] == nil,string.format("function findClearSpot expects a valid shape in the object list table item index %i, but got %s instead",i,item.shape))
 				if item.shape == "circle" then
-					assert(type(item.obj)=="table",string.format("function findClearSpot expects a space object or table as the object in the object list table item index %i, but got a %s instead",i,type(item.obj)))
+					assert(type(item.obj)=="table" or type(item.obj)=="userdata",string.format("function findClearSpot expects a space object or table as the object in the object list table item index %i, but got a %s instead",i,type(item.obj)))
 					local ix, iy = item.obj:getPosition()
 					assert(type(item.dist)=="number",string.format("function findClearSpot expects a distance number as the dist value in the object list table item index %i, but got a %s instead",i,type(item.dist)))
 					local comparison_dist = item.dist
@@ -1039,7 +1039,7 @@ function findClearSpot(objects,area_shape,area_point_x,area_point_y,area_distanc
 				assert(item.shape ~= nil,string.format("function findClearSpot expects an object list table where each item in the table is identified by shape, but item index %s's shape was nil",i))
 				assert(valid_table_item_shapes[item.shape] == nil,string.format("function findClearSpot expects a valid shape in the object list table item index %i, but got %s instead",i,item.shape))
 				if item.shape == "circle" then
-					assert(type(item.obj)=="table",string.format("function findClearSpot expects a space object or table as the object in the object list table item index %i, but got a %s instead",i,type(item.obj)))
+					assert(type(item.obj)=="table" or type(item.obj)=="userdata",string.format("function findClearSpot expects a space object or table as the object in the object list table item index %i, but got a %s instead",i,type(item.obj)))
 					local ix, iy = item.obj:getPosition()
 					assert(type(item.dist)=="number",string.format("function findClearSpot expects a distance number as the dist value in the object list table item index %i, but got a %s instead",i,type(item.dist)))
 					local comparison_dist = item.dist
@@ -1074,7 +1074,7 @@ function findClearSpot(objects,area_shape,area_point_x,area_point_y,area_distanc
 				assert(item.shape ~= nil,string.format("function findClearSpot expects an object list table where each item in the table is identified by shape, but item index %s's shape was nil",i))
 				assert(valid_table_item_shapes[item.shape] == nil,string.format("function findClearSpot expects a valid shape in the object list table item index %i, but got %s instead",i,item.shape))
 				if item.shape == "circle" then
-					assert(type(item.obj)=="table",string.format("function findClearSpot expects a space object or table as the object in the object list table item index %i, but got a %s instead",i,type(item.obj)))
+					assert(type(item.obj)=="table" or type(item.obj)=="userdata",string.format("function findClearSpot expects a space object or table as the object in the object list table item index %i, but got a %s instead",i,type(item.obj)))
 					local ix, iy = item.obj:getPosition()
 					assert(type(item.dist)=="number",string.format("function findClearSpot expects a distance number as the dist value in the object list table item index %i, but got a %s instead",i,type(item.dist)))
 					local comparison_dist = item.dist
@@ -1109,7 +1109,7 @@ function findClearSpot(objects,area_shape,area_point_x,area_point_y,area_distanc
 				assert(item.shape ~= nil,string.format("function findClearSpot expects an object list table where each item in the table is identified by shape, but item index %s's shape was nil",i))
 				assert(valid_table_item_shapes[item.shape] == nil,string.format("function findClearSpot expects a valid shape in the object list table item index %i, but got %s instead",i,item.shape))
 				if item.shape == "circle" then
-					assert(type(item.obj)=="table",string.format("function findClearSpot expects a space object or table as the object in the object list table item index %i, but got a %s instead",i,type(item.obj)))
+					assert(type(item.obj)=="table" or type(item.obj)=="userdata",string.format("function findClearSpot expects a space object or table as the object in the object list table item index %i, but got a %s instead",i,type(item.obj)))
 					local ix, iy = item.obj:getPosition()
 					assert(type(item.dist)=="number",string.format("function findClearSpot expects a distance number as the dist value in the object list table item index %i, but got a %s instead",i,type(item.dist)))
 					local comparison_dist = item.dist

--- a/scripts/scenario_34_cadet.lua
+++ b/scripts/scenario_34_cadet.lua
@@ -1769,6 +1769,7 @@ function unStringStore()
 	local sc = {}
 	while(store:get(i) ~= "") do
 		local ship = store:get(i)
+		if not ship then break end
 		local name_key = string.format("%s-%s-name",store_name,ship)
 		local name = store:get(name_key)
 		local level_key = string.format("%s-%s-level",store_name,ship)

--- a/scripts/scenario_59_border.lua
+++ b/scripts/scenario_59_border.lua
@@ -942,8 +942,8 @@ function setBorderZones()
 		if random(1,upBound) <= cutOff then
 			positiveBendCount = positiveBendCount + newBend
 		else
-			newBend = -1*newBend
 			negativeBendCount = negativeBendCount + newBend
+			newBend = -1*newBend
 		end
 	end
 	newBend = bendAngle + newBend


### PR DESCRIPTION
This PR plus #2507 results in all EE-repo scenarios starting up and running the first few seconds without throwing script errors; specifically, running `EmptyEpsilon headless=<file> startpaused=0` for a few seconds does not print any line beginning with `[INFO    ]: LUA-Error:`

Note that I did _not_ test any scenario functionality beyond "runs without triggering Lua errors". I suspect some scenarios print-and-continue for certain failures, rather than letting errors bubble up; this PR does not attempt to address those errors.