### PR TITLE
Move Convert<CrewPosition> to script/crewPosition.h

### DIFF
--- a/src/script/crewPosition.h
+++ b/src/script/crewPosition.h
@@ -1,11 +1,25 @@
 #pragma once
 
 #include "../crewPosition.h"
-#include "script/enum.h"
 #include "script/environment.h"
 
-
 namespace sp::script {
+template<> struct Convert<CrewPosition> {
+    static int toLua(lua_State* L, CrewPosition value) {
+        lua_pushstring(L, crewPositionToString(value).c_str());
+        return 1;
+    }
+    static CrewPosition fromLua(lua_State* L, int idx) {
+        string str = string(luaL_checkstring(L, idx)).lower();
+
+        auto result = tryParseCrewPosition(str);
+        if (!result.has_value()) {
+            luaL_error(L, "Unknown CrewPosition: %s", str.c_str());
+        }
+        return result.value_or(CrewPosition::helmsOfficer);
+    }
+};
+
 template<> struct Convert<CrewPositions> {
     static int toLua(lua_State* L, CrewPositions value) {
         lua_newtable(L);

--- a/src/script/enum.h
+++ b/src/script/enum.h
@@ -378,21 +378,6 @@ template<> struct Convert<CustomShipFunctions::Function::Type> {
         return CustomShipFunctions::Function::Type::Info;
     }
 };
-template<> struct Convert<CrewPosition> {
-    static int toLua(lua_State* L, CrewPosition value) {
-        lua_pushstring(L, crewPositionToString(value).c_str());
-        return 1;
-    }
-    static CrewPosition fromLua(lua_State* L, int idx) {
-        string str = string(luaL_checkstring(L, idx)).lower();
-
-        auto result = tryParseCrewPosition(str);
-        if (!result.has_value()) {
-            luaL_error(L, "Unknown CrewPosition: %s", str.c_str());
-        }
-        return result.value_or(CrewPosition::helmsOfficer);
-    }
-};
 
 template<> struct Convert<MainScreenSetting> {
     static int toLua(lua_State* L, MainScreenSetting value) {


### PR DESCRIPTION
Move the `Convert<CrewPosition>` template from `script/enum.h` to `script/crewPosition.h`, alongside `Convert<CrewPositions>`, and remove the related `enum.h` include from `crewPosition.h`.

This fixes a strict compilation issue on MSVC and consolidates the two related `CrewPosition` converstion templates to one place.