### PR TITLE
Use color passed to GuiPowerDamageIndicator::drawIcon

### DIFF
--- a/src/screenComponents/powerDamageIndicator.cpp
+++ b/src/screenComponents/powerDamageIndicator.cpp
@@ -145,6 +145,6 @@ void GuiPowerDamageIndicator::onDraw(sp::RenderTarget& renderer)
 
 void GuiPowerDamageIndicator::drawIcon(sp::RenderTarget& renderer, string icon_name, glm::u8vec4 color)
 {
-    renderer.drawSprite(icon_name, icon_position, icon_size);
+    renderer.drawSprite(icon_name, icon_position, icon_size, color);
     icon_position += icon_offset;
 }


### PR DESCRIPTION
`GuiPowerDamageIndicator::drawIcon` has a color parameter but doesn't pass the color to `drawSprite`. Pass the color.

Before:

<img width="129" height="372" alt="Screenshot_20251107_223702" src="https://github.com/user-attachments/assets/0ce104f1-a11c-499f-9547-5815c09c032a" />

After:

<img width="129" height="372" alt="Screenshot_20251107_223623" src="https://github.com/user-attachments/assets/1a035e79-8513-46db-895c-18bf4c98f89e" />
