### PR TITLE
Render explosions on radar

### DIFF
--- a/src/systems/damage.cpp
+++ b/src/systems/damage.cpp
@@ -175,7 +175,9 @@ void DamageSystem::destroyedByDamage(sp::ecs::Entity entity, const DamageInfo& i
     if (auto transform = entity.getComponent<sp::Transform>()) {
         if (auto physics = entity.getComponent<sp::Physics>()) {
             auto e = sp::ecs::Entity::create();
-            e.addComponent<ExplosionEffect>().size = physics->getSize().x * 1.5f;
+            auto& ee = e.addComponent<ExplosionEffect>();
+            ee.size = physics->getSize().x * 1.5f;
+            ee.radar = true;
             e.addComponent<sp::Transform>(*transform);
             e.addComponent<RawRadarSignatureInfo>(0.0f, 0.4f, 0.4f);
         }

--- a/src/systems/energysystem.cpp
+++ b/src/systems/energysystem.cpp
@@ -60,7 +60,9 @@ void EnergySystem::update(float delta)
                 auto transform = entity.getComponent<sp::Transform>();
                 if (transform) {
                     auto e = sp::ecs::Entity::create();
-                    e.addComponent<ExplosionEffect>().size = 1000.0;
+                    auto& ee = e.addComponent<ExplosionEffect>();
+                    ee.size = 1000.0;
+                    ee.radar = true;
                     e.addComponent<sp::Transform>(*transform);
                     e.addComponent<RawRadarSignatureInfo>(0.0f, 0.4f, 0.4f);
 

--- a/src/systems/rendering.cpp
+++ b/src/systems/rendering.cpp
@@ -210,6 +210,17 @@ void ExplosionRenderSystem::update(float delta)
     }
 }
 
+void ExplosionRenderSystem::renderOnRadar(sp::RenderTarget& renderer, sp::ecs::Entity entity, glm::vec2 screen_position, float scale, float rotation, ExplosionEffect& explosion)
+{
+    if (!explosion.radar) return;
+
+    // Fade alpha over lifetime
+    uint8_t alpha = static_cast<uint8_t>(64.0f * explosion.lifetime / ExplosionEffect::max_lifetime);
+
+    // Draw electrical/EMP explosions blue, rest red
+    renderer.fillCircle(screen_position, explosion.size * scale, explosion.electrical ? glm::u8vec4(0, 0, 255, alpha) : glm::u8vec4(255, 0, 0, alpha));
+}
+
 void ExplosionRenderSystem::render3D(sp::ecs::Entity e, sp::Transform& transform, ExplosionEffect& ee)
 {
     float f = (1.0f - (ee.lifetime / ee.max_lifetime));

--- a/src/systems/rendering.h
+++ b/src/systems/rendering.h
@@ -6,6 +6,7 @@
 #include "components/collision.h"
 #include "components/rendering.h"
 #include "main.h"
+#include "systems/radar.h"
 #include <glm/geometric.hpp>
 
 template<typename COMPONENT, bool TRANSPARENT> class Render3DInterface {
@@ -90,11 +91,12 @@ public:
     void render3D(sp::ecs::Entity e, sp::Transform& transform, NebulaRenderer& nr) override;
 };
 
-class ExplosionRenderSystem : public sp::ecs::System, public Render3DInterface<ExplosionEffect, true>
+class ExplosionRenderSystem : public sp::ecs::System, public Render3DInterface<ExplosionEffect, true>, public RenderRadarInterface<ExplosionEffect, 15, RadarRenderSystem::FlagNone>
 {
 public:
     void update(float delta) override;
     void render3D(sp::ecs::Entity e, sp::Transform& transform, ExplosionEffect& ee) override;
+    void renderOnRadar(sp::RenderTarget& renderer, sp::ecs::Entity entity, glm::vec2 screen_position, float scale, float rotation, ExplosionEffect& explosion) override;
 };
 
 class BillboardRenderSystem : public sp::ecs::System, public Render3DInterface<BillboardRenderer, true>

--- a/src/systems/selfdestruct.cpp
+++ b/src/systems/selfdestruct.cpp
@@ -45,7 +45,9 @@ void SelfDestructSystem::update(float delta)
                     for(int n = 0; n < 5; n++)
                     {
                         auto e = sp::ecs::Entity::create();
-                        e.addComponent<ExplosionEffect>().size = self_destruct.size * 0.67f;
+                        auto& ee = e.addComponent<ExplosionEffect>();
+                        ee.size = self_destruct.size * 0.67f;
+                        ee.radar = true;
                         e.addComponent<sp::Transform>(*transform);
                         e.addComponent<RawRadarSignatureInfo>(0.0f, 0.6f, 0.6f);
                     }


### PR DESCRIPTION
Restore explosion rendering on radars as circles that fade out. This fixes a regression from legacy.

[Screencast_20260210_090522.webm](https://github.com/user-attachments/assets/fb07a286-aa77-4099-bda7-abc019ad40e2)
