### PR TITLE
Refactor GuiScrollingBanner

### DIFF
--- a/src/screenComponents/scrollingBanner.h
+++ b/src/screenComponents/scrollingBanner.h
@@ -1,9 +1,7 @@
-#ifndef SCROLLING_BANNER_H
-#define SCROLLING_BANNER_H
+#pragma once
 
 #include "gui/gui2_element.h"
 #include "timer.h"
-
 
 class GuiScrollingBanner : public GuiElement
 {
@@ -13,10 +11,8 @@ public:
     virtual void onDraw(sp::RenderTarget& target) override;
 private:
     static constexpr float scroll_speed_per_second = 150.0f;
-    static constexpr float black_area = 200.0f;
 
     sp::SystemStopwatch update_clock;
-    float draw_offset;
+    bool has_scrolling_started = false;
+    float draw_offset = 0.0f;
 };
-
-#endif//SCROLLING_BANNER_H


### PR DESCRIPTION
- Fix reset behavior to restart scrolling from beyond the right edge of the rect after the end of the text scrolls off the left edge, instead of resetting at the left edge after the largest threshold is reached.
- Fix initial scrolling state to start at the middle of the rect instead of the left edge.
- Use rectangular label background instead of rounded-corner panel background.
- Reduce the text size to fit within the background.

Before:

[Screencast_20251225_165904.webm](https://github.com/user-attachments/assets/5d0825a8-a668-4deb-a7fc-1c66f34477a6)

After:

[Screencast_20251225_165312.webm](https://github.com/user-attachments/assets/aa5ce67c-fe41-4502-a415-fae385714f5d)
