### PR TITLE
Add options to set, configure keyboard repeating

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -209,6 +209,15 @@ int main(int argc, char** argv)
     }
 #endif
 
+    if (PreferencesManager::get("key_repeat", "0") == "1")
+    {
+        sp::io::Keybinding::setRepeating(true);
+        sp::io::Keybinding::setRepeatDelay(PreferencesManager::get("key_repeat_delay", "0").toInt());
+        int key_repeat_interval = PreferencesManager::get("key_repeat_interval", "40").toInt();
+        if (key_repeat_interval > 0)
+            sp::io::Keybinding::setRepeatInterval(key_repeat_interval);
+    }
+
     P<HardwareController> hardware_controller = new HardwareController();
     hardware_controller->loadConfiguration(configuration_path + "/hardware.ini");
 

--- a/src/menus/optionsMenu.cpp
+++ b/src/menus/optionsMenu.cpp
@@ -222,6 +222,55 @@ void OptionsMenu::setupInterfaceOptions(OptionsMenu::ReturnTo return_to)
         }
     }
 
+    // Key repeat options.
+    {
+        (new GuiLabel(interface_left_column, "KEY_REPEAT_OPTIONS_LABEL", tr("Key repeat"), 30.0f))
+            ->addBackground()
+            ->setSize(GuiElement::GuiSizeMax, 50.0f);
+
+        key_repeat_toggle = new GuiToggleButton(interface_left_column, "KEY_REPEAT_TOGGLE", tr("key_repeat", "Enable key repeat"),
+            [](bool value)
+            {
+                PreferencesManager::set("key_repeat", value ? "1" : "0");
+                sp::io::Keybinding::setRepeating(value);
+            }
+        );
+        key_repeat_toggle
+            ->setValue(PreferencesManager::get("key_repeat", "0") == "1")
+            ->setSize(GuiElement::GuiSizeMax, 50.0f);
+
+        int initial_delay = PreferencesManager::get("key_repeat_delay", "0").toInt();
+        auto delay_slider = new GuiBasicSlider(interface_left_column, "KEY_REPEAT_DELAY_SLIDER", 0.0f, 1000.0f, float(initial_delay),
+            [this](float value)
+            {
+                value = std::round(value / 10.0f) * 10.0f;
+                PreferencesManager::set("key_repeat_delay", string(int(value)));
+                sp::io::Keybinding::setRepeatDelay(int(value));
+                key_repeat_delay_label->setText(tr("key_repeat", "Repeat delay: {ms} ms").format({{"ms", string(int(value))}}));
+            }
+        );
+        delay_slider->setSize(GuiElement::GuiSizeMax, 50.0f);
+        key_repeat_delay_label = new GuiLabel(delay_slider, "KEY_REPEAT_DELAY_LABEL",
+            tr("key_repeat", "Repeat delay: {ms} ms").format({{"ms", string(initial_delay)}}), 30);
+        key_repeat_delay_label->setSize(GuiElement::GuiSizeMax, GuiElement::GuiSizeMax);
+
+        int initial_interval = PreferencesManager::get("key_repeat_interval", "40").toInt();
+        auto interval_slider = new GuiBasicSlider(interface_left_column, "KEY_REPEAT_INTERVAL_SLIDER", 10.0f, 500.0f, float(initial_interval),
+            [this](float value)
+            {
+                value = std::round(value / 10.0f) * 10.0f;
+                value = std::max(10.0f, value);
+                PreferencesManager::set("key_repeat_interval", string(int(value)));
+                sp::io::Keybinding::setRepeatInterval(int(value));
+                key_repeat_interval_label->setText(tr("key_repeat", "Repeat interval: {ms} ms").format({{"ms", string(int(value))}}));
+            }
+        );
+        interval_slider->setSize(GuiElement::GuiSizeMax, 50.0f);
+        key_repeat_interval_label = new GuiLabel(interval_slider, "KEY_REPEAT_INTERVAL_LABEL",
+            tr("key_repeat", "Repeat interval: {ms} ms").format({{"ms", string(initial_interval)}}), 30);
+        key_repeat_interval_label->setSize(GuiElement::GuiSizeMax, GuiElement::GuiSizeMax);
+    }
+
     // Interface page, right column
 
     // Control configuration

--- a/src/menus/optionsMenu.h
+++ b/src/menus/optionsMenu.h
@@ -39,6 +39,10 @@ private:
     GuiBasicSlider* graphics_fov_slider{};
     GuiLabel* graphics_fov_overlay_label{};
 
+    GuiToggleButton* key_repeat_toggle{};
+    GuiLabel* key_repeat_delay_label{};
+    GuiLabel* key_repeat_interval_label{};
+
     std::vector<string> hotkey_categories;
     GuiLabel* impulse_volume_overlay_label;
     OptionsMenu::ReturnTo return_to;


### PR DESCRIPTION
Requires daid/SeriousProton#304.

- Add key_repeat, key_repeat_delay, and key_repeat_interval preferences file options to control SeriousProton bind repeating behaviors.
- Add options menu interface tab controls for these options.

[Screencast_20260314_141502.webm](https://github.com/user-attachments/assets/88db98a0-995f-4e94-9ee3-229e50378eba)
