### PR TITLE
Fix broken isObjectType CpuShip checks

### DIFF
--- a/scripts/comms_scenario_utility.lua
+++ b/scripts/comms_scenario_utility.lua
@@ -244,7 +244,7 @@ function isObjectType(obj,typ)
 				elseif typ == "ScanProbe" then
 					return obj.components.allow_radar_link
 				elseif typ == "CpuShip" then
-					return obj.ai_controller
+					return obj.components.ai_controller
 				elseif typ == "Asteroid" then
 					return obj.components.mesh_render and string.sub(obj.components.mesh_render.mesh, 7) == "Astroid"
 				else

--- a/scripts/scenario_10_empty.lua
+++ b/scripts/scenario_10_empty.lua
@@ -78,7 +78,7 @@ function isObjectType(obj,typ,qualifier)
 				elseif typ == "ScanProbe" then
 					return obj.components.allow_radar_link
 				elseif typ == "CpuShip" then
-					return obj.ai_controller
+					return obj.components.ai_controller
 				elseif typ == "Asteroid" then
 					return obj.components.mesh_render and string.sub(obj.components.mesh_render.mesh, 7) == "Astroid"
 				elseif typ == "Nebula" then

--- a/scripts/scenario_34_cadet.lua
+++ b/scripts/scenario_34_cadet.lua
@@ -700,7 +700,7 @@ function isObjectType(obj,typ)
 				elseif typ == "ScanProbe" then
 					return obj.components.allow_radar_link
 				elseif typ == "CpuShip" then
-					return obj.ai_controller
+					return obj.components.ai_controller
 				elseif typ == "Asteroid" then
 					return obj.components.mesh_render and string.sub(obj.components.mesh_render.mesh, 7) == "Astroid"
 				else


### PR DESCRIPTION
Some, but not all, `isObjectType()` checks for `CpuShip`s had broken checks for AIController components:

```lua
elseif typ == "CpuShip" then
    return obj.ai_controller
```

Fix those checks:

```lua
elseif typ == "CpuShip" then
    return obj.components.ai_controller
```