### PR TITLE
Add Docked/Docking mode to PowerDamageIndicator

### DIFF
--- a/resources/gui/colors.ini
+++ b/resources/gui/colors.ini
@@ -3,6 +3,7 @@ radar_outline = #FFFFFF
 
 overlay_damaged = #FF0000
 overlay_jammed = #FF0000
+overlay_docked = #40C040
 overlay_no_power = #FF0000
 overlay_low_energy = #FF8000
 overlay_low_power = #FF8000

--- a/src/gui/colorConfig.cpp
+++ b/src/gui/colorConfig.cpp
@@ -41,6 +41,7 @@ void ColorConfig::load()
     DEF_COLOR(log_receive_neutral);
     DEF_WIDGETCOLORSET(textbox);
     DEF_COLOR(overlay_damaged);
+    DEF_COLOR(overlay_docked);
     DEF_COLOR(overlay_jammed);
     DEF_COLOR(overlay_hacked);
     DEF_COLOR(overlay_no_power);

--- a/src/gui/colorConfig.h
+++ b/src/gui/colorConfig.h
@@ -1,5 +1,4 @@
-#ifndef COLOR_CONFIG_H
-#define COLOR_CONFIG_H
+#pragma once
 
 #include <glm/gtc/type_precision.hpp>
 
@@ -33,6 +32,7 @@ public:
     WidgetColorSet textbox;
 
     glm::u8vec4 overlay_damaged;
+    glm::u8vec4 overlay_docked;
     glm::u8vec4 overlay_jammed;
     glm::u8vec4 overlay_hacked;
     glm::u8vec4 overlay_no_power;
@@ -46,5 +46,3 @@ public:
     void load();
 };
 extern ColorConfig colorConfig;
-
-#endif//COLOR_CONFIG_H

--- a/src/screenComponents/powerDamageIndicator.cpp
+++ b/src/screenComponents/powerDamageIndicator.cpp
@@ -3,6 +3,7 @@
 #include "powerDamageIndicator.h"
 #include "systems/warpsystem.h"
 #include "components/reactor.h"
+#include "components/docking.h"
 #include "components/shipsystem.h"
 #include "main.h"
 
@@ -13,12 +14,12 @@ GuiPowerDamageIndicator::GuiPowerDamageIndicator(GuiContainer* owner, string nam
 
 void GuiPowerDamageIndicator::onDraw(sp::RenderTarget& renderer)
 {
-    if (!my_spaceship)
-        return;
+    if (!my_spaceship) return;
+
     auto reactor = my_spaceship.getComponent<Reactor>();
     auto sys = ShipSystem::get(my_spaceship, system);
-    if (!sys)
-        return;
+    if (!sys) return;
+    auto port = my_spaceship.getComponent<DockingPort>();
 
     glm::u8vec4 color;
     string display_text;
@@ -29,8 +30,8 @@ void GuiPowerDamageIndicator::onDraw(sp::RenderTarget& renderer)
     float hacked_level = sys->hacked_level;
     if (system == ShipSystem::Type::FrontShield)
     {
-        auto rear = ShipSystem::get(my_spaceship, ShipSystem::Type::RearShield);
-        if (rear) {
+        if (auto rear = ShipSystem::get(my_spaceship, ShipSystem::Type::RearShield))
+        {
             power = std::max(power, rear->power_level);
             health = std::max(health, rear->health);
             heat = std::max(heat, rear->heat_level);
@@ -41,6 +42,10 @@ void GuiPowerDamageIndicator::onDraw(sp::RenderTarget& renderer)
     {
         color = colorConfig.overlay_damaged;
         display_text = tr("systems", "DAMAGED");
+    }else if ((system == ShipSystem::Type::Warp || system == ShipSystem::Type::JumpDrive || system == ShipSystem::Type::Impulse) && (port && port->state != DockingPort::State::NotDocking))
+    {
+        color = colorConfig.overlay_docked;
+        display_text = port->state == DockingPort::State::Docking ? tr("systems", "DOCKING") :  tr("systems", "DOCKED");
     }else if ((system == ShipSystem::Type::Warp || system == ShipSystem::Type::JumpDrive) && WarpSystem::isWarpJammed(my_spaceship))
     {
         color = colorConfig.overlay_jammed;
@@ -121,10 +126,16 @@ void GuiPowerDamageIndicator::onDraw(sp::RenderTarget& renderer)
     {
         drawIcon(renderer, "gui/icons/status_damaged", colorConfig.overlay_damaged);
     }
-    if ((system == ShipSystem::Type::Warp || system == ShipSystem::Type::JumpDrive) && WarpSystem::isWarpJammed(my_spaceship))
+
+    if ((system == ShipSystem::Type::Warp || system == ShipSystem::Type::JumpDrive || system == ShipSystem::Type::Impulse) && (port && port->state != DockingPort::State::NotDocking))
+    {
+        drawIcon(renderer, "gui/icons/docking", colorConfig.overlay_docked);
+    }
+    else if ((system == ShipSystem::Type::Warp || system == ShipSystem::Type::JumpDrive) && WarpSystem::isWarpJammed(my_spaceship))
     {
         drawIcon(renderer, "gui/icons/status_jammed", colorConfig.overlay_jammed);
     }
+
     if (power == 0.0f)
     {
         drawIcon(renderer, "gui/icons/status_no_power", colorConfig.overlay_no_power);
@@ -133,10 +144,12 @@ void GuiPowerDamageIndicator::onDraw(sp::RenderTarget& renderer)
     {
         drawIcon(renderer, "gui/icons/status_low_power", colorConfig.overlay_low_power);
     }
+
     if (reactor && reactor->energy < 10.0f)
     {
         drawIcon(renderer, "gui/icons/status_low_energy", colorConfig.overlay_low_energy);
     }
+
     if (heat > 0.90f)
     {
         drawIcon(renderer, "gui/icons/status_overheat", colorConfig.overlay_overheating);


### PR DESCRIPTION
Add an overlay type for when controls are overridden by docking states.

Resolves #2451.

<img width="705" height="577" alt="Screenshot_20251107_224721" src="https://github.com/user-attachments/assets/2d1ce220-00ef-4d57-aaef-3d74212743c2" />
<img width="1180" height="593" alt="Screenshot_20251107_224642" src="https://github.com/user-attachments/assets/1a7c95d8-2a5d-46c5-a0ec-58d53870f632" />
