### PR TITLE
[#2527] List own faction relationship in DB

### DIFF
--- a/scripts/science_db.lua
+++ b/scripts/science_db.lua
@@ -253,10 +253,10 @@ function __fillDefaultDatabaseData()
 	-- Populate the Factions top-level entry.
 	local faction_database = ScienceDatabase():setName(_("database", "Factions"))
 	for name, info in pairs(__faction_info) do
-        local entry = faction_database:addEntry(info.components.faction_info.locale_name);
+		local entry = faction_database:addEntry(info.components.faction_info.locale_name);
 		for name2, info2 in pairs(__faction_info) do
-            if info ~= info2 then
-				local stance = _("stance", "Neutral");
+			local stance = _("stance", "Neutral");
+			if info ~= info2 then
 				for idx, relation in ipairs(info.components.faction_info) do
 					if relation.other_faction == info2 then
 						if relation.relation == "neutral" then stance = _("stance", "Neutral") end
@@ -264,11 +264,13 @@ function __fillDefaultDatabaseData()
 						if relation.relation == "friendly" then stance = _("stance", "Friendly") end
 					end
 				end
-				entry:addKeyValue(info2.components.faction_info.locale_name, stance);
+			else
+				stance = "-";
 			end
-        end
-        entry:setLongDescription(info.components.faction_info.description);
-    end
+			entry:addKeyValue(info2.components.faction_info.locale_name, stance);
+		end
+		entry:setLongDescription(info.components.faction_info.description);
+	end
 
     -- Populate the Ships top-level entry.
     local ship_database = ScienceDatabase():setName(_("database", "Ships"))

--- a/scripts/science_db.lua
+++ b/scripts/science_db.lua
@@ -255,8 +255,9 @@ function __fillDefaultDatabaseData()
 	for name, info in pairs(__faction_info) do
 		local entry = faction_database:addEntry(info.components.faction_info.locale_name);
 		for name2, info2 in pairs(__faction_info) do
-			local stance = _("stance", "Neutral");
+			local stance = "-"
 			if info ~= info2 then
+				stance = _("stance", "Neutral")
 				for idx, relation in ipairs(info.components.faction_info) do
 					if relation.other_faction == info2 then
 						if relation.relation == "neutral" then stance = _("stance", "Neutral") end
@@ -264,8 +265,6 @@ function __fillDefaultDatabaseData()
 						if relation.relation == "friendly" then stance = _("stance", "Friendly") end
 					end
 				end
-			else
-				stance = "-";
 			end
 			entry:addKeyValue(info2.components.faction_info.locale_name, stance);
 		end


### PR DESCRIPTION
List the viewed faction's relationship to itself as `-` in the science DB to retain consistency in key-value lists between factions. 

<img width="864" height="588" alt="image" src="https://github.com/user-attachments/assets/d82dae64-3523-4d3c-af76-8e07eadcbda4" />
