### PR TITLE
Initialize position and size of new GM chat dialogs

### DIFF
--- a/src/screens/gm/gameMasterScreen.cpp
+++ b/src/screens/gm/gameMasterScreen.cpp
@@ -675,6 +675,7 @@ GameMasterChatDialog* GameMasterScreen::getChatDialog(sp::ecs::Entity entity)
         if (d->player == entity)
             return d;
     auto dialog = new GameMasterChatDialog(chat_layer, main_radar, entity);
+    dialog->setPosition(0, 0)->setSize(300, 300);
     chat_dialog_per_ship.push_back(dialog);
     return dialog;
 }


### PR DESCRIPTION
When a comms entity is being hailed by or has an open channel with a GM that isn't created via the GM screen "Hail ship" button, the dialog might be created via GameMasterScreen::getChatDialog with an uninitialized position and size. This can be reliably reproduced when the first GM chat with a ship occurs while the GM is intercepting all comms:

<img width="1302" height="982" alt="image" src="https://github.com/user-attachments/assets/ad56eae0-76ef-4283-bcd9-e44202d9f050" />

This creates an unusuable dialog that can't always be moved or resized, and sometimes causes an infinite GUI layout loop.

Assign a default position (0, 0) and size (300, 300) to any new GM chat dialog created via getChatDialog.

Reproduction case behavior after this PR:

<img width="1259" height="967" alt="image" src="https://github.com/user-attachments/assets/057249bd-3fe8-4dd5-8e40-7489cfff58b2" />
