### PR TITLE
Add Lua setLocalSkybox() function for zones

### DIFF
--- a/scripts/api/entity/zone.lua
+++ b/scripts/api/entity/zone.lua
@@ -56,9 +56,15 @@ end
 ---   zone:setLocalSkybox("purple") -- sets the local skybox but doesn't modify the fade distance
 function Entity:setLocalSkybox(skybox, transition)
     if self.components.zone then
+        -- Values without corresponding image sets result in pink skyboxes!
+        if skybox ~= "" then
+            self.components.zone.skybox = skybox
+        end
+
         transition = transition or self.components.zone.skybox_fade_distance
-        self.components.zone.skybox = skybox
-        self.components.zone.skybox_fade_distance = transition
+        if transition >= 0 then
+            self.components.zone.skybox_fade_distance = transition
+        end
     end
     return self
 end


### PR DESCRIPTION
Add a `setLocalSkybox()` function that takes a skybox image set string and an optional, validated transition distance value. Empty skybox strings are ignored, but invalid strings aren't validated and result in pink textures (same as passing an invalid value directly to the component property).