### PR TITLE
Prevent ScienceDatabase Lua removeKey() error if called on last key/value

### DIFF
--- a/scripts/api/entity/sciencedatabase.lua
+++ b/scripts/api/entity/sciencedatabase.lua
@@ -154,15 +154,22 @@ end
 --- Example: entry:removeKey("Legs") -- removes all key/value data with the key "Legs"
 function Entity:removeKey(key)
     if not self.components.science_database then return self end
-    local n=1
+
+    local n = 1
     while n <= #self.components.science_database do
-        while self.components.science_database[n].key == key do
-            for m=n,#self.components.science_database-1 do
-                self.components.science_database[n] = {key=self.components.science_database[n+1].key, value=self.components.science_database[n+1].value}
+        -- If this entry's key matches the key to be removed, move the remaining entries down one place and remove the last one.
+        if self.components.science_database[n].key == key then
+            for m = n, #self.components.science_database - 1 do
+                self.components.science_database[m] = {
+                    key = self.components.science_database[m + 1].key,
+                    value = self.components.science_database[m + 1].value
+                }
             end
+
             self.components.science_database[#self.components.science_database] = nil
+        else
+            n = n + 1
         end
-        n = n + 1
     end
     return self
 end


### PR DESCRIPTION
After removing the last key/value from a ScienceDatabase entry, the removeKey() function could throw an "attempt to index a nil value" error because the loop would attempt to act on an out-of-bounds entry.

Check for nil and fix iterator variable usage.

Before:

```
> sdb = ScienceDatabase()
> sdb:addKeyValue("Key1", "Value1")
entity: 0x269
> sdb:addKeyValue("Key2", "Value2")
entity: 0x269
> sdb:addKeyValue("Key3", "Value3")
entity: 0x269
> sdb:getKeyValue("Key1")
Value1
> sdb:getKeyValue("Key2")
Value2
> sdb:getKeyValue("Key3")
Value3
> sdb:removeKey("Key2")
entity: 0x269 -- works as expected
> sdb:removeKey("Key3")
api/entity/sciencedatabase.lua:159: attempt to index a nil value (field '?')
stack traceback:
> sdb:getKeyValue("Key1")
Value1
> sdb:getKeyValue("Key2")
-- works as expected
> sdb:getKeyValue("Key3")
-- works as expected
```

After:

```
> sdb = ScienceDatabase()
> sdb:addKeyValue("Key1", "Value1")
entity: 0x269
> sdb:addKeyValue("Key2", "Value2")
entity: 0x269
> sdb:addKeyValue("Key3", "Value3")
entity: 0x269
> sdb:getKeyValue("Key1")
Value1
> sdb:getKeyValue("Key2")
Value2
> sdb:getKeyValue("Key3")
Value3
> sdb:removeKey("Key2")
entity: 0x269 -- works as expected
> sdb:removeKey("Key3")
entity: 0x269 -- fixed; works as expected
> sdb:getKeyValue("Key1")
Value1
> sdb:getKeyValue("Key2")
-- works as expected
> sdb:getKeyValue("Key3")
-- works as expected
```