### PR TITLE
Smoother keyboard turning.

### DIFF
--- a/src/screens/crew1/singlePilotScreen.cpp
+++ b/src/screens/crew1/singlePilotScreen.cpp
@@ -162,7 +162,7 @@ void SinglePilotScreen::onUpdate()
 {
     if (my_spaceship && isVisible())
     {
-        auto angle = (keys.helms_turn_right.getValue() - keys.helms_turn_left.getValue()) * 5.0f;
+        auto angle = (keys.helms_turn_right.getValue() - keys.helms_turn_left.getValue()) * 1.0f;
         if (angle != 0.0f)
         {
             if (auto transform = my_spaceship.getComponent<sp::Transform>())

--- a/src/screens/crew4/tacticalScreen.cpp
+++ b/src/screens/crew4/tacticalScreen.cpp
@@ -143,7 +143,7 @@ void TacticalScreen::onUpdate()
 {
     if (my_spaceship && isVisible())
     {
-        auto angle = (keys.helms_turn_right.getValue() - keys.helms_turn_left.getValue()) * 5.0f;
+        auto angle = (keys.helms_turn_right.getValue() - keys.helms_turn_left.getValue()) * 1.0f;
         if (angle != 0.0f)
         {
             if (auto transform = my_spaceship.getComponent<sp::Transform>())

--- a/src/screens/crew6/helmsScreen.cpp
+++ b/src/screens/crew6/helmsScreen.cpp
@@ -136,7 +136,7 @@ void HelmsScreen::onUpdate()
 {
     if (my_spaceship && isVisible())
     {
-        auto angle = (keys.helms_turn_right.getValue() - keys.helms_turn_left.getValue()) * 5.0f;
+        auto angle = (keys.helms_turn_right.getValue() - keys.helms_turn_left.getValue()) *1.0f;
         if (angle != 0.0f)
         {
             auto transform = my_spaceship.getComponent<sp::Transform>();


### PR DESCRIPTION
Split out from #2611.  This change is largely purposed to fix an issue also addressed in #2412, but I don't think that fit or discussion excludes this change.

The x5 that was done for turning seems very excessive, even when maneuvering at 300% in Engineering x1 is, I think, rather enough.  With the target heading indicator added with #2611, the x1 also looks a bit smoother (not jumping the target heading indicator ahead).

I personally think this PR would not be a bad adjustment regardless of the conclusions from #2412.