### PR TITLE
Expose i18n plural handling to Lua

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -761,7 +761,7 @@ if(Python3_Interpreter_FOUND)
 endif()
 
 add_custom_target(update_locale
-    COMMAND xgettext --keyword=tr:1c,2 --keyword=tr:1 --keyword=trMark:1c,2 --keyword=trMark:1 --add-comments=TRANSLATORS --omit-header -d resources/locale/main.en ${MAIN_SOURCES} ${GUI_LIB_SOURCES}
+    COMMAND xgettext --keyword=tr:1c,2 --keyword=tr:1 --keyword=trn:2c,3,4 --keyword=trn:2,3 --keyword=trMark:1c,2 --keyword=trMark:1 --add-comments=TRANSLATORS --omit-header -d resources/locale/main.en ${MAIN_SOURCES} ${GUI_LIB_SOURCES}
     COMMAND python3 update_locale.py
     WORKING_DIRECTORY ${PROJECT_SOURCE_DIR})
 

--- a/scripts/locale/scenario_00_basic.de.po
+++ b/scripts/locale/scenario_00_basic.de.po
@@ -311,23 +311,14 @@ msgctxt "msgMainscreen&Spectbanner"
 msgid "Mission: FAILED (time has run out)"
 msgstr "Mission FEHLGESCHLAGEN (Zeit abgelaufen)"
 
-#: scripts/scenario_00_basic.lua:539
-#, lua-format
+#: scripts/scenario_00_basic.lua:544 scripts/scenario_00_basic.lua:549
+#: scripts/scenario_00_basic.lua:554
+#, fuzzy, lua-format
 msgctxt "time-incCall"
-msgid "%s, you have %d minute remaining."
-msgstr "%s, Sie haben noch %d Minute Zeit."
-
-#: scripts/scenario_00_basic.lua:544
-#, lua-format
-msgctxt "time-incCall"
-msgid "%s, you have %d minutes remaining."
-msgstr "%s, Sie haben noch %d Minuten Zeit."
-
-#: scripts/scenario_00_basic.lua:549
-#, lua-format
-msgctxt "time-incCall"
-msgid "%s, you have %d minutes remaining of mission time."
-msgstr "%s, Sie haben noch %d Minuten Zeit für die Mission."
+msgid "%s, you have one minute remaining."
+msgid_plural "%s, you have %d minutes remaining."
+msgstr[0] "%s, Sie haben noch %d Minute Zeit."
+msgstr[1] "%s, Sie haben noch %d Minuten Zeit."
 
 #: scripts/scenario_00_basic.lua:559
 msgctxt "msgMainscreen&Spectbanner"

--- a/scripts/locale/scenario_00_basic.en.po
+++ b/scripts/locale/scenario_00_basic.en.po
@@ -269,20 +269,10 @@ msgstr ""
 #: scripts/scenario_00_basic.lua:539
 #, lua-format
 msgctxt "time-incCall"
-msgid "%s, you have %d minute remaining."
-msgstr ""
-
-#: scripts/scenario_00_basic.lua:544
-#, lua-format
-msgctxt "time-incCall"
-msgid "%s, you have %d minutes remaining."
-msgstr ""
-
-#: scripts/scenario_00_basic.lua:549
-#, lua-format
-msgctxt "time-incCall"
-msgid "%s, you have %d minutes remaining of mission time."
-msgstr ""
+msgid "%s, you have one minute remaining."
+msgid_plural "%s, you have %d minutes remaining."
+msgstr[0] ""
+msgstr[1] ""
 
 #: scripts/scenario_00_basic.lua:559
 msgctxt "msgMainscreen&Spectbanner"

--- a/scripts/locale/scenario_00_basic.fr.po
+++ b/scripts/locale/scenario_00_basic.fr.po
@@ -327,23 +327,14 @@ msgctxt "msgMainscreen&Spectbanner"
 msgid "Mission: FAILED (time has run out)"
 msgstr "Mission : ECHEC (temps écoulé)"
 
-#: scripts/scenario_00_basic.lua:539
-#, lua-format
+#: scripts/scenario_00_basic.lua:544 scripts/scenario_00_basic.lua:549
+#: scripts/scenario_00_basic.lua:554
+#, fuzzy, lua-format
 msgctxt "time-incCall"
-msgid "%s, you have %d minute remaining."
-msgstr "%s, il ne vous reste qu'%d minute."
-
-#: scripts/scenario_00_basic.lua:544
-#, lua-format
-msgctxt "time-incCall"
-msgid "%s, you have %d minutes remaining."
-msgstr "%s, il ne vous reste que %d minutes."
-
-#: scripts/scenario_00_basic.lua:549
-#, lua-format
-msgctxt "time-incCall"
-msgid "%s, you have %d minutes remaining of mission time."
-msgstr "%s, il ne vous reste que %d minutes pour réussir votre mission."
+msgid "%s, you have one minute remaining."
+msgid_plural "%s, you have %d minutes remaining."
+msgstr[0] "%s, il ne vous reste qu'%d minute."
+msgstr[1] "%s, il ne vous reste que %d minutes."
 
 #: scripts/scenario_00_basic.lua:559
 msgctxt "msgMainscreen&Spectbanner"

--- a/scripts/scenario_00_basic.lua
+++ b/scripts/scenario_00_basic.lua
@@ -538,19 +538,20 @@ function update(delta)
             return
         end
         if gametimeleft < timewarning then
+            local minutes = timewarning / 60
             if timewarning <= 1 * 60 then -- Less then 1 minutes left.
                 for idx, player in ipairs(playerList) do
-                    friendlyList[1]:sendCommsMessage(player, string.format(_("time-incCall", [[%s, you have %d minute remaining.]]), player:getCallSign(), timewarning / 60))
+                    friendlyList[1]:sendCommsMessage(player, string.format(_(minutes, "time-incCall", [[%s, you have one minute remaining.]], [[%s, you have %d minutes remaining.]]), player:getCallSign(), minutes))
                 end
                 timewarning = timewarning - 2 * 60
             elseif timewarning <= 5 * 60 then -- Less then 5 minutes left. Warn ever 2 minutes instead of every 5.
                 for idx, player in ipairs(playerList) do
-                    friendlyList[1]:sendCommsMessage(player, string.format(_("time-incCall", [[%s, you have %d minutes remaining.]]), player:getCallSign(), timewarning / 60))
+                    friendlyList[1]:sendCommsMessage(player, string.format(_(minutes, "time-incCall", [[%s, you have one minute remaining.]], [[%s, you have %d minutes remaining.]]), player:getCallSign(), minutes))
                 end
                 timewarning = timewarning - 2 * 60
             else
                 for idx, player in ipairs(playerList) do
-                    friendlyList[1]:sendCommsMessage(player, string.format(_("time-incCall", [[%s, you have %d minutes remaining of mission time.]]), player:getCallSign(), timewarning / 60))
+                    friendlyList[1]:sendCommsMessage(player, string.format(_(minutes, "time-incCall", [[%s, you have one minute remaining.]], [[%s, you have %d minutes remaining.]]), player:getCallSign(), minutes))
                 end
                 timewarning = timewarning - 5 * 60
             end

--- a/src/script.cpp
+++ b/src/script.cpp
@@ -95,6 +95,17 @@ static int luaRequire(lua_State* L)
 
 static int luaTranslate(lua_State* L)
 {
+    if (lua_type(L, 1) == LUA_TNUMBER) {
+        auto n = luaL_checkinteger(L, 1);
+        auto str_1 = luaL_checkstring(L, 2);
+        auto str_2 = luaL_checkstring(L, 3);
+        auto str_3 = luaL_optstring(L, 4, nullptr);
+        if (str_3)
+            lua_pushstring(L, trn(n, str_1, str_2, str_3).c_str());
+        else
+            lua_pushstring(L, trn(n, str_1, str_2).c_str());
+        return 1;
+    }
     auto str_1 = luaL_checkstring(L, 1);
     auto str_2 = luaL_optstring(L, 2, nullptr);
     if (str_2)

--- a/update_locale.py
+++ b/update_locale.py
@@ -69,10 +69,10 @@ for script in glob.glob("scripts/**/*.lua", recursive=True):
                         f.write("msgstr \"\"\n")
     f.close()
 
-    cmd = ["xgettext", "--keyword=_:1c,2", "--keyword=_:1", "--omit-header", "-j", "-d", output[:-3], "-C", "-"]
+    cmd = ["xgettext", "--keyword=_:1c,2", "--keyword=_:1", "--keyword=_:2c,3,4", "--keyword=2,3", "--omit-header", "-j", "-d", output[:-3], "-C", "-"]
     subprocess.run(cmd, check=True, input=b"")
     pre = open(output, "rt").read()
-    cmd = ["xgettext", "--keyword=_:1c,2", "--keyword=_:1", "--add-comments=TRANSLATORS", "--omit-header", "-j", "-d" , output[:-3], script]
+    cmd = ["xgettext", "--keyword=_:1c,2", "--keyword=_:1", "--keyword=_:2c,3,4", "--keyword=2,3", "--add-comments=TRANSLATORS", "--omit-header", "-j", "-d" , output[:-3], script]
     subprocess.run(cmd, check=True)
     post = open(output, "rt").read()
     if pre == post and "name" not in info:


### PR DESCRIPTION
Depends on https://github.com/daid/SeriousProton/pull/270

Changes applied to scenario_00_basic as an example; this does not affect the existing translations since both French and German agree on 1 being singular and 2+ being plural; if the scenario was translated into Czech (as the only other language with a `main.*.po` file), it would require three forms (for 1, 2-4, and 5+); assuming Google Translate is in any way close to correct this would look something like:

```po
msgctxt "time-incCall"
msgid "%s, you have one minute remaining."
msgid_plural "%s, you have %d minutes remaining."
msgstr[0] "%s, zbývá ti %d minuta"
msgstr[1] "%s, zbývají ti %d minuty"
msgstr[2] "%s, zbývá ti %d minut"
```