### PR TITLE
Allow dynamic FoV changes in Viewport

### DIFF
--- a/src/screenComponents/viewport3d.h
+++ b/src/screenComponents/viewport3d.h
@@ -9,12 +9,15 @@
 
 class GuiViewport3D : public GuiElement
 {
-    bool show_callsigns;
-    bool show_headings;
-    bool show_spacedust;
+    bool show_callsigns = false;
+    bool show_headings = false;
+    bool show_spacedust = false;
 
     glm::mat4 projection_matrix;
     glm::mat4 view_matrix;
+
+    float base_fov; // set by main_screen_camera_fov preference on init
+    float fov_modifier = 0.0f;
 
     enum class Uniforms : uint8_t
     {
@@ -72,6 +75,10 @@ public:
     GuiViewport3D* toggleCallsigns() { show_callsigns = !show_callsigns; return this; }
     GuiViewport3D* showHeadings() { show_headings = true; return this; }
     GuiViewport3D* showSpacedust() { show_spacedust = true; return this; }
+
+    float getModifiedFoV() { return base_fov + fov_modifier; }
+    float getFoVModifier() { return fov_modifier; }
+    float modifyFoV(float modifier) { fov_modifier = std::clamp(base_fov + modifier, 30.0f, 140.0f) - base_fov; return fov_modifier; }
 private:
     glm::vec3 worldToScreen(sp::RenderTarget& window, glm::vec3 world);
 };


### PR DESCRIPTION
Add modifyFoV() function to set a temporary modifier for FoV values, for instance to facilitate camera zoom or speed-scaling effects. Also add getModifiedFoV() and getFoVModifier() getters.