### PR TITLE
Reduce length of Break for DMX serial connection, add config for delay for enttec devices

### DIFF
--- a/src/hardware/devices/enttecDMXProDevice.cpp
+++ b/src/hardware/devices/enttecDMXProDevice.cpp
@@ -8,6 +8,7 @@ EnttecDMXProDevice::EnttecDMXProDevice()
     for(int n=0; n<512; n++)
         channel_data[n] = 0;
     channel_count = 512;
+    resend_delay = 25;
 }
 
 EnttecDMXProDevice::~EnttecDMXProDevice()
@@ -36,6 +37,10 @@ bool EnttecDMXProDevice::configure(std::unordered_map<string, string> settings)
     if (settings.find("channels") != settings.end())
     {
         channel_count = std::max(1, std::min(512, settings["channels"].toInt()));
+    }
+    if (settings.find("resend_delay") != settings.end())
+    {
+        resend_delay = settings["resend_delay"].toInt();
     }
     if (port)
     {
@@ -74,6 +79,6 @@ void EnttecDMXProDevice::updateLoop()
         port->send(end_code, sizeof(end_code));
 
         //Delay a bit before sending again.
-        std::this_thread::sleep_for(std::chrono::milliseconds(100));
+        std::this_thread::sleep_for(std::chrono::milliseconds(resend_delay));
     }
 }

--- a/src/hardware/devices/enttecDMXProDevice.h
+++ b/src/hardware/devices/enttecDMXProDevice.h
@@ -16,6 +16,7 @@ private:
 
     bool run_thread;
     int channel_count;
+    int resend_delay;
     uint8_t channel_data[512];
 public:
     EnttecDMXProDevice();

--- a/src/hardware/serialDriver.cpp
+++ b/src/hardware/serialDriver.cpp
@@ -426,7 +426,9 @@ void SerialPort::sendBreak()
     ClearCommBreak(handle);
 #endif
 #if (defined(__gnu_linux__) && !defined(ANDROID)) || (defined(__APPLE__) && defined(__MACH__))
-    tcsendbreak(handle, 0);
+    ioctl(handle, TIOCSBRK);
+    usleep(88);
+    ioctl(handle, TIOCCBRK);
 #endif
 }
 


### PR DESCRIPTION
# Changes
## entttecDMXProDevice
added `resend_delay` parameter, to bring it inline with `dmx512SerialDevice`
## dmx512SerialDevice / serialDriver.cpp 
replaced the call to `tcsendbreak()`, which takes 250-500ms, depenind on OS, with an explicit call to `TIOCSBRK` > sleep 88μs > `TIOCCBRK`, as specified in the DMX spec, which increases the refresh rate from about 2Hz to about 44Hz, allowing for smoother effects and more responsive DMX triggers.

# Testing
Tested with both types of device, on mac and linux.