### PR TITLE
[#2519] Set ExplodeOnTouch blast_range on Asteroid:setSize

### DIFF
--- a/scripts/api/entity/asteroid.lua
+++ b/scripts/api/entity/asteroid.lua
@@ -71,6 +71,7 @@ function Entity:setSize(radius)
     if comp.mesh_render then comp.mesh_render.scale=radius end
     if comp.avoid_object then comp.avoid_object.range=radius*2 end
     if comp.explosion_effect then comp.explosion_effect.size=radius end
+    if comp.explode_on_touch then comp.explode_on_touch.blast_range=radius end
     return self
 end
 --- Returns this Asteroid's radius.


### PR DESCRIPTION
When using `setSize(radius)` on an asteroid, the blast radius isn't reset. If the asteroid's size exceeds its blast radius, a colliding object thus won't sustain damage from the resulting `damageArea` because it won't be inside the too-small blast radius.

When using `setSize()`, also set the blast radius to the new size.

Fixes #2519.