### PR TITLE
Further align power and coolant request behaviors

### DIFF
--- a/src/playerInfo.cpp
+++ b/src/playerInfo.cpp
@@ -729,9 +729,9 @@ void PlayerInfo::onReceiveClientCommand(int32_t client_id, sp::io::DataBuffer& p
             ShipSystem::Type system;
             float request;
             packet >> system >> request;
-            auto sys = ShipSystem::get(ship, system);
-            if (sys && request >= 0.0f && request <= 3.0f)
-                sys->power_request = request;
+
+            if (auto sys = ShipSystem::get(ship, system))
+                sys->power_request = std::clamp(request, 0.0f, 3.0f);
         }
         break;
     case CMD_SET_SYSTEM_COOLANT_REQUEST:
@@ -740,12 +740,10 @@ void PlayerInfo::onReceiveClientCommand(int32_t client_id, sp::io::DataBuffer& p
             float request;
             packet >> system >> request;
 
-            auto coolant = ship.getComponent<Coolant>();
-            if (coolant) {
-                request = std::clamp(request, 0.0f, std::min(coolant->max_coolant_per_system, coolant->max));
-                auto sys = ShipSystem::get(ship, system);
-                if (sys)
-                    sys->coolant_request = request;
+            if (auto coolant = ship.getComponent<Coolant>())
+            {
+                if (auto sys = ShipSystem::get(ship, system))
+                    sys->coolant_request = std::clamp(request, 0.0f, std::min(coolant->max_coolant_per_system, coolant->max));
             }
         }
         break;

--- a/src/script.cpp
+++ b/src/script.cpp
@@ -959,21 +959,26 @@ void luaCommandScan(sp::ecs::Entity ship, sp::ecs::Entity target) {
     }
 }
 void luaCommandSetSystemPowerRequest(sp::ecs::Entity ship, ShipSystem::Type system, float power_level) {
-    if (my_player_info && my_player_info->ship == ship) { my_player_info->commandSetSystemPowerRequest(system, power_level); return; }
-    auto sys = ShipSystem::get(ship, system);
-    if (sys && power_level >= 0.0f && power_level <= 3.0f)
-        sys->power_request = power_level;
+    if (my_player_info && my_player_info->ship == ship)
+    {
+        my_player_info->commandSetSystemPowerRequest(system, power_level);
+        return;
+    }
+
+    if (auto sys = ShipSystem::get(ship, system))
+        sys->power_request = std::clamp(power_level, 0.0f, 3.0f);
 }
 void luaCommandSetSystemCoolantRequest(sp::ecs::Entity ship, ShipSystem::Type system, float coolant_level) {
-    if (my_player_info && my_player_info->ship == ship) { my_player_info->commandSetSystemCoolantRequest(system, coolant_level); return; }
+    if (my_player_info && my_player_info->ship == ship)
+    {
+        my_player_info->commandSetSystemCoolantRequest(system, coolant_level);
+        return;
+    }
+
     if (auto coolant = ship.getComponent<Coolant>())
     {
-        coolant_level = std::clamp(coolant_level, 0.0f, std::min(coolant->max_coolant_per_system, coolant->max));
-        auto sys = ShipSystem::get(ship, system);
-        if (sys && coolant_level >= 0.0f && coolant_level <= coolant->max_coolant_per_system)
-            sys->coolant_request = coolant_level;
-        else
-            LOG(Warning, "Invalid system or coolant level passed via Lua commandSetSystemCoolantRequest()");
+        if (auto sys = ShipSystem::get(ship, system))
+            sys->coolant_request = std::clamp(coolant_level, 0.0f, std::min(coolant->max_coolant_per_system, coolant->max));
     }
 }
 void luaCommandDock(sp::ecs::Entity ship, sp::ecs::Entity station) {


### PR DESCRIPTION
Followup to #2604, align power and coolant request behaviors across playerInfo and scripting API functions by always clamping out-of-range values, instead of sometimes discarding them or redundantly clamping and range-checking them.