### PR TITLE
[#2650] Allow pause keybind to toggle out of pause

### DIFF
--- a/src/screens/cinematicViewScreen.cpp
+++ b/src/screens/cinematicViewScreen.cpp
@@ -141,11 +141,9 @@ void CinematicViewScreen::update(float delta)
         destroy();
         returnToShipSelection(getRenderLayer());
     }
+
     if (keys.pause.getDown())
-    {
-        if (game_server)
-            engine->setGameSpeed(0.0);
-    }
+        if (game_server && !gameGlobalInfo->getVictoryFaction()) engine->setGameSpeed(engine->getGameSpeed() > 0.0f ? 0.0f : 1.0f);
 
     if (keys.cinematic.move_forward.get())
     {

--- a/src/screens/crewStationScreen.cpp
+++ b/src/screens/crewStationScreen.cpp
@@ -1,6 +1,7 @@
 #include "crewStationScreen.h"
 #include "epsilonServer.h"
 #include "main.h"
+#include "gameGlobalInfo.h"
 #include "preferenceManager.h"
 #include "playerInfo.h"
 #include "multiplayer_client.h"
@@ -306,11 +307,9 @@ void CrewStationScreen::update(float delta)
         // Toggle keyboard help.
         keyboard_help->frame->setVisible(!keyboard_help->frame->isVisible());
     }
+
     if (keys.pause.getDown())
-    {
-        if (game_server)
-            engine->setGameSpeed(0.0);
-    }
+        if (game_server && !gameGlobalInfo->getVictoryFaction()) engine->setGameSpeed(engine->getGameSpeed() > 0.0f ? 0.0f : 1.0f);
 
     if (viewport)
     {

--- a/src/screens/gm/gameMasterScreen.cpp
+++ b/src/screens/gm/gameMasterScreen.cpp
@@ -302,16 +302,11 @@ void GameMasterScreen::update(float delta)
         destroy();
         returnToShipSelection(getRenderLayer());
     }
+
     if (keys.pause.getDown())
-    {
-        if (game_server)
-            engine->setGameSpeed(0.0);
-    }
-    if (engine->getGameSpeed() == 0.0f) {
-        pause_button->setValue(true);
-    } else {
-        pause_button->setValue(false);
-    }
+        if (game_server && !gameGlobalInfo->getVictoryFaction()) engine->setGameSpeed(engine->getGameSpeed() > 0.0f ? 0.0f : 1.0f);
+
+    pause_button->setValue(engine->getGameSpeed() == 0.0f);
 
     if (keys.gm_show_callsigns.getDown())
     {

--- a/src/screens/mainScreen.cpp
+++ b/src/screens/mainScreen.cpp
@@ -107,11 +107,9 @@ void ScreenMainScreen::update(float delta)
         // Toggle keyboard help.
         keyboard_help->frame->setVisible(!keyboard_help->frame->isVisible());
     }
+
     if (keys.pause.getDown())
-    {
-        if (game_server)
-            engine->setGameSpeed(0.0);
-    }
+        if (game_server && !gameGlobalInfo->getVictoryFaction()) engine->setGameSpeed(engine->getGameSpeed() > 0.0f ? 0.0f : 1.0f);
 
     if (game_client && game_client->getStatus() == GameClient::Disconnected)
     {

--- a/src/screens/spectatorScreen.cpp
+++ b/src/screens/spectatorScreen.cpp
@@ -200,7 +200,7 @@ void SpectatorScreen::update(float delta)
     }
 
     if (keys.pause.getDown())
-        if (game_server) engine->setGameSpeed(0.0);
+        if (game_server && !gameGlobalInfo->getVictoryFaction()) engine->setGameSpeed(engine->getGameSpeed() > 0.0f ? 0.0f : 1.0f);
 
     if (keys.spectator_show_callsigns.getDown())
         main_radar->showCallsigns(!main_radar->getCallsigns());

--- a/src/screens/topDownScreen.cpp
+++ b/src/screens/topDownScreen.cpp
@@ -156,11 +156,9 @@ void TopDownScreen::update(float delta)
         destroy();
         returnToShipSelection(getRenderLayer());
     }
+
     if (keys.pause.getDown())
-    {
-        if (game_server)
-            engine->setGameSpeed(0.0);
-    }
+        if (game_server && !gameGlobalInfo->getVictoryFaction()) engine->setGameSpeed(engine->getGameSpeed() > 0.0f ? 0.0f : 1.0f);
 
     // Add and remove entries from the player ship list.
     for(auto [entity, pc] : sp::ecs::Query<PlayerControl>())

--- a/src/screens/windowScreen.cpp
+++ b/src/screens/windowScreen.cpp
@@ -36,11 +36,9 @@ void WindowScreen::update(float delta)
         destroy();
         returnToShipSelection(getRenderLayer());
     }
+
     if (keys.pause.getDown())
-    {
-        if (game_server)
-            engine->setGameSpeed(0.0);
-    }
+        if (game_server && !gameGlobalInfo->getVictoryFaction()) engine->setGameSpeed(engine->getGameSpeed() > 0.0f ? 0.0f : 1.0f);
 
     if (game_client && game_client->getStatus() == GameClient::Disconnected)
     {


### PR DESCRIPTION
Allows the `keys.pause` keybind to toggle both into and out of pause. Also adds a check to the pause keybind to ensure it doesn't unpause after victory/defeat.

Fixes #2650.