### PR TITLE
[#2693] Fix cursor position in themed & long-content GuiTextEntry

### DIFF
--- a/src/gui/gui2_textentry.cpp
+++ b/src/gui/gui2_textentry.cpp
@@ -443,16 +443,17 @@ void GuiTextEntry::setCursorPosition(int offset)
 
 int GuiTextEntry::getTextOffsetForPosition(glm::vec2 position)
 {
-    position -= rect.position;
+    position = position - rect.position - render_offset;
     position.x -= 16.0f;
     int result = text.size();
+    const auto& front = front_style->get(getState());
     //if (vertical_scroll)
     //    position.y -= vertical_scroll->getValue();
     std::string shown_text = text;
     if (hide_password) {
         shown_text = std::string(text.size(), '*');
     }
-    auto pfs = sp::RenderTarget::getDefaultFont()->prepare(shown_text, 32, text_size, {255,255,255,255}, rect.size - glm::vec2(32, 0), multiline ? sp::Alignment::TopLeft : sp::Alignment::CenterLeft);
+    auto pfs = front.font->prepare(shown_text, 32, text_size, {255,255,255,255}, rect.size - glm::vec2(32, 0), multiline ? sp::Alignment::TopLeft : sp::Alignment::CenterLeft);
     unsigned int n;
     for(n=0; n<pfs.data.size(); n++)
     {
@@ -474,6 +475,7 @@ int GuiTextEntry::getTextOffsetForPosition(glm::vec2 position)
             break;
         result = d.string_offset;
     }
+
     return result;
 }
 


### PR DESCRIPTION
- Factor `render_offset` into `GuiTextEntry::getTextOffsetForPosition()`
- Use the element's theme font instead of `RenderTarget::getDefaultFont()` in `getTextOffsetForPosition()`

Fixes #2693.

Before:

https://github.com/user-attachments/assets/fd008a8a-09a6-4f48-baca-3aa274f10fc8

https://github.com/user-attachments/assets/cb0ef1f6-b7a6-4098-af04-ba075cb3f696

After:

https://github.com/user-attachments/assets/69890e9a-99f2-4bfb-af8e-3d6d2f62e7e0

https://github.com/user-attachments/assets/b778a7f1-9965-4a3c-a26a-3392ceb40c22
