### PR TITLE
Disable voice chat with voice_chat_enabled=0 Pref

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -172,7 +172,7 @@ int main(int argc, char** argv)
     // Since there is no way to access it (yet) via a touchscreen, compile out.
 #if !defined(ANDROID)
     // Set up voice chat and key bindings.
-    if (PreferencesManager::get("voice_chat_enabled", "1") == "1")
+    if (PreferencesManager::get("voice_chat_enabled", "0") == "1")
     {
         NetworkAudioRecorder* nar = new NetworkAudioRecorder();
         nar->addKeyActivation(&keys.voice_all, 0);


### PR DESCRIPTION
EE's built-in voice chat can degrade all Bluetooth audio output on some Linux distros while EE is running and a headset with mic is connected, even if EE's built-in voice isn't sending or receiving voice data. For example, Fedora 40+ drops audio output from A2DP to HSP/HFP while EE is running.

Add a Preferences File option to disable built-in voice chat. This setting defaults to 1 (enabled) and should not change the existing default state of EE's built-in voice chat.