### PR TITLE
Perform GuiOverlay::onDraw on OperationsScreen::onDraw

### DIFF
--- a/src/screens/crew4/operationsScreen.cpp
+++ b/src/screens/crew4/operationsScreen.cpp
@@ -108,8 +108,9 @@ OperationScreen::OperationScreen(GuiContainer* owner)
 
 void OperationScreen::onDraw(sp::RenderTarget& target)
 {
-    if (!my_spaceship)
-        return;
+    GuiOverlay::onDraw(target);
+
+    if (!my_spaceship) return;
     if (science->radar_view->isVisible())
     {
         info_reputation->setValue(string(Faction::getInfo(my_spaceship).reputation_points, 0))->show();


### PR DESCRIPTION
This ensures the background color is rendered for the entire Operations screen.

Fixes #2620.

Before:

<img width="2396" height="435" alt="Screenshot 2025-12-03 at 4 55 56 PM" src="https://github.com/user-attachments/assets/37c6d0ff-7e96-4102-9ae3-66d058fcd0ca" />

After:

<img width="2396" height="423" alt="Screenshot 2025-12-03 at 4 55 25 PM" src="https://github.com/user-attachments/assets/23e8918d-e05d-4886-8884-d2d44fcb17cd" />
