### PR TITLE
Add a null guard on my_player_info access

### DIFF
--- a/src/menus/shipSelectionScreen.cpp
+++ b/src/menus/shipSelectionScreen.cpp
@@ -634,7 +634,7 @@ void ShipSelectionScreen::update(float delta)
     player_ship_list->setVisible(player_ship_list->entryCount() > 0);
 
     // Sync our configured user name with the server
-    if (my_player_info->name != PreferencesManager::get("username"))
+    if (my_player_info && my_player_info->name != PreferencesManager::get("username"))
         my_player_info->commandSetName(PreferencesManager::get("username"));
 
     // Update the list of connected players


### PR DESCRIPTION
Add a null check for `my_player_info` to prevent a crash on accessing ShipSelectionScreen when my_player_info doesn't exist yet or was destroyed, which can intermittently occur when a proxy is in use.