### PR TITLE
Refactor DatabaseViewComponent

### DIFF
--- a/src/playerInfo.cpp
+++ b/src/playerInfo.cpp
@@ -142,6 +142,31 @@ void PlayerInfo::reset()
     crew_positions.clear();
 }
 
+// Return the total number of positions populated by this player.
+int PlayerInfo::countTotalPlayerPositions()
+{
+    if (crew_positions.empty()) return 0;
+
+    int count = 0;
+    for (auto monitor : crew_positions)
+        for (auto position : monitor) count++;
+
+    LOG(Info, "count: ", count);
+    return count;
+}
+
+// Return the total number of positions populated by this player.
+int PlayerInfo::countPlayerPositionsOnMonitor(int monitor)
+{
+    if (crew_positions.empty()) return 0;
+
+    int count = 0;
+    for (auto position : crew_positions[monitor]) count++;
+
+    LOG(Info, "count: ", count);
+    return count;
+}
+
 bool PlayerInfo::hasPosition(CrewPosition cp)
 {
     for(auto cps : crew_positions) {

--- a/src/playerInfo.h
+++ b/src/playerInfo.h
@@ -30,6 +30,8 @@ public:
 
     void reset();
 
+    int countTotalPlayerPositions();
+    int countPlayerPositionsOnMonitor(int monitor);
     bool hasPosition(CrewPosition cp);
     bool isOnlyMainScreen(int monitor_index);
 

--- a/src/screenComponents/databaseView.h
+++ b/src/screenComponents/databaseView.h
@@ -1,5 +1,4 @@
-#ifndef DATABASE_VIEW_H
-#define DATABASE_VIEW_H
+#pragma once
 
 #include "gui/gui2_element.h"
 #include "ecs/entity.h"
@@ -13,21 +12,24 @@ public:
     DatabaseViewComponent(GuiContainer* owner);
 
     bool findAndDisplayEntry(string name);
+    DatabaseViewComponent* setDetailsPadding(int padding);
+    DatabaseViewComponent* setItemsPadding(int padding);
 
 private:
     bool findAndDisplayEntry(string name, sp::ecs::Entity parent);
-    //Fill the selection listbox with options from the selected_entry, or the main database list if selected_entry is nullptr
+    // Fill the selection listbox with options from the selected_entry, or the main database list if selected_entry is nullptr
     void fillListBox();
     void display();
 
     sp::ecs::Entity selected_entry;
     string back_entry;
+    GuiElement* navigation_element = nullptr;
     GuiButton* back_button = nullptr;
     GuiListbox* item_list = nullptr;
     GuiElement* keyvalue_container = nullptr;
     GuiElement* details_container = nullptr;
 
     static constexpr int navigation_width = 400;
+    int details_padding = 0;
+    int items_padding = 0;
 };
-
-#endif//DATABASE_VIEW_H

--- a/src/screens/crew6/scienceScreen.cpp
+++ b/src/screens/crew6/scienceScreen.cpp
@@ -185,7 +185,23 @@ ScienceScreen::ScienceScreen(GuiContainer* owner, CrewPosition crew_position)
 
     // Prep and hide the database view.
     database_view = new DatabaseViewComponent(this);
-    database_view->hide()->setSize(GuiElement::GuiSizeMax, GuiElement::GuiSizeMax);
+    database_view
+        ->setSize(GuiElement::GuiSizeMax, GuiElement::GuiSizeMax)
+        ->hide()
+        ->setAttribute("padding", "20");
+
+    // Pad top of details column if crew screen selection controls are visible,
+    // and bottom of item list column to prevent overlap with probe/radar view
+    // selectors.
+    int details_padding = 0;
+    if (my_player_info)
+    {
+        if (my_player_info->main_screen_control != 0) details_padding = 120;
+        else if (my_player_info->countTotalPlayerPositions() > 1) details_padding = 70;
+    }
+    database_view
+        ->setDetailsPadding(details_padding)
+        ->setItemsPadding(120);
 
     // Probe view button
     probe_view_button = new GuiToggleButton(radar_view, "PROBE_VIEW", tr("scienceButton", "Probe View"), [this](bool value){

--- a/src/screens/extra/databaseScreen.cpp
+++ b/src/screens/extra/databaseScreen.cpp
@@ -1,4 +1,5 @@
 #include "databaseScreen.h"
+#include "playerInfo.h"
 
 #include "screenComponents/databaseView.h"
 #include "screenComponents/customShipFunctions.h"
@@ -6,7 +7,28 @@
 DatabaseScreen::DatabaseScreen(GuiContainer* owner)
 : GuiOverlay(owner, "DATABASE_SCREEN", colorConfig.background)
 {
-    (new DatabaseViewComponent(this))->setPosition(0, 0, sp::Alignment::TopLeft)->setSize(GuiElement::GuiSizeMax, GuiElement::GuiSizeMax);
+    // Render background decorations.
+    (new GuiOverlay(this, "BACKGROUND_CROSSES", glm::u8vec4{255,255,255,255}))
+        ->setTextureTiled("gui/background/crosses.png");
 
-    (new GuiCustomShipFunctions(this, CrewPosition::databaseView, ""))->setPosition(-20, 120, sp::Alignment::TopRight)->setSize(250, GuiElement::GuiSizeMax);
+    // Render database.
+    DatabaseViewComponent* dvc = new DatabaseViewComponent(this);
+    dvc->setPosition(0.0f, 0.0f, sp::Alignment::TopLeft)
+        ->setSize(GuiElement::GuiSizeMax, GuiElement::GuiSizeMax);
+    dvc->setAttribute("padding", "20");
+
+    // Pad top of details column if crew screen selection controls are visible.
+    int details_padding = 0;
+    if (my_player_info)
+    {
+        if (my_player_info->main_screen_control != 0) details_padding = 120;
+        else if (my_player_info->countTotalPlayerPositions() > 1) details_padding = 70;
+    }
+    dvc->setDetailsPadding(details_padding);
+
+    // Render Databse View custom ship functions.
+    (new GuiCustomShipFunctions(this, CrewPosition::databaseView, "DB_CUSTOM_SHIP_FUNCTIONS"))
+        ->setSize(250.0f, GuiElement::GuiSizeMax)
+        ->setPosition(0.0f, 0.0f, sp::Alignment::TopRight)
+        ->setAttribute("padding", "0, 20, 120, 0");
 }

--- a/src/screens/extra/databaseScreen.h
+++ b/src/screens/extra/databaseScreen.h
@@ -1,7 +1,8 @@
-#ifndef DATABASE_SCREEN_H
-#define DATABASE_SCREEN_H
+#pragma once
 
 #include "gui/gui2_overlay.h"
+
+class DatabaseViewComponent;
 
 class DatabaseScreen : public GuiOverlay
 {
@@ -9,5 +10,3 @@ private:
 public:
     DatabaseScreen(GuiContainer* owner);
 };
-
-#endif//DATABASE_SCREEN_H


### PR DESCRIPTION
- Use layout attributes to set padding on DatabaseScreen
- Use layout attributes to set margins between between item list Back button and list, and between columns
- Prevent extraneous bottom padding from being applied to item list
- Prevent database details column from overlapping with crew screen/ main screen controls

Also, this PR adds counting functions to PlayerInfo to support detecting when more than one crew screen is visible.

## Before (first) and after

Database screen, no other crew screens:

<img alt="Screenshot 2025-12-12 142214" src="https://github.com/user-attachments/assets/823ef673-2b78-47ae-b7b5-a33644d125a7" />
<img alt="Screenshot 2025-12-12 141952" src="https://github.com/user-attachments/assets/30b7283a-ad83-4cc8-8d24-d6ff5c95c71a" />

Changes:

- Item list extends to the bottom of the screen, responsive to view height
- Details column extends to the top of the screen
- Padding tightened on either side of the key-value column
- Crosses pattern applied to background

Science screen, with other crew screens and main screen controls selected:

<img alt="Screenshot 2025-12-12 142231" src="https://github.com/user-attachments/assets/c10b0052-7728-421c-ab0b-0c6230c97555" />
<img alt="Screenshot 2025-12-12 142014" src="https://github.com/user-attachments/assets/38ccf031-5286-4dd0-b554-9df3e8739f43" />

Changes:

- Item list extends to 20px above the top of the view control buttons, responsive to view height
- Details column starts 20px below the bottom of the main screen controls button