### PR TITLE
[#2615] Attempt to restore getScienceDatabases() function

### DIFF
--- a/scripts/api/entity/sciencedatabase.lua
+++ b/scripts/api/entity/sciencedatabase.lua
@@ -47,8 +47,7 @@ function getScienceDatabases()
 
     for idx, e in ipairs(entities) do
         -- Only return valid, parentless entries
-        local parent = e:getParentId()
-        if e:isValid() and parent == nil then
+        if e:isValid() and e:getParentId() == nil then
             table.insert(sdb, e)
         end
     end


### PR DESCRIPTION
Attempts to address #2615 by having `getParentId()` return 0 if the ScienceDatabase entry entity lacks a parent, and then restoring `getScienceDatabases()` to return a table of all unparented entry entities.

```
> sdb = getScienceDatabases()
> sdb[1]
entity: 0xa
> sdb[1]:getName()
Natural
> sdb[1]:getParentId()
0 -- legacy-compatible response for entry with no parent
> sdb[1]:getEntries()
table: 0x13af1270
> sdb[1]:getEntries()[1]
entity: 0xb -- first child entry of Natural
> sdb[1]:getEntries()[1]:getName()
Asteroid
> sdb[1]:getEntries()[1]:getParentId()
entity: 0xa
```

This also fixes `hasEntries()`, which attempts to call a global `getEntries()` instead of `self:getEntries()` for the count.

Before:

```
> getScienceDatabases()[1]:hasEntries()
api/entity/sciencedatabase.lua:119: attempt to call a nil value (global 'getEntries')
stack traceback:
```

After:

```
> getScienceDatabases()[1]:hasEntries()
true
```