### PR TITLE
Allow manual control of GuiRotatingModelView

### DIFF
--- a/src/screenComponents/rotatingModelView.cpp
+++ b/src/screenComponents/rotatingModelView.cpp
@@ -25,9 +25,7 @@ GuiRotatingModelView::GuiRotatingModelView(GuiContainer* owner, string id, sp::e
 
 void GuiRotatingModelView::onDraw(sp::RenderTarget& renderer)
 {
-
-    if (rect.size.x <= 0) return;
-    if (rect.size.y <= 0) return;
+    if (rect.size.x <= 0 || rect.size.y <= 0) return;
 
     auto mrc = entity.getComponent<MeshRenderComponent>();
     if (!mrc) return;
@@ -42,27 +40,42 @@ void GuiRotatingModelView::onDraw(sp::RenderTarget& renderer)
     if (GLAD_GL_ES_VERSION_2_0)
         glClearDepthf(1.f);
     else
-        glClearDepth(1.f);
+        glClearDepth(1.0);
 
     glClear(GL_DEPTH_BUFFER_BIT);
     glEnable(GL_CULL_FACE);
     glCullFace(GL_BACK);
     glFrontFace(GL_CCW);
 
-
     auto mesh_radius = mrc->getMesh()->greatest_distance_from_center * mrc->scale;
-    float mesh_diameter = mesh_radius * 2.f;
     float near_clip_boundary = 1.f;
 
-    auto projection_matrix = glm::perspective(glm::radians(camera_fov), rect.size.x / rect.size.y, near_clip_boundary, 25000.f);
-    float view_distance = mesh_diameter / glm::tan(glm::radians(camera_fov / 2.f));
+    float aspect_ratio = rect.size.x / rect.size.y;
+    auto projection_matrix = glm::perspective(glm::radians(camera_fov), aspect_ratio, near_clip_boundary, 25000.f);
+
+    // Calculate distance needed to fit the model in both dimensions based on
+    // the element's aspect ratio.
+    float vertical_fov_rad = glm::radians(camera_fov / 2.0f);
+    float horizontal_fov_rad = glm::atan(glm::tan(vertical_fov_rad) * aspect_ratio);
+
+    float view_distance = glm::max(mesh_radius / glm::tan(vertical_fov_rad), mesh_radius / glm::tan(horizontal_fov_rad)) / (desired_fill_percentage * zoom_level);
 
     // OpenGL standard: X across (left-to-right), Y up, Z "towards".
     auto view_matrix = glm::rotate(glm::identity<glm::mat4>(), glm::radians(90.f), glm::vec3(1.f, 0.f, 0.f)); // -> X across (l-t-r), Y "towards", Z down
     view_matrix = glm::scale(view_matrix, glm::vec3(1.f, 1.f, -1.f)); // -> X across (l-t-r), Y "towards", Z up
     view_matrix = glm::translate(view_matrix, glm::vec3(0.f, -1.f * view_distance - near_clip_boundary, 0.f));
-    view_matrix = glm::rotate(view_matrix, glm::radians(-30.f), glm::vec3(1.f, 0.f, 0.f));
-    view_matrix = glm::rotate(view_matrix, glm::radians(engine->getElapsedTime() * 360.0f / 10.0f), glm::vec3(0.f, 0.f, 1.f));
+
+    // Apply rotation
+    if (manual_rotation_mode)
+    {
+        view_matrix = glm::rotate(view_matrix, glm::radians(manual_rotation_x), glm::vec3(1.f, 0.f, 0.f));
+        view_matrix = glm::rotate(view_matrix, glm::radians(manual_rotation_z), glm::vec3(0.f, 0.f, 1.f));
+    }
+    else
+    {
+        view_matrix = glm::rotate(view_matrix, glm::radians(-30.f), glm::vec3(1.f, 0.f, 0.f));
+        view_matrix = glm::rotate(view_matrix, glm::radians(engine->getElapsedTime() * 360.0f / 10.0f), glm::vec3(0.f, 0.f, 1.f));
+    }
 
     glDisable(GL_BLEND);
     glBindTexture(GL_TEXTURE_2D, 0);
@@ -115,4 +128,99 @@ void GuiRotatingModelView::onDraw(sp::RenderTarget& renderer)
     glBlendFunc(GL_SRC_ALPHA, GL_ONE_MINUS_SRC_ALPHA);
 
     glViewport(0, 0, renderer.getPhysicalSize().x, renderer.getPhysicalSize().y);
+}
+
+bool GuiRotatingModelView::onMouseWheelScroll(glm::vec2 position, float value)
+{
+    // Positive value = scroll up = zoom in, negative value = scroll down = zoom out
+    zoom_level += value * 0.5f;
+
+    // Clamp zoom level to reasonable bounds
+    zoom_level = glm::clamp(zoom_level, 0.3f, 5.0f);
+
+    return true;
+}
+
+GuiRotatingModelView* GuiRotatingModelView::setFillPercentage(float percentage)
+{
+    desired_fill_percentage = glm::clamp(percentage, 0.3f, 2.0f);
+    return this;
+}
+
+GuiRotatingModelView* GuiRotatingModelView::setZoom(float zoom)
+{
+    zoom_level = glm::clamp(zoom, 0.3f, 5.0f);
+    return this;
+}
+
+GuiRotatingModelView* GuiRotatingModelView::setManualRotationAllowed(bool allowed)
+{
+    manual_rotation_allowed = allowed;
+    return this;
+}
+
+bool GuiRotatingModelView::onMouseDown(sp::io::Pointer::Button button, glm::vec2 position, sp::io::Pointer::ID id)
+{
+    if (!manual_rotation_allowed || button != sp::io::Pointer::Button::Left) return false;
+
+    mouse_down = true;
+    is_dragging = false;
+    mouse_down_position = position;
+    return true;
+
+    return false;
+}
+
+void GuiRotatingModelView::onMouseDrag(glm::vec2 position, sp::io::Pointer::ID id)
+{
+    if (!manual_rotation_allowed || !mouse_down) return;
+
+    glm::vec2 drag_delta = position - mouse_down_position;
+
+    // Only register as a drag with significant movement
+    float drag_threshold = 2.0f;
+    if (!is_dragging && glm::length(drag_delta) > drag_threshold)
+    {
+        is_dragging = true;
+        manual_rotation_mode = true;
+    }
+
+    if (is_dragging)
+    {
+        // Update rotation based on drag
+        // Degrees per pixel
+        float sensitivity = 0.5f;
+        // Horizontal: drag X, model Z; Vertical: drag y, model X
+        // Both are intentionally inverted so that click-drag rotates model
+        // as if pulling it at the clicked point
+        manual_rotation_z -= drag_delta.x * sensitivity;
+        manual_rotation_x -= drag_delta.y * sensitivity;
+
+        // Clamp X rotation to prevent flipping
+        manual_rotation_x = glm::clamp(manual_rotation_x, -89.0f, 89.0f);
+
+        // Normalize Z rotation
+        manual_rotation_z = fmod(manual_rotation_z, 360.0f);
+        if (manual_rotation_z < 0.0f) manual_rotation_z += 360.0f;
+
+        // Update mouse down position for next frame
+        mouse_down_position = position;
+    }
+}
+
+void GuiRotatingModelView::onMouseUp(glm::vec2 position, sp::io::Pointer::ID id)
+{
+    if (!manual_rotation_allowed || !mouse_down) return;
+
+    // Reset to default rotation behavior on single click
+    if (!is_dragging)
+    {
+        manual_rotation_mode = false;
+        manual_rotation_x = -30.0f;
+        manual_rotation_z = 0.0f;
+        zoom_level = 1.0f;
+    }
+
+    mouse_down = false;
+    is_dragging = false;
 }

--- a/src/screenComponents/rotatingModelView.h
+++ b/src/screenComponents/rotatingModelView.h
@@ -1,5 +1,4 @@
-#ifndef ROTATING_MODEL_VIEW_H
-#define ROTATING_MODEL_VIEW_H
+#pragma once
 
 #include "gui/gui2_element.h"
 #include "components/rendering.h"
@@ -8,10 +7,32 @@ class GuiRotatingModelView : public GuiElement
 {
 private:
     sp::ecs::Entity &entity;
+    // Zoom 1.0 = default, >1 zooms in, <1 zooms out
+    float zoom_level = 1.0f;
+    // Default to filling 90% of narrowest dimension
+    float desired_fill_percentage = 0.90f;
+
+    // Mouse interaction state
+    bool mouse_down = false;
+    bool is_dragging = false;
+    glm::vec2 mouse_down_position{0.0f, 0.0f};
+
+    // Manual rotation defaults
+    bool manual_rotation_allowed = true;
+    bool manual_rotation_mode = false;
+    float manual_rotation_x = -30.0f;
+    float manual_rotation_z = 0.0f;
+
 public:
     GuiRotatingModelView(GuiContainer* owner, string id, sp::ecs::Entity& entity);
 
     virtual void onDraw(sp::RenderTarget& target) override;
-};
+    virtual bool onMouseWheelScroll(glm::vec2 position, float value) override;
+    virtual bool onMouseDown(sp::io::Pointer::Button button, glm::vec2 position, sp::io::Pointer::ID id) override;
+    virtual void onMouseDrag(glm::vec2 position, sp::io::Pointer::ID id) override;
+    virtual void onMouseUp(glm::vec2 position, sp::io::Pointer::ID id) override;
 
-#endif//ROTATING_MODEL_VIEW_H
+    GuiRotatingModelView* setFillPercentage(float percentage);
+    GuiRotatingModelView* setZoom(float zoom);
+    GuiRotatingModelView* setManualRotationAllowed(bool allowed);
+};


### PR DESCRIPTION
Implement optional manual control of GuiRotatingModelView elements, such as those used in DatabaseView.

The default initial behavior of the model rotating within the view is unchanged, except for new FoV checks that attempt to better fit the model in the viewport when the viewport is vertically oriented. On load, the model spins automatically within the viewport. When clicked/tapped, this feature allows the model view to be manually manipulated.

- Implement mouse click, drag, scrollwheel on element
  - Single left click resets to default spinning view behavior
  - Left click-drag rotates the model around its center, with constraints
  - Mouse wheel up zooms in, down zooms out
- Default view FoV constrained to avoid clipping in vertical aspect ratios; see https://www.litchiutilities.com/docs/fov.php on horizontal/vertical FoV conversion logic
- Enabled by default; `GuiRotatingModelView::setManualRotationAllowed(false)` to disable
- Touch interactions that are read as mouse inputs also work


https://github.com/user-attachments/assets/d1b4fba4-4cd7-4bb9-aea3-e47fb1c5bf8e



