### PR TITLE
While creating an entity on GM Screen, drag after click to set rotation

### DIFF
--- a/src/gameGlobalInfo.h
+++ b/src/gameGlobalInfo.h
@@ -7,6 +7,7 @@
 #include "multiplayer.h"
 #include <list>
 #include <functional>
+#include <optional>
 #include <unordered_map>
 
 
@@ -67,7 +68,7 @@ public:
     //Callback called when a new player ship is created on the ship selection screen.
     sp::script::Callback on_new_player_ship;
 
-    std::function<void(glm::vec2)> on_gm_click;
+    std::function<void(glm::vec2, std::optional<float>)> on_gm_click;
     const string DEFAULT_ON_GM_CLICK_CURSOR = "mouse_create.png";
     string on_gm_click_cursor = DEFAULT_ON_GM_CLICK_CURSOR;
 

--- a/src/screens/gm/gameMasterScreen.cpp
+++ b/src/screens/gm/gameMasterScreen.cpp
@@ -1,6 +1,7 @@
 #include "gameMasterScreen.h"
 #include "i18n.h"
 #include "main.h"
+#include "vectorUtils.h"
 #include "gui/mouseRenderer.h"
 #include "gameGlobalInfo.h"
 #include "objectCreationView.h"
@@ -483,7 +484,7 @@ void GameMasterScreen::onMouseDown(sp::io::Pointer::Button button, glm::vec2 pos
     {
         if (gameGlobalInfo->on_gm_click)
         {
-            gameGlobalInfo->on_gm_click(position);
+            click_and_drag_state = CD_CreateWithDrag;
         }else{
             click_and_drag_state = CD_ClickSelectOrBoxSelect;
 
@@ -676,6 +677,15 @@ void GameMasterScreen::onMouseUp(glm::vec2 position)
                         faction_selector->setSelectionIndex(n);
                 }
             }
+        }
+        break;
+    case CD_CreateWithDrag:
+        {
+            float min_drag_distance = main_radar->getDistance() / 450 * 10;
+            std::optional<float> rotation;
+            if (glm::length(position - drag_start_position) > min_drag_distance)
+                rotation = vec2ToAngle(position - drag_start_position);
+            gameGlobalInfo->on_gm_click(drag_start_position, rotation);
         }
         break;
     default:

--- a/src/screens/gm/gameMasterScreen.h
+++ b/src/screens/gm/gameMasterScreen.h
@@ -68,7 +68,8 @@ private:
         CD_ClickSelectOrBoxSelect,
         CD_BoxSelect,
         CD_ClickSelectOrDragObjects,
-        CD_DragObjects
+        CD_DragObjects,
+        CD_CreateWithDrag
     } click_and_drag_state;
     glm::vec2 drag_start_position{};
     glm::vec2 drag_previous_position{};

--- a/src/screens/gm/objectCreationView.cpp
+++ b/src/screens/gm/objectCreationView.cpp
@@ -88,15 +88,18 @@ GuiObjectCreationView::GuiObjectCreationView(GuiContainer* owner)
                         gameGlobalInfo->on_gm_click_cursor = gameGlobalInfo->DEFAULT_ON_GM_CLICK_CURSOR;
                     else
                         gameGlobalInfo->on_gm_click_cursor = info.icon;
-                    gameGlobalInfo->on_gm_click = [&info, this] (glm::vec2 position)
+                    gameGlobalInfo->on_gm_click = [&info, this] (glm::vec2 position, std::optional<float> rotation)
                     {
                         auto res = info.create_callback.call<sp::ecs::Entity>();
                         LuaConsole::checkResult(res);
                         if (res.isOk()) {
                             auto e = res.value();
-                            auto transform = e.getComponent<sp::Transform>();
-                            if (transform)
+                            if (auto transform = e.getComponent<sp::Transform>())
+                            {
                                 transform->setPosition(position);
+                                if (rotation)
+                                    transform->setRotation(*rotation);
+                            }
                             if (auto faction = e.getComponent<Faction>()) {
                                 for(auto [entity, info] : sp::ecs::Query<FactionInfo>()) {
                                     if (info.name == faction_selector->getSelectionValue())

--- a/src/script/gm.cpp
+++ b/src/script/gm.cpp
@@ -47,7 +47,7 @@ static int lua_getGMSelection(lua_State* L)
 static void lua_onGMClick(sp::script::Callback callback, string icon = gameGlobalInfo->DEFAULT_ON_GM_CLICK_CURSOR)
 {
     if (callback) {
-        gameGlobalInfo->on_gm_click=[callback](glm::vec2 position) mutable {
+        gameGlobalInfo->on_gm_click=[callback](glm::vec2 position, std::optional<float>) mutable {
             auto res = callback.call<void>(position.x, position.y);
             LuaConsole::checkResult(res);
         };


### PR DESCRIPTION
While the Create menu is actively creating entities on the GM Screen, clicking and dragging the mouse will set the created entity's rotation to face the direction of the drag.

Behavior of single-click without drag is the same (random rotation).

[Screencast_20260222_024335.webm](https://github.com/user-attachments/assets/d11377fb-7b5a-4acd-aa87-b76c597dc14f)
