### PR TITLE
Add reparenting setParent function to GuiElement

### DIFF
--- a/src/gui/gui2_element.cpp
+++ b/src/gui/gui2_element.cpp
@@ -111,6 +111,31 @@ GuiElement* GuiElement::setMargins(float left, float top, float right, float bot
     return this;
 }
 
+GuiElement* GuiElement::setParent(GuiContainer* new_parent)
+{
+    if (GuiContainer* old_owner = this->getOwner())
+    {
+        // Works only if both the old owner and new parent are valid.
+        if (new_parent && old_owner != new_parent)
+        {
+            // Remove from old owner's children list.
+            old_owner->children.remove(this);
+
+            // Add to new owner's children list.
+            new_parent->children.push_back(this);
+
+            // Update owner pointer.
+            this->owner = new_parent;
+        }
+        else
+            LOG(Debug, "GuiElement::setParent called, but new parent is invalid.");
+    }
+    else
+        LOG(Debug, "GuiElement::setParent called, but old owner is invalid.");
+
+    return this;
+}
+
 GuiElement* GuiElement::setPosition(float x, float y, sp::Alignment alignment)
 {
     layout.position.x = x;

--- a/src/gui/gui2_element.h
+++ b/src/gui/gui2_element.h
@@ -81,6 +81,9 @@ public:
     GuiContainer* getTopLevelContainer();
     const string& getID() { return id; }
 
+    // Change this element's owner/container safely (removes from old owner and adds to new owner)
+    GuiElement* setParent(GuiContainer* new_owner);
+
     //Have this GuiElement destroyed, but at a safe point&time in the code. (handled by the container)
     void destroy();
 


### PR DESCRIPTION
Add a `GuiElement::setParent()` function to reparent elements by removing them from their former parent element's tree, adding them to the new parent element's tree, and updating its pointer.

For example, this allows for the dynamic reparenting of elements based on the parent element's width or height.

```cpp
    // If a container already exists for this system, reparent it to the new row instead of recreating widgets.
    if (auto this_container = systems[system_index].container)
        this_container->setParent(systems_row);
    ...
```