### PR TITLE
Revert #2494, #2667 for reducing mouse precision

### DIFF
--- a/src/screens/crew6/relayScreen.cpp
+++ b/src/screens/crew6/relayScreen.cpp
@@ -204,12 +204,6 @@ RelayScreen::RelayScreen(GuiContainer* owner, bool allow_comms)
     }
 }
 
-RelayScreen::~RelayScreen()
-{
-    if (P<MouseRenderer> mouse_renderer = engine->getObject("mouseRenderer"))
-        mouse_renderer->setSpriteImage("mouse.png");
-}
-
 void RelayScreen::onDraw(sp::RenderTarget& renderer)
 {
     ///Handle mouse wheel
@@ -333,21 +327,4 @@ void RelayScreen::onDraw(sp::RenderTarget& renderer)
     }
 
     delete_waypoint_button->setEnable(targets.getWaypointIndex() >= 0);
-
-    if (P<MouseRenderer> mouse_renderer = engine->getObject("mouseRenderer"))
-    {
-        switch(mode)
-        {
-        case TargetSelection:
-        case MoveWaypoint:
-            mouse_renderer->setSpriteImage("mouse.png");
-            break;
-        case WaypointPlacement:
-            mouse_renderer->setSpriteImage("waypoint.png");
-            break;
-        case LaunchProbe:
-            mouse_renderer->setSpriteImage("radar/probe.png");
-            break;
-        }
-    }
 }

--- a/src/screens/crew6/relayScreen.h
+++ b/src/screens/crew6/relayScreen.h
@@ -47,7 +47,6 @@ private:
     glm::vec2 mouse_down_position{};
 public:
     RelayScreen(GuiContainer* owner, bool allow_comms);
-    virtual ~RelayScreen();
 
     virtual void onDraw(sp::RenderTarget& target) override;
 };

--- a/src/screens/gm/gameMasterScreen.cpp
+++ b/src/screens/gm/gameMasterScreen.cpp
@@ -2,7 +2,6 @@
 #include "i18n.h"
 #include "main.h"
 #include "vectorUtils.h"
-#include "gui/mouseRenderer.h"
 #include "gameGlobalInfo.h"
 #include "objectCreationView.h"
 #include "globalMessageEntryView.h"
@@ -259,10 +258,9 @@ GameMasterScreen::GameMasterScreen(RenderLayer* render_layer)
     gameGlobalInfo->on_gm_click = nullptr;
 }
 
-//due to a suspected compiler bug this deconstructor needs to be explicitly defined
+// Due to a suspected compiler bug this deconstructor needs to be explicitly defined
 GameMasterScreen::~GameMasterScreen()
 {
-    if (P<MouseRenderer> mouse_renderer = engine->getObject("mouseRenderer")) mouse_renderer->setSpriteImage("mouse.png");
 }
 
 void GameMasterScreen::update(float delta)
@@ -443,32 +441,16 @@ void GameMasterScreen::update(float delta)
         message_frame->hide();
     }
 
-    P<MouseRenderer> mouse_renderer = engine->getObject("mouseRenderer");
-
     if (gameGlobalInfo->on_gm_click)
     {
         create_button->hide();
         object_creation_view->hide();
         cancel_action_button->show();
-        if (mouse_renderer)
-        {
-            if (gameGlobalInfo->on_gm_click_cursor == "")
-                mouse_renderer->setSpriteImage(gameGlobalInfo->DEFAULT_ON_GM_CLICK_CURSOR);
-            else
-                mouse_renderer->setSpriteImage(gameGlobalInfo->on_gm_click_cursor);
-        }
     }
     else
     {
         create_button->show();
         cancel_action_button->hide();
-        if (mouse_renderer)
-        {
-            if (SDL_GetModState() & KMOD_CTRL) mouse_renderer->setSpriteImage("mouse_ship.png");
-            else if (SDL_GetModState() & KMOD_ALT) mouse_renderer->setSpriteImage("mouse_faction.png");
-            else if (SDL_GetModState() & KMOD_SHIFT) mouse_renderer->setSpriteImage("mouse_add.png");
-            else mouse_renderer->setSpriteImage("mouse.png");
-        }
     }
 }
 


### PR DESCRIPTION
Revert modal mouse cursor implementations per feedback that it reduces precision. This is a prerequisite to a proper fix that uses #2753 to allow cursor resizing and arbitrary placement of the cursor hotspot within the cursor sprite.