### PR TITLE
Mark functions as dirty after message dismissal

### DIFF
--- a/src/playerInfo.cpp
+++ b/src/playerInfo.cpp
@@ -1002,6 +1002,7 @@ void PlayerInfo::onReceiveClientCommand(int32_t client_id, sp::io::DataBuffer& p
                             auto cb = f.callback;
                             cb.call<void>();
                             csf->functions.erase(std::remove_if(csf->functions.begin(), csf->functions.end(), [name](const CustomShipFunctions::Function& f) { return f.name == name; }), csf->functions.end());
+                            csf->functions_dirty = true;
                         }
                         break;
                     }


### PR DESCRIPTION
This PR addresses an issue where customMessages were not being properly replicated to client systems as the functions object was not being marked dirty after being updated