### PR TITLE
Implement SeriousProton's Lua destroyScript()

### DIFF
--- a/src/script.cpp
+++ b/src/script.cpp
@@ -1300,6 +1300,16 @@ bool setupScriptEnvironment(sp::script::Environment& env)
     env.setGlobal("addGMFunction", &luaAddGMFunction);
     env.setGlobal("clearGMFunctions", &luaClearGMFunctions);
 
+    /// void Script()
+    /// Creates an additional script.
+    /// Use this to set up Lua scripts to execute alongside the current script.
+    /// Use Script()'s setVariable function to pass values to the additional script.
+    /// Use Script()'s run function to pass the script's filename and begin running it.
+    /// Additional scripts run until they are destroyed, and can flag themselves for self-destruction by invoking destroyScript() in their update() loop.
+    /// Example:
+    /// local script = Script()
+    /// script:setVariable("callsign", player:getCallSign()) -- passes the value into the variable "callsign" in the additional script
+    /// script:run("some_script.lua") -- runs scripts/some_script.lua
     env.setGlobal("Script", &luaCreateAdditionalScript);
 
     /// void setCommsMessage(string message)


### PR DESCRIPTION
Implement functions in SeriousProton to track scripting environments for destruction if they invoke destroyScript().

Part of a fix for #2594. Depends on the implementation of those functions in daid/SeriousProton#279.

Also documents the `Script()` initializer.