### PR TITLE
Add linger period to main screen view target lock

### DIFF
--- a/src/screenComponents/viewportMainScreen.h
+++ b/src/screenComponents/viewportMainScreen.h
@@ -1,5 +1,4 @@
-#ifndef VIEWPORT_MAIN_SCREEN_H
-#define VIEWPORT_MAIN_SCREEN_H
+#pragma once
 
 #include "viewport3d.h"
 
@@ -15,6 +14,10 @@ public:
     constexpr static uint8_t flag_callsigns = 0x04;
     constexpr static uint8_t flag_headings  = 0x02;
     constexpr static uint8_t flag_spacedust = 0x01;
-};
 
-#endif//VIEWPORT_MAIN_SCREEN_H
+private:
+    glm::vec2 tot_coordinates{0.0f, 0.0f};
+    const float linger_period = 3.0f;
+    float linger_timer = 0.0f;
+    float previous_draw = 0.0f;
+};


### PR DESCRIPTION
When a target is destroyed or lost on main screen camera view, linger on the target's last known coordinates for 3 seconds before reverting to Front view.

Before:

https://github.com/user-attachments/assets/e9746e38-e874-430e-9e6c-3ea48e5ad6e0

After:

https://github.com/user-attachments/assets/891e06f1-35e5-4fcd-8518-91f5d1acb55a


