### PR TITLE
[#2674] Assign callsigns to player-launched ScanProbes

### DIFF
--- a/src/playerInfo.cpp
+++ b/src/playerInfo.cpp
@@ -914,6 +914,7 @@ void PlayerInfo::onReceiveClientCommand(int32_t client_id, sp::io::DataBuffer& p
 
                 auto p = sp::ecs::Entity::create();
                 p.addComponent<sp::Transform>(*t);
+                p.addComponent<CallSign>().callsign = p.toString().split(":", 1)[0] + "P";
                 p.addComponent<LifeTime>().lifetime = 60*10;
                 if (auto faction = ship.getComponent<Faction>())
                     p.addComponent<Faction>() = *faction;


### PR DESCRIPTION
As in legacy, assign a callsign to scan probes launched by player ships by suffixing its entity ID with "P".

Fixes #2674.

Before:

<img width="85" height="135" alt="image" src="https://github.com/user-attachments/assets/c11e352d-7e65-44ca-a93b-603da7c25163" />

After:

<img width="85" height="135" alt="image" src="https://github.com/user-attachments/assets/a4d54cea-cc49-44b9-8bd7-4e9deddbee5f" />

Legacy:

<img width="154" height="238" alt="image" src="https://github.com/user-attachments/assets/29cc3ee4-9832-4820-b667-13a921e10a2e" />
