### PR TITLE
Don't overwrite existing DockingPort component with setCanDock(true)

### DIFF
--- a/scripts/api/shipTemplate.lua
+++ b/scripts/api/shipTemplate.lua
@@ -577,11 +577,22 @@ function ShipTemplate:setCanHack(enabled)
     if enabled then self.hacking_device = {} else self.hacking_device = nil end
     return self
 end
---- Defines whether the "Request Docking" button appears on related crew screens in PlayerSpaceships created from this ShipTemplate.
---- Defaults to true.
+--- Defines whether the entity can dock with other entities.
+--- If true, adds an empty DockingPort component to the entity if it lacks one.
+--- If false, removes any existing DockingPort component, if any.
+--- To specify the entity's ship class for docking logic with DockingBays, use setClass() instead.
 --- Example: template:setCanDock(false)
 function ShipTemplate:setCanDock(enabled)
-    if enabled then self.docking_port = {} else self.docking_port = nil end
+    if enabled then
+        -- Don't overwrite an existing DockingPort component
+        if self.docking_port ~= nil then
+            return self
+        else
+            self.docking_port = {}
+        end
+    else
+        self.docking_port = nil
+    end
     return self
 end
 --- Defines whether combat maneuver controls appear on related crew screens in PlayerSpaceships created from this ShipTemplate.


### PR DESCRIPTION
When setting `ShipTemplate:setCanDock(true)` on a template that already has a DockingPort component, it overwrites the existing component with an empty DockingPort. This overrides any docking classes set by `setClass()`, or the auto missile reload enablement by `setClass()` or `setType()`.

Instead, set a DockingPort on `setCanDock(true)` only if the entity lacks a DockingPort.

Also, update the function docstring to be more specific about what it does in ECS, which has changed from legacy.