### PR TITLE
[#2525] Update ShipSelectionScreen PlayerShip list

### DIFF
--- a/src/menus/shipSelectionScreen.cpp
+++ b/src/menus/shipSelectionScreen.cpp
@@ -437,6 +437,16 @@ void ShipSelectionScreen::update(float delta)
         player_ship_list->setEntryName(index, ship_name + " (" + string(ship_position_count) + ")");
     }
 
+    // Clear player ships that no longer exist.
+    for (int i = 0; i < player_ship_list->entryCount(); i++)
+    {
+        bool keeper = false;
+
+        for (auto [entity, pc] : sp::ecs::Query<PlayerControl>())
+            if (entity.toString() == player_ship_list->getEntryValue(i)) keeper = true;
+
+        if (!keeper) player_ship_list->removeEntry(i);
+    }
 
     // If there aren't any player ships, show a label stating so.
     if (player_ship_list->entryCount() > 0)


### PR DESCRIPTION
Remove player ships that no longer exist from the list on the ShipSelectionScreen.

[Screencast_20250720_184355.webm](https://github.com/user-attachments/assets/b4570a4c-b761-4cdb-8b22-9f2fde4e5559)

Fixes #2525.