### PR TITLE
Add Transform, Physics components to GM tweaks menu

### DIFF
--- a/src/screens/gm/tweak.cpp
+++ b/src/screens/gm/tweak.cpp
@@ -373,6 +373,10 @@ GuiEntityTweak::GuiEntityTweak(GuiContainer* owner)
         };
     }
 
+    // Physics component
+    ADD_PAGE(tr("tweak-tab", "Physics"), sp::Physics);
+    // TODO: Figure out how to set Physics values
+
     ADD_PAGE(tr("tweak-tab", "Callsign"), CallSign);
     ADD_TEXT_TWEAK(tr("tweak-text", "Callsign:"), CallSign, callsign);
 


### PR DESCRIPTION
Add custom GM tweak controls for the Transform component's position and rotation properties.

<img width="1283" height="268" alt="image" src="https://github.com/user-attachments/assets/c005005a-20ca-44b9-8ed4-eb25238e06b7" />

Also add an empty Physics component page. Physics properties on ships are overridden (velocities) or rely on enums (shape, type) that aren't yet handled in this PR.