### PR TITLE
Return an optional third value from Lua sectorToXY() indicating sector name validity

### DIFF
--- a/src/script.cpp
+++ b/src/script.cpp
@@ -1170,10 +1170,13 @@ bool setupScriptEnvironment(sp::script::Environment& env)
     env.setGlobal("getSectorName", &luaGetSectorName);
     /// glm::vec2 sectorToXY(string sector_name)
     /// Returns the top-left ("northwest") x/y coordinates for the given sector mame.
+    /// If the sector name is invalid, this returns coordinates 0, 0. This function also returns a third optional Boolean value that indicates whether the sector name was valid.
     /// Examples:
-    /// x,y = sectorToXY("A0") -- x = -100000, y = -100000
-    /// x,y = sectorToXY("zz-23") -- x = -560000, y = -120000
-    /// x,y = sectorToXY("BA12") -- x = 140000, y = 940000
+    /// x, y = sectorToXY("F5") -- x = 0, y = 0
+    /// x, y = sectorToXY("A0") -- x = -100000, y = -100000
+    /// x, y = sectorToXY("zz-23") -- x = -560000, y = -120000
+    /// x, y, valid = sectorToXY("BA12") -- x = 140000, y = 940000, valid = true
+    /// x, y, valid = sectorToXY("FOOBAR9000") -- x = 0, y = 0, valid = false
     env.setGlobal("sectorToXY", &luaSectorToXY);
     env.setGlobal("isInsideZone", &luaIsInsideZone);
     /// void setBanner(string banner)


### PR DESCRIPTION
Return a third Boolean value from Lua `sectorToXY()` that's `true` if the sector name passed to it was valid, and `false` if not. This allows scripts to reliably catch and handle when an invalid sector name is passed to `sectorToXY()`.

Otherwise, `sectorToXY()` silently returns only `0.0, 0.0`, valid coordinates for the real sector F5 located at the world origin coordinates.

This PR doesn't change the coordinates returned by `sectorToXY()` when passing it an invalid sector name, and Lua automatically discards the third value if not handled by the script, making this backward compatible with existing uses of `sectorToXY()`.

Example:

```lua
local sector = getSectorName(5000, 5000) -- returns 0.0, 0.0, true

local x, y, valid = sectorToXY(sector) -- x = 0.0, y = 0.0, valid = true
local compat_x, compat_y = sectorToXY(sector) -- x = 0.0, y = 0.0; Boolean is discarded, no change in behavior

local invalid_sector = "FOOBAR"

x, y, valid = sectorToXY(invalid_sector) -- x = 0.0, y = 0.0, valid = false
compat_x, compat_y = sectorToXY(sector) -- x = 0.0, y = 0.0; Boolean is discarded, no change in behavior

if not valid then print("Sector name was invalid") end -- "Sector name was invalid"
```
