### PR TITLE
[#2175] Add Strategic Map view to main screen

### DIFF
--- a/src/components/player.h
+++ b/src/components/player.h
@@ -12,7 +12,8 @@ enum class MainScreenSetting
     Right,
     Target,
     Tactical,
-    LongRange
+    LongRange,
+    Strategic
 };
 
 enum class MainScreenOverlay

--- a/src/gameGlobalInfo.cpp
+++ b/src/gameGlobalInfo.cpp
@@ -33,6 +33,7 @@ GameGlobalInfo::GameGlobalInfo()
     use_system_damage = true;
     allow_main_screen_tactical_radar = true;
     allow_main_screen_long_range_radar = true;
+    allow_main_screen_strategic_map = true;
     gm_control_code = "";
     elapsed_time = 0.0f;
 
@@ -49,6 +50,7 @@ GameGlobalInfo::GameGlobalInfo()
     registerMemberReplication(&use_system_damage);
     registerMemberReplication(&allow_main_screen_tactical_radar);
     registerMemberReplication(&allow_main_screen_long_range_radar);
+    registerMemberReplication(&allow_main_screen_strategic_map);
     registerMemberReplication(&gm_control_code);
     registerMemberReplication(&elapsed_time, 0.1);
     registerMemberReplication(&default_skybox);

--- a/src/gameGlobalInfo.h
+++ b/src/gameGlobalInfo.h
@@ -55,6 +55,7 @@ public:
     bool use_system_damage;
     bool allow_main_screen_tactical_radar;
     bool allow_main_screen_long_range_radar;
+    bool allow_main_screen_strategic_map;
     string default_skybox = "default";
     string gm_control_code;
     float elapsed_time;

--- a/src/gui/hotkeyConfig.cpp
+++ b/src/gui/hotkeyConfig.cpp
@@ -95,6 +95,7 @@ Keys::Keys() :
     mainscreen_target("MAINSCREEN_TARGET", "T"),
     mainscreen_tactical_radar("MAINSCREEN_TACTICAL", "Tab"),
     mainscreen_long_range_radar("MAINSCREEN_LONG_RANGE", "Q"),
+    mainscreen_strategic_map("MAINSCREEN_STRATEGIC", "W"),
     mainscreen_first_person("MAINSCREEN_FIRST_PERSON", "F"),
 
     //helms

--- a/src/gui/hotkeyConfig.h
+++ b/src/gui/hotkeyConfig.h
@@ -41,6 +41,7 @@ public:
     sp::io::Keybinding mainscreen_target;
     sp::io::Keybinding mainscreen_tactical_radar;
     sp::io::Keybinding mainscreen_long_range_radar;
+    sp::io::Keybinding mainscreen_strategic_map;
     sp::io::Keybinding mainscreen_first_person;
 
     //helms

--- a/src/screenComponents/mainScreenControls.cpp
+++ b/src/screenComponents/mainScreenControls.cpp
@@ -49,6 +49,11 @@ GuiMainScreenControls::GuiMainScreenControls(GuiContainer* owner)
             long_range_button->setValue(active_mode == MainScreenSetting::LongRange);
             long_range_button->setVisible(gameGlobalInfo->allow_main_screen_long_range_radar);
         }
+        if (strategic_map_button)
+        {
+            strategic_map_button->setValue(active_mode == MainScreenSetting::Strategic);
+            strategic_map_button->setVisible(gameGlobalInfo->allow_main_screen_strategic_map);
+        }
 
         // Overlay controls
         if (show_comms_button)
@@ -148,6 +153,17 @@ GuiMainScreenControls::GuiMainScreenControls(GuiContainer* owner)
         closePopup();
     }));
     long_range_button = buttons.back();
+
+    // Strategic map button.
+    buttons.push_back(new GuiToggleButton(button_strip, "MAIN_SCREEN_STRATEGIC_MAP_BUTTON", tr("mainscreen", "Strategic map"),
+    [this](bool value)
+    {
+        if (my_spaceship)
+            my_player_info->commandMainScreenSetting(MainScreenSetting::Strategic);
+
+        closePopup();
+    }));
+    strategic_map_button = buttons.back();
 
     // If the player has control over comms, they can toggle the comms overlay
     // on the main screen.

--- a/src/screenComponents/mainScreenControls.h
+++ b/src/screenComponents/mainScreenControls.h
@@ -19,6 +19,7 @@ private:
     GuiToggleButton* target_lock_button;
     GuiToggleButton* tactical_button;
     GuiToggleButton* long_range_button;
+    GuiToggleButton* strategic_map_button;
     GuiToggleButton* show_comms_button;
     bool onscreen_comms_active;
 

--- a/src/screens/mainScreen.cpp
+++ b/src/screens/mainScreen.cpp
@@ -44,7 +44,7 @@ ScreenMainScreen::ScreenMainScreen(RenderLayer* render_layer)
     strategic_map = new GuiRadarView(this, "STRATEGIC", 50000.0f, nullptr);
     strategic_map->setPosition(0.0f, 0.0f, sp::Alignment::TopLeft)->setSize(GuiElement::GuiSizeMax, GuiElement::GuiSizeMax);
     strategic_map->longRange()->enableWaypoints()->enableCallsigns()->setStyle(GuiRadarView::Rectangular)->hide();
-    strategic_map->setAutoCentering(false)->setFogOfWarStyle(GuiRadarView::FriendlysShortRangeFogOfWar);
+    strategic_map->setAutoCentering(true)->setFogOfWarStyle(GuiRadarView::FriendlysShortRangeFogOfWar);
 
     // Overlays
     onscreen_comms = new GuiCommsOverlay(this);

--- a/src/screens/mainScreen.h
+++ b/src/screens/mainScreen.h
@@ -22,6 +22,7 @@ private:
     GuiRadarView* main_screen_radar;
     GuiRadarView* tactical_radar;
     GuiRadarView* long_range_radar;
+    GuiRadarView* strategic_map;
     GuiCommsOverlay* onscreen_comms;
     std::unique_ptr<ImpulseSound> impulse_sound;
 public:

--- a/src/script.cpp
+++ b/src/script.cpp
@@ -827,6 +827,11 @@ static bool luaIsLongRangeRadarAllowed()
     return gameGlobalInfo->allow_main_screen_long_range_radar;
 }
 
+static bool luaIsStrategicMapAllowed()
+{
+    return gameGlobalInfo->allow_main_screen_strategic_map;
+}
+
 void luaCommandTargetRotation(sp::ecs::Entity ship, float rotation) {
     if (my_player_info && my_player_info->ship == ship) { my_player_info->commandTargetRotation(rotation); return; }
     auto thrusters = ship.getComponent<ManeuveringThrusters>();
@@ -1295,6 +1300,10 @@ bool setupScriptEnvironment(sp::script::Environment& env)
     /// Returns whether the "Long Range Radar" setting for main screens is enabled in the running scenario.
     /// Example: isLongRangeRadarAllowed() -- returns true by default
     env.setGlobal("isLongRangeRadarAllowed", &luaIsLongRangeRadarAllowed);
+    /// bool isStrategicMapAllowed()
+    /// Returns whether the "Strategic Map" setting for main screens is enabled in the running scenario.
+    /// Example: isStrategicMapAllowed() -- returns true by default
+    env.setGlobal("isStrategicMapAllowed", &luaIsStrategicMapAllowed);
 
 
     env.setGlobal("addGMFunction", &luaAddGMFunction);

--- a/src/script/enum.h
+++ b/src/script/enum.h
@@ -404,6 +404,7 @@ template<> struct Convert<MainScreenSetting> {
         case MainScreenSetting::Target: lua_pushstring(L, "target"); break;
         case MainScreenSetting::Tactical: lua_pushstring(L, "tactical"); break;
         case MainScreenSetting::LongRange: lua_pushstring(L, "longrange"); break;
+        case MainScreenSetting::Strategic: lua_pushstring(L, "strategic"); break;
         default: lua_pushstring(L, "none"); break;
         }
         return 1;
@@ -424,6 +425,8 @@ template<> struct Convert<MainScreenSetting> {
             return MainScreenSetting::Tactical;
         else if (str == "longrange")
             return MainScreenSetting::LongRange;
+        else if (str == "strategic")
+            return MainScreenSetting::Strategic;
         luaL_error(L, "Unknown MainScreenSetting: %s", str.c_str());
         return MainScreenSetting::Front;
     }

--- a/src/tutorialGame.cpp
+++ b/src/tutorialGame.cpp
@@ -65,10 +65,11 @@ void TutorialGame::createScreens()
     tactical_radar = new GuiRadarView(this, "TACTICAL", nullptr);
     tactical_radar->setPosition(0, 0, sp::Alignment::TopLeft)->setSize(GuiElement::GuiSizeMax, GuiElement::GuiSizeMax);
     tactical_radar->setRangeIndicatorStepSize(1000.0f)->shortRange()->enableCallsigns()->hide();
-    long_range_radar = new GuiRadarView(this, "TACTICAL", nullptr);
+    long_range_radar = new GuiRadarView(this, "LONG_RANGE", nullptr);
     long_range_radar->setPosition(0, 0, sp::Alignment::TopLeft)->setSize(GuiElement::GuiSizeMax, GuiElement::GuiSizeMax);
     long_range_radar->setRangeIndicatorStepSize(5000.0f)->longRange()->enableCallsigns()->hide();
     long_range_radar->setFogOfWarStyle(GuiRadarView::NebulaFogOfWar);
+    // TODO: Strategic map
 
     station_screen[0] = new HelmsScreen(this);
     station_screen[1] = new WeaponsScreen(this);

--- a/src/tutorialGame.cpp
+++ b/src/tutorialGame.cpp
@@ -69,7 +69,6 @@ void TutorialGame::createScreens()
     long_range_radar->setPosition(0, 0, sp::Alignment::TopLeft)->setSize(GuiElement::GuiSizeMax, GuiElement::GuiSizeMax);
     long_range_radar->setRangeIndicatorStepSize(5000.0f)->longRange()->enableCallsigns()->hide();
     long_range_radar->setFogOfWarStyle(GuiRadarView::NebulaFogOfWar);
-    // TODO: Strategic map
 
     station_screen[0] = new HelmsScreen(this);
     station_screen[1] = new WeaponsScreen(this);

--- a/src/tutorialGame.h
+++ b/src/tutorialGame.h
@@ -18,6 +18,7 @@ class TutorialGame : public Updatable, public GuiCanvas
     GuiElement* viewport;
     GuiRadarView* tactical_radar;
     GuiRadarView* long_range_radar;
+    // TODO: GuiRadarView* strategic_map;
     GuiElement* station_screen[8];
 
     GuiPanel* frame;

--- a/src/tutorialGame.h
+++ b/src/tutorialGame.h
@@ -18,7 +18,6 @@ class TutorialGame : public Updatable, public GuiCanvas
     GuiElement* viewport;
     GuiRadarView* tactical_radar;
     GuiRadarView* long_range_radar;
-    // TODO: GuiRadarView* strategic_map;
     GuiElement* station_screen[8];
 
     GuiPanel* frame;


### PR DESCRIPTION
Adds a third radar view to Main Screen that provides the same 50U rectangular radar view as Relay and Strategic Map.

Also adds a default keybind of `W` to select it from the main screen view. This also sets a Lua function `isStrategicMapAllowed()` in parallel to `isTacticalRadarAllowed()` and `isLongRangeRadarAllowed()`, and a corresponding Boolean value that's replicated to clients, although I'm not sure what (if anything) sets those values in ECS at this time.

Main Screen Controls:

<img width="540" height="734" alt="Screenshot_20251030_122951" src="https://github.com/user-attachments/assets/e6a6088b-9f8b-4770-aab1-c3549d2bd17c" />

Strategic Map main screen view:

<img width="2385" height="1786" alt="Screenshot_20251030_123036" src="https://github.com/user-attachments/assets/f3725ccc-7e4d-4265-8851-1b52f70481a2" />

Attempts to address the problem raised in #2175.