### PR TITLE
Mark functions as dirty after message dismissal

### DIFF
--- a/src/playerInfo.cpp
+++ b/src/playerInfo.cpp
@@ -1192,3 +1192,4 @@ bool PlayerInfo::hasPlayerAtPosition(sp::ecs::Entity entity, CrewPosition positi
     }
     return false;
 }
+


### PR DESCRIPTION
This PR addresses an issue where customMessages were not being properly replicated to client systems as the functions object was not being marked dirty after being updated
