### PR TITLE
Fix Ghost from the Past issues

### DIFF
--- a/scripts/scenario_07_gftp.lua
+++ b/scripts/scenario_07_gftp.lua
@@ -128,10 +128,10 @@ function commsNSA()
         _("NSA-comms", "Locate the infected Swarm Commander."),
         function()
             if (comms_target:getDescription() == _("scienceDescription-station", "Nosy Sensing Array, an old SIGINT platform. The signal is now crystal clear.")) then
-                setCommsMessage(string.format(_("NSA-comms", "With the parasite noise eliminated, locating the Hive signal is now easier. Its approximate heading is %d. With this information, it will be easier to track down the Swarm Commander."), find(35000, 53000, 20)))
+                setCommsMessage(string.format(_("NSA-comms", "With the parasite noise eliminated, locating the Hive signal is now easier. Its approximate heading is %.0f. With this information, it will be easier to track down the Swarm Commander."), find(35000, 53000, 20)))
                 comms_target:setDescription(_("scienceDescription-station", "Nosy Sensing Array, an old SIGINT platform. The Ktlitan Swarm Commander has been located."))
             else
-                setCommsMessage(string.format(_("NSA-comms", "The array picks up a very strong signal at approximate heading %d. However, it seems that you picked up a garbage emission that masks the Swarm Commander's emissions. This garbage noise must be taken offline if you want to find the Swarm Commander."), find(-10000, -20000, 20)))
+                setCommsMessage(string.format(_("NSA-comms", "The array picks up a very strong signal at approximate heading %.0f. However, it seems that you picked up a garbage emission that masks the Swarm Commander's emissions. This garbage noise must be taken offline if you want to find the Swarm Commander."), find(-10000, -20000, 20)))
             end
         end
     )


### PR DESCRIPTION
- Fix a broken `mission_timer` reset on `main_mission` 12
- Fix a `string.format` that breaks `commsNSA()`
- Remove the bespoke `distance()` function and include `utils.lua`
- Fix typos and inconsistencies in comms strings
- Make `ship` refs in spawn functions local, not global
- Use the `pi` global defined in the bespoke `find` function instead of ignoring it and hardcoding `3.14`