### PR TITLE
Make Relay's "Center On Ship" button a toggle button

### DIFF
--- a/src/screens/crew6/relayScreen.cpp
+++ b/src/screens/crew6/relayScreen.cpp
@@ -164,18 +164,9 @@ RelayScreen::RelayScreen(GuiContainer* owner, bool allow_comms)
     launch_probe_button->setSize(GuiElement::GuiSizeMax, 50)->setVisible(my_spaceship.hasComponent<ScanProbeLauncher>());
 
     // Center on ship
-    center_button = new GuiButton(option_buttons, "CENTER_ON_SHIP", tr("Center On Ship"), [this](){
+    center_button = new GuiToggleButton(option_buttons, "CENTER_ON_SHIP", tr("Center On Ship"), [this](bool value) {
         if(!my_spaceship) return;
-        auto transform = my_spaceship.getComponent<sp::Transform>();
-        // If my ship has no transform, it might be docked inside another ship
-        if (!transform) {
-            if (auto dp = my_spaceship.getComponent<DockingPort>()) {
-                transform = dp->target.getComponent<sp::Transform>();
-            }
-        }
-        if(transform) {
-            radar->setViewPosition(transform->getPosition());
-        }
+        radar->setAutoCentering(value);
     });
     center_button->setSize(GuiElement::GuiSizeMax, 50);
 

--- a/src/screens/crew6/relayScreen.h
+++ b/src/screens/crew6/relayScreen.h
@@ -38,7 +38,7 @@ private:
     GuiToggleButton* link_to_science_button;
     GuiButton* delete_waypoint_button;
     GuiButton* launch_probe_button;
-    GuiButton* center_button;
+    GuiToggleButton* center_button;
 
     GuiSlider* zoom_slider;
     GuiLabel* zoom_label;


### PR DESCRIPTION
Requires #2521.

Use `RadarView::auto_center_target` to convert Relay's "Center On Ship" button from a one-off view change to a toggle that follows the ship when enabled. Since this uses code in RadarView that continues following an internally docked ship, it no longer needs to apply its own workaround.

[Screencast_20250717_160352.webm](https://github.com/user-attachments/assets/3adb5823-cfcb-464c-bfea-b7fb3cafd663)
