### PR TITLE
Document Empty space, add entity examples

### DIFF
--- a/scripts/scenario_10_empty.lua
+++ b/scripts/scenario_10_empty.lua
@@ -1,37 +1,105 @@
 -- Name: Empty space
--- Description: Empty scenario, no enemies, no friendlies. Can be used by a GM player to setup a scenario in the GM screen. The F5 key can be used to copy the current layout to the clipboard for use in scenario scripts.
+-- Description: Empty scenario with no ships or terrain. Game masters can use this to set up a scenario in the GM screen. Use the F5 key or "Copy scenario" and "Copy selection" buttons on the GM screen to copy Lua code of the layout to the clipboard for use in scenario scripts.
 -- Type: Development
 
 --- Scenario
 -- @script scenario_10_empty
 
+-- Add functions from utils.lua, particularly isObjectType()
+require("utils.lua")
+
 function init()
-	ECS = false
-	if createEntity then
-		ECS = true
-	end
-    --SpaceStation():setPosition(1000, 1000):setTemplate('Small Station'):setFaction("Human Navy"):setRotation(random(0, 360))
-    --SpaceStation():setPosition(-1000, 1000):setTemplate('Medium Station'):setFaction("Human Navy"):setRotation(random(0, 360))
-    --SpaceStation():setPosition(1000, -1000):setTemplate('Large Station'):setFaction("Human Navy"):setRotation(random(0, 360))
-    --SpaceStation():setPosition(-1000, -1000):setTemplate('Huge Station'):setFaction("Human Navy"):setRotation(random(0, 360))
-    --player1 = PlayerSpaceship():setFaction("Human Navy"):setTemplate("Atlantis"):setRotation(200)
-    --player2 = PlayerSpaceship():setFaction("Human Navy"):setTemplate("Atlantis"):setRotation(0)
-    --Nebula():setPosition(-5000, 0)
-    --Artifact():setPosition(1000, 9000):setModel("small_frigate_1"):setDescription(_("scienceDescription-artifact", "An old space derelict."))
+    -- Check if EE is running the ECS branch (true) or the legacy branch false.
+    ECS = createEntity ~= nil
+
+    --[[
+    Several example entities follow. Remove the comments from these examples, or copy and paste them onto new lines, to add them to the scenario.
+
+    For more a detailed scripting reference, see the script_reference.html file included with your EmptyEpsilon install. For a tutorial, see https://daid.github.io/EmptyEpsilon/#tabs=4.
+    ]]--
+
+    -- Example entities:
+
+    --[[ Create a small Human Navy space station at coordinates 1000, 10000 with a random rotation:
+
+    SpaceStation()
+        :setPosition(2000, 2000)
+        :setTemplate("Small Station")
+        :setFaction("Human Navy")
+        :setRotation(random(0, 360))
+    ]]--
+    --SpaceStation():setPosition(-2000, 2000):setTemplate("Medium Station"):setFaction("Human Navy"):setRotation(random(0, 360))
+    --SpaceStation():setPosition(2000, -2000):setTemplate("Large Station"):setFaction("Human Navy"):setRotation(random(0, 360))
+    --SpaceStation():setPosition(-2000, -2000):setTemplate("Huge Station"):setFaction("Human Navy"):setRotation(random(0, 360))
+
+    --[[ Create a player Atlantis ship of the Human Navy faction. Place it at coordinates 100, 100 with a heading of 270 (facing west). Set its callsign to "Player 1". Assign it to the Lua variable player1.
+
+    player1 = PlayerSpaceship()
+        :setTemplate("Atlantis")
+        :setFaction("Human Navy")
+        :setPosition(-250, 100)
+        :setHeading(270)
+        :setCallSign(_("Player 1"))
+    ]]--
+    --player2 = PlayerSpaceship():setFaction("Human Navy"):setTemplate("Atlantis"):setPosition(250, 100):setHeading(0):setCallSign(_("Player 2"))
+
+    --[[ Create an AI-controlled Adder MK5 ship of the Human Navy faction. Place it at coordinates 0, 0 with a heading of 90 (facing east). Set its callsign to "Friendly 1" and its orders to "Defend location" at coordinates 0, 0. Assign it to the Lua variable defender.
+
+    defender = CpuShip()
+        :setTemplate("Adder MK5")
+        :setFaction("Human Navy")
+        :setPosition(0, -100)
+        :setHeading(90)
+        :setCallSign(_("Friendly 1"))
+    defender:orderDefendLocation(0, 0)
+    ]]--
+    --CpuShip():setTemplate("Piranha F12"):setFaction("Kraylor"):setPosition(10000, 0):setHeading(270):setCallSign(_("Hostile 1")):orderFlyTowards(0, 0)
+
+    --[[ Create a wormhole that teleports entities that enter its center to coordinates within 0.1U^2 of 0, 0.
+
+    WormHole()
+        :setTargetPosition(random(-100, 100), random(-100, 100))
+        :onTeleportation(function(this_wormhole,teleported_object) print(teleported_object:getCallSign() .. " teleported to " .. this_wormhole:getTargetPosition()) end)
+        :setPosition(-15000, 15000)
+    ]]--
+    --Nebula():setPosition(-15000, -15000)
+    --BlackHole():setPosition(15000, -15000)
+
+    --[[ Create an artifact that uses the small_frigate_1 model. Place it at coordinates 1000, 9000 and add a localizable description that appears on the Science scanner.
+
+    Artifact()
+        :setModel("small_frigate_1")
+        :setPosition(1000, 9000)
+        :setDescription(_("scienceDescription-artifact", "An old space derelict."))
+    ]]--
     --Artifact():setPosition(9000, 2000):setModel("small_frigate_1"):setDescription(_("scienceDescription-artifact", "A wrecked ship."))
     --Artifact():setPosition(3000, 4000):setModel("small_frigate_1"):setDescription(_("scienceDescription-artifact", "Tons of rotting plasteel."))
-    --addGMFunction(_("buttonGM", "move 1 to 2"), function() player1:transferPlayersToShip(player2) end)
-    --addGMFunction(_("buttonGM", "move 2 to 1"), function() player2:transferPlayersToShip(player1) end)
-    --CpuShip():setTemplate("Adder MK5"):setPosition(0, 0):setRotation(0):setFaction("Human Navy")
-    --CpuShip():setTemplate("Piranha F12"):setPosition(2000, 0):setRotation(-90):setFaction("Kraylor")
-    local planet1 = Planet():setPosition(5000, 5000):setPlanetRadius(3000):setDistanceFromMovementPlane(-2000):setPlanetSurfaceTexture("planets/planet-1.png"):setPlanetCloudTexture("planets/clouds-1.png"):setPlanetAtmosphereTexture("planets/atmosphere.png"):setPlanetAtmosphereColor(0.2, 0.2, 1.0)
-    local moon1 = Planet():setPosition(5000, 0):setPlanetRadius(1000):setDistanceFromMovementPlane(-2000):setPlanetSurfaceTexture("planets/moon-1.png"):setAxialRotationTime(20.0)
-    local sun1 = Planet():setPosition(5000, 15000):setPlanetRadius(1000):setDistanceFromMovementPlane(-2000):setPlanetAtmosphereTexture("planets/star-1.png"):setPlanetAtmosphereColor(1.0, 1.0, 1.0)
-    planet1:setOrbit(sun1, 40)
-    moon1:setOrbit(planet1, 20.0)
 
+    --[[ Create a planet at coordinates 5000, 5000 with a 3U radius positioned 2U below the movement plane. Set its surface, cloud, and atmosphere textures from images in EmptyEpsilon's resources/planets directory. Set the atmosphere color to a shade of blue (red 20%, green 20%, blue 100%). Assign it to the local variable planet1.
+
+    local planet1 = Planet()
+        :setPosition(5000, 5000)
+        :setPlanetRadius(3000)
+        :setDistanceFromMovementPlane(-2000)
+        :setPlanetSurfaceTexture("planets/planet-1.png")
+        :setPlanetCloudTexture("planets/clouds-1.png")
+        :setPlanetAtmosphereTexture("planets/atmosphere.png")
+        :setPlanetAtmosphereColor(0.2, 0.2, 1.0)
+    ]]--
+    --local moon1 = Planet():setPosition(5000, 0):setPlanetRadius(1000):setDistanceFromMovementPlane(-2000):setPlanetSurfaceTexture("planets/moon-1.png"):setAxialRotationTime(20.0)
+    --local sun1 = Planet():setPosition(5000, 15000):setPlanetRadius(1000):setDistanceFromMovementPlane(-2000):setPlanetAtmosphereTexture("planets/star-1.png"):setPlanetAtmosphereColor(1.0, 1.0, 1.0)
+
+    --[[ Set the planet assigned to local variable planet 1 to orbit around the sun (assigned to local variable sun1) once every 40 seconds. Set the moon assigned to local variable moon1 to orbit around planet1 every 20 seconds
+
+    planet1:setOrbit(sun1, 40)
+    moon1:setOrbit(planet1, 20)
+    ]]--
+
+    -- Example GM functions:
+
+    -- Delete all entities except for player ships, and generate a new 100U^2 field of 2,000 randomly placed asteroids centered around coordinates 0, 0. Move the player ships to coordinates near 0, 0. Spawn half of the asteroids on the same movement plane as ships and the other half as decoration above and below the plane.
     addGMFunction(
-        _("buttonGM", "Random asteroid field"),
+        _("buttonGM", "Reset to asteroids"),
         function()
             cleanup()
             for n = 1, 1000 do
@@ -40,8 +108,9 @@ function init()
             end
         end
     )
+    -- Delete all entities except for player ships, and generate a new 100U^2 field of 50 randomly placed nebulae centered around coordinates 0, 0. Move the player ships to coordinates near 0, 0.
     addGMFunction(
-        _("buttonGM", "Random nebula field"),
+        _("buttonGM", "Reset to nebulae"),
         function()
             cleanup()
             for n = 1, 50 do
@@ -49,6 +118,7 @@ function init()
             end
         end
     )
+    -- Delete all entities not currently selected on the GM screen.
     addGMFunction(
         _("buttonGM", "Delete unselected"),
         function()
@@ -67,78 +137,12 @@ function init()
         end
     )
 end
-function isObjectType(obj,typ,qualifier)
-	if obj ~= nil and obj:isValid() then
-		if typ ~= nil then
-			if ECS then
-				if typ == "SpaceStation" then
-					return obj.components.docking_bay and obj.components.physics and obj.components.physics.type == "static"
-				elseif typ == "PlayerSpaceship" then
-					return obj.components.player_control
-				elseif typ == "ScanProbe" then
-					return obj.components.allow_radar_link
-				elseif typ == "CpuShip" then
-					return obj.components.ai_controller
-				elseif typ == "Asteroid" then
-					return obj.components.mesh_render and string.sub(obj.components.mesh_render.mesh, 7) == "Astroid"
-				elseif typ == "Nebula" then
-					return obj.components.nebula_renderer
-				elseif typ == "Planet" then
-					return obj.components.planet_render
-				elseif typ == "SupplyDrop" then
-					return obj.components.pickup and obj.components.radar_trace.icon == "radar/blip.png" and obj.components.radar_trace.color_by_faction
-				elseif typ == "BlackHole" then
-					return obj.components.gravity and obj.components.billboard_render.texture == "blackHole3d.png"
-				elseif typ == "WarpJammer" then
-					return obj.components.warp_jammer
-				elseif typ == "Mine" then
-					return obj.components.delayed_explode_on_touch and obj.components.constant_particle_emitter
-				elseif typ == "EMPMissile" then
-					return obj.components.radar_trace.icon == "radar/missile.png" and obj.components.explode_on_touch.damage_type == "emp"
-				elseif typ == "Nuke" then
-					return obj.components.radar_trace.icon == "radar/missile.png" and obj.components.explosion_sfx == "sfx/nuke_explosion.wav"
-				elseif typ == "Zone" then
-					return obj.components.zone
-				else
-					if qualifier == "MovingMissile" then
-						if typ == "HomingMissile" or typ == "HVLI" or typ == "Nuke" or typ == "EMPMissile" then
-							return obj.components.radar_trace.icon == "radar/missile.png"
-						else
-							return false
-						end
-					elseif qualifier == "SplashMissile" then
-						if typ == "Nuke" or typ == "EMPMissile" then
-							if obj.components.radar_trace.icon == "radar/missile.png" then
-								if typ == "Nuke" then
-									return obj.components.explosion_sfx == "sfx/nuke_explosion.wav"
-								else	--EMP
-									return obj.components.explode_on_touch.damage_type == "emp"
-								end
-							else
-								return false
-							end
-						else
-							return false
-						end
-					else
-						return false
-					end
-				end
-			else
-				return obj.typeName == typ
-			end
-		else
-			return false
-		end
-	else
-		return false
-	end
-end
+
+-- Clean up the current play field. Find all objects and destroy everything that is not a player ship.
+-- If it is a player ship, position it near the center of the play field.
 function cleanup()
-    -- Clean up the current play field. Find all objects and destroy everything that is not a player.
-    -- If it is a player, position him in the center of the scenario.
     for idx, obj in ipairs(getAllObjects()) do
-        if isObjectType(obj,"PlayerSpaceship") then
+        if isObjectType(obj, "PlayerSpaceship") then
             obj:setPosition(random(-100, 100), random(-100, 100))
         else
             obj:destroy()
@@ -147,18 +151,17 @@ function cleanup()
 end
 
 function update(delta)
-    -- No victory condition
+    -- No victory condition, continue indefinitely
 end
 
--- Set callback function
+-- Set a callback function to run whenever a player ship is created.
 onNewPlayerShip(
     function(ship)
-        -- Decide what you do with new ships:
+        -- Print the new ship's callsign.
         if ECS then
-        	print(ship, ship:getTypeName(), ship:getCallSign())
+            print(ship, ship:getTypeName(), ship:getCallSign())
         else
-	        print(ship, ship.typeName, ship:getTypeName(), ship:getCallSign())
-	    end
-        -- ship:destroy()
+            print(ship, ship.typeName, ship:getTypeName(), ship:getCallSign())
+        end
     end
 )


### PR DESCRIPTION
- Add comments to example entities and GM functions to beginners.
- Use setHeading() instead of setRotation() for ships.
- Add orders to CpuShip examples.
- Add WormHole and BlackHole terrain examples.
- Comment out the planet, sun, and moon entities.
- Improve button text on GM functions that reset the scenario.
- Require utils.lua and remove its bespoke isObjectType() function.
- Consistently indent code using 4 spaces, instead of a mix of tab characters, 2 spaces, and 4 spaces.