### PR TITLE
Configurable radar centering target

### DIFF
--- a/src/screenComponents/radarView.cpp
+++ b/src/screenComponents/radarView.cpp
@@ -4,8 +4,9 @@
 #include "featureDefs.h"
 #include "ecs/query.h"
 #include "systems/collision.h"
-#include "components/collision.h"
 #include "components/beamweapon.h"
+#include "components/collision.h"
+#include "components/docking.h"
 #include "components/hull.h"
 #include "components/shields.h"
 #include "components/missiletubes.h"
@@ -103,14 +104,26 @@ void GuiRadarView::onDraw(sp::RenderTarget& renderer)
 {
     //Hacky, when not relay and we have a ship, center on it.
     auto transform = my_spaceship.getComponent<sp::Transform>();
-    if (transform) {
-        if (auto_center_on_my_ship) {
-            view_position = transform->getPosition();
-        }
-        if (auto_rotate_on_my_ship) {
-            view_rotation = transform->getRotation() + 90;
-        }
+
+    if (auto_center_target)
+        transform = auto_center_target.getComponent<sp::Transform>();
+    else
+        auto_center_target = my_spaceship;
+
+    // If target has no transform, it might be docked inside another ship
+    if (!transform)
+    {
+        if (auto dp = auto_center_target.getComponent<DockingPort>())
+            transform = dp->target.getComponent<sp::Transform>();
     }
+
+    if (transform && auto_center_on_my_ship)
+    {
+        view_position = transform->getPosition();
+        if (auto_rotate_on_my_ship)
+            view_rotation = transform->getRotation() + 90;
+    }
+
     if (auto_distance)
     {
         distance = long_range ? 30000.0f : 5000.0f;

--- a/src/screenComponents/radarView.cpp
+++ b/src/screenComponents/radarView.cpp
@@ -50,8 +50,9 @@ GuiRadarView::GuiRadarView(GuiContainer* owner, string id, TargetsContainer* tar
     missile_tube_controls(nullptr),
     view_position(0.0f,0.0f),
     view_rotation(0),
-    auto_center_on_my_ship(true),
-    auto_rotate_on_my_ship(false),
+    auto_center_target(my_spaceship),
+    auto_center_on_ship(true),
+    auto_rotate_on_ship(false),
     auto_distance(true),
     distance(5000.0f),
     long_range(false),
@@ -79,8 +80,9 @@ GuiRadarView::GuiRadarView(GuiContainer* owner, string id, float distance, Targe
     missile_tube_controls(nullptr),
     view_position(0.0f, 0.0f),
     view_rotation(0),
-    auto_center_on_my_ship(true),
-    auto_rotate_on_my_ship(false),
+    auto_center_target(my_spaceship),
+    auto_center_on_ship(true),
+    auto_rotate_on_ship(false),
     distance(distance),
     long_range(false),
     show_ghost_dots(false),
@@ -102,25 +104,26 @@ GuiRadarView::GuiRadarView(GuiContainer* owner, string id, float distance, Targe
 
 void GuiRadarView::onDraw(sp::RenderTarget& renderer)
 {
-    //Hacky, when not relay and we have a ship, center on it.
-    auto transform = my_spaceship.getComponent<sp::Transform>();
+    // Auto-center on the target, defaulting to my_spaceship on creation.
+    auto transform = auto_center_target.getComponent<sp::Transform>();
 
-    if (auto_center_target)
-        transform = auto_center_target.getComponent<sp::Transform>();
-    else
-        auto_center_target = my_spaceship;
-
-    // If target has no transform, it might be docked inside another ship
+    // If target has no transform, it might be docked inside another ship.
+    // Otherwise, if the target doesn't physically exist, fall back to
+    // my_spaceship if possible.
     if (!transform)
     {
         if (auto dp = auto_center_target.getComponent<DockingPort>())
             transform = dp->target.getComponent<sp::Transform>();
+        else if (!transform && my_spaceship)
+            auto_center_target = my_spaceship;
+        else
+            auto_center_target = sp::ecs::Entity();
     }
 
-    if (transform && auto_center_on_my_ship)
+    if (transform && auto_center_on_ship)
     {
         view_position = transform->getPosition();
-        if (auto_rotate_on_my_ship)
+        if (auto_rotate_on_ship)
             view_rotation = transform->getRotation() + 90;
     }
 

--- a/src/screenComponents/radarView.h
+++ b/src/screenComponents/radarView.h
@@ -4,7 +4,6 @@
 #include "gui/gui2_element.h"
 #include "engine.h"
 
-
 class GuiMissileTubeControls;
 class TargetsContainer;
 
@@ -46,6 +45,7 @@ private:
 
     glm::vec2 view_position{0, 0};
     float view_rotation;
+    sp::ecs::Entity auto_center_target;
     bool auto_center_on_my_ship;
     bool auto_rotate_on_my_ship;
     bool auto_distance = false;
@@ -96,6 +96,8 @@ public:
     GuiRadarView* setFogOfWarStyle(EFogOfWarStyle style) { this->fog_style = style; return this; }
     bool getAutoCentering() { return auto_center_on_my_ship; }
     GuiRadarView* setAutoCentering(bool value) { this->auto_center_on_my_ship = value; return this; }
+    sp::ecs::Entity getAutoCenterTarget() { return auto_center_target; }
+    GuiRadarView* setAutoCenterTarget(sp::ecs::Entity target) { this->auto_center_target = target; return this; }
     bool getAutoRotating() { return auto_rotate_on_my_ship; }
     GuiRadarView* setAutoRotating(bool value) { this->auto_rotate_on_my_ship = value; return this; }
     GuiRadarView* setCallbacks(bpfunc_t mouse_down_func, pfunc_t mouse_drag_func, pfunc_t mouse_up_func) { this->mouse_down_func = mouse_down_func; this->mouse_drag_func = mouse_drag_func; this->mouse_up_func = mouse_up_func; return this; }

--- a/src/screenComponents/radarView.h
+++ b/src/screenComponents/radarView.h
@@ -46,8 +46,8 @@ private:
     glm::vec2 view_position{0, 0};
     float view_rotation;
     sp::ecs::Entity auto_center_target;
-    bool auto_center_on_my_ship;
-    bool auto_rotate_on_my_ship;
+    bool auto_center_on_ship;
+    bool auto_rotate_on_ship;
     bool auto_distance = false;
     float distance;
     bool long_range;
@@ -94,12 +94,12 @@ public:
     GuiRadarView* setBackgroundAlpha(uint8_t background_alpha) { this->background_alpha = background_alpha; return this; }
     GuiRadarView* setStyle(ERadarStyle style) { this->style = style; return this; }
     GuiRadarView* setFogOfWarStyle(EFogOfWarStyle style) { this->fog_style = style; return this; }
-    bool getAutoCentering() { return auto_center_on_my_ship; }
-    GuiRadarView* setAutoCentering(bool value) { this->auto_center_on_my_ship = value; return this; }
+    bool getAutoCentering() { return auto_center_on_ship; }
+    GuiRadarView* setAutoCentering(bool value) { this->auto_center_on_ship = value; return this; }
     sp::ecs::Entity getAutoCenterTarget() { return auto_center_target; }
     GuiRadarView* setAutoCenterTarget(sp::ecs::Entity target) { this->auto_center_target = target; return this; }
-    bool getAutoRotating() { return auto_rotate_on_my_ship; }
-    GuiRadarView* setAutoRotating(bool value) { this->auto_rotate_on_my_ship = value; return this; }
+    bool getAutoRotating() { return auto_rotate_on_ship; }
+    GuiRadarView* setAutoRotating(bool value) { this->auto_rotate_on_ship = value; return this; }
     GuiRadarView* setCallbacks(bpfunc_t mouse_down_func, pfunc_t mouse_drag_func, pfunc_t mouse_up_func) { this->mouse_down_func = mouse_down_func; this->mouse_drag_func = mouse_drag_func; this->mouse_up_func = mouse_up_func; return this; }
     GuiRadarView* setViewPosition(glm::vec2 view_position) { this->view_position = view_position; return this; }
     glm::vec2 getViewPosition() { return view_position; }


### PR DESCRIPTION
Allow screens using autocentering on `RadarView` to define the entity that it places at its center. This also incorporates the check for whether the tracked ship has docked, which is currently implemented on Relay's "Center On Ship".

Fixes #2520, by transferring radar centering to the carrier after docking.