### PR TITLE
Add Reset button to hotkey menu

### DIFF
--- a/src/menus/hotkeyMenu.h
+++ b/src/menus/hotkeyMenu.h
@@ -31,6 +31,7 @@ private:
     const int KEY_COLUMN_WIDTH = KEY_LABEL_WIDTH + KEY_LABEL_MARGIN + KEY_FIELD_WIDTH;
     const int KEY_COLUMN_HEIGHT = ROW_HEIGHT * KEY_ROW_COUNT + FRAME_MARGIN * 2;
     const int PAGER_BREAKPOINT = KEY_COLUMN_WIDTH * 2 + FRAME_MARGIN * 2;
+    const float RESET_LABEL_TIMEOUT = 5.0f;
 
     GuiScrollText* help_text;
     GuiElement* container;
@@ -46,10 +47,11 @@ private:
     std::vector<GuiLabel*> label_entries;
     GuiArrowButton* previous_page;
     GuiArrowButton* next_page;
-    GuiOverlay* error_window;
+    GuiLabel* reset_label;
 
     string category = "";
     int category_index = 1;
+    float reset_label_timer = 0.0f;
     std::vector<string> category_list;
     std::vector<sp::io::Keybinding*> hotkey_list;
     OptionsMenu::ReturnTo return_to;


### PR DESCRIPTION
Add a button to the hotkey menu that triggers a reset to default keybinds.

This implementation relies on a change to SP (daid/SeriousProton#273) that stores each keybind's default in its Keybinding object.

Attempts to address #2421.

In use:

[Screencast_20251029_164733.webm](https://github.com/user-attachments/assets/2ac660f6-50a3-4f49-8ab5-2a33254fd132)
