### PR TITLE
[#2673] Implement callbacks on scan start, finish, cancel

### DIFF
--- a/scripts/api/entity/spaceobject.lua
+++ b/scripts/api/entity/spaceobject.lua
@@ -467,3 +467,48 @@ function Entity:onDestroyed(callback)
     if self.components.hull then self.components.hull.on_destruction = callback end
     return self
 end
+--- Defines a function to call when a scan is initiated against this entity.
+--- The callback receives three parameters:
+--- - target: The entity being scanned (the entity this callback is registered on)
+--- - scanner: The entity performing the scan (player ship or probe)
+--- - source: The entity that initiated the scan command (player ship, or probe if scan was initiated via radar link)
+--- Example:
+--- obj:onScanInitiated(function(target, scanner, source)
+---     print(target:getCallSign() .. " is being scanned by " .. scanner:getCallSign())
+---     if source ~= scanner then
+---         print("(Scan initiated via radar-linked probe)")
+---     end
+--- end)
+function Entity:onScanInitiated(callback)
+    if self.components.scan_state then self.components.scan_state.on_scan_initiated = callback end
+    return self
+end
+--- Defines a function to call when a scan is completed against this entity.
+--- The callback receives three parameters:
+--- - target: The entity being scanned (the entity this callback is registered on)
+--- - scanner: The entity performing the scan (player ship or probe)
+--- - source: The entity that initiated the scan command (player ship, or probe if scan was initiated via radar link)
+--- Example:
+--- obj:onScanCompleted(function(target, scanner, source)
+---     print(target:getCallSign() .. " has been scanned by " .. scanner:getCallSign())
+---     if source ~= scanner then
+---         print("(Scan completed via radar-linked probe)")
+---     end
+--- end)
+function Entity:onScanCompleted(callback)
+    if self.components.scan_state then self.components.scan_state.on_scan_completed = callback end
+    return self
+end
+--- Defines a function to call when a scan is cancelled against this entity.
+--- The callback receives three parameters:
+--- - target: The entity being scanned (the entity this callback is registered on)
+--- - scanner: The entity performing the scan (player ship or probe)
+--- - source: The entity that initiated the scan command (player ship, or probe if scan was initiated via radar link)
+--- Example:
+--- obj:onScanCancelled(function(target, scanner, source)
+---     print("Scan of " .. target:getCallSign() .. " was cancelled")
+--- end)
+function Entity:onScanCancelled(callback)
+    if self.components.scan_state then self.components.scan_state.on_scan_cancelled = callback end
+    return self
+end

--- a/src/components/scanning.h
+++ b/src/components/scanning.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include "ecs/entity.h"
+#include "script/callback.h"
 #include <vector>
 
 
@@ -35,6 +36,10 @@ public:
     void setStateFor(sp::ecs::Entity entity, State state);
     State getStateForFaction(sp::ecs::Entity entity);
     void setStateForFaction(sp::ecs::Entity entity, State state);
+
+    sp::script::Callback on_scan_initiated;
+    sp::script::Callback on_scan_completed;
+    sp::script::Callback on_scan_cancelled;
 };
 
 class ScienceDescription
@@ -52,4 +57,5 @@ public:
     float delay = 0.0f; // When a delay based scan is done, this will count down.
     float max_scanning_delay = 6.0f;
     sp::ecs::Entity target;
+    sp::ecs::Entity source;
 };

--- a/src/multiplayer/scanning.cpp
+++ b/src/multiplayer/scanning.cpp
@@ -30,4 +30,5 @@ BASIC_REPLICATION_IMPL(ScienceScannerReplication, ScienceScanner)
     BASIC_REPLICATION_FIELD(delay);
     BASIC_REPLICATION_FIELD(max_scanning_delay);
     BASIC_REPLICATION_FIELD(target);
+    BASIC_REPLICATION_FIELD(source);
 }

--- a/src/playerInfo.h
+++ b/src/playerInfo.h
@@ -49,7 +49,7 @@ public:
     void commandSetShields(bool enabled);
     void commandMainScreenSetting(MainScreenSetting mainScreen);
     void commandMainScreenOverlay(MainScreenOverlay mainScreen);
-    void commandScan(sp::ecs::Entity object);
+    void commandScan(sp::ecs::Entity object, sp::ecs::Entity link_source = sp::ecs::Entity());
     void commandSetSystemPowerRequest(ShipSystem::Type system, float power_level);
     void commandSetSystemCoolantRequest(ShipSystem::Type system, float coolant_level);
     void commandDock(sp::ecs::Entity station);

--- a/src/screenComponents/scanTargetButton.cpp
+++ b/src/screenComponents/scanTargetButton.cpp
@@ -17,9 +17,9 @@ GuiScanTargetButton::GuiScanTargetButton(GuiContainer* owner, string id, Targets
         {
             if (my_spaceship && this->targets && this->targets->get())
             {
-                // Always check for active radar link dynamically
+                // Check for active radar link and validate the linked entity
                 auto rl = my_spaceship.getComponent<RadarLink>();
-                if (rl && rl->linked_entity)
+                if (rl && rl->linked_entity && rl->linked_entity.hasComponent<AllowRadarLink>())
                     my_player_info->commandScan(this->targets->get(), rl->linked_entity);
                 else
                     my_player_info->commandScan(this->targets->get());

--- a/src/screenComponents/scanTargetButton.cpp
+++ b/src/screenComponents/scanTargetButton.cpp
@@ -3,6 +3,7 @@
 #include "targetsContainer.h"
 #include "gui/gui2_button.h"
 #include "gui/gui2_progressbar.h"
+#include "components/radar.h"
 #include "components/scanning.h"
 #include "components/target.h"
 #include "i18n.h"
@@ -11,10 +12,22 @@
 GuiScanTargetButton::GuiScanTargetButton(GuiContainer* owner, string id, TargetsContainer* targets)
 : GuiElement(owner, id), targets(targets)
 {
-    button = new GuiButton(this, id + "_BUTTON", tr("scienceButton", "Scan"), [this]() {
-        if (my_spaceship && this->targets && this->targets->get())
-            my_player_info->commandScan(this->targets->get());
-    });
+    button = new GuiButton(this, id + "_BUTTON", tr("scienceButton", "Scan"),
+        [this]()
+        {
+            if (my_spaceship && this->targets && this->targets->get())
+            {
+                // Always check for active radar link dynamically
+                auto rl = my_spaceship.getComponent<RadarLink>();
+                if (rl && rl->linked_entity)
+                    my_player_info->commandScan(this->targets->get(), rl->linked_entity);
+                else
+                    my_player_info->commandScan(this->targets->get());
+            }
+
+
+        }
+    );
     button->setSize(GuiElement::GuiSizeMax, GuiElement::GuiSizeMax);
     progress = new GuiProgressbar(this, id + "_PROGRESS", 0, 6.0f, 0.0);
     progress->setSize(GuiElement::GuiSizeMax, GuiElement::GuiSizeMax);

--- a/src/screenComponents/scanTargetButton.h
+++ b/src/screenComponents/scanTargetButton.h
@@ -1,5 +1,4 @@
-#ifndef SCAN_TARGET_BUTTON_H
-#define SCAN_TARGET_BUTTON_H
+#pragma once
 
 #include "gui/gui2_element.h"
 
@@ -19,5 +18,3 @@ public:
     virtual void onUpdate() override;
     virtual void onDraw(sp::RenderTarget& target) override;
 };
-
-#endif//SCAN_TARGET_BUTTON_H

--- a/src/screens/crew6/scienceScreen.cpp
+++ b/src/screens/crew6/scienceScreen.cpp
@@ -535,9 +535,9 @@ void ScienceScreen::onUpdate()
             auto scanstate = obj.getComponent<ScanState>();
             if (scanstate && scanstate->getStateFor(my_spaceship) != ScanState::State::FullScan)
             {
-                // Check if scanning via radar link (e.g., from a probe)
+                // Check for active radar link and validate the linked entity
                 auto rl = my_spaceship.getComponent<RadarLink>();
-                if (rl && rl->linked_entity)
+                if (rl && rl->linked_entity && rl->linked_entity.hasComponent<AllowRadarLink>() && probe_radar->isVisible())
                     my_player_info->commandScan(obj, rl->linked_entity);
                 else
                     my_player_info->commandScan(obj);

--- a/src/screens/crew6/scienceScreen.h
+++ b/src/screens/crew6/scienceScreen.h
@@ -1,5 +1,4 @@
-#ifndef SCIENCE_SCREEN_H
-#define SCIENCE_SCREEN_H
+#pragma once
 
 #include "screenComponents/targetsContainer.h"
 #include "gui/gui2_overlay.h"
@@ -68,5 +67,3 @@ private:
     float previous_long_range_radar=0;
     float previous_short_range_radar=0;
 };
-
-#endif//SCIENCE_SCREEN_H

--- a/src/script/components.cpp
+++ b/src/script/components.cpp
@@ -623,6 +623,9 @@ void initComponentScriptBindings()
     BIND_MEMBER(ScanState, allow_simple_scan);
     BIND_MEMBER(ScanState, complexity);
     BIND_MEMBER(ScanState, depth);
+    BIND_MEMBER(ScanState, on_scan_initiated);
+    BIND_MEMBER(ScanState, on_scan_completed);
+    BIND_MEMBER(ScanState, on_scan_cancelled);
     BIND_ARRAY_DIRTY_FLAG(ScanState, per_faction, per_faction_dirty);
     BIND_ARRAY_DIRTY_FLAG_MEMBER(ScanState, per_faction, faction, per_faction_dirty);
     BIND_ARRAY_DIRTY_FLAG_MEMBER(ScanState, per_faction, state, per_faction_dirty);

--- a/src/systems/scanning.cpp
+++ b/src/systems/scanning.cpp
@@ -2,50 +2,62 @@
 #include "components/scanning.h"
 #include "gameGlobalInfo.h"
 #include "multiplayer_server.h"
+#include "menus/luaConsole.h"
 
 #include <ecs/query.h>
 
 
 void ScanningSystem::update(float delta)
 {
-    for(auto [entity, scanner] : sp::ecs::Query<ScienceScanner>()) {
-        if (auto ss = scanner.target.getComponent<ScanState>()) {
-            // If the scan setting or a target's scan complexity is none/0,
-            // complete the scan after a delay.
+    for (auto [entity, scanner] : sp::ecs::Query<ScienceScanner>())
+    {
+        // If the scan setting or a target's scan complexity is none/0,
+        // complete the scan after a delay.
+        if (auto ss = scanner.target.getComponent<ScanState>())
+        {
             if (ss->complexity == 0 || (ss->complexity < 0 && gameGlobalInfo->scanning_complexity == SC_None))
             {
+                // If scan has just started, fire the onScanInitiated callback.
+                if (scanner.delay == scanner.max_scanning_delay && ss->on_scan_initiated)
+                    LuaConsole::checkResult(ss->on_scan_initiated.call<void>(scanner.target, entity, scanner.source));
+
                 scanner.delay -= delta;
-                if (scanner.delay < 0 && game_server)
+                if (scanner.delay < 0.0f && game_server)
                     scanningFinished(entity);
             }
-        }else{
-            // Otherwise, ignore the scanning_delay setting.
-            scanner.delay = 0.0;
         }
+        // Otherwise, ignore the scanning_delay setting.
+        else scanner.delay = 0.0f;
     }
 }
 
-void ScanningSystem::scanningFinished(sp::ecs::Entity source)
+void ScanningSystem::scanningFinished(sp::ecs::Entity command_source)
 {
-    auto scanner = source.getComponent<ScienceScanner>();
+    auto scanner = command_source.getComponent<ScienceScanner>();
     if (!scanner) return;
-    auto ss = scanner->target.getComponent<ScanState>();
-    if (ss) {
-        switch(ss->getStateFor(source)) {
+
+    if (auto ss = scanner->target.getComponent<ScanState>())
+    {
+        switch(ss->getStateFor(command_source))
+        {
         case ScanState::State::NotScanned:
         case ScanState::State::FriendOrFoeIdentified:
             if (ss->allow_simple_scan)
-                ss->setStateFor(source, ScanState::State::SimpleScan);
+                ss->setStateFor(command_source, ScanState::State::SimpleScan);
             else
-                ss->setStateFor(source, ScanState::State::FullScan);
+                ss->setStateFor(command_source, ScanState::State::FullScan);
             break;
         case ScanState::State::SimpleScan:
-            ss->setStateFor(source, ScanState::State::FullScan);
+            ss->setStateFor(command_source, ScanState::State::FullScan);
             break;
         case ScanState::State::FullScan:
             break;
         }
+
+        LuaConsole::checkResult(ss->on_scan_completed.call<void>(scanner->target, command_source, scanner->source));
     }
+
     scanner->target = {};
-    scanner->delay = 0.0;
+    scanner->source = {};
+    scanner->delay = 0.0f;
 }


### PR DESCRIPTION
Implement new Lua callbacks that fire when a scan is:

- initiated onScanInitiated()
- completed onScanCompleted()
- cancelled onScanCancelled()

The callbacks are passed

- the ship performing the scan
- the source entity for the radar used to perform the scan, such as a ship or scan probe

Fixes #2673.