### PR TITLE
Compile tweak.cpp with /bigobj on MSVC to fix COFF limit error

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -701,6 +701,11 @@ if(WIN32)
     endif()
 endif()
 
+if(MSVC)
+    # tweak.cpp exceeds the default COFF section limit
+    set_source_files_properties(src/screens/gm/tweak.cpp PROPERTIES COMPILE_FLAGS "/bigobj")
+endif()
+
 set_target_properties(${PROJECT_NAME}
     PROPERTIES
         MACOSX_BUNDLE_INFO_PLIST ${CMAKE_SOURCE_DIR}/osx/MacOSXBundleInfo.plist.in


### PR DESCRIPTION
On at least MSVC 14.50.35717, EE builds can fail with an error while compiling tweak.cpp:

    fatal error C1128: number of sections exceeded object file
    format limit: compile with /bigobj

This commit adds a section to CMakeLists.txt to compile tweak.cpp with this flag when using MSVC.

Per [the docs](https://learn.microsoft.com/en-us/cpp/build/reference/bigobj-increase-number-of-sections-in-dot-obj-file?view=msvc-170), MSVC's default limit is 65,279 (~16-bit unsigned integer) common object file format (COFF) sections per .obj file, and the number of templates instantiating sections in this file is near or at that limit.

The `/bigobj` flag raises the COFF section limit to about 4 billion (32-bit unsigned integer). Alternatives would be to either split tweak.cpp into per-component units or enable `/bigobj` across the project in MSVC.

GCC and MinGW don't limit COFF sections, so they aren't affected.