### PR TITLE
Add right-click handler, flags, fail count to Minesweeper

### DIFF
--- a/src/screenComponents/mineSweeper.cpp
+++ b/src/screenComponents/mineSweeper.cpp
@@ -7,17 +7,37 @@
 #include "gui/gui2_progressbar.h"
 #include "gui/gui2_panel.h"
 
+static constexpr int MAX_FAILURES = 2;
+
 MineSweeper::MineSweeper(GuiPanel* owner, GuiHackingDialog* parent, int difficulty)
-: MiniGame(owner, parent, difficulty) {
+: MiniGame(owner, parent, difficulty)
+{
     field_size = difficulty * 2 + 6;
     bomb_count = difficulty * 2 + 6;
+
+    // Create failures remaining label
+    failures_label = new GuiLabel(owner, "MINESWEEPER_FAILURES", "", 25.0f);
+    failures_label
+        ->setPosition(0.0f, -30.0f, sp::Alignment::BottomCenter)
+        ->setSize(100.0f, 30.0f);
+
     for(int x=0; x<field_size; x++)
     {
         for(int y=0; y<field_size; y++)
         {
-            FieldItem* item = new FieldItem(owner, "", "", [this, x, y](bool value) { getFieldItem(x, y)->setValue(!value); onFieldClick(x, y); });
-            item->setSize(50, 50);
-            item->setPosition(x * 50 - field_size * 25, 25 + y * 50 - field_size * 25, sp::Alignment::Center);
+            FieldItem* item = new FieldItem(
+                owner, "", "",
+                [this, x, y](bool value) {
+                    onFieldClick(x, y);
+                },
+                [this, x, y](bool value) {
+                    onFieldRightClick(x, y);
+                }
+            );
+
+            item
+                ->setSize(50, 50)
+                ->setPosition(x * 50 - field_size * 25, 25 + y * 50 - field_size * 25, sp::Alignment::Center);
             board.emplace_back(item);
         }
     }
@@ -32,9 +52,10 @@ void MineSweeper::disable()
         for(int y=0; y < field_size; y++)
         {
             FieldItem* item = getFieldItem(x, y);
-            item->setText("");
-            item->setValue(false);
-            item->disable();
+            item
+                ->setValue(false)
+                ->setText("")
+                ->disable();
         }
     }
 }
@@ -47,9 +68,10 @@ void MineSweeper::reset()
         for(int y=0; y < field_size; y++)
         {
             FieldItem* item = getFieldItem(x, y);
-            item->setText("");
-            item->setValue(false);
-            item->enable();
+            item
+                ->setValue(false)
+                ->setText("")
+                ->enable();
             item->bomb = false;
         }
     }
@@ -67,6 +89,7 @@ void MineSweeper::reset()
     }
     error_count = 0;
     correct_count = 0;
+    updateFailuresLabel();
 }
 
 float MineSweeper::getProgress()
@@ -89,18 +112,25 @@ glm::vec2 MineSweeper::getBoardSize()
 void MineSweeper::onFieldClick(int x, int y)
 {
     FieldItem* item = getFieldItem(x, y);
-    if (item->getValue() || item->getText() == "X" || error_count > 1 || correct_count == (field_size * field_size - bomb_count))
+
+    if (item->getValue() || item->getText() == "X" || item->getText() == "F" || error_count > 1 || correct_count == (field_size * field_size - bomb_count))
     {
-        //Unpressing an already pressed button.
+        //Unpressing an already pressed button, or flagged tile, or game over.
         return;
     }
+
     item->setValue(true);
+
     if (item->bomb)
     {
-        item->setText("X");
-        item->setValue(false);
+        item
+            ->setValue(false)
+            ->setText("X");
         error_count++;
-    }else{
+        updateFailuresLabel();
+    }
+    else
+    {
         correct_count++;
         int proximity = 0;
         if (x > 0 && y > 0 && getFieldItem(x - 1, y - 1)->bomb) proximity++;
@@ -123,15 +153,15 @@ void MineSweeper::onFieldClick(int x, int y)
         {
             //if no bombs found in proximity, auto click on all surrounding tiles
             if (x > 0 && y > 0) onFieldClick(x - 1, y - 1);
-            if (x > 0)  onFieldClick(x - 1, y);
+            if (x > 0) onFieldClick(x - 1, y);
             if (x > 0 && y < field_size - 1) onFieldClick(x - 1, y + 1);
 
-            if (y > 0)  onFieldClick(x, y - 1);
-            if (y < field_size - 1)  onFieldClick(x, y + 1);
+            if (y > 0) onFieldClick(x, y - 1);
+            if (y < field_size - 1) onFieldClick(x, y + 1);
 
-            if (x < field_size - 1 && y > 0)  onFieldClick(x + 1, y - 1);
-            if (x < field_size - 1)  onFieldClick(x + 1, y);
-            if (x < field_size - 1 && y < field_size - 1)  onFieldClick(x + 1, y + 1);
+            if (x < field_size - 1 && y > 0) onFieldClick(x + 1, y - 1);
+            if (x < field_size - 1) onFieldClick(x + 1, y);
+            if (x < field_size - 1 && y < field_size - 1) onFieldClick(x + 1, y + 1);
         }
     }
 
@@ -141,12 +171,55 @@ void MineSweeper::onFieldClick(int x, int y)
     }
 }
 
+void MineSweeper::onFieldRightClick(int x, int y)
+{
+    FieldItem* item = getFieldItem(x, y);
+
+    // Don't allow flagging already revealed tiles
+    if (item->getValue()) return;
+
+    // Don't allow flagging after game is over
+    if (error_count > 1 || correct_count == (field_size * field_size - bomb_count)) return;
+
+    // Toggle flag
+    if (item->getIcon() == "waypoint.png") item->setIcon("");
+    else item->setIcon("waypoint.png", sp::Alignment::Center);
+}
+
+void MineSweeper::updateFailuresLabel()
+{
+    int failures_remaining = MAX_FAILURES - error_count;
+    failures_label->setText("Failures: " + string(failures_remaining) + "/" + string(MAX_FAILURES));
+}
+
 MineSweeper::FieldItem* MineSweeper::getFieldItem(int x, int y)
 {
     return dynamic_cast<MineSweeper::FieldItem*>(board[x * field_size + y]);
 }
 
-MineSweeper::FieldItem::FieldItem(GuiContainer* owner, string id, string text, func_t func)
-: GuiToggleButton(owner, id, text, func), bomb(false)
+MineSweeper::FieldItem::FieldItem(GuiContainer* owner, string id, string text, func_t left_func, func_t right_func)
+: GuiToggleButton(owner, id, text, nullptr), bomb(false), left_click_func(left_func), right_click_func(right_func), last_button(sp::io::Pointer::Button::Unknown)
 {
+}
+
+bool MineSweeper::FieldItem::onMouseDown(sp::io::Pointer::Button button, glm::vec2 position, sp::io::Pointer::ID id)
+{
+    last_button = button;
+    return true;
+}
+
+void MineSweeper::FieldItem::onMouseUp(glm::vec2 position, sp::io::Pointer::ID id)
+{
+    if (!rect.contains(position)) return;
+
+    if (last_button == sp::io::Pointer::Button::Left && left_click_func)
+    {
+        func_t f = left_click_func;
+        f(getValue());
+    }
+    else if (last_button == sp::io::Pointer::Button::Right && right_click_func)
+    {
+        func_t f = right_click_func;
+        f(getValue());
+    }
 }

--- a/src/screenComponents/mineSweeper.h
+++ b/src/screenComponents/mineSweeper.h
@@ -1,14 +1,13 @@
-/** An implementation of mineSweeper for use as a hacking minigame.
- *  Original implementation by https://github.com/daid
- */
-
-#ifndef MINESWEEPER_H
-#define MINESWEEPER_H
+#pragma once
 
 #include "miniGame.h"
 #include "gui/gui2_togglebutton.h"
 
+class GuiLabel;
 
+/** An implementation of mineSweeper for use as a hacking minigame.
+ *  Original implementation by https://github.com/daid
+ */
 class MineSweeper : public MiniGame {
   public:
     MineSweeper(GuiPanel* owner, GuiHackingDialog* parent, int difficulty);
@@ -20,18 +19,27 @@ class MineSweeper : public MiniGame {
     virtual void gameComplete() override;
   private:
     void onFieldClick(int x, int y);
+    void onFieldRightClick(int x, int y);
+    void updateFailuresLabel();
     int error_count;
     int correct_count;
     int field_size;
     int bomb_count;
+    GuiLabel* failures_label;
     class FieldItem : public GuiToggleButton
     {
     public:
-        FieldItem(GuiContainer* owner, string id, string text, func_t func);
+        FieldItem(GuiContainer* owner, string id, string text, func_t left_func, func_t right_func);
+
+        virtual bool onMouseDown(sp::io::Pointer::Button button, glm::vec2 position, sp::io::Pointer::ID id) override;
+        virtual void onMouseUp(glm::vec2 position, sp::io::Pointer::ID id) override;
 
         bool bomb;
+
+    private:
+        func_t left_click_func;
+        func_t right_click_func;
+        sp::io::Pointer::Button last_button;
     };
     FieldItem* getFieldItem(int x, int y);
 };
-
-#endif//MINESWEEPER_H


### PR DESCRIPTION
Allow right-clicking on Minesweeper cells to flag them, and add a label that tracks the number of failures.

<img width="1817" height="1329" alt="Screenshot 2025-12-09 at 3 07 51 PM" src="https://github.com/user-attachments/assets/ed49d603-d2f9-4a55-93e2-0f8418197a06" />

Partially addresses requests for flagging/marking in #467.