### PR TITLE
tutorials: enable repeating tutorials

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -201,8 +201,9 @@ int main(int argc, char** argv)
 
     if (!tutorial.empty())
     {
+        bool repeat_tutorial = PreferencesManager::get("repeat_tutorial", "false") == "true";
         LOG(DEBUG) << "Starting tutorial: " << tutorial;
-        new TutorialGame(false, tutorial);
+        new TutorialGame(repeat_tutorial, tutorial);
     }
     else if (server_scenario.empty())
         returnToMainMenu(defaultRenderLayer);

--- a/src/tutorialGame.cpp
+++ b/src/tutorialGame.cpp
@@ -39,8 +39,9 @@ TutorialGame::TutorialGame(bool repeated_tutorial, string filename)
 
     this->viewport = nullptr;
     this->repeated_tutorial = repeated_tutorial;
+    this->filename = filename;
 
-    gameGlobalInfo->startScenario(filename);
+    gameGlobalInfo->startScenario(this->filename);
 
     gameGlobalInfo->main_scenario_script->setGlobal("tutorial_setPlayerShip", &TutorialGame::setPlayerShip);
     gameGlobalInfo->main_scenario_script->setGlobal("tutorial_switchViewToMainScreen", &TutorialGame::switchViewToMainScreen);
@@ -108,7 +109,7 @@ void TutorialGame::createScreens()
 void TutorialGame::update(float delta)
 {
     if (keys.escape.getDown())
-        finish();
+        quit(); // NOT finish() -- finish can choose to loop
     if (my_spaceship)
     {
         auto pc = my_spaceship.getComponent<PlayerControl>();
@@ -221,7 +222,7 @@ void TutorialGame::finish()
         sp::ecs::Entity::destroyAllEntities();
         instance->hideAllScreens();
 
-        gameGlobalInfo->startScenario("tutorial.lua");
+        gameGlobalInfo->startScenario(instance->filename);
 
         gameGlobalInfo->main_scenario_script->setGlobal("tutorial_setPlayerShip", &TutorialGame::setPlayerShip);
         gameGlobalInfo->main_scenario_script->setGlobal("tutorial_switchViewToMainScreen", &TutorialGame::switchViewToMainScreen);
@@ -236,11 +237,16 @@ void TutorialGame::finish()
 
         auto res = gameGlobalInfo->main_scenario_script->call<void>("tutorial_init");
         LuaConsole::checkResult(res);
-    }else{
-        disconnectFromServer();
-        returnToMainMenu(instance->getRenderLayer());
-        instance->destroy();
+    } else {
+        quit();
     }
+}
+
+void TutorialGame::quit()
+{
+    disconnectFromServer();
+    returnToMainMenu(instance->getRenderLayer());
+    instance->destroy();
 }
 
 void TutorialGame::hideAllScreens()

--- a/src/tutorialGame.h
+++ b/src/tutorialGame.h
@@ -25,6 +25,7 @@ class TutorialGame : public Updatable, public GuiCanvas
     GuiButton* next_button;
 
     bool repeated_tutorial;
+    string filename;
 public:
     sp::script::Callback _onNext;
 
@@ -44,6 +45,7 @@ public:
 
     static void onNext(sp::script::Callback callback) { instance->_onNext = callback; }
     static void finish();
+    static void quit();
 private:
     void hideAllScreens();
     void createScreens();


### PR DESCRIPTION
Some tutorial use-cases benefit from repeating and having a reset button available (in particular public kiosks). Repeating tutorials was disabled in daid/EmptyEpsilon#2310 - start specific tutorial before autoconnect.

- add a new preference "repeat_tutorial" to enable repeating tutorials
  - should leave tutorial-before-autoconnect usecase intact
- store the tutorial filename when launching so it can be re-used when the tutorial is finished
- support exitting the tutorial (via ESC)
- unfixed: the tutorial repeat appears to pause the game on loop.