### PR TITLE
Enhance Ship Selection main screen

### DIFF
--- a/src/menus/shipSelectionScreen.h
+++ b/src/menus/shipSelectionScreen.h
@@ -22,11 +22,25 @@ class PasswordDialog;
 class ShipSelectionScreen : public GuiCanvas, public Updatable
 {
 private:
-    GuiScrollText* playership_info;
+    void joinPlayerShip(string entity_string);
+
     GuiElement* container;
     GuiElement* left_container;
+    GuiElement* left_column;
+    GuiPanel* left_panel;
+    GuiPanel* left_panel_2;
+    GuiLabel* left_panel_2_label;
+    GuiScrollText* left_panel_2_text;
     GuiElement* right_container;
+    GuiElement* right_column;
+    GuiPanel* right_panel;
+    GuiPanel* right_panel_2;
+    GuiLabel* right_panel_2_label;
+    GuiScrollText* right_panel_2_text;
 
+    GuiElement* ship_action_row;
+    GuiSelector* ship_template_selector;
+    GuiButton* ship_template_button;
     GuiLabel* no_ships_label;
     GuiListbox* player_ship_list;
 
@@ -35,6 +49,8 @@ private:
 
     PasswordDialog* password_dialog;
     std::vector<GameGlobalInfo::ShipSpawnInfo> ship_spawn_info;
+
+    int last_selection_index = -1;
 public:
     ShipSelectionScreen();
 


### PR DESCRIPTION
Restructure the Ship Selection screen to use layout attributes and add a list of connected players and the ship to which they're assigned.

On the server, consolidate spawnable ship selection controls with the ship description. As a fallback on scenarios without spawnable ships, display the scenario description in the panel instead.

On clients, make selecting a ship a two-click action to allow the player to view the selected ship template's description if available, and add an explicit "Join ship" button (optional; clicking the selected ship again also joins the ship).

- Use layout attributes to compose the panels.
  - Apply consistent padding and margins in panels and between elements.
  - Center both columns in a fixed-width area, instead of drifting the columns apart on widescreen views.
  - Extend columns to fill vertical-orientation views.
  - Label the upper-right panel of additional views and options, and resize it relative to the number of buttons within.
- Combine server ship creation and template description into one panel and move them to the left column.
- Add second panel to right column on clients that lists connected players and to which ship each player is connected.
- If a scenario prevents player ship creation from the server's ship selection screen, repurpose the second left panel to display the scenario title and description.

Server before (4:3, tall, wide):

<img width="1182" height="877" alt="image" src="https://github.com/user-attachments/assets/06d22682-e62f-4e23-b09c-4ad017dae9eb" />
<img width="743" height="877" alt="image" src="https://github.com/user-attachments/assets/9e7f144e-ae97-44e5-828f-e0cfd71edd5e" />
<img width="1599" height="877" alt="image" src="https://github.com/user-attachments/assets/e458e592-e992-40e1-8aec-ab73b4e8ba4b" />

Server after (4:3, tall, wide):

<img width="1182" height="877" alt="image" src="https://github.com/user-attachments/assets/21873e7b-a913-4aab-9836-69970965338c" />
<img width="743" height="877" alt="image" src="https://github.com/user-attachments/assets/ad3ab551-eb80-4ca5-89da-ed53572a1d7e" />
<img width="1599" height="877" alt="image" src="https://github.com/user-attachments/assets/ba784076-8463-4a94-af87-ccac9fe4536e" />

Server after, scenario with no spawnable player ship template types:

<img width="1187" height="886" alt="image" src="https://github.com/user-attachments/assets/2f455bac-c2b3-4184-b5ea-972d1bf291bb" />

Server after, in German, with the ship list, ship description, and player list scrolling boxes all overflowing:

<img width="1187" height="886" alt="image" src="https://github.com/user-attachments/assets/c8869e99-61dc-489e-9a90-66dd1d11187c" />

Client after:

<img width="1187" height="886" alt="image" src="https://github.com/user-attachments/assets/7cfb1434-1794-45b5-9f6a-a5b7a8df682f" />

Connected player list showing to which ship a player is assigned:

<img width="1187" height="886" alt="image" src="https://github.com/user-attachments/assets/397467a5-33ed-4c3a-a438-3c695a9838a5" />