### PR TITLE
[#2771] Implement GuiScrollContainer, a scrolling GuiContainer

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -158,6 +158,7 @@ set(GUI_LIB_SOURCES
     src/gui/gui2_progressbar.cpp
     src/gui/gui2_progressslider.cpp
     src/gui/gui2_scrolltext.cpp
+    src/gui/gui2_scrollcontainer.cpp
     src/gui/gui2_advancedscrolltext.cpp
     src/gui/gui2_button.cpp
     src/gui/gui2_resizabledialog.cpp
@@ -194,6 +195,7 @@ set(GUI_LIB_SOURCES
     src/gui/gui2_resizabledialog.h
     src/gui/gui2_rotationdial.h
     src/gui/gui2_scrollbar.h
+    src/gui/gui2_scrollcontainer.h
     src/gui/gui2_scrolltext.h
     src/gui/gui2_selector.h
     src/gui/gui2_slider.h

--- a/src/gui/gui2_container.cpp
+++ b/src/gui/gui2_container.cpp
@@ -161,6 +161,13 @@ GuiElement* GuiContainer::callExecuteScrollOnElement(GuiContainer* container, gl
     return container->executeScrollOnElement(pos, value);
 }
 
+void GuiContainer::offsetElementRect(GuiContainer* container, glm::vec2 offset)
+{
+    container->rect.position += offset;
+    for (auto* child : container->children)
+        offsetElementRect(child, offset);
+}
+
 void GuiContainer::setAttribute(const string& key, const string& value)
 {
     if (key == "size")

--- a/src/gui/gui2_container.cpp
+++ b/src/gui/gui2_container.cpp
@@ -4,7 +4,7 @@
 
 GuiContainer::~GuiContainer()
 {
-    for(GuiElement* element : children)
+    for (GuiElement* element : children)
     {
         element->owner = nullptr;
         delete element;
@@ -13,15 +13,14 @@ GuiContainer::~GuiContainer()
 
 void GuiContainer::drawElements(glm::vec2 mouse_position, sp::Rect parent_rect, sp::RenderTarget& renderer)
 {
-    for(auto it = children.begin(); it != children.end(); )
+    for (auto it = children.begin(); it != children.end(); )
     {
         GuiElement* element = *it;
         if (element->destroyed)
         {
             //Find the owning cancas, as we need to remove ourselves if we are the focus or click element.
             GuiCanvas* canvas = dynamic_cast<GuiCanvas*>(element->getTopLevelContainer());
-            if (canvas)
-                canvas->unfocusElementTree(element);
+            if (canvas) canvas->unfocusElementTree(element);
 
             //Delete it from our list.
             it = children.erase(it);
@@ -29,7 +28,9 @@ void GuiContainer::drawElements(glm::vec2 mouse_position, sp::Rect parent_rect, 
             // Free up the memory used by the element.
             element->owner = nullptr;
             delete element;
-        }else{
+        }
+        else
+        {
             element->hover = element->rect.contains(mouse_position);
 
             if (element->visible)
@@ -61,49 +62,45 @@ void GuiContainer::drawDebugElements(sp::Rect parent_rect, sp::RenderTarget& ren
 
 GuiElement* GuiContainer::getClickElement(sp::io::Pointer::Button button, glm::vec2 position, sp::io::Pointer::ID id)
 {
-    for(auto it = children.rbegin(); it != children.rend(); it++)
+    for (auto it = children.rbegin(); it != children.rend(); it++)
     {
         GuiElement* element = *it;
 
         if (element->visible && element->enabled && element->rect.contains(position))
         {
             GuiElement* clicked = element->getClickElement(button, position, id);
-            if (clicked)
-                return clicked;
-            if (element->onMouseDown(button, position, id))
-            {
-                return element;
-            }
+            if (clicked) return clicked;
+            if (element->onMouseDown(button, position, id)) return element;
         }
     }
+
     return nullptr;
 }
 
 GuiElement* GuiContainer::executeScrollOnElement(glm::vec2 position, float value)
 {
-    for(auto it = children.rbegin(); it != children.rend(); it++)
+    for (auto it = children.rbegin(); it != children.rend(); it++)
     {
         GuiElement* element = *it;
 
         if (element->visible && element->enabled && element->rect.contains(position))
         {
             GuiElement* scrolled = element->executeScrollOnElement(position, value);
-            if (scrolled)
-                return scrolled;
-            if (element->onMouseWheelScroll(position, value))
-                return element;
+            if (scrolled) return scrolled;
+            if (element->onMouseWheelScroll(position, value)) return element;
         }
     }
+
     return nullptr;
 }
 
 void GuiContainer::updateLayout(const sp::Rect& rect)
 {
     this->rect = rect;
+
     if (layout_manager || !children.empty())
     {
-        if (!layout_manager)
-            layout_manager = std::make_unique<GuiLayout>();
+        if (!layout_manager) layout_manager = std::make_unique<GuiLayout>();
 
         glm::vec2 padding_size(layout.padding.left + layout.padding.right, layout.padding.top + layout.padding.bottom);
         layout_manager->updateLoop(*this, sp::Rect(rect.position + glm::vec2{layout.padding.left, layout.padding.top}, rect.size - padding_size));
@@ -111,7 +108,8 @@ void GuiContainer::updateLayout(const sp::Rect& rect)
         {
             glm::vec2 content_size_min(std::numeric_limits<float>::max(), std::numeric_limits<float>::max());
             glm::vec2 content_size_max(std::numeric_limits<float>::min(), std::numeric_limits<float>::min());
-            for(auto w : children)
+
+            for (auto w : children)
             {
                 if (w && w->isVisible())
                 {
@@ -123,6 +121,7 @@ void GuiContainer::updateLayout(const sp::Rect& rect)
                     content_size_max.y = std::max(content_size_max.y, p1.y + w->layout.margin.bottom);
                 }
             }
+
             if (content_size_max.x != std::numeric_limits<float>::min())
             {
                 this->rect.size = (content_size_max - content_size_min) + padding_size;
@@ -132,34 +131,34 @@ void GuiContainer::updateLayout(const sp::Rect& rect)
     }
 }
 
-void GuiContainer::clearElementOwner(GuiElement* e)
+void GuiContainer::clearElementOwner(GuiElement* element)
 {
-    e->owner = nullptr;
+    element->owner = nullptr;
 }
 
-void GuiContainer::setElementHover(GuiElement* e, bool h)
+void GuiContainer::setElementHover(GuiElement* element, bool has_hover)
 {
-    e->hover = h;
+    element->hover = has_hover;
 }
 
-void GuiContainer::setElementFocus(GuiElement* e, bool f)
+void GuiContainer::setElementFocus(GuiElement* element, bool has_focus)
 {
-    e->focus = f;
+    element->focus = has_focus;
 }
 
-void GuiContainer::callDrawElements(GuiContainer* c, glm::vec2 mp, sp::Rect r, sp::RenderTarget& rt)
+void GuiContainer::callDrawElements(GuiContainer* container, glm::vec2 mouse_pos, sp::Rect rect, sp::RenderTarget& render_target)
 {
-    c->drawElements(mp, r, rt);
+    container->drawElements(mouse_pos, rect, render_target);
 }
 
-GuiElement* GuiContainer::callGetClickElement(GuiContainer* c, sp::io::Pointer::Button b, glm::vec2 p, sp::io::Pointer::ID id)
+GuiElement* GuiContainer::callGetClickElement(GuiContainer* container, sp::io::Pointer::Button button, glm::vec2 pos, sp::io::Pointer::ID id)
 {
-    return c->getClickElement(b, p, id);
+    return container->getClickElement(button, pos, id);
 }
 
-GuiElement* GuiContainer::callExecuteScrollOnElement(GuiContainer* c, glm::vec2 p, float v)
+GuiElement* GuiContainer::callExecuteScrollOnElement(GuiContainer* container, glm::vec2 pos, float value)
 {
-    return c->executeScrollOnElement(p, v);
+    return container->executeScrollOnElement(pos, value);
 }
 
 void GuiContainer::setAttribute(const string& key, const string& value)
@@ -217,9 +216,7 @@ void GuiContainer::setAttribute(const string& key, const string& value)
     {
         auto values = value.split(",", 3);
         if (values.size() == 1)
-        {
-            layout.padding.top = layout.padding.bottom = layout.padding.left = layout.padding.right = values[0].strip().toFloat();
-        }
+           layout.padding.top = layout.padding.bottom = layout.padding.left = layout.padding.right = values[0].strip().toFloat();
         else if (values.size() == 2)
         {
             layout.padding.left = layout.padding.right = values[0].strip().toFloat();
@@ -262,17 +259,14 @@ void GuiContainer::setAttribute(const string& key, const string& value)
     else if (key == "layout")
     {
         GuiLayoutClassRegistry* reg;
-        for(reg = GuiLayoutClassRegistry::first; reg != nullptr; reg = reg->next)
-        {
-            if (value == reg->name)
-                break;
-        }
+
+        for (reg = GuiLayoutClassRegistry::first; reg != nullptr; reg = reg->next)
+            if (value == reg->name) break;
+
         if (reg)
-        {
             layout_manager = reg->creation_function();
-        }else{
+        else
             LOG(Error, "Failed to find layout type:", value);
-        }
     }
     else if (key == "stretch")
     {
@@ -280,6 +274,7 @@ void GuiContainer::setAttribute(const string& key, const string& value)
             layout.fill_height = layout.fill_width = layout.lock_aspect_ratio = true;
         else
             layout.fill_height = layout.fill_width = value.toBool();
+
         layout.match_content_size = false;
     }
     else if (key == "fill_height")
@@ -293,7 +288,5 @@ void GuiContainer::setAttribute(const string& key, const string& value)
         layout.match_content_size = false;
     }
     else
-    {
         LOG(Warning, "Tried to set unknown widget attribute:", key, "to", value);
-    }
 }

--- a/src/gui/gui2_container.cpp
+++ b/src/gui/gui2_container.cpp
@@ -161,12 +161,6 @@ GuiElement* GuiContainer::callExecuteScrollOnElement(GuiContainer* container, gl
     return container->executeScrollOnElement(pos, value);
 }
 
-void GuiContainer::offsetElementRect(GuiContainer* container, glm::vec2 offset)
-{
-    container->rect.position += offset;
-    for (auto* child : container->children)
-        offsetElementRect(child, offset);
-}
 
 void GuiContainer::setAttribute(const string& key, const string& value)
 {

--- a/src/gui/gui2_container.cpp
+++ b/src/gui/gui2_container.cpp
@@ -132,6 +132,36 @@ void GuiContainer::updateLayout(const sp::Rect& rect)
     }
 }
 
+void GuiContainer::clearElementOwner(GuiElement* e)
+{
+    e->owner = nullptr;
+}
+
+void GuiContainer::setElementHover(GuiElement* e, bool h)
+{
+    e->hover = h;
+}
+
+void GuiContainer::setElementFocus(GuiElement* e, bool f)
+{
+    e->focus = f;
+}
+
+void GuiContainer::callDrawElements(GuiContainer* c, glm::vec2 mp, sp::Rect r, sp::RenderTarget& rt)
+{
+    c->drawElements(mp, r, rt);
+}
+
+GuiElement* GuiContainer::callGetClickElement(GuiContainer* c, sp::io::Pointer::Button b, glm::vec2 p, sp::io::Pointer::ID id)
+{
+    return c->getClickElement(b, p, id);
+}
+
+GuiElement* GuiContainer::callExecuteScrollOnElement(GuiContainer* c, glm::vec2 p, float v)
+{
+    return c->executeScrollOnElement(p, v);
+}
+
 void GuiContainer::setAttribute(const string& key, const string& value)
 {
     if (key == "size")

--- a/src/gui/gui2_container.h
+++ b/src/gui/gui2_container.h
@@ -78,6 +78,9 @@ protected:
     static void callDrawElements(GuiContainer* container, glm::vec2 mouse_pos, sp::Rect rect, sp::RenderTarget& render_target);
     static GuiElement* callGetClickElement(GuiContainer* container, sp::io::Pointer::Button button, glm::vec2 pos, sp::io::Pointer::ID id);
     static GuiElement* callExecuteScrollOnElement(GuiContainer* container, glm::vec2 pos, float value);
+    // Apply an offset to this rect's position, and then recursively to all of
+    // its descendents. Used for nested scrolling/GuiScrollContainer.
+    static void offsetElementRect(GuiContainer* container, glm::vec2 offset);
 
     friend class GuiElement;
 };

--- a/src/gui/gui2_container.h
+++ b/src/gui/gui2_container.h
@@ -54,20 +54,27 @@ public:
     virtual ~GuiContainer();
 
     template<typename T> void setLayout() { layout_manager = std::make_unique<T>(); }
-    void updateLayout(const sp::Rect& rect);
+    virtual void updateLayout(const sp::Rect& rect);
     const sp::Rect& getRect() const { return rect; }
 
     virtual void setAttribute(const string& key, const string& value);
 protected:
     virtual void drawElements(glm::vec2 mouse_position, sp::Rect parent_rect, sp::RenderTarget& window);
     virtual void drawDebugElements(sp::Rect parent_rect, sp::RenderTarget& window);
-    GuiElement* getClickElement(sp::io::Pointer::Button button, glm::vec2 position, sp::io::Pointer::ID id);
-    GuiElement* executeScrollOnElement(glm::vec2 position, float value);
+    virtual GuiElement* getClickElement(sp::io::Pointer::Button button, glm::vec2 position, sp::io::Pointer::ID id);
+    virtual GuiElement* executeScrollOnElement(glm::vec2 position, float value);
+
+    // Static helpers for subclass access to protected members.
+    static void clearElementOwner(GuiElement* element);
+    static void setElementHover(GuiElement* element, bool has_hover);
+    static void setElementFocus(GuiElement* element, bool has_focus);
+    static void callDrawElements(GuiContainer* container, glm::vec2 mouse_pos, sp::Rect rect, sp::RenderTarget& render_target);
+    static GuiElement* callGetClickElement(GuiContainer* container, sp::io::Pointer::Button button, glm::vec2 pos, sp::io::Pointer::ID id);
+    static GuiElement* callExecuteScrollOnElement(GuiContainer* container, glm::vec2 pos, float value);
 
     friend class GuiElement;
 
     sp::Rect rect{0,0,0,0};
-private:
     std::unique_ptr<GuiLayout> layout_manager = nullptr;
 };
 

--- a/src/gui/gui2_container.h
+++ b/src/gui/gui2_container.h
@@ -1,5 +1,4 @@
-#ifndef GUI2_CONTAINER_H
-#define GUI2_CONTAINER_H
+#pragma once
 
 #include <list>
 #include <memory>
@@ -17,25 +16,26 @@ namespace sp {
 class GuiElement;
 class GuiLayout;
 class GuiTheme;
+
 class GuiContainer : sp::NonCopyable
 {
 public:
-public:
+    // Nested type to capture layout attributes
     class LayoutInfo
     {
     public:
         class Sides
         {
         public:
-            float left = 0;
-            float right = 0;
-            float top = 0;
-            float bottom = 0;
+            float left = 0.0f;
+            float right = 0.0f;
+            float top = 0.0f;
+            float bottom = 0.0f;
         };
         
-        glm::vec2 position{0, 0};
+        glm::vec2 position{0.0f, 0.0f};
         sp::Alignment alignment = sp::Alignment::TopLeft;
-        glm::vec2 size{1, 1};
+        glm::vec2 size{1.0f, 1.0f};
         glm::ivec2 span{1, 1};
         Sides margin;
         Sides padding;
@@ -45,20 +45,27 @@ public:
         bool match_content_size = true;
     };
 
-    LayoutInfo layout;    
-    std::list<GuiElement*> children;
-protected:
-    GuiTheme* theme;
-public:
     GuiContainer() = default;
     virtual ~GuiContainer();
 
+    // Public data
+    LayoutInfo layout;
+    std::list<GuiElement*> children;
+
+    // Public interfaces
     template<typename T> void setLayout() { layout_manager = std::make_unique<T>(); }
     virtual void updateLayout(const sp::Rect& rect);
+    virtual void setAttribute(const string& key, const string& value);
     const sp::Rect& getRect() const { return rect; }
 
-    virtual void setAttribute(const string& key, const string& value);
 protected:
+    GuiTheme* theme;
+
+    // Protected data
+    sp::Rect rect{0,0,0,0};
+    std::unique_ptr<GuiLayout> layout_manager = nullptr;
+
+    // Protected interfaces
     virtual void drawElements(glm::vec2 mouse_position, sp::Rect parent_rect, sp::RenderTarget& window);
     virtual void drawDebugElements(sp::Rect parent_rect, sp::RenderTarget& window);
     virtual GuiElement* getClickElement(sp::io::Pointer::Button button, glm::vec2 position, sp::io::Pointer::ID id);
@@ -73,9 +80,4 @@ protected:
     static GuiElement* callExecuteScrollOnElement(GuiContainer* container, glm::vec2 pos, float value);
 
     friend class GuiElement;
-
-    sp::Rect rect{0,0,0,0};
-    std::unique_ptr<GuiLayout> layout_manager = nullptr;
 };
-
-#endif//GUI2_CONTAINER_H

--- a/src/gui/gui2_container.h
+++ b/src/gui/gui2_container.h
@@ -78,9 +78,6 @@ protected:
     static void callDrawElements(GuiContainer* container, glm::vec2 mouse_pos, sp::Rect rect, sp::RenderTarget& render_target);
     static GuiElement* callGetClickElement(GuiContainer* container, sp::io::Pointer::Button button, glm::vec2 pos, sp::io::Pointer::ID id);
     static GuiElement* callExecuteScrollOnElement(GuiContainer* container, glm::vec2 pos, float value);
-    // Apply an offset to this rect's position, and then recursively to all of
-    // its descendents. Used for nested scrolling/GuiScrollContainer.
-    static void offsetElementRect(GuiContainer* container, glm::vec2 offset);
 
     friend class GuiElement;
 };

--- a/src/gui/gui2_scrollcontainer.cpp
+++ b/src/gui/gui2_scrollcontainer.cpp
@@ -121,7 +121,7 @@ void GuiScrollContainer::drawElements(glm::vec2 mouse_position, sp::Rect /* pare
     sp::Rect content_rect = getContentRect();
 
     // Capture clipping and scroll translation.
-    renderer.pushScissorRect(content_rect);
+    renderer.pushClipRegion(content_rect);
     renderer.pushTranslation({0.0f, -scroll_offset});
 
     // Track mouse position on element relative to the vertical scroll offset.
@@ -163,7 +163,7 @@ void GuiScrollContainer::drawElements(glm::vec2 mouse_position, sp::Rect /* pare
 
     // Apply scroll translation and clipping. Order matters here.
     renderer.popTranslation();
-    renderer.popScissorRect();
+    renderer.popClipRegion();
 
     // Draw the scrollbar if intended to be visible. Never clip nor scroll the
     // scrollbar itself.

--- a/src/gui/gui2_scrollcontainer.cpp
+++ b/src/gui/gui2_scrollcontainer.cpp
@@ -1,0 +1,392 @@
+#include "gui2_scrollcontainer.h"
+#include "gui2_scrollbar.h"
+#include "gui2_canvas.h"
+#include "gui/layout/layout.h"
+
+
+GuiScrollContainer::GuiScrollContainer(GuiContainer* owner, const string& id, ScrollMode mode)
+: GuiElement(owner, id), mode(mode)
+{
+    // Don't lock content size to element.
+    // We need to manipulate content size when toggling scrollbar visibility.
+    layout.match_content_size = false;
+
+    // Define the scrollbar and hide it.
+    scrollbar_v = new GuiScrollbar(this, id + "_SCROLLBAR_V", 0, 100, 0,
+        [this](int value)
+        {
+            scroll_offset = static_cast<float>(value);
+        }
+    );
+    scrollbar_v->setClickChange(50);
+    scrollbar_v
+        ->setPosition(0.0f, 0.0f, sp::Alignment::TopRight)
+        ->setSize(scrollbar_width, GuiSizeMax)
+        ->hide();
+}
+
+GuiScrollContainer* GuiScrollContainer::setMode(ScrollMode new_mode)
+{
+    mode = new_mode;
+    return this;
+}
+
+GuiScrollContainer* GuiScrollContainer::setScrollbarWidth(float width)
+{
+    scrollbar_width = width;
+    return this;
+}
+
+void GuiScrollContainer::scrollToFraction(float fraction)
+{
+    const float max_scroll = std::max(0.0f, content_height - visible_height);
+    scroll_offset = std::clamp(fraction * max_scroll, 0.0f, max_scroll);
+    scrollbar_v->setValue(static_cast<int>(scroll_offset));
+}
+
+void GuiScrollContainer::scrollToOffset(float pixel_offset)
+{
+    const float max_scroll = std::max(0.0f, content_height - visible_height);
+    scroll_offset = std::clamp(pixel_offset, 0.0f, max_scroll);
+    scrollbar_v->setValue(static_cast<int>(scroll_offset));
+}
+
+void GuiScrollContainer::updateLayout(const sp::Rect& rect)
+{
+    this->rect = rect;
+    visible_height = rect.size.y - layout.padding.top - layout.padding.bottom;
+
+    // Show the scrollbar only if we're clipping anything.
+    bool has_overflow = (mode != ScrollMode::None) && (content_height > visible_height + 0.5f);
+    scrollbar_v->setVisible(has_overflow);
+
+    // Don't factor scrollbar width if it isn't visible.
+    const float sb_width = scrollbar_v->isVisible() ? scrollbar_width : 0.0f;
+
+    // Manually factor padding into content layout around the scrollbar.
+    glm::vec2 padding_offset{
+        layout.padding.left,
+        layout.padding.top
+    };
+
+    glm::vec2 padding_size{
+        layout.padding.left + layout.padding.right,
+        layout.padding.top + layout.padding.bottom
+    };
+
+    sp::Rect content_layout_rect{
+        rect.position + padding_offset,
+        rect.size - padding_size - glm::vec2{sb_width, 0.0f}
+    };
+
+    if (!layout_manager) layout_manager = std::make_unique<GuiLayout>();
+
+    // Temporarily hide the scrollbar so the layout manager ignores it for
+    // sizing, then restore it if enabled.
+    scrollbar_v->setVisible(false);
+
+    layout_manager->updateLoop(*this, content_layout_rect);
+
+    scrollbar_v->setVisible(has_overflow);
+
+    // Override the scrollbar rect.
+    scrollbar_v->updateLayout({
+        {rect.position.x + rect.size.x - scrollbar_width, rect.position.y},
+        {scrollbar_width, rect.size.y}
+    });
+
+    // Compute content_height from non-scrollbar visible children.
+    float max_bottom = 0.0f;
+    for (GuiElement* child : children)
+    {
+        if (child == scrollbar_v) continue;
+        if (!child->isVisible()) continue;
+
+        const float bottom = child->getRect().position.y + child->getRect().size.y + child->layout.margin.bottom - rect.position.y;
+        if (bottom > max_bottom) max_bottom = bottom;
+    }
+    content_height = max_bottom + layout.padding.bottom;
+
+    // Clamp scroll offset.
+    scroll_offset = std::clamp(scroll_offset, 0.0f, std::max(0.0f, content_height - visible_height));
+
+    // Sync scrollbar properties to new layout.
+    scrollbar_v->setRange(0, static_cast<int>(content_height));
+    scrollbar_v->setValueSize(static_cast<int>(visible_height));
+    scrollbar_v->setValue(static_cast<int>(scroll_offset));
+}
+
+void GuiScrollContainer::drawElements(glm::vec2 mouse_position, sp::Rect /* parent_rect */, sp::RenderTarget& renderer)
+{
+    sp::Rect content_rect = getContentRect();
+
+    // Capture clipping and scroll translation.
+    renderer.pushScissorRect(content_rect);
+    renderer.pushTranslation({0.0f, -scroll_offset});
+
+    // Track mouse position on element relative to the vertical scroll offset.
+    glm::vec2 layout_mouse = mouse_position + glm::vec2{0.0f, scroll_offset};
+
+    // Pass the relative mouse position through to each child element.
+    for (auto it = children.begin(); it != children.end(); )
+    {
+        GuiElement* element = *it;
+
+        if (element == scrollbar_v)
+        {
+            ++it;
+            continue;
+        }
+
+        if (element->isDestroyed())
+        {
+            GuiCanvas* canvas = dynamic_cast<GuiCanvas*>(element->getTopLevelContainer());
+            if (canvas) canvas->unfocusElementTree(element);
+
+            it = children.erase(it);
+            clearElementOwner(element);
+            delete element;
+
+            continue;
+        }
+
+        setElementHover(element, element->getRect().contains(layout_mouse));
+
+        if (element->isVisible())
+        {
+            element->onDraw(renderer);
+            callDrawElements(element, layout_mouse, element->getRect(), renderer);
+        }
+
+        ++it;
+    }
+
+    // Apply scroll translation and clipping. Order matters here.
+    renderer.popTranslation();
+    renderer.popScissorRect();
+
+    // Draw the scrollbar if intended to be visible. Never clip nor scroll the
+    // scrollbar itself.
+    scrollbar_v->setVisible(scrollbar_v->isVisible() && mode != ScrollMode::None);
+    if (scrollbar_v->isVisible())
+    {
+        setElementHover(scrollbar_v, scrollbar_v->getRect().contains(mouse_position));
+        scrollbar_v->onDraw(renderer);
+        callDrawElements(scrollbar_v, mouse_position, scrollbar_v->getRect(), renderer);
+    }
+}
+
+GuiElement* GuiScrollContainer::getClickElement(sp::io::Pointer::Button button, glm::vec2 position, sp::io::Pointer::ID id)
+{
+    // Pass the click to the scrollbar first, and don't translate its position.
+    if (scrollbar_v->isVisible()
+        && scrollbar_v->isEnabled()
+        && scrollbar_v->getRect().contains(position)
+    )
+    {
+        GuiElement* clicked = callGetClickElement(scrollbar_v, button, position, id);
+        if (clicked) return clicked;
+        if (scrollbar_v->onMouseDown(button, position, id)) return scrollbar_v;
+    }
+
+    // Don't pass clicks to elements outside of the content rect.
+    if (!getContentRect().contains(position)) return nullptr;
+
+    // Pass the click to each nested child, which should take priority if it can
+    // use it.
+    glm::vec2 layout_pos = position + glm::vec2{0.0f, scroll_offset};
+
+    for (auto it = children.rbegin(); it != children.rend(); ++it)
+    {
+        GuiElement* element = *it;
+
+        // We already handled the scrollbar.
+        if (element == scrollbar_v) continue;
+        // We don't care about buttons that aren't visible or enabled.
+        if (!element->isVisible() || !element->isEnabled()) continue;
+
+        // Figure out if we can click the element. If so, capture the scroll
+        // offset to pass to drag events, focus it, and click it.
+        GuiElement* clicked = callGetClickElement(element, button, layout_pos, id);
+        if (clicked)
+        {
+            switchFocusTo(clicked);
+            pressed_element = clicked;
+            pressed_scroll = scroll_offset;
+            return this;
+        }
+
+        // The click didn't fire, but we still recurse into children regardless.
+        // This helps find children or child-like elements (like GuiSelector
+        // popups) that can exist outside of their parent's rect.
+        if (element->getRect().contains(layout_pos) && element->onMouseDown(button, layout_pos, id))
+        {
+            switchFocusTo(element);
+            pressed_element = element;
+            pressed_scroll = scroll_offset;
+            return this;
+        }
+    }
+
+    // Otherwise, do nothing.
+    return nullptr;
+}
+
+void GuiScrollContainer::switchFocusTo(GuiElement* new_element)
+{
+    // Apply focus change, if any.
+    if (focused_element == new_element) return;
+
+    if (focused_element)
+    {
+        setElementFocus(focused_element, false);
+        focused_element->onFocusLost();
+    }
+
+    focused_element = new_element;
+
+    // If this scroll container already has canvas focus, forward focus gained
+    // to the new child now (GuiCanvas won't call our onFocusGained again).
+    // If this scroll container is not yet focused, canvas will call our
+    // onFocusGained after getClickElement returns, which will forward it.
+    if (focus)
+    {
+        setElementFocus(focused_element, true);
+        focused_element->onFocusGained();
+    }
+}
+
+void GuiScrollContainer::onFocusGained()
+{
+    if (focused_element)
+    {
+        setElementFocus(focused_element, true);
+        focused_element->onFocusGained();
+    }
+}
+
+void GuiScrollContainer::onFocusLost()
+{
+    if (focused_element)
+    {
+        setElementFocus(focused_element, false);
+        focused_element->onFocusLost();
+        focused_element = nullptr;
+    }
+}
+
+void GuiScrollContainer::onTextInput(const string& text)
+{
+    if (focused_element) focused_element->onTextInput(text);
+}
+
+void GuiScrollContainer::onTextInput(sp::TextInputEvent e)
+{
+    if (focused_element) focused_element->onTextInput(e);
+}
+
+bool GuiScrollContainer::onMouseDown(sp::io::Pointer::Button button, glm::vec2 position, sp::io::Pointer::ID id)
+{
+    if (pressed_element)
+    {
+        pressed_element->onMouseDown(button, position + glm::vec2{0.0f, pressed_scroll}, id);
+        pressed_element = nullptr;
+        return true;
+    }
+
+    return false;
+}
+
+void GuiScrollContainer::onMouseDrag(glm::vec2 position, sp::io::Pointer::ID id)
+{
+    if (pressed_element) pressed_element->onMouseDrag(position + glm::vec2{0.0f, pressed_scroll}, id);
+}    
+
+void GuiScrollContainer::onMouseUp(glm::vec2 position, sp::io::Pointer::ID id)
+{
+    if (pressed_element)
+    {
+        pressed_element->onMouseUp(position + glm::vec2{0.0f, pressed_scroll}, id);
+        pressed_element = nullptr;
+    }
+}
+
+GuiElement* GuiScrollContainer::executeScrollOnElement(glm::vec2 position, float value)
+{
+    // Pass the scroll to the scrollbar first, and don't translate its position.
+    if (scrollbar_v->isVisible()
+        && scrollbar_v->isEnabled()
+        && scrollbar_v->getRect().contains(position))
+    {
+        GuiElement* scrolled = callExecuteScrollOnElement(scrollbar_v, position, value);
+        if (scrolled) return scrolled;
+        // Handle mousewheel scroll, if any.
+        if (scrollbar_v->onMouseWheelScroll(position, value)) return scrollbar_v;
+    }
+
+    // Return nothing if the scroll isn't within the container.
+    if (!getContentRect().contains(position)) return nullptr;
+
+    // Execute the scroll on each nested child. If a child can use the mousewheel
+    // scroll event, give it to them.
+    glm::vec2 layout_pos = position + glm::vec2{0.0f, scroll_offset};
+
+    for (auto it = children.rbegin(); it != children.rend(); ++it)
+    {
+        GuiElement* element = *it;
+        if (element == scrollbar_v) continue;
+
+        if (element
+            && element->isVisible()
+            && element->isEnabled()
+            && element->getRect().contains(layout_pos)
+        )
+        {
+            GuiElement* scrolled = callExecuteScrollOnElement(element, layout_pos, value);
+            if (scrolled) return scrolled;
+            if (element->onMouseWheelScroll(layout_pos, value)) return element;
+        }
+    }
+
+    // No child used the mousewheel scroll event, so use it to scroll the
+    // container.
+    if (onMouseWheelScroll(position, value)) return this;
+
+    // Otherwise, nothing happens.
+    return nullptr;
+}
+
+bool GuiScrollContainer::onMouseWheelScroll(glm::vec2 /* position */, float value)
+{
+    // Don't scroll if used only to clip.
+    if (mode == ScrollMode::None) return false;
+
+    // Scroll by a default interval of 50, or by the container height if set to
+    // paged mode.
+    const float step = (mode == ScrollMode::Page) ? visible_height : 50.0f;
+    const float max_scroll = std::max(0.0f, content_height - visible_height);
+    scroll_offset = std::clamp(scroll_offset - value * step, 0.0f, max_scroll);
+
+    // Update the scrollbar.
+    scrollbar_v->setValue(static_cast<int>(scroll_offset));
+
+    return true;
+}
+
+sp::Rect GuiScrollContainer::getContentRect() const
+{
+    // Return the rect, inset by padding and minus room for the scrollbar if it's visible.
+    return sp::Rect{
+        rect.position + glm::vec2{layout.padding.left, layout.padding.top},
+        {
+            rect.size.x - layout.padding.left - layout.padding.right - getEffectiveScrollbarWidth(),
+            rect.size.y - layout.padding.top - layout.padding.bottom
+        }
+    };
+}
+
+float GuiScrollContainer::getEffectiveScrollbarWidth() const
+{
+    // Save room for the scrollbar only if it's visible.
+    return scrollbar_v->isVisible() ? scrollbar_width : 0.0f;
+}

--- a/src/gui/gui2_scrollcontainer.cpp
+++ b/src/gui/gui2_scrollcontainer.cpp
@@ -110,6 +110,14 @@ void GuiScrollContainer::updateLayout(const sp::Rect& rect)
     // Clamp scroll offset.
     scroll_offset = std::clamp(scroll_offset, 0.0f, std::max(0.0f, content_height - visible_height));
 
+    // Apply the scroll offset to non-scrollbar children so their rects are in
+    // screen space.
+    for (GuiElement* child : children)
+    {
+        if (child == scrollbar_v) continue;
+        offsetElementRect(child, {0.0f, -scroll_offset});
+    }
+
     // Sync scrollbar properties to new layout.
     scrollbar_v->setRange(0, static_cast<int>(content_height));
     scrollbar_v->setValueSize(static_cast<int>(visible_height));
@@ -120,14 +128,11 @@ void GuiScrollContainer::drawElements(glm::vec2 mouse_position, sp::Rect /* pare
 {
     sp::Rect content_rect = getContentRect();
 
-    // Capture clipping and scroll translation.
+    // Clip child rendering to the visible content area.
     renderer.pushClipRegion(content_rect);
-    renderer.pushTranslation({0.0f, -scroll_offset});
 
-    // Track mouse position on element relative to the vertical scroll offset.
-    glm::vec2 layout_mouse = mouse_position + glm::vec2{0.0f, scroll_offset};
-
-    // Pass the relative mouse position through to each child element.
+    // Draw each child element and pass mouse events, skipping this container's
+    // scrollbar.
     for (auto it = children.begin(); it != children.end(); )
     {
         GuiElement* element = *it;
@@ -150,19 +155,17 @@ void GuiScrollContainer::drawElements(glm::vec2 mouse_position, sp::Rect /* pare
             continue;
         }
 
-        setElementHover(element, element->getRect().contains(layout_mouse));
+        setElementHover(element, element->getRect().contains(mouse_position));
 
         if (element->isVisible())
         {
             element->onDraw(renderer);
-            callDrawElements(element, layout_mouse, element->getRect(), renderer);
+            callDrawElements(element, mouse_position, element->getRect(), renderer);
         }
 
         ++it;
     }
 
-    // Apply scroll translation and clipping. Order matters here.
-    renderer.popTranslation();
     renderer.popClipRegion();
 
     // Draw the scrollbar if intended to be visible. Never clip nor scroll the
@@ -194,8 +197,6 @@ GuiElement* GuiScrollContainer::getClickElement(sp::io::Pointer::Button button, 
 
     // Pass the click to each nested child, which should take priority if it can
     // use it.
-    glm::vec2 layout_pos = position + glm::vec2{0.0f, scroll_offset};
-
     for (auto it = children.rbegin(); it != children.rend(); ++it)
     {
         GuiElement* element = *it;
@@ -205,25 +206,22 @@ GuiElement* GuiScrollContainer::getClickElement(sp::io::Pointer::Button button, 
         // We don't care about buttons that aren't visible or enabled.
         if (!element->isVisible() || !element->isEnabled()) continue;
 
-        // Figure out if we can click the element. If so, capture the scroll
-        // offset to pass to drag events, focus it, and click it.
-        GuiElement* clicked = callGetClickElement(element, button, layout_pos, id);
+        // Figure out if we can click the element. If so, focus it and click it.
+        GuiElement* clicked = callGetClickElement(element, button, position, id);
         if (clicked)
         {
             switchFocusTo(clicked);
             pressed_element = clicked;
-            pressed_scroll = scroll_offset;
             return this;
         }
 
         // The click didn't fire, but we still recurse into children regardless.
         // This helps find children or child-like elements (like GuiSelector
         // popups) that can exist outside of their parent's rect.
-        if (element->getRect().contains(layout_pos) && element->onMouseDown(button, layout_pos, id))
+        if (element->getRect().contains(position) && element->onMouseDown(button, position, id))
         {
             switchFocusTo(element);
             pressed_element = element;
-            pressed_scroll = scroll_offset;
             return this;
         }
     }
@@ -289,7 +287,7 @@ bool GuiScrollContainer::onMouseDown(sp::io::Pointer::Button button, glm::vec2 p
 {
     if (pressed_element)
     {
-        pressed_element->onMouseDown(button, position + glm::vec2{0.0f, pressed_scroll}, id);
+        pressed_element->onMouseDown(button, position, id);
         pressed_element = nullptr;
         return true;
     }
@@ -299,14 +297,14 @@ bool GuiScrollContainer::onMouseDown(sp::io::Pointer::Button button, glm::vec2 p
 
 void GuiScrollContainer::onMouseDrag(glm::vec2 position, sp::io::Pointer::ID id)
 {
-    if (pressed_element) pressed_element->onMouseDrag(position + glm::vec2{0.0f, pressed_scroll}, id);
-}    
+    if (pressed_element) pressed_element->onMouseDrag(position, id);
+}
 
 void GuiScrollContainer::onMouseUp(glm::vec2 position, sp::io::Pointer::ID id)
 {
     if (pressed_element)
     {
-        pressed_element->onMouseUp(position + glm::vec2{0.0f, pressed_scroll}, id);
+        pressed_element->onMouseUp(position, id);
         pressed_element = nullptr;
     }
 }
@@ -329,8 +327,6 @@ GuiElement* GuiScrollContainer::executeScrollOnElement(glm::vec2 position, float
 
     // Execute the scroll on each nested child. If a child can use the mousewheel
     // scroll event, give it to them.
-    glm::vec2 layout_pos = position + glm::vec2{0.0f, scroll_offset};
-
     for (auto it = children.rbegin(); it != children.rend(); ++it)
     {
         GuiElement* element = *it;
@@ -339,12 +335,12 @@ GuiElement* GuiScrollContainer::executeScrollOnElement(glm::vec2 position, float
         if (element
             && element->isVisible()
             && element->isEnabled()
-            && element->getRect().contains(layout_pos)
+            && element->getRect().contains(position)
         )
         {
-            GuiElement* scrolled = callExecuteScrollOnElement(element, layout_pos, value);
+            GuiElement* scrolled = callExecuteScrollOnElement(element, position, value);
             if (scrolled) return scrolled;
-            if (element->onMouseWheelScroll(layout_pos, value)) return element;
+            if (element->onMouseWheelScroll(position, value)) return element;
         }
     }
 

--- a/src/gui/gui2_scrollcontainer.cpp
+++ b/src/gui/gui2_scrollcontainer.cpp
@@ -18,8 +18,8 @@ GuiScrollContainer::GuiScrollContainer(GuiContainer* owner, const string& id, Sc
             scroll_offset = static_cast<float>(value);
         }
     );
-    scrollbar_v->setClickChange(50);
     scrollbar_v
+        ->setClickChange(50)
         ->setPosition(0.0f, 0.0f, sp::Alignment::TopRight)
         ->setSize(scrollbar_width, GuiSizeMax)
         ->hide();
@@ -56,6 +56,10 @@ void GuiScrollContainer::updateLayout(const sp::Rect& rect)
     this->rect = rect;
     visible_height = rect.size.y - layout.padding.top - layout.padding.bottom;
 
+    // Clamp scroll_offset using last frame's content_height to validate the
+    // value passed to the layout manager.
+    scroll_offset = std::clamp(scroll_offset, 0.0f, std::max(0.0f, content_height - visible_height));
+
     // Show the scrollbar only if we're clipping anything.
     bool has_overflow = (mode != ScrollMode::None) && (content_height > visible_height + 0.5f);
     scrollbar_v->setVisible(has_overflow);
@@ -63,7 +67,7 @@ void GuiScrollContainer::updateLayout(const sp::Rect& rect)
     // Don't factor scrollbar width if it isn't visible.
     const float sb_width = scrollbar_v->isVisible() ? scrollbar_width : 0.0f;
 
-    // Manually factor padding into content layout around the scrollbar.
+    // Factor layout padding.
     glm::vec2 padding_offset{
         layout.padding.left,
         layout.padding.top
@@ -74,8 +78,10 @@ void GuiScrollContainer::updateLayout(const sp::Rect& rect)
         layout.padding.top + layout.padding.bottom
     };
 
+    // Subtract scroll_offset from the layout rect so all children (and their
+    // descendants) are offset.
     sp::Rect content_layout_rect{
-        rect.position + padding_offset,
+        rect.position + padding_offset + glm::vec2{0.0f, -scroll_offset},
         rect.size - padding_size - glm::vec2{sb_width, 0.0f}
     };
 
@@ -95,33 +101,27 @@ void GuiScrollContainer::updateLayout(const sp::Rect& rect)
         {scrollbar_width, rect.size.y}
     });
 
-    // Compute content_height from non-scrollbar visible children.
+    // Compute content_height. Child elements are scrolled, so add
+    // scroll_offset from extents.
     float max_bottom = 0.0f;
     for (GuiElement* child : children)
     {
         if (child == scrollbar_v) continue;
         if (!child->isVisible()) continue;
 
-        const float bottom = child->getRect().position.y + child->getRect().size.y + child->layout.margin.bottom - rect.position.y;
+        const float bottom = child->getRect().position.y + child->getRect().size.y + child->layout.margin.bottom - rect.position.y + scroll_offset;
         if (bottom > max_bottom) max_bottom = bottom;
     }
     content_height = max_bottom + layout.padding.bottom;
 
-    // Clamp scroll offset.
+    // Clamp again in case content shrank this frame.
     scroll_offset = std::clamp(scroll_offset, 0.0f, std::max(0.0f, content_height - visible_height));
 
-    // Apply the scroll offset to non-scrollbar children so their rects are in
-    // screen space.
-    for (GuiElement* child : children)
-    {
-        if (child == scrollbar_v) continue;
-        offsetElementRect(child, {0.0f, -scroll_offset});
-    }
-
     // Sync scrollbar properties to new layout.
-    scrollbar_v->setRange(0, static_cast<int>(content_height));
-    scrollbar_v->setValueSize(static_cast<int>(visible_height));
-    scrollbar_v->setValue(static_cast<int>(scroll_offset));
+    scrollbar_v
+        ->setRange(0, static_cast<int>(content_height))
+        ->setValueSize(static_cast<int>(visible_height))
+        ->setValue(static_cast<int>(scroll_offset));
 }
 
 void GuiScrollContainer::drawElements(glm::vec2 mouse_position, sp::Rect /* parent_rect */, sp::RenderTarget& renderer)

--- a/src/gui/gui2_scrollcontainer.cpp
+++ b/src/gui/gui2_scrollcontainer.cpp
@@ -37,6 +37,15 @@ GuiScrollContainer* GuiScrollContainer::setScrollbarWidth(float width)
     return this;
 }
 
+void GuiScrollContainer::cleanTree()
+{
+    if (focused_element && focused_element->isDestroyed())
+        focused_element = nullptr;
+    if (pressed_element && pressed_element->isDestroyed())
+        pressed_element = nullptr;
+    GuiContainer::cleanTree();
+}
+
 void GuiScrollContainer::scrollToFraction(float fraction)
 {
     const float max_scroll = std::max(0.0f, content_height - visible_height);

--- a/src/gui/gui2_scrollcontainer.cpp
+++ b/src/gui/gui2_scrollcontainer.cpp
@@ -145,6 +145,9 @@ void GuiScrollContainer::drawElements(glm::vec2 mouse_position, sp::Rect /* pare
 
         if (element->isDestroyed())
         {
+            if (pressed_element == element) pressed_element = nullptr;
+            if (focused_element == element) focused_element = nullptr;
+
             GuiCanvas* canvas = dynamic_cast<GuiCanvas*>(element->getTopLevelContainer());
             if (canvas) canvas->unfocusElementTree(element);
 

--- a/src/gui/gui2_scrollcontainer.cpp
+++ b/src/gui/gui2_scrollcontainer.cpp
@@ -364,6 +364,10 @@ bool GuiScrollContainer::onMouseWheelScroll(glm::vec2 /* position */, float valu
     // paged mode.
     const float step = (mode == ScrollMode::Page) ? visible_height : 50.0f;
     const float max_scroll = std::max(0.0f, content_height - visible_height);
+
+    // If there's no overflow, let mousewheel pass through.
+    if (max_scroll < 0.5f) return false;
+
     scroll_offset = std::clamp(scroll_offset - value * step, 0.0f, max_scroll);
 
     // Update the scrollbar.

--- a/src/gui/gui2_scrollcontainer.h
+++ b/src/gui/gui2_scrollcontainer.h
@@ -82,8 +82,6 @@ private:
     GuiElement* focused_element = nullptr;
     // Defines the element being clicked/tapped within this element's subtree.
     GuiElement* pressed_element = nullptr;
-    // Defines the scroll position of the pressed element.
-    float pressed_scroll = 0.0f;
 
     // Returns a rect for the area where content is visible.
     sp::Rect getContentRect() const;

--- a/src/gui/gui2_scrollcontainer.h
+++ b/src/gui/gui2_scrollcontainer.h
@@ -1,0 +1,95 @@
+#pragma once
+
+#include "gui2_element.h"
+
+class GuiScrollbar;
+
+// GuiContainer-like GuiElement with support for clipping or scrolling arbitrary
+// child elements that overflow its bounds.
+class GuiScrollContainer : public GuiElement
+{
+public:
+    // Define modes to indicate whether this element scrolls, and if so, how.
+    enum class ScrollMode {
+        None,   // Cut overflow off at element borders; no scrolling
+        Scroll, // Scroll by fixed increments, regardless of contents or element size
+        Page    // Scroll by increments equal to the element size
+    };
+
+    GuiScrollContainer(GuiContainer* owner, const string& id, ScrollMode mode = ScrollMode::Scroll);
+
+    // TODO: Right now this clips both horizontally and vertically, but supports
+    // only vertical scrolling/paging.
+
+    // Set scrolling mode. All modes clip at the element boundaries.
+    GuiScrollContainer* setMode(ScrollMode mode);
+    // Set width of scrollbar if visible.
+    GuiScrollContainer* setScrollbarWidth(float width);
+    // Scroll element to this fraction of the total scrollbar limit.
+    // Value passed here represents where the top of the scrollbar pill goes
+    // on the scrollbar.
+    void scrollToFraction(float fraction);
+    // Scroll element to this pixel offset from the top (clamped to valid range).
+    void scrollToOffset(float pixel_offset);
+
+    // Override layout updates to update child elements and juggle scrollbar
+    // visibility.
+    virtual void updateLayout(const sp::Rect& rect) override;
+    // Handle mousewheel scroll, with behavior depending on the ScrollMode.
+    virtual bool onMouseWheelScroll(glm::vec2 position, float value) override;
+    // Pass mouse down to child elements, but only if they're visible.
+    virtual bool onMouseDown(sp::io::Pointer::Button button, glm::vec2 position, sp::io::Pointer::ID id) override;
+    // Pass mouse drag to child elements. This relies on 
+    virtual void onMouseDrag(glm::vec2 position, sp::io::Pointer::ID id) override;
+    // Pass mouse up to child elements.
+    virtual void onMouseUp(glm::vec2 position, sp::io::Pointer::ID id) override;
+    // Pass focus to child elements.
+    virtual void onFocusGained() override;
+    // Pass focus loss to child elements.
+    virtual void onFocusLost() override;
+    // Pass text input events to child elements.
+    virtual void onTextInput(const string& text) override;
+    // Pass text input events to child elements.
+    virtual void onTextInput(sp::TextInputEvent e) override;
+
+protected:
+    // Draw elements if they're in view. Translate mouse positions by the scroll
+    // amount.
+    virtual void drawElements(glm::vec2 mouse_position, sp::Rect parent_rect, sp::RenderTarget& renderer) override;
+    // Find the clicked element, checking children of this container if they're
+    // visible.
+    virtual GuiElement* getClickElement(sp::io::Pointer::Button button, glm::vec2 position, sp::io::Pointer::ID id) override;
+    // Scroll the element's children. Pass any mousewheel events to children
+    // first if they can use it.
+    virtual GuiElement* executeScrollOnElement(glm::vec2 position, float value) override;
+
+private:
+    // Define whether this element scrolls, paginates, or only clips content.
+    ScrollMode mode;
+    // Defines the scrollbar's width, in virtual pixels.
+    float scrollbar_width = 30.0f;
+    // Scrollbar element, visible only if there's overflow.
+    GuiScrollbar* scrollbar_v;
+
+    // Defines the scroll offset in virtual pixels, with 0 as the top.
+    float scroll_offset = 0.0f;
+    // Defines the total height of content, in virtual pixels.
+    float content_height = 0.0f;
+    // Defines the visible height of the element, in virtual pixels.
+    float visible_height = 0.0f;
+
+    // Defines the element that has focus within this element's subtree.
+    GuiElement* focused_element = nullptr;
+    // Defines the element being clicked/tapped within this element's subtree.
+    GuiElement* pressed_element = nullptr;
+    // Defines the scroll position of the pressed element.
+    float pressed_scroll = 0.0f;
+
+    // Returns a rect for the area where content is visible.
+    sp::Rect getContentRect() const;
+    // Returns the effective scrollbar width, factoring in whether it appears
+    // at all.
+    float getEffectiveScrollbarWidth() const;
+    // Passes focus to another element.
+    void switchFocusTo(GuiElement* new_element);
+};

--- a/src/gui/gui2_scrollcontainer.h
+++ b/src/gui/gui2_scrollcontainer.h
@@ -32,6 +32,11 @@ public:
     // Scroll element to this pixel offset from the top (clamped to valid range).
     void scrollToOffset(float pixel_offset);
 
+    // Clean up the scroll container's tree: clear internal focus/click
+    // pointers before the base class removes destroyed children via
+    // swap-and-pop. Call this explicitly instead of relying on the
+    // canvas's cleanTree() since the base method is not virtual.
+    void cleanTree();
     // Override layout updates to update child elements and juggle scrollbar
     // visibility.
     virtual void updateLayout(const sp::Rect& rect) override;

--- a/src/gui/gui2_selector.cpp
+++ b/src/gui/gui2_selector.cpp
@@ -49,13 +49,16 @@ void GuiSelector::onDraw(sp::RenderTarget& renderer)
 
     if (!focus)
         popup->hide();
-    float top = rect.position.y;
+    // rect.position is in layout space; the popup lives at the canvas level
+    // (no scroll translation), so convert to screen coordinates first.
+    glm::vec2 screen_pos = rect.position + renderer.getTranslation();
+    float top = screen_pos.y;
     float height = entries.size() * 50;
     if (selection_index >= 0)
         top -= selection_index * 50;
     top = std::max(0.0f, top);
     top = std::min(900.0f - height, top);
-    popup->setPosition(rect.position.x, top, sp::Alignment::TopLeft)->setSize(rect.size.x, height);
+    popup->setPosition(screen_pos.x, top, sp::Alignment::TopLeft)->setSize(rect.size.x, height);
 }
 
 GuiSelector* GuiSelector::setTextSize(float size)

--- a/src/gui/gui2_selector.cpp
+++ b/src/gui/gui2_selector.cpp
@@ -49,16 +49,13 @@ void GuiSelector::onDraw(sp::RenderTarget& renderer)
 
     if (!focus)
         popup->hide();
-    // rect.position is in layout space; the popup lives at the canvas level
-    // (no scroll translation), so convert to screen coordinates first.
-    glm::vec2 screen_pos = rect.position + renderer.getTranslation();
-    float top = screen_pos.y;
+    float top = rect.position.y;
     float height = entries.size() * 50;
     if (selection_index >= 0)
         top -= selection_index * 50;
     top = std::max(0.0f, top);
     top = std::min(900.0f - height, top);
-    popup->setPosition(screen_pos.x, top, sp::Alignment::TopLeft)->setSize(rect.size.x, height);
+    popup->setPosition(rect.position.x, top, sp::Alignment::TopLeft)->setSize(rect.size.x, height);
 }
 
 GuiSelector* GuiSelector::setTextSize(float size)


### PR DESCRIPTION
Implements #2771. Requires daid/SeriousProton#300.

Add `GuiScrollContainer`, a subclass of `GuiElement` that further modifies its drawing functions to support clipping and vertical scrolling. 

- Add static helper functions for subclass access to protected `GuiContainer` members related to this purpose (ownership, hover/focus, drawing, clicking, and scroll behavior).
   - Update `GuiContainer` style and formatting for consistency.
- Add a `GuiScrollContainer` subclass of `GuiElement`.
   - Implement RenderTarget features added in daid/SeriousProton#300 to mask rendering visibility to the element's rect.
   - Implement a scroll offset for GuiScrollContainer contents, and apply the scroll offset recursively to child elements to allow nesting of elements that use GuiScrollContainer.

This also modifies `GuiSelector` to apply scroll translation to the popup generated by `GuiSelector`, which is created outside of the tree.

Closes #2652.