### PR TITLE
Expose JumpDrive just_jumped to scripting

### DIFF
--- a/src/script/components.cpp
+++ b/src/script/components.cpp
@@ -587,7 +587,8 @@ void initComponentScriptBindings()
     BIND_MEMBER(JumpDrive, charge);
     BIND_MEMBER(JumpDrive, distance);
     BIND_MEMBER(JumpDrive, delay);
-    
+    BIND_MEMBER(JumpDrive, just_jumped);
+
     sp::script::ComponentHandler<MissileTubes>::name("missile_tubes");
     BIND_SHIP_SYSTEM(MissileTubes);
     BIND_MEMBER_NAMED(MissileTubes, storage[int(MW_Homing)], "storage_homing");


### PR DESCRIPTION
Expose the JumpDrive component's just_jumped member to scripting, to either override or force a post-jump drive effect.