### PR TITLE
Support optional text clipping on refactored GuiLabel

### DIFF
--- a/src/gui/gui2_label.cpp
+++ b/src/gui/gui2_label.cpp
@@ -2,7 +2,7 @@
 #include "theme.h"
 
 GuiLabel::GuiLabel(GuiContainer* owner, string id, string text, float text_size)
-: GuiElement(owner, id), text(text), text_size(text_size), text_color(glm::u8vec4{255,255,255,255}), text_alignment(sp::Alignment::Center), background(false), font_flag(sp::Font::FlagLineWrap)
+: GuiElement(owner, id), text(text), text_size(text_size), text_color(glm::u8vec4{255,255,255,255}), text_alignment(sp::Alignment::Center), background(false), font_flag(0)
 {
     front_style = theme->getStyle("label.front");
     back_style = theme->getStyle("label.back");
@@ -47,9 +47,9 @@ GuiLabel* GuiLabel::setVertical()
     return this;
 }
 
-GuiLabel* GuiLabel::setUnwrapped()
+GuiLabel* GuiLabel::setWrapped()
 {
-    font_flag &= ~sp::Font::FlagLineWrap;
+    font_flag |= sp::Font::FlagLineWrap;
     return this;
 }
 

--- a/src/gui/gui2_label.h
+++ b/src/gui/gui2_label.h
@@ -24,7 +24,7 @@ public:
     GuiLabel* setAlignment(sp::Alignment alignment);
     GuiLabel* addBackground();
     GuiLabel* setVertical();
-    GuiLabel* setUnwrapped();
+    GuiLabel* setWrapped();
     GuiLabel* setClipped();
 };
 


### PR DESCRIPTION
Add a `font_flag` bitwise parameter to `GuiAutoSizeLabel`, defaulting to `0x01` to maintain existing text wrapping behavior.

Add `setUnwrapped()` and `setClipped()` and revise `setVertical()` to change font flags accordingly. This replaces or removes existing Boolean parameters.

Refactor `GuiLabel` to simplify its `onDraw()` and remove the now-redundant override in `GuiAutoSizeLabel`.

Supports #2551.