### PR TITLE
Find both localized and internal names on DB button

### DIFF
--- a/src/screens/crew6/scienceScreen.cpp
+++ b/src/screens/crew6/scienceScreen.cpp
@@ -122,7 +122,7 @@ ScienceScreen::ScienceScreen(GuiContainer* owner, CrewPosition crew_position)
         auto ship = targets.get();
         if (auto tn = ship.getComponent<TypeName>())
         {
-            if (database_view->findAndDisplayEntry(tn->type_name))
+            if (database_view->findAndDisplayEntry(tn->type_name) || database_view->findAndDisplayEntry(tn->localized))
             {
                 view_mode_selection->setSelectionIndex(1);
                 radar_view->hide();


### PR DESCRIPTION
If the internal type name of a ship template (`name("...")` or `template:copy("...")`) doesn't match its localized name (`setLocaleName(...)`), the "DB" database view button on the Science screen's target info sidebar doesn't work, because `DatabaseView::findAndDisplayEntry` can't match the differing names. This prevents the localization of ship names that would differ in other languages.

Run the search against both the entity's internal and localized names when clicking the "DB" button. This preserves existing behavior of preferring an internal type name match, while also allowing localized names to match if the internal name search fails.

Alternative solutions might involve modifying `findAndDisplayEntry` to accept multiple parameters, or for `Database` to store both internal and localized/display names for each entry.