### PR TITLE
[#2456] Add options menu to ship selection screen

### DIFF
--- a/src/menus/mainMenus.cpp
+++ b/src/menus/mainMenus.cpp
@@ -49,7 +49,7 @@ MainMenu::MainMenu()
     }))->setPosition({50, -170}, sp::Alignment::BottomLeft)->setSize(300, 50);
 
     (new GuiButton(this, "OPEN_OPTIONS", tr("mainMenu", "Options"), [this]() {
-        new OptionsMenu(OR_Main);
+        new OptionsMenu(OptionsMenu::ReturnTo::OR_Main);
         destroy();
     }))->setPosition({50, -110}, sp::Alignment::BottomLeft)->setSize(300, 50);
 

--- a/src/menus/optionsMenu.cpp
+++ b/src/menus/optionsMenu.cpp
@@ -19,7 +19,7 @@
 #include "gui/gui2_keyvaluedisplay.h"
 
 
-OptionsMenu::OptionsMenu(EOptionsReturnTo return_to)
+OptionsMenu::OptionsMenu(OptionsMenu::ReturnTo return_to)
 {
     new GuiOverlay(this, "", colorConfig.background);
     (new GuiOverlay(this, "", glm::u8vec4{255,255,255,255}))->setTextureTiled("gui/background/crosses.png");
@@ -196,9 +196,9 @@ OptionsMenu::OptionsMenu(EOptionsReturnTo return_to)
         // Close this menu, stop the music, and return to the main menu.
         destroy();
         soundManager->stopMusic();
-        if (return_to == OR_Main)
+        if (return_to == ReturnTo::OR_Main)
             returnToMainMenu(getRenderLayer());
-        else if (return_to == OR_ShipSelection)
+        else if (return_to == ReturnTo::OR_ShipSelection)
             returnToShipSelection(getRenderLayer());
         else
         {

--- a/src/menus/optionsMenu.h
+++ b/src/menus/optionsMenu.h
@@ -10,13 +10,6 @@ class GuiSlider;
 class GuiToggleButton;
 class GuiLabel;
 
-enum EOptionsReturnTo
-{
-    OR_Main,
-    OR_ShipSelection,
-    OR_None
-};
-
 class OptionsMenu : public GuiCanvas, public Updatable
 {
 private:
@@ -42,7 +35,14 @@ private:
     void setupGraphicsOptions();
     void setupAudioOptions();
 public:
-    OptionsMenu(EOptionsReturnTo return_to=OR_Main);
+    enum class ReturnTo
+    {
+        OR_Main,          // Return to Main Menu
+        OR_ShipSelection, // Return to Ship Selection
+        OR_None
+    };
+
+    OptionsMenu(ReturnTo return_to=ReturnTo::OR_Main);
 
     virtual void update(float delta) override;
 };

--- a/src/menus/shipSelectionScreen.cpp
+++ b/src/menus/shipSelectionScreen.cpp
@@ -219,7 +219,7 @@ ShipSelectionScreen::ShipSelectionScreen()
     cinematic_button->setSize(GuiElement::GuiSizeMax, 50);
 
     (new GuiButton(right_content, "OPEN_OPTIONS", tr("mainMenu", "Options"), [this]() {
-        new OptionsMenu(OR_ShipSelection);
+        new OptionsMenu(OptionsMenu::ReturnTo::OR_ShipSelection);
         this->destroy();
     }))->setSize(GuiElement::GuiSizeMax, 50);
 


### PR DESCRIPTION
Add a button to access the Options menu from the ShipSelectionScreen, and an enum to manage the "Back" button behavior on the Options menu.

This allows a player on the server to access the Options menu without halting the server, and allows players on clients to access the Options menu without disconnecting from the server.

https://github.com/user-attachments/assets/d8783215-792d-47e8-b965-cbd0f93fdeef

Addresses part of #2456.