### PR TITLE
[#2644] Don't update ShipSystemsSystem on clients

### DIFF
--- a/src/systems/shipsystemssystem.cpp
+++ b/src/systems/shipsystemssystem.cpp
@@ -1,4 +1,5 @@
 #include "shipsystemssystem.h"
+#include "multiplayer_server.h"
 #include "components/reactor.h"
 #include "components/beamweapon.h"
 #include "components/missiletubes.h"
@@ -12,6 +13,7 @@
 
 void ShipSystemsSystem::update(float delta)
 {
+    if (!game_server) return;
     for(auto [entity, system] : sp::ecs::Query<Reactor>())
         updateSystem(system, delta, entity.hasComponent<Coolant>());
     for(auto [entity, system] : sp::ecs::Query<BeamWeaponSys>())


### PR DESCRIPTION
ShipSystemsSystem shouldn't be updated on clients, and doing so can lead to client drift if the server intentionally stops replicating a value, such as #2644.