### PR TITLE
Fix -Wformat-security complaint about headless error reporting

### DIFF
--- a/src/gameGlobalInfo.cpp
+++ b/src/gameGlobalInfo.cpp
@@ -381,7 +381,7 @@ void GameGlobalInfo::startScenario(string filename, std::unordered_map<string, s
             main_script_error_count = max_repeated_script_errors;
             const string error_message = "init() function failed, not going to call update()";
             if (is_headless)
-                printf(error_message.c_str());
+                printf("%s", error_message.c_str());
             else
                 LuaConsole::addLog(error_message);
         }


### PR DESCRIPTION
Strict builds fail on a `-Wformat-security` warning:

```
gameGlobalInfo.cpp:384:24: error: format string is not a string literal (potentially insecure) [-Werror,-Wformat-security]
                    printf(error_message.c_str());
                           ^~~~~~~~~~~~~~~~~~~~~
gameGlobalInfo.cpp:384:24: note: treat the string as an argument to avoid this
                    printf(error_message.c_str());
                           ^
                           "%s",
```

Add a format string literal.