### PR TITLE
Extend GuiScrollText scroll length to fit descenders

### DIFF
--- a/src/gui/gui2_scrolltext.cpp
+++ b/src/gui/gui2_scrolltext.cpp
@@ -31,7 +31,8 @@ void GuiScrollText::onDraw(sp::RenderTarget& renderer)
 {
     auto text_rect = sp::Rect(rect.position.x, rect.position.y, rect.size.x - scrollbar->getSize().x, rect.size.y);
     auto prepared = sp::RenderTarget::getDefaultFont()->prepare(this->text, 32, text_size, selectColor(colorConfig.textbox.forground), text_rect.size, sp::Alignment::TopLeft, sp::Font::FlagClip | sp::Font::FlagLineWrap);
-    auto text_draw_size = prepared.getUsedAreaSize();
+    // Extend the scroll by a fraction of a line height to accomodate descenders (jypq etc.)
+    auto text_draw_size = prepared.getUsedAreaSize() + glm::vec2{0.0f, text_size * 0.25f};
 
     int scroll_max = text_draw_size.y;
     if (scrollbar->getMax() != scroll_max)
@@ -113,7 +114,8 @@ void GuiScrollFormattedText::onDraw(sp::RenderTarget& renderer)
     }
     prepared.append(text.substr(last_end), text_size * size_mod, current_color);
     prepared.finish();
-    auto text_draw_size = prepared.getUsedAreaSize();
+    // Extend the scroll by a fraction of a line height to accomodate descenders (jypq etc.)
+    auto text_draw_size = prepared.getUsedAreaSize() + glm::vec2{0.0f, (text_size * 0.25f) * size_mod};
 
     int scroll_max = text_draw_size.y;
     if (scrollbar->getMax() != scroll_max)


### PR DESCRIPTION
When the final line of a `GuiScrollText` box ends with characters containing descenders, such as j, y, p, and q, the descender is cut off. Extend the scrolling height of `GuiScrollText` and `GuiScrollFormattedText` by 25% of a single line's height to accommodate these descenders.

Before (final line of the Doomed Outpost description on the scenario selection screen):

<img width="419" height="65" alt="Screenshot_20250723_224749" src="https://github.com/user-attachments/assets/7c211100-14ba-4045-83c4-fdf0a38d3f4a" />

After:

<img width="419" height="65" alt="Screenshot_20250723_224722" src="https://github.com/user-attachments/assets/7a4c3ed2-dfc8-40a7-a884-babf5a030f42" />
