### PR TITLE
Refactor GuiMainScreenControls

### DIFF
--- a/src/screenComponents/mainScreenControls.cpp
+++ b/src/screenComponents/mainScreenControls.cpp
@@ -3,137 +3,180 @@
 #include "gameGlobalInfo.h"
 #include "i18n.h"
 
+#include "gui/gui2_panel.h"
 #include "gui/gui2_togglebutton.h"
 
 GuiMainScreenControls::GuiMainScreenControls(GuiContainer* owner)
-: GuiElement(owner, "MAIN_SCREEN_CONTROLS")
+: GuiElement(owner, "MAIN_SCREEN_CONTROLS"), open_button(nullptr), target_lock_button(nullptr), tactical_button(nullptr),
+  long_range_button(nullptr), show_comms_button(nullptr), onscreen_comms_active(false)
 {
-    setSize(250, GuiElement::GuiSizeMax);
-    setPosition(-20, 70, sp::Alignment::TopRight);
-    setAttribute("layout", "vertical");
+    setSize(250.0f, GuiElement::GuiSizeMax);
+    setPosition(-20.0f, 70.0f, sp::Alignment::TopRight);
+
+    button_strip = new GuiPanel(this, "MAIN_SCREEN_CONTROLS_STRIP");
+    button_strip->setPosition(0.0f, 0.0f, sp::Alignment::TopLeft)->setSize(GuiElement::GuiSizeMax, 0.0f)->hide();
+    // button_strip->setAttribute("padding", "0, 0, 50, 0");
+    button_strip->setAttribute("layout", "vertical");
 
     // Set which buttons appear when opening the main screen controls.
-    open_button = new GuiToggleButton(this, "MAIN_SCREEN_CONTROLS_SHOW", tr("controlbutton", "Main screen"), [this](bool value)
+    open_button = new GuiToggleButton(this, "MAIN_SCREEN_CONTROLS_SHOW", tr("controlbutton", "Main screen"),
+    [this](bool value)
     {
-        for(GuiButton* button : buttons)
-            button->setVisible(value);
-        if (!gameGlobalInfo->allow_main_screen_tactical_radar)
-            tactical_button->setVisible(false);
-        if (!gameGlobalInfo->allow_main_screen_long_range_radar)
-            long_range_button->setVisible(false);
-        if (show_comms_button && onscreen_comms_active)
-            show_comms_button->setVisible(false);
-        if (hide_comms_button && !onscreen_comms_active)
-            hide_comms_button->setVisible(false);
+        auto active_mode = MainScreenSetting::Front;
+        if (!my_spaceship) return;
+        if (auto pc = my_spaceship.getComponent<PlayerControl>()) active_mode = pc->main_screen_setting;
+
+        // 3D controls
+        if (front_button)
+            front_button->setValue(active_mode == MainScreenSetting::Front);
+        if (back_button)
+            back_button->setValue(active_mode == MainScreenSetting::Back);
+        if (left_button)
+            left_button->setValue(active_mode == MainScreenSetting::Left);
+        if (right_button)
+            right_button->setValue(active_mode == MainScreenSetting::Right);
+        if (target_lock_button)
+            target_lock_button->setValue(active_mode == MainScreenSetting::Target);
+
+        // Radar controls
+        if (tactical_button)
+        {
+            tactical_button->setValue(active_mode == MainScreenSetting::Tactical);
+            tactical_button->setVisible(gameGlobalInfo->allow_main_screen_tactical_radar);
+        }
+        if (long_range_button)
+        {
+            long_range_button->setValue(active_mode == MainScreenSetting::LongRange);
+            long_range_button->setVisible(gameGlobalInfo->allow_main_screen_long_range_radar);
+        }
+
+        // Overlay controls
+        if (show_comms_button)
+            show_comms_button->setValue(onscreen_comms_active);
+
+        if (value)
+        {
+            // Resize background strip to match number of buttons.
+            float strip_size = 0.0f;
+
+            for (GuiButton* button : buttons)
+                if (button->isVisible()) strip_size += 50.0f;
+
+            button_strip->setSize(GuiElement::GuiSizeMax, strip_size);
+        }
+
+        button_strip->setVisible(value)->moveToFront();
     });
-    open_button->setValue(false);
-    open_button->setSize(GuiElement::GuiSizeMax, 50);
+    open_button->setValue(false)->setSize(GuiElement::GuiSizeMax, 50.0f);
 
     // Front, back, left, and right view buttons.
-    buttons.push_back(new GuiButton(this, "MAIN_SCREEN_FRONT_BUTTON", tr("mainscreen", "Front"), [this]()
+    buttons.push_back(new GuiToggleButton(button_strip, "MAIN_SCREEN_FRONT_BUTTON", tr("mainscreen", "Front"),
+    [this](bool value)
     {
         if (my_spaceship)
-        {
             my_player_info->commandMainScreenSetting(MainScreenSetting::Front);
-        }
-        closePopup();
-    }));
-    buttons.push_back(new GuiButton(this, "MAIN_SCREEN_BACK_BUTTON", tr("mainscreen", "Back"), [this]()
-    {
-        if (my_spaceship)
-        {
-            my_player_info->commandMainScreenSetting(MainScreenSetting::Back);
-        }
-        closePopup();
-    }));
-    buttons.push_back(new GuiButton(this, "MAIN_SCREEN_LEFT_BUTTON", tr("mainscreen", "Left"), [this]()
-    {
-        if (my_spaceship)
-        {
-            my_player_info->commandMainScreenSetting(MainScreenSetting::Left);
-        }
-        closePopup();
-    }));
-    buttons.push_back(new GuiButton(this, "MAIN_SCREEN_RIGHT_BUTTON", tr("mainscreen", "Right"), [this]()
-    {
-        if (my_spaceship)
-        {
-            my_player_info->commandMainScreenSetting(MainScreenSetting::Right);
-        }
-        closePopup();
-    }));
 
-    // If the player has control over weapons targeting, enable the target view
-    // option in the main screen controls.
-    if (my_player_info->hasPosition(CrewPosition::weaponsOfficer) || my_player_info->hasPosition(CrewPosition::tacticalOfficer) || my_player_info->hasPosition(CrewPosition::singlePilot))
+        closePopup();
+    }));
+    front_button = buttons.back();
+
+    buttons.push_back(new GuiToggleButton(button_strip, "MAIN_SCREEN_BACK_BUTTON", tr("mainscreen", "Back"),
+    [this](bool value)
     {
-        buttons.push_back(new GuiButton(this, "MAIN_SCREEN_TARGET_BUTTON", tr("mainscreen", "Target lock"), [this]()
+        if (my_spaceship)
+            my_player_info->commandMainScreenSetting(MainScreenSetting::Back);
+
+        closePopup();
+    }));
+    back_button = buttons.back();
+
+    buttons.push_back(new GuiToggleButton(button_strip, "MAIN_SCREEN_LEFT_BUTTON", tr("mainscreen", "Left"),
+    [this](bool value)
+    {
+        if (my_spaceship)
+            my_player_info->commandMainScreenSetting(MainScreenSetting::Left);
+
+        closePopup();
+    }));
+    left_button = buttons.back();
+
+    buttons.push_back(new GuiToggleButton(button_strip, "MAIN_SCREEN_RIGHT_BUTTON", tr("mainscreen", "Right"),
+    [this](bool value)
+    {
+        if (my_spaceship)
+            my_player_info->commandMainScreenSetting(MainScreenSetting::Right);
+
+        closePopup();
+    }));
+    right_button = buttons.back();
+
+    // If the player has control over weapons targeting, they can enable the
+    // target view on the main screen.
+    if (my_player_info->hasPosition(CrewPosition::weaponsOfficer)
+       || my_player_info->hasPosition(CrewPosition::tacticalOfficer)
+       || my_player_info->hasPosition(CrewPosition::singlePilot))
+    {
+        buttons.push_back(new GuiToggleButton(button_strip, "MAIN_SCREEN_TARGET_BUTTON", tr("mainscreen", "Target lock"),
+        [this](bool value)
         {
             if (my_spaceship)
-            {
                 my_player_info->commandMainScreenSetting(MainScreenSetting::Target);
-            }
+
             closePopup();
         }));
         target_lock_button = buttons.back();
     }
 
     // Tactical radar button.
-    buttons.push_back(new GuiButton(this, "MAIN_SCREEN_TACTICAL_BUTTON", tr("mainscreen", "Tactical"), [this]()
+    buttons.push_back(new GuiToggleButton(button_strip, "MAIN_SCREEN_TACTICAL_BUTTON", tr("mainscreen", "Tactical radar"),
+    [this](bool value)
     {
         if (my_spaceship)
-        {
             my_player_info->commandMainScreenSetting(MainScreenSetting::Tactical);
-        }
+
         closePopup();
     }));
     tactical_button = buttons.back();
 
     // Long-range radar button.
-    buttons.push_back(new GuiButton(this, "MAIN_SCREEN_LONG_RANGE_BUTTON", tr("mainscreen", "Long Range"), [this]()
+    buttons.push_back(new GuiToggleButton(button_strip, "MAIN_SCREEN_LONG_RANGE_BUTTON", tr("mainscreen", "Long-range radar"),
+    [this](bool value)
     {
         if (my_spaceship)
-        {
             my_player_info->commandMainScreenSetting(MainScreenSetting::LongRange);
-        }
+
         closePopup();
     }));
     long_range_button = buttons.back();
 
     // If the player has control over comms, they can toggle the comms overlay
     // on the main screen.
-    if (my_player_info->hasPosition(CrewPosition::relayOfficer) || my_player_info->hasPosition(CrewPosition::operationsOfficer) || my_player_info->hasPosition(CrewPosition::singlePilot))
+    if (my_player_info->hasPosition(CrewPosition::relayOfficer)
+       || my_player_info->hasPosition(CrewPosition::operationsOfficer)
+       || my_player_info->hasPosition(CrewPosition::singlePilot)
+       || my_player_info->hasPosition(CrewPosition::commsOnly))
     {
-        buttons.push_back(new GuiButton(this, "MAIN_SCREEN_SHOW_COMMS_BUTTON", tr("mainscreen", "Show comms"), [this]()
+        buttons.push_back(new GuiToggleButton(button_strip, "MAIN_SCREEN_SHOW_COMMS_BUTTON", tr("mainscreen", "Comms overlay"),
+        [this](bool value)
         {
             if (my_spaceship)
             {
-                my_player_info->commandMainScreenOverlay(MainScreenOverlay::ShowComms);
-                onscreen_comms_active = true;
+                my_player_info->commandMainScreenOverlay(value ? MainScreenOverlay::ShowComms: MainScreenOverlay::HideComms);
+                onscreen_comms_active = value;
             }
+
             closePopup();
         }));
         show_comms_button = buttons.back();
-
-        buttons.push_back(new GuiButton(this, "MAIN_SCREEN_HIDE_COMMS_BUTTON", tr("mainscreen", "Hide comms"), [this]()
-        {
-            if (my_spaceship)
-            {
-                my_player_info->commandMainScreenOverlay(MainScreenOverlay::HideComms);
-                onscreen_comms_active = false;
-            }
-            closePopup();
-        }));
-        hide_comms_button = buttons.back();
     }
 
-    for(GuiButton* button : buttons)
-        button->setSize(GuiElement::GuiSizeMax, 50)->setVisible(false);
+    for (GuiButton* button : buttons) button->setSize(GuiElement::GuiSizeMax, 50);
+
+    button_strip->hide();
 }
 
 void GuiMainScreenControls::closePopup()
 {
-    open_button->setValue(false);
-    for (GuiButton* button : buttons)
-        button->setVisible(false);
+    button_strip->hide();
+    open_button->setValue(false)->show();
 }

--- a/src/screenComponents/mainScreenControls.h
+++ b/src/screenComponents/mainScreenControls.h
@@ -1,26 +1,28 @@
-#ifndef MAIN_SCREEN_CONTROLS_H
-#define MAIN_SCREEN_CONTROLS_H
+#pragma once
 
 #include "gui/gui2_element.h"
 
 class GuiToggleButton;
 class GuiButton;
+class GuiPanel;
 
 class GuiMainScreenControls : public GuiElement
 {
 private:
-    GuiToggleButton* open_button = nullptr;
-    std::vector<GuiButton*> buttons;
-    GuiButton* target_lock_button = nullptr;
-    GuiButton* tactical_button = nullptr;
-    GuiButton* long_range_button = nullptr;
-    GuiButton* show_comms_button = nullptr;
-    GuiButton* hide_comms_button = nullptr;
-    bool onscreen_comms_active = false;
+    GuiPanel* button_strip;
+    GuiToggleButton* open_button;
+    std::vector<GuiToggleButton*> buttons;
+    GuiToggleButton* front_button;
+    GuiToggleButton* back_button;
+    GuiToggleButton* left_button;
+    GuiToggleButton* right_button;
+    GuiToggleButton* target_lock_button;
+    GuiToggleButton* tactical_button;
+    GuiToggleButton* long_range_button;
+    GuiToggleButton* show_comms_button;
+    bool onscreen_comms_active;
 
     void closePopup();
 public:
     GuiMainScreenControls(GuiContainer* owner);
 };
-
-#endif//MAIN_SCREEN_CONTROLS_H


### PR DESCRIPTION
- Add a GuiPanel behind GuiMainScreenControls, bringing its presentation in line with the CrewStationScreen's select_station_button.
- Use GuiToggleButtons to indicate current states of the active view and comms overlay, also similar to select_station_button.
- Allow the commsOnly station to toggle the main screen comms overlay.
- Move variable initialization into the constructor.
- Use consistent case in strings.

Before and after, comms overlay off, player at Weapons and commsOnly screens:

<img width="534" height="831" alt="Screenshot_20251028_151924" src="https://github.com/user-attachments/assets/c50cb272-34d0-4bb9-9c6c-dc2dd8d90eda" />

<img width="528" height="925" alt="Screenshot_20251028_155929" src="https://github.com/user-attachments/assets/9848699a-6eef-40ef-a98d-3576d7bca4a9" />

Before and after, comms overlay on, player at Weapons and Relay screens:

<img width="522" height="1023" alt="image" src="https://github.com/user-attachments/assets/7a55dcb4-4a59-4d7a-84b8-b91bdd8385cb" />

<img width="528" height="925" alt="Screenshot_20251028_155941" src="https://github.com/user-attachments/assets/97010493-9e8f-40cd-a2f9-fea5e418006a" />

