### PR TITLE
[#2705] Note that FSAA change requires restart

### DIFF
--- a/src/menus/optionsMenu.cpp
+++ b/src/menus/optionsMenu.cpp
@@ -217,6 +217,8 @@ void OptionsMenu::setupInterfaceOptions(OptionsMenu::ReturnTo return_to)
                 //Render default font is applied on back only
                 PreferencesManager::set("guitheme", theme_name);
             }))->setOptions(themes)->setSelectionIndex(default_index)->setSize(GuiElement::GuiSizeMax, 50);
+            (new GuiLabel(interface_left_column, "THEME_APPLICATION_LABEL", tr("Click Back to apply change"), 20.0f))
+                ->setSize(GuiElement::GuiSizeMax, 30.0f);
         }
     }
 
@@ -354,7 +356,13 @@ void OptionsMenu::setupGraphicsOptions()
         foreach(Window, window, windows) {
             window->setFSAA(fsaa[index]);
         }
-    }))->setOptions({ "FSAA: off", "FSAA: 2x", "FSAA: 4x", "FSAA: 8x" })->setSelectionIndex(fsaa_index)->setSize(GuiElement::GuiSizeMax, 50);
+    }))
+        ->setOptions({"FSAA: off", "FSAA: 2x", "FSAA: 4x", "FSAA: 8x"})
+        ->setSelectionIndex(fsaa_index)
+        ->setSize(GuiElement::GuiSizeMax, 50.0f);
+
+    (new GuiLabel(graphics_page, "THEME_APPLICATION_LABEL", tr("Restart EmptyEpsilon to apply FSAA change"), 20.0f))
+        ->setSize(GuiElement::GuiSizeMax, 30.0f);
 
     // FoV slider.
     auto initial_fov = PreferencesManager::get("main_screen_camera_fov", "60").toFloat();


### PR DESCRIPTION
daid/SeriousProton#292 implements multisampling when an FSAA option is selected, which requires resetting the OpenGL context. The easiest way to do this is to require a restart to apply the setting. Note this as a label beneath the FSAA option.

<img width="958" height="136" alt="Screenshot 2026-01-27 154706" src="https://github.com/user-attachments/assets/491fcec1-1d9b-49fb-a906-b1b866ab73c1" />

Before (FSAA off, or any FSAA setting without SP 292):

<img width="1542" height="619" alt="Screenshot 2026-01-27 153734" src="https://github.com/user-attachments/assets/46e7cc03-bcb5-422c-8be9-a8749850fd46" />
<img width="259" height="153" alt="image" src="https://github.com/user-attachments/assets/e6204ca7-24e6-4a80-8827-037da305aa3e" />

After (FSAA 8x with SP 292):

<img width="1543" height="618" alt="Screenshot 2026-01-27 153752" src="https://github.com/user-attachments/assets/76247408-ed92-426a-bd33-be604ba105ed" />
<img width="254" height="144" alt="image" src="https://github.com/user-attachments/assets/20458626-40e1-43f2-9dc5-720e288dac49" />