### PR TITLE
Correctly handle hex values passed from Lua

### DIFF
--- a/src/script/vector.h
+++ b/src/script/vector.h
@@ -83,10 +83,12 @@ template<> struct Convert<glm::u8vec4> {
 
             if (str.startswith("#") && str.length() == 7)
             {
-                result.r = static_cast<uint8_t>(str.substr(1, 2).toInt(16));
-                result.g = static_cast<uint8_t>(str.substr(3, 2).toInt(16));
-                result.b = static_cast<uint8_t>(str.substr(5, 2).toInt(16));
-            } else {
+                result.r = static_cast<uint8_t>(str.substr(1, 3).toInt(16));
+                result.g = static_cast<uint8_t>(str.substr(3, 5).toInt(16));
+                result.b = static_cast<uint8_t>(str.substr(5, 7).toInt(16));
+            }
+            else
+            {
                 std::vector<string> parts = str.split(",");
                 if (parts.size() == 3)
                 {


### PR DESCRIPTION
Fix substring parsing of hex-code colors (i.e. `#C0C0FF`) passed from Lua scripts.

For example, `sendCommsMessage()` passes hex-code colors, such as:

```
    if self:isEnemy(target) then
        target:addToShipLog(message, "#FFC0C0")
    else
        target:addToShipLog(message, "#C0C0FF")
    ...
```

This should also fix colors of scripted log messages in Defender Hunter and Carrier and Fighters scenarios.

Before:

<img width="1799" height="344" alt="image" src="https://github.com/user-attachments/assets/91f0459b-38ef-4ccc-9278-4b524d5e0c3a" />

After:

<img width="1683" height="357" alt="Screenshot 2025-11-20 at 9 53 23 AM" src="https://github.com/user-attachments/assets/b4802b77-7443-44cc-9d83-bf61166dd50c" />
