### PR TITLE
Validate beam weapon frequency

### DIFF
--- a/src/components/beamweapon.h
+++ b/src/components/beamweapon.h
@@ -35,6 +35,8 @@ public:
 
     constexpr static int max_frequency = 20;
     int frequency = 0;
+    int getFrequency() const { return frequency; }
+    void setFrequency(int freq) { frequency = std::clamp(freq, 0, max_frequency); }
     ShipSystem::Type system_target = ShipSystem::Type::None;
 
     std::vector<MountPoint> mounts;

--- a/src/playerInfo.cpp
+++ b/src/playerInfo.cpp
@@ -830,9 +830,8 @@ void PlayerInfo::onReceiveClientCommand(int32_t client_id, sp::io::DataBuffer& p
         {
             int32_t new_frequency;
             packet >> new_frequency;
-            auto beamweapons = ship.getComponent<BeamWeaponSys>();
-            if (beamweapons)
-                beamweapons->frequency = std::clamp(new_frequency, 0, BeamWeaponSys::max_frequency);
+            if (auto beam_weapons = ship.getComponent<BeamWeaponSys>())
+                beam_weapons->setFrequency(new_frequency);
         }
         break;
     case CMD_SET_BEAM_SYSTEM_TARGET:

--- a/src/screens/gm/tweak.cpp
+++ b/src/screens/gm/tweak.cpp
@@ -335,7 +335,7 @@ GuiEntityTweak::GuiEntityTweak(GuiContainer* owner)
     ADD_NUM_TEXT_TWEAK(tr("tweak-text", "Seconds to full recharge from 0:"), CombatManeuveringThrusters, charge_time);
 
     ADD_PAGE(tr("tweak-tab", "Beam system"), BeamWeaponSys);
-    ADD_INT_SLIDER_TWEAK(tr("tweak-text", "Frequency:"), BeamWeaponSys, 0u, 20u, frequency);
+    ADD_INT_SLIDER_TWEAK(tr("tweak-text", "Frequency:"), BeamWeaponSys, 0u, BeamWeaponSys::max_frequency, frequency);
     ADD_LABEL(tr("tweak-text", "Beam weapons system"));
     ADD_SHIP_SYSTEM_TWEAK(BeamWeaponSys);
 

--- a/src/script.cpp
+++ b/src/script.cpp
@@ -1032,7 +1032,7 @@ void luaCommandSetAutoRepair(sp::ecs::Entity ship, bool enabled) {
 void luaCommandSetBeamFrequency(sp::ecs::Entity ship, int frequency) {
     if (my_player_info && my_player_info->ship == ship) { my_player_info->commandSetBeamFrequency(frequency); return; }
     if (auto beamweapons = ship.getComponent<BeamWeaponSys>())
-        beamweapons->frequency = std::clamp(frequency, 0, BeamWeaponSys::max_frequency);
+        beamweapons->setFrequency(frequency);
 }
 
 void luaCommandSetBeamSystemTarget(sp::ecs::Entity ship, ShipSystem::Type type) {

--- a/src/script/components.cpp
+++ b/src/script/components.cpp
@@ -68,6 +68,8 @@
             t->MEMBER = sp::script::Convert<std::remove_cv_t<std::remove_reference_t<decltype(t->MEMBER)>>>::fromLua(L, -1); \
         } \
     };
+// Bind a member using getter and setter functions for validation.
+// The getter must be const.
 #define BIND_MEMBER_GS(T, NAME, GET, SET) \
     sp::script::ComponentHandler<T>::members[NAME] = { \
         [](lua_State* L, const void* ptr) { \
@@ -498,7 +500,7 @@ void initComponentScriptBindings()
 
     sp::script::ComponentHandler<BeamWeaponSys>::name("beam_weapons");
     BIND_SHIP_SYSTEM(BeamWeaponSys);
-    BIND_MEMBER(BeamWeaponSys, frequency);
+    BIND_MEMBER_GS(BeamWeaponSys, "frequency", getFrequency, setFrequency);
     BIND_MEMBER(BeamWeaponSys, system_target);
     BIND_ARRAY(BeamWeaponSys, mounts);
     BIND_ARRAY_MEMBER(BeamWeaponSys, mounts, position);


### PR DESCRIPTION
Lua scripts are granted direct and unvalidated access to beam weapon frequency, allowing it to be set beyond the configured 0-20 bounds.

Validate the beam weapon frequency:

- Add a validating setter to the `BeamWeaponSys` component that clamps inputs between 0 and `max_frequency` (20).
- Bind `components.beam_weapons.frequency` using `BIND_MEMBER_GS` to use the setter on Lua assignment instead of directly changing the value.
- Update `PlayerInfo` and `commandSetBeamFrequency` to use the validating setter instead of their own bespoke validation.
- Use `max_frequency` as the upper bound on the frequency GM tweak instead of hard-coding 20.