### PR TITLE
Fix BeamFrequencySelector drift on changes

### DIFF
--- a/src/gui/hotkeyConfig.cpp
+++ b/src/gui/hotkeyConfig.cpp
@@ -212,8 +212,8 @@ Keys::Keys() :
     weapons_shield_calibration_start("WEAPONS_SHIELD_CALIBRATION_START", "/"),
     weapons_beam_subsystem_target_next("WEAPONS_SUBSYSTEM_TARGET_NEXT", '"'),
     weapons_beam_subsystem_target_previous("WEAPONS_SUBSYSTEM_TARGET_PREVIOUS", ";"),
-    weapons_beam_frequence_increase("WEAPONS_FREQUENCY_INCREASE", "M"),
-    weapons_beam_frequence_decrease("WEAPONS_FREQUENCY_DECREASE", "N"),
+    weapons_beam_frequency_increase("WEAPONS_FREQUENCY_INCREASE", "M"),
+    weapons_beam_frequency_decrease("WEAPONS_FREQUENCY_DECREASE", "N"),
     weapons_toggle_aim_lock("WEAPONS_AIM_LOCK_TOGGLE"),
     weapons_enable_aim_lock("WEAPONS_AIM_LOCK_ENABLE"),
     weapons_disable_aim_lock("WEAPONS_AIM_LOCK_DISABLE"),
@@ -413,8 +413,8 @@ void Keys::init()
     weapons_shield_calibration_start.setLabel(tr("hotkey_menu", "Weapons"), tr("hotkey_Weapons", "Start shield calibration"));
     weapons_beam_subsystem_target_next.setLabel(tr("hotkey_menu", "Weapons"), tr("hotkey_Weapons", "Next beam subsystem target type"));
     weapons_beam_subsystem_target_previous.setLabel(tr("hotkey_menu", "Weapons"), tr("hotkey_Weapons", "Previous beam subsystem target type"));
-    weapons_beam_frequence_increase.setLabel(tr("hotkey_menu", "Weapons"), tr("hotkey_Weapons", "Increase beam frequency"));
-    weapons_beam_frequence_decrease.setLabel(tr("hotkey_menu", "Weapons"), tr("hotkey_Weapons", "Decrease beam frequency"));
+    weapons_beam_frequency_increase.setLabel(tr("hotkey_menu", "Weapons"), tr("hotkey_Weapons", "Increase beam frequency"));
+    weapons_beam_frequency_decrease.setLabel(tr("hotkey_menu", "Weapons"), tr("hotkey_Weapons", "Decrease beam frequency"));
     weapons_toggle_aim_lock.setLabel(tr("hotkey_menu", "Weapons"), tr("hotkey_Weapons", "Toggle missile aim lock"));
     weapons_enable_aim_lock.setLabel(tr("hotkey_menu", "Weapons"), tr("hotkey_Weapons", "Enable missile aim lock"));
     weapons_disable_aim_lock.setLabel(tr("hotkey_menu", "Weapons"), tr("hotkey_Weapons", "Disable missile aim lock"));

--- a/src/gui/hotkeyConfig.h
+++ b/src/gui/hotkeyConfig.h
@@ -102,8 +102,8 @@ public:
     sp::io::Keybinding weapons_shield_calibration_start;
     sp::io::Keybinding weapons_beam_subsystem_target_next;
     sp::io::Keybinding weapons_beam_subsystem_target_previous;
-    sp::io::Keybinding weapons_beam_frequence_increase;
-    sp::io::Keybinding weapons_beam_frequence_decrease;
+    sp::io::Keybinding weapons_beam_frequency_increase;
+    sp::io::Keybinding weapons_beam_frequency_decrease;
     sp::io::Keybinding weapons_toggle_aim_lock;
     sp::io::Keybinding weapons_enable_aim_lock;
     sp::io::Keybinding weapons_disable_aim_lock;

--- a/src/screenComponents/beamFrequencySelector.cpp
+++ b/src/screenComponents/beamFrequencySelector.cpp
@@ -19,7 +19,7 @@ void GuiBeamFrequencySelector::onUpdate()
     if (!isVisible()) return;
 
     // Handle inc/dec keybinds.
-    if (keys.weapons_beam_frequence_increase.getDown())
+    if (keys.weapons_beam_frequency_increase.getDown())
     {
         if (getSelectionIndex() >= static_cast<int>(entries.size()) - 1)
             setSelectionIndex(0);
@@ -29,7 +29,7 @@ void GuiBeamFrequencySelector::onUpdate()
         callback();
     }
 
-    if (keys.weapons_beam_frequence_decrease.getDown())
+    if (keys.weapons_beam_frequency_decrease.getDown())
     {
         if (getSelectionIndex() <= 0)
             setSelectionIndex(static_cast<int>(entries.size()) - 1);


### PR DESCRIPTION
Fix client/server drift in `BeamFrequencySelector`.

- When the beam frequency changes elsewhere, for instance on another crew screen or via Lua, update the selector.

   Before:

   [Screencast_20260314_213430.webm](https://github.com/user-attachments/assets/ca0381f2-3dba-4b0e-b6d5-e893d12f7f7a)
   - Move `setSelectionIndex` from init to `onUpdate`.

- When the server's beam/shield frequency setting is changed mid-game, update the control on connected clients.

   Before:

   [Screencast_20260314_213601.webm](https://github.com/user-attachments/assets/2bdd4729-026e-4700-9450-d6d71b55d831)

   - Move the `gameGlobalInfo->use_beam_shield_frequencies` check from init to `onUpdate`.

- When the beam frequency is decreased via keybind, send the frequency change command to the server.

   Before:

   [Screencast_20260314_113357.webm](https://github.com/user-attachments/assets/6fc7ede6-db1c-4fd8-81bc-fa14fcd49b4c)

   - Invoke the selector callback, which runs the command, when using the frequency decrease bind.
   - Fix a typo in the bind's variable name.