### PR TITLE
Check bounds on debug graph points

### DIFF
--- a/src/gui/debugRenderer.cpp
+++ b/src/gui/debugRenderer.cpp
@@ -72,6 +72,11 @@ void DebugRenderer::render(sp::RenderTarget& renderer)
             timing_graph_points[key].push_back(value);
         }
 
+        // Update max_size after adding new points
+        max_size = 0;
+        for (auto it : timing_graph_points)
+            max_size = std::max(it.second.size(), max_size);
+
         std::vector<string> key_order;
         std::map<string, float> total;
         for(auto& [key, data] : timing_graph_points) {
@@ -84,11 +89,16 @@ void DebugRenderer::render(sp::RenderTarget& renderer)
         std::sort(key_order.begin(), key_order.end(), [&total](const auto& a, const auto& b) { return total[a] > total[b]; });
 
         std::map<string, std::vector<glm::vec2>> points;
-        for(unsigned int n=0; n<max_size; n++) {
-            float sum = 0;
-            for(const auto& key : key_order) {
-                sum += timing_graph_points[key][n];
-                points[key].emplace_back(float(n), window_size.y - sum * 10000);
+        for (unsigned int n = 0; n < max_size; n++)
+        {
+            float sum = 0.0f;
+            for (const auto& key : key_order)
+            {
+                // Bounds check if vectors are different sizes
+                if (n < timing_graph_points[key].size())
+                    sum += timing_graph_points[key][n];
+
+                points[key].emplace_back(float(n), window_size.y - sum * 10000.0f);
             }
         }
 


### PR DESCRIPTION
Debug builds can intermittently crash when moving between screens while the debug graph is visible, in my experience especially exiting from a crew screen to ship selection. This seems to be caused by attempting to access the index of a point that no longer exists as a result of the screen change.

On Fedora, this crashes with an assertion `'__n < this->size()' failed`:

```
> /usr/include/c++/15/bits/stl_vector.h:1263: std::vector<_Tp, _Alloc>::reference std::vector<_Tp, _Alloc>::operator[](size_type) [with _Tp = float; _Alloc = std::allocator<float>; reference = float&; size_type = long unsigned int]: Assertion '__n < this->size()' failed.
```

This traces back to DebugRenderer:

```
...
    at ../../../../../libstdc++-v3/src/c++11/assert_fail.cc:41
#5  0x00000000008f85e9 in std::vector<float, std::allocator<float> 
>::operator[] (
    this=0x3d0685d0, __n=157) at /usr/include/c++/15/bits/stl_vector.h:1263
#6  0x00000000009ebdf6 in DebugRenderer::render (this=0x3be87590, 
renderer=...)
    at /home/oznogon/git/daid/EmptyEpsilon/src/gui/debugRenderer.cpp:90
#7  0x00000000004b3bd1 in RenderLayer::render (this=0x3ace4da0, target=...)
```

L89:

```
            for(const auto& key : key_order) {
                sum += timing_graph_points[key][n];
```

Add a max_size reset before this and bounds check around the sum to try to ensure this crash doesn't occur.

This will conflict with #2471, which modifies the same code.