### PR TITLE
Add visual and hardware effects for gravity system

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -424,6 +424,8 @@ set(MAIN_SOURCES
     src/systems/scanning.cpp
     src/systems/planet.h
     src/systems/planet.cpp
+    src/systems/player.h
+    src/systems/player.cpp
     src/systems/gm.h
     src/systems/gm.cpp
     src/systems/radar.h

--- a/scripts/api/entity/blackhole.lua
+++ b/scripts/api/entity/blackhole.lua
@@ -10,7 +10,7 @@ function BlackHole()
     e.components = {
         transform = {},
         never_radar_blocked = {},
-        gravity = {range=5000, damage=true},
+        gravity = {range=5000, damage=true, visual_effect=true},
         avoid_object = {range=7000},
         radar_signature = {gravity=0.9},
         radar_trace = {icon="radar/blackHole.png", min_size=0, max_size = 2048, radius=5000},
@@ -24,13 +24,14 @@ end
 --- Any SpaceObject that reaches its center is teleported to another point in space.
 --- AI behaviors avoid WormHoles by a 2U margin.
 --- Example: wormhole = WormHole():setPosition(1000,1000):setTargetPosition(10000,10000)
+--- @type creation
 function WormHole()
     local e = createEntity()
     local radius = 2500
     e.components = {
         transform = {},
         never_radar_blocked = {},
-        gravity = {range=radius, damage=false},
+        gravity = {range=radius, damage=false, visual_effect=true},
         avoid_object = {range=radius*1.2},
         radar_signature = {gravity=0.9},
         radar_trace = {icon="radar/wormHole.png", min_size=0, max_size=2048, radius=radius},

--- a/src/components/gravity.h
+++ b/src/components/gravity.h
@@ -10,6 +10,7 @@ public:
     float range = 5000.0f;
     float force = 50.0f;
     bool damage = false;
+    bool visual_effect = false;
 
     glm::vec2 wormhole_target{};
     sp::script::Callback on_teleportation;

--- a/src/components/player.h
+++ b/src/components/player.h
@@ -44,6 +44,12 @@ public:
     string control_code;
 
     CrewPositions allowed_positions = CrewPositions::all();
+
+    float gravity_alpha = 0.0f; //[output] used for visual effect going through a wormhole.
+
+    float just_teleported = 0.0f; //[output] used for triggers after going through a wormhole.
+
+    float in_gravity = 0.0f; //[output] used when in a gravity well.
 };
 
 class Waypoints

--- a/src/hardware/hardwareController.cpp
+++ b/src/hardware/hardwareController.cpp
@@ -404,6 +404,9 @@ bool HardwareController::getVariableValue(string variable_name, float& value)
     SHIP_VARIABLE("RedAlert", PlayerControl, c->alert_level != AlertLevel::RedAlert ? 1.0f : 0.0f);
     SHIP_VARIABLE("SelfDestruct", SelfDestruct, c->active ? 1.0f : 0.0f);
     SHIP_VARIABLE("SelfDestructCountdown", SelfDestruct, c->countdown / 10.0f);
+    SHIP_VARIABLE("Gravity", PlayerControl, c->in_gravity * 100);
+    SHIP_VARIABLE("Teleported", PlayerControl, c->just_teleported > 0.0f ? 1.0f : 0.0f);
+
     for(unsigned int n=0; n<16; n++)
     {
         SHIP_VARIABLE("TubeLoaded" + string(n), MissileTubes, c->mounts.size() > n && c->mounts[n].state == MissileTubes::MountPoint::State::Loaded ? 1.0f : 0.0f);

--- a/src/init/ecs.cpp
+++ b/src/init/ecs.cpp
@@ -67,6 +67,7 @@
 #include "systems/gm.h"
 #include "systems/pickup.h"
 #include "systems/debugrender.h"
+#include "systems/player.h"
 
 
 void initSystemsAndComponents()
@@ -164,6 +165,7 @@ void initSystemsAndComponents()
     engine->registerSystem<ZoneSystem>();
     engine->registerSystem<GMRadarRender>();
     engine->registerSystem<PickupSystem>();
+    engine->registerSystem<PlayerSystem>();
 #ifdef DEBUG
     engine->registerSystem<DebugRenderSystem>();
 #endif

--- a/src/screenComponents/indicatorOverlays.cpp
+++ b/src/screenComponents/indicatorOverlays.cpp
@@ -9,6 +9,7 @@
 #include "components/jumpdrive.h"
 #include "components/shields.h"
 #include "components/hull.h"
+#include "components/player.h"
 #include "multiplayer_server.h"
 #include "i18n.h"
 
@@ -92,14 +93,21 @@ void GuiIndicatorOverlays::onDraw(sp::RenderTarget& renderer)
     {
         auto jump = my_spaceship.getComponent<JumpDrive>();
         auto warp = my_spaceship.getComponent<WarpDrive>();
+        auto player = my_spaceship.getComponent<PlayerControl>();
         if (jump && jump->just_jumped > 0.0f)
         {
             glitchPostProcessor->enabled = true;
             glitchPostProcessor->setUniform("u_magtitude", jump->just_jumped * 10.0f);
             glitchPostProcessor->setUniform("u_delta", random(0, 360));
-        }else{
+        } else if (player && player->gravity_alpha > 0.0f)
+        {
+            glitchPostProcessor->enabled = true;
+            glitchPostProcessor->setUniform("u_magtitude", player->gravity_alpha * 10.0f);
+            glitchPostProcessor->setUniform("u_delta", random(0, 360));
+        } else{
             glitchPostProcessor->enabled = false;
         }
+
         if (warp && warp->current > 0.0f && PreferencesManager::get("warp_post_processor_disable").toInt() != 1)
         {
             warpPostProcessor->enabled = true;

--- a/src/script/components.cpp
+++ b/src/script/components.cpp
@@ -651,6 +651,9 @@ void initComponentScriptBindings()
     BIND_MEMBER(PlayerControl, alert_level);
     BIND_MEMBER(PlayerControl, control_code);
     BIND_MEMBER(PlayerControl, allowed_positions);
+    BIND_MEMBER(PlayerControl, gravity_alpha);
+    BIND_MEMBER(PlayerControl, in_gravity);
+    BIND_MEMBER(PlayerControl, just_teleported);
     sp::script::ComponentHandler<HackingDevice>::name("hacking_device");
     BIND_MEMBER(HackingDevice, effectiveness);
     sp::script::ComponentHandler<ShipLog>::name("ship_log");
@@ -707,6 +710,7 @@ void initComponentScriptBindings()
     BIND_MEMBER(Gravity, range);
     BIND_MEMBER(Gravity, force);
     BIND_MEMBER(Gravity, damage);
+    BIND_MEMBER(Gravity, visual_effect);
     BIND_MEMBER(Gravity, wormhole_target);
     BIND_MEMBER(Gravity, on_teleportation);
 

--- a/src/systems/gravity.cpp
+++ b/src/systems/gravity.cpp
@@ -1,6 +1,7 @@
 #include "systems/gravity.h"
 #include "components/gravity.h"
 #include "components/collision.h"
+#include "components/player.h"
 #include "components/hull.h"
 #include "systems/collision.h"
 #include "systems/damage.h"
@@ -15,6 +16,7 @@ void GravitySystem::update(float delta)
 {
     static constexpr float max_force = 10000.0f;
     static constexpr float wormhole_target_spread = 500.0f;
+    static constexpr float max_gravity_alpha = 2.0f;
     if (delta <= 0.0f) return;
 
     for(auto [source, grav, source_transform] : sp::ecs::Query<Gravity, sp::Transform>()) {
@@ -30,13 +32,20 @@ void GravitySystem::update(float delta)
                 force = max_force;
             tt->setPosition(tt->getPosition() + diff / std::sqrt(dist2) * delta * force);
 
-            if (grav.wormhole_target.x || grav.wormhole_target.y) {
-                /*TODO
-                // Warp postprocessor-alpha is calculated using alpha = (1 - (delay/10))
-                if (spaceship)
-                    spaceship->wormhole_alpha = ((distance / grav.range) * ALPHA_MULTIPLIER);
-                */
+            auto player = target.getComponent<PlayerControl>();
+            if (player)
+            {
+                player->in_gravity = (1 - (dist2 / (grav.range * grav.range)));
+                if (grav.visual_effect)
+                {
+                    // Apply glitch effect that gets stronger the closer to the center of the gravity system
+                    player->gravity_alpha = ((1 - (dist2 / (grav.range * grav.range))) * max_gravity_alpha);
+                }
 
+            }
+
+
+            if (grav.wormhole_target.x || grav.wormhole_target.y) {
                 if (force >= max_force)
                 {
                     if (game_server) {
@@ -46,8 +55,10 @@ void GravitySystem::update(float delta)
                             LuaConsole::checkResult(grav.on_teleportation.call<void>(source, target));
                             continue; //callback could destroy the entity, so do no extra processing.
                         }
-                        //if (spaceship)
-                        //    spaceship->wormhole_alpha = 0.0;
+                        if (player)
+                            // set just_teleported for use by hardware
+                            player->just_teleported = 2.0f;
+                            player->in_gravity = 0.0f;
                     }
                 }
             }

--- a/src/systems/player.cpp
+++ b/src/systems/player.cpp
@@ -1,0 +1,18 @@
+#include "systems/player.h"
+#include "components/player.h"
+#include "ecs/query.h"
+
+void PlayerSystem::update(float delta)
+{
+    if (delta <= 0.0f) return;
+    for(auto [entity, player] : sp::ecs::Query<PlayerControl>())
+    {
+        // Decrease wormhole visual effects
+        if (player.gravity_alpha > 0.0f)
+            player.gravity_alpha -= delta;
+
+        // Decrease post-wormhole teleport
+        if (player.just_teleported > 0.0f)
+            player.just_teleported -= delta;
+    }
+}

--- a/src/systems/player.h
+++ b/src/systems/player.h
@@ -1,0 +1,10 @@
+#pragma once
+
+#include "ecs/system.h"
+
+
+class PlayerSystem : public sp::ecs::System
+{
+public:
+    void update(float delta) override;
+};


### PR DESCRIPTION
This change adds visual and hardware effects to the Gravity Component/System.  
 
`gravity` components get a new field , boolean: `visual_effect`, which determines if a player ship should have the glitch postprocessor applied when in the gravity well of the entity. 
this  was added to the lua helper functions for Wormholes and Blackholes

`player_control` components get new fields:
* float: `gravity_alpha` - how much visual glitch should be applied
* float: `in_gravity` - 0-1 value of how close to the center of a gravity component the entity is
* float `just_teleported` - like`just_jumped`, but for wormhole teleportation

new `PlayerSystem` that provides a countdown to pull `gravity_alpha` and `just_teleported` back to 0 over time

new DMX/Hardware states:
`Gravity` 0-100, how close to the center of a gravity component-having entity the player ship is
`Teleported` 0 / 1, 1 for about 1 second after a Wormhole teleport (same logic as `Jumped`)

Youtube demo:
[![Demonstration of Wormhole Glitch Effect](https://img.youtube.com/vi/E8Iw7yP4b6U/0.jpg)](https://www.youtube.com/watch?v=E8Iw7yP4b6U)
