### PR TITLE
Add Viewport3D callsign toggle, controls on topdown and cinematic views

### DIFF
--- a/src/gui/hotkeyConfig.cpp
+++ b/src/gui/hotkeyConfig.cpp
@@ -8,6 +8,7 @@ extern sp::io::Keybinding fullscreen_key;
 // Cinematic Keys
 Keys::CinematicKeys::CinematicKeys() :
     toggle_ui("CINEMATIC_TOGGLE_UI", "H"),
+    toggle_callsigns("CINEMATIC_TOGGLE_CALLSIGNS", "G"),
     lock_camera("CINEMATIC_LOCK_CAMERA", "L"),
     cycle_camera("CINEMATIC_CYCLE_CAMERA", "C"),
     previous_player_ship("CINEMATIC_PREVIOUS_PLAYER_SHIP", "J"),
@@ -28,6 +29,7 @@ void Keys::CinematicKeys::init()
 {
     const auto localized_category = tr("hotkey_menu", "Cinematic View");
     toggle_ui.setLabel(localized_category, tr("hotkey_Cinematic", "Toggle UI"));
+    toggle_callsigns.setLabel(localized_category, tr("hotkey_Cinematic", "Toggle callsigns"));
     lock_camera.setLabel(localized_category, tr("hotkey_Cinematic", "Camera lock"));
     cycle_camera.setLabel(localized_category, tr("hotkey_Cinematic", "Camera cycle"));
     previous_player_ship.setLabel(localized_category, tr("hotkey_Cinematic", "Cycle previous player ship"));
@@ -46,6 +48,7 @@ void Keys::CinematicKeys::init()
 
 Keys::TopDownKeys::TopDownKeys() :
     toggle_ui("TOPDOWN_TOGGLE_UI", "H"),
+    toggle_callsigns("TOPDOWN_TOGGLE_CALLSIGNS", "G"),
     lock_camera("TOPDOWN_LOCK_CAMERA", "L"),
     previous_player_ship("TOPDOWN_PREVIOUS_PLAYER_SHIP", "J"),
     next_player_ship("TOPDOWN_NEXT_PLAYER_SHIP", "K"),
@@ -59,6 +62,7 @@ void Keys::TopDownKeys::init()
 {
     const auto localized_category = tr("hotkey_menu", "Top-down View");
     toggle_ui.setLabel(localized_category, tr("hotkey_Topdown", "Toggle UI"));
+    toggle_callsigns.setLabel(localized_category, tr("hotkey_Topdown", "Toggle callsigns"));
     lock_camera.setLabel(localized_category, tr("hotkey_Topdown", "Camera lock"));
     previous_player_ship.setLabel(localized_category, tr("hotkey_Topdown", "Cycle previous player ship"));
     next_player_ship.setLabel(localized_category, tr("hotkey_Topdown", "Cycle next player ship"));

--- a/src/gui/hotkeyConfig.h
+++ b/src/gui/hotkeyConfig.h
@@ -156,6 +156,7 @@ public:
         CinematicKeys();
         void init();
         sp::io::Keybinding toggle_ui;
+        sp::io::Keybinding toggle_callsigns;
         sp::io::Keybinding lock_camera;
         sp::io::Keybinding cycle_camera;
         sp::io::Keybinding previous_player_ship;
@@ -177,6 +178,7 @@ public:
         TopDownKeys();
         void init();
         sp::io::Keybinding toggle_ui;
+        sp::io::Keybinding toggle_callsigns;
         sp::io::Keybinding lock_camera;
         sp::io::Keybinding previous_player_ship;
         sp::io::Keybinding next_player_ship;

--- a/src/screenComponents/viewport3d.h
+++ b/src/screenComponents/viewport3d.h
@@ -1,5 +1,4 @@
-#ifndef VIEWPORT_3D_H
-#define VIEWPORT_3D_H
+#pragma once
 
 #include "gui/gui2_element.h"
 #include "glObjects.h"
@@ -70,10 +69,9 @@ public:
     virtual void onDraw(sp::RenderTarget& target) override;
 
     GuiViewport3D* showCallsigns() { show_callsigns = true; return this; }
+    GuiViewport3D* toggleCallsigns() { show_callsigns = !show_callsigns; return this; }
     GuiViewport3D* showHeadings() { show_headings = true; return this; }
     GuiViewport3D* showSpacedust() { show_spacedust = true; return this; }
 private:
     glm::vec3 worldToScreen(sp::RenderTarget& window, glm::vec3 world);
 };
-
-#endif//VIEWPORT_3D_H

--- a/src/screens/cinematicViewScreen.cpp
+++ b/src/screens/cinematicViewScreen.cpp
@@ -105,6 +105,11 @@ void CinematicViewScreen::update(float delta)
         }
     }
 
+    if (keys.cinematic.toggle_callsigns.getDown())
+    {
+        viewport->toggleCallsigns();
+    }
+
     if (keys.cinematic.lock_camera.getDown())
     {
         camera_lock_toggle->setValue(!camera_lock_toggle->getValue());

--- a/src/screens/topDownScreen.cpp
+++ b/src/screens/topDownScreen.cpp
@@ -101,6 +101,11 @@ void TopDownScreen::update(float delta)
         }
     }
 
+    if (keys.topdown.toggle_callsigns.getDown())
+    {
+        viewport->toggleCallsigns();
+    }
+
     if (keys.topdown.lock_camera.getDown())
     {
         camera_lock_toggle->setValue(!camera_lock_toggle->getValue());

--- a/src/screens/topDownScreen.h
+++ b/src/screens/topDownScreen.h
@@ -1,5 +1,4 @@
-#ifndef TOP_DOWN_SCREEN_H
-#define TOP_DOWN_SCREEN_H
+#pragma once
 
 #include "engine.h"
 #include "gui/gui2_canvas.h"
@@ -23,5 +22,3 @@ public:
 
     virtual void update(float delta) override;
 };
-
-#endif//TOP_DOWN_SCREEN_H


### PR DESCRIPTION
Add a function to toggle callsign rendering on Viewport3D, and allow Top Down and Cinematic views to toggle callsigns. Default keybind for both views is <kbd>G</kbd>.