### PR TITLE
[#2681] Prevent scan autosolve and hard lock if a scan is initiated with multiple GuiScanDialogs

### DIFF
--- a/src/screenComponents/signalQualityIndicator.cpp
+++ b/src/screenComponents/signalQualityIndicator.cpp
@@ -13,9 +13,12 @@ GuiSignalQualityIndicator::GuiSignalQualityIndicator(GuiContainer* owner, string
 
 void GuiSignalQualityIndicator::onDraw(sp::RenderTarget& renderer)
 {
+    int point_count = rect.size.x / 4 - 1;
+    // Bail if there's not enough space to draw the signal.
+    if (point_count < 2) return;
+
     renderer.drawStretchedHV(rect, 25.0f, "gui/widget/PanelBackground.png");
 
-    int point_count = rect.size.x / 4 - 1;
     std::vector<glm::vec2> r;
     std::vector<glm::vec2> g;
     std::vector<glm::vec2> b;


### PR DESCRIPTION
Attempt to avoid initialization issues and potential race conditions that can cause a GuiScanDialog to set `locked = true` before it's first drawn, causing the first depth of the first scan initiated before its parent crew screen is first drawn to automatically solve itself.

- Hide the parent `box` GuiPanel on init so that it fails the `onDraw()` `isVisible()` check that runs scan logic.
- Explicitly reset `locked = false` in the dialog's `setupParameters()` helper
- Require at least one slider to be visible in the locking check
- Prevent a potential hard lock when `signalQualityIndicator` attempts to draw in a 0,0 rect

For example, joining both Science and Ops and starting a scan on Science causes `GuiScanDialog::onDraw` to be called on the Ops screen's instance before its rect size is defined. Since the rect size is 0,0, and the slider width depends on `rect.size.x`, it gets start and target positions of 0; since the start is then < 0.05 from the target, `locked = true`.

This means it's reproducible only on the first load of the second scan dialog crew screen. This also means it's reproducible by having a player join a ship, join a screen other than Science or Ops (i.e. Helms), then initiating a scan via Lua scripting/HTTP API (...components.science_scanner.target = some entity) and then switching to Science or Ops for the first time.