### PR TITLE
 Support modulating the illumination map (rebased)

### DIFF
--- a/resources/shaders/objectShader.shader
+++ b/resources/shaders/objectShader.shader
@@ -40,6 +40,7 @@ uniform sampler2D u_specularMap;
 #endif
 #ifdef ILLUMINATION
 uniform sampler2D u_illuminationMap;
+uniform vec4 u_illuminationModulation;
 #endif
 #ifdef NORMAL
 uniform sampler2D u_normalMap;
@@ -62,7 +63,7 @@ void main()
 	
 	vec4 base = texture2D(u_baseMap, v_texcoords.st);
 #ifdef ILLUMINATION
-	vec4 illumination = texture2D(u_illuminationMap, v_texcoords.st);
+	vec4 illumination = texture2D(u_illuminationMap, v_texcoords.st) * u_illuminationModulation;
 #else
     vec4 illumination = vec4(0.0, 0.0, 0.0, 0.0);
 #endif

--- a/scripts/api/modelData.lua
+++ b/scripts/api/modelData.lua
@@ -86,6 +86,18 @@ function ModelData:setNormalMap(texture)
     self.mesh_render.normal_texture=texture
     return self
 end
+--- Modulates this ModelData's illumination map as RGBA values.
+--- Values range from 0.0 (unlit) to 1.0 (max brightness).
+--- Illumination maps default to bright white {1.0, 1.0, 1.0, 1.0}.
+--- Examples:
+--- model:modulateIllumination(1.0, 0.0, 0.0, 1.0) -- red lights
+--- model:modulateIllumination(1.0, 1.0, 1.0, 0.0) -- unlit
+function ModelData:modulateIllumination(r, g, b, a)
+    if self.mesh_render.illumination_texture then
+        self.mesh_render.illumination_modulation = {r, g, b, a}
+    end
+    return self
+end
 --- Sets this ModelData's mesh offset, relative to its position in its mesh data.
 --- If a 3D mesh's central origin point is not at 0,0,0, use this to compensate.
 --- If you view the model in Blender, these values are equivalent to -X,+Y,+Z.

--- a/src/components/rendering.h
+++ b/src/components/rendering.h
@@ -27,6 +27,7 @@ public:
     TextureRef normal_texture;
     glm::vec3 mesh_offset{};
     float scale = 1.0;
+    glm::vec4 illumination_modulation{1.0, 1.0, 1.0, 1.0};
 
     Mesh* getMesh();
     sp::Texture* getTexture();

--- a/src/script/components.cpp
+++ b/src/script/components.cpp
@@ -266,6 +266,7 @@ void initComponentScriptBindings()
     BIND_MEMBER_NAMED(MeshRenderComponent, normal_texture.name, "normal_texture");
     BIND_MEMBER(MeshRenderComponent, mesh_offset);
     BIND_MEMBER(MeshRenderComponent, scale);
+    BIND_MEMBER(MeshRenderComponent, illumination_modulation);
     sp::script::ComponentHandler<BillboardRenderer>::name("billboard_render");
     BIND_MEMBER(BillboardRenderer, texture);
     BIND_MEMBER(BillboardRenderer, size);

--- a/src/script/vector.h
+++ b/src/script/vector.h
@@ -3,6 +3,7 @@
 #include "script/environment.h"
 #include <glm/vec2.hpp>
 #include <glm/vec3.hpp>
+#include <glm/vec4.hpp>
 #include <glm/gtc/type_precision.hpp>
 
 
@@ -50,6 +51,37 @@ template<> struct Convert<glm::vec3> {
         lua_pop(L, 1);
         lua_geti(L, idx, 3);
         result.z = lua_tonumber(L, -1);
+        lua_pop(L, 1);
+        return result;
+    }
+};
+template<> struct Convert<glm::vec4> {
+    static int toLua(lua_State* L, glm::vec4 value) {
+        lua_createtable(L, 4, 0);
+        lua_pushnumber(L, value.x);
+        lua_rawseti(L, -2, 1);
+        lua_pushnumber(L, value.y);
+        lua_rawseti(L, -2, 2);
+        lua_pushnumber(L, value.z);
+        lua_rawseti(L, -2, 3);
+        lua_pushnumber(L, value.w);
+        lua_rawseti(L, -2, 4);
+        return 1;
+    }
+    static glm::vec4 fromLua(lua_State* L, int idx) {
+        glm::vec4 result{1.0, 1.0, 1.0, 1.0};
+        luaL_checktype(L, idx, LUA_TTABLE);
+        lua_geti(L, idx, 1);
+        result.x = lua_tonumber(L, -1);
+        lua_pop(L, 1);
+        lua_geti(L, idx, 2);
+        result.y = lua_tonumber(L, -1);
+        lua_pop(L, 1);
+        lua_geti(L, idx, 3);
+        result.z = lua_tonumber(L, -1);
+        lua_pop(L, 1);
+        lua_geti(L, idx, 4);
+        result.w = lua_tonumber(L, -1);
         lua_pop(L, 1);
         return result;
     }

--- a/src/shaderRegistry.cpp
+++ b/src/shaderRegistry.cpp
@@ -44,6 +44,7 @@ namespace ShaderRegistry
             "u_view",
             "u_camera_position",
             "u_atmosphereColor",
+            "u_illuminationModulation",
             
             "u_textureMap",
             "u_baseMap",

--- a/src/shaderRegistry.h
+++ b/src/shaderRegistry.h
@@ -52,6 +52,7 @@ namespace ShaderRegistry
 		View,
 		CameraPosition,
 		AtmosphereColor,
+		IlluminationModulation,
 
 		TextureMap,
 		BaseMap,

--- a/src/systems/rendering.cpp
+++ b/src/systems/rendering.cpp
@@ -139,6 +139,9 @@ void MeshRenderSystem::render3D(sp::ecs::Entity e, sp::Transform& transform, Mes
     // Lights setup.
     ShaderRegistry::setupLights(shader.get(), modeldata_matrix);
 
+    // Set illumination modulation
+    glUniform4fv(shader.get().uniform(ShaderRegistry::Uniforms::IlluminationModulation), 1, glm::value_ptr(mrc.illumination_modulation));
+
     // Textures
     activateAndBindMeshTextures(mrc);
 


### PR DESCRIPTION
This is @gcask's PR #1589 rebased onto the master branch and implemented in `MeshRenderComponent`, with a `modulateIllumination()` Lua function. 

This also implements an XYZW conversion of glm::vec4 values to and from Lua scripting.

Examples:

```lua
model = ModelData()
model:setName("battleship_destroyer_1_upgraded")
...
model:setIllumination("battleship_destroyer_1_upgraded/battleship_destroyer_1_upgraded_illumination.jpg")
model:modulateIllumination(1.0, 0.0, 0.0, 1.0)
```

results in all ships using this mesh, such as the Atlantis template, defaulting to using red for its illumination map instead of white.

```lua
player = PlayerSpaceship():setFaction("Human Navy"):setTemplate("Atlantis")
blinken_period = 1.0
blinken_elapsed = 0.0
blinken_result = 1.0

function update(delta)
    if blinken_elapsed > blinken_period then
        blinken_result = -1.0
    end
    if blinken_elapsed < 0 then
        blinken_result = 1.0
    end
    blinken_elapsed = blinken_elapsed + (delta * blinken_result)
    player.components.mesh_render.illumination_modulation = {blinken_elapsed, 0.0, 0.0, 1.0}
end
```

results in only the player Atlantis' illumination map pulsing between red and black every second:

https://github.com/user-attachments/assets/320f2d3a-bdef-4760-9a0e-5ce904dfb2e6
