### PR TITLE
Clean up GuiListbox includes

### DIFF
--- a/src/gui/gui2_listbox.cpp
+++ b/src/gui/gui2_listbox.cpp
@@ -2,6 +2,7 @@
 #include "soundManager.h"
 #include "theme.h"
 
+#include "gui2_scrollbar.h"
 
 GuiListbox::GuiListbox(GuiContainer* owner, string id, func_t func)
 : GuiEntryList(owner, id, func), text_size(30), button_height(50), text_alignment(sp::Alignment::Center), mouse_scroll_steps(25)

--- a/src/gui/gui2_listbox.h
+++ b/src/gui/gui2_listbox.h
@@ -1,10 +1,8 @@
-#ifndef GUI2_LISTBOX_H
-#define GUI2_LISTBOX_H
+#pragma once
 
-#include "gui2_element.h"
 #include "gui2_entrylist.h"
-#include "gui2_togglebutton.h"
-#include "gui2_scrollbar.h"
+
+class GuiScrollbar;
 
 class GuiListbox : public GuiEntryList
 {
@@ -33,5 +31,3 @@ public:
     virtual void onMouseUp(glm::vec2 position, sp::io::Pointer::ID id) override;
     virtual bool onMouseWheelScroll(glm::vec2 position, float value) override;
 };
-
-#endif//GUI2_LISTBOX_H

--- a/src/screens/gm/objectCreationView.cpp
+++ b/src/screens/gm/objectCreationView.cpp
@@ -1,16 +1,17 @@
 #include "objectCreationView.h"
 #include "GMActions.h"
-#include "components/faction.h"
+#include "i18n.h"
+#include "gameGlobalInfo.h"
 #include "ecs/query.h"
+#include "components/collision.h"
+#include "components/faction.h"
+#include "gui/gui2_button.h"
 #include "gui/gui2_panel.h"
 #include "gui/gui2_selector.h"
 #include "gui/gui2_listbox.h"
 #include "gui/gui2_scrolltext.h"
 #include "gui/gui2_textentry.h"
 #include "menus/luaConsole.h"
-#include "i18n.h"
-#include "gameGlobalInfo.h"
-#include "components/collision.h"
 #include <unordered_set>
 
 

--- a/src/screens/gm/objectCreationView.h
+++ b/src/screens/gm/objectCreationView.h
@@ -1,8 +1,6 @@
-#ifndef OBJECT_CREATION_VIEW_H
-#define OBJECT_CREATION_VIEW_H
+#pragma once
 
 #include "gui/gui2_overlay.h"
-#include "gui/gui2_listbox.h"
 #include "gameGlobalInfo.h"
 
 
@@ -27,5 +25,3 @@ public:
 
     virtual bool onMouseDown(sp::io::Pointer::Button button, glm::vec2 position, sp::io::Pointer::ID id) override;
 };
-
-#endif//OBJECT_CREATION_VIEW_H


### PR DESCRIPTION
Remove unnecessary includes, forward declare GuiScrollbar, and include GuiButton on GuiObjectCreationView because it relied on GuiListbox unnecessarily including GuiToggleButton.