### PR TITLE
Fix vertical layout resizing axis

### DIFF
--- a/src/gui/layout/vertical.cpp
+++ b/src/gui/layout/vertical.cpp
@@ -14,7 +14,7 @@ void GuiLayoutVertical::update(GuiContainer& container, const sp::Rect& rect)
         float height = w->layout.size.y + w->layout.margin.top + w->layout.margin.bottom;
         total_height += height;
         if (w->layout.fill_height)
-            fill_height += w->layout.size.x;
+            fill_height += w->layout.size.y;
     }
     float remaining_height = rect.size.y - total_height;
     float y = rect.position.y;
@@ -41,7 +41,7 @@ void GuiLayoutVerticalBottom::update(GuiContainer& container, const sp::Rect& re
         float height = w->layout.size.y + w->layout.margin.top + w->layout.margin.bottom;
         total_height += height;
         if (w->layout.fill_height)
-            fill_height += w->layout.size.x;
+            fill_height += w->layout.size.y;
     }
     float remaining_height = rect.size.y - total_height;
     float y = rect.position.y + rect.size.y;


### PR DESCRIPTION
Child elements of a GuiElement with a vertical layout can fail to fill their height when they have a fixed width. This appears to be due to the `x` axis being incorrectly incremented to fill the parent element's height, instead of the `y` axis.

For example, given this code:

```cpp
    GuiElement* container = new GuiElement(this, "CONTAINER");
    container->setSize(GuiElement::GuiSizeMax, GuiElement::GuiSizeMax);
    container->setAttribute("padding", "50");
    container->setAttribute("layout", "vertical");

    GuiElement* column = new GuiElement(container, "COLUMN");
    column->setSize(750.0f, GuiElement::GuiSizeMax);
```

The column's height is rendered as 1-2 pixels, despite being set to `GuiElement::GuiSizeMax`.

Before:

<img width="2387" height="1791" alt="Image" src="https://github.com/user-attachments/assets/56d1dd28-f371-4630-a5d2-4463e37cb5db" />

After:

<img width="2394" height="1796" alt="Screenshot 2025-11-21 at 3 42 00 PM" src="https://github.com/user-attachments/assets/5e420d0d-a4fb-4f9f-b5bb-168672570fb1" />
