### PR TITLE
Set Lua commandSetSystemCoolantRequest upper limit to system max

### DIFF
--- a/src/script.cpp
+++ b/src/script.cpp
@@ -966,13 +966,14 @@ void luaCommandSetSystemPowerRequest(sp::ecs::Entity ship, ShipSystem::Type syst
 }
 void luaCommandSetSystemCoolantRequest(sp::ecs::Entity ship, ShipSystem::Type system, float coolant_level) {
     if (my_player_info && my_player_info->ship == ship) { my_player_info->commandSetSystemCoolantRequest(system, coolant_level); return; }
-    auto coolant = ship.getComponent<Coolant>();
-    if (coolant) {
+    if (auto coolant = ship.getComponent<Coolant>())
+    {
         coolant_level = std::clamp(coolant_level, 0.0f, std::min(coolant->max_coolant_per_system, coolant->max));
         auto sys = ShipSystem::get(ship, system);
-        if (sys && coolant_level >= 0.0f && coolant_level <= 3.0f) {
+        if (sys && coolant_level >= 0.0f && coolant_level <= coolant->max_coolant_per_system)
             sys->coolant_request = coolant_level;
-        }
+        else
+            LOG(Warning, "Invalid system or coolant level passed via Lua commandSetSystemCoolantRequest()");
     }
 }
 void luaCommandDock(sp::ecs::Entity ship, sp::ecs::Entity station) {


### PR DESCRIPTION
If Lua attempts to set the coolant level of a ship system to a value greater than 3, it silently fails.

Instead use the max_coolant_per_system value as the upper limit, and log if the request is invalid. This aligns the behavior with the equivalent C++ playerInfo command function.