### PR TITLE
Render the texture on beam fire ring backfaces

### DIFF
--- a/src/systems/beamweapon.cpp
+++ b/src/systems/beamweapon.cpp
@@ -242,14 +242,9 @@ void BeamWeaponSystem::render3D(sp::ecs::Entity e, sp::Transform& transform, Bea
         glVertexAttribPointer(positions.get(), 3, GL_FLOAT, GL_FALSE, sizeof(VertexAndTexCoords), (GLvoid*)quad.data());
         glVertexAttribPointer(texcoords.get(), 2, GL_FLOAT, GL_FALSE, sizeof(VertexAndTexCoords), (GLvoid*)((char*)quad.data() + sizeof(glm::vec3)));
 
-        // Disable backface culling to render fire ring on both sides
-        glDisable(GL_CULL_FACE);
-
-        std::initializer_list<uint16_t> indices = { 0, 1, 2, 2, 3, 0 };
-        glDrawElements(GL_TRIANGLES, 6, GL_UNSIGNED_SHORT, std::begin(indices));
-
-        // Re-enable backface culling
-        glEnable(GL_CULL_FACE);
+        // Draw two quads with opposite winding order for double-sided rendering
+        std::initializer_list<uint16_t> indices = { 0, 1, 2, 2, 3, 0, 0, 3, 2, 2, 1, 0 };
+        glDrawElements(GL_TRIANGLES, 12, GL_UNSIGNED_SHORT, std::begin(indices));
     }
 }
 


### PR DESCRIPTION
Fire rings on beam impacts are rendered only on their front faces, causing them to disappear from certain angles, such as facing in a ship's forward direction and taking a hit from a ship directly in front of them.

Disable backface culling only on fire rings in order to render them from both sides.

Before:

<img width="913" height="865" alt="Screenshot 2025-11-20 at 10 55 07 AM" src="https://github.com/user-attachments/assets/506eb593-828a-4e32-ba06-909d83fab22f" />

After:

<img width="913" height="861" alt="Screenshot 2025-11-20 at 10 55 26 AM" src="https://github.com/user-attachments/assets/482f21a8-d8db-47bb-ae04-b667a4e66cad" />