### PR TITLE
[#2563] Clamp system coolant request to 100% when using autocoolant

### DIFF
--- a/src/systems/coolantsystem.cpp
+++ b/src/systems/coolantsystem.cpp
@@ -67,8 +67,7 @@ void CoolantSystem::update(float delta)
 
                             if (sys->coolant_request < coolant.max_coolant_per_system && sys->heat_level > 0.0f)
                             {
-                                float additional = excess_coolant * sys->heat_level / available_heat;
-                                sys->coolant_request += additional;
+                                sys->coolant_request += excess_coolant * sys->heat_level / available_heat;
                                 excess_redistributed = true;
                             }
                         }


### PR DESCRIPTION
Autocoolant behavior is inconsistent when max coolant exceeds the default of 10 (equal to `max_coolant_per_system`). Coolant requests would exceed 100% of `max_coolant_per_system`, and capping the request to `max_coolant_per_system` would distribute the remaining coolant inefficiently.

Instead, track the ideal request amounts, then modify them to fit within the limits while redistributing the excess coolant to other systems in need.

Should fix #2563.