### PR TITLE
[#2796] Reorder comms data assignment in station placement

### DIFF
--- a/scripts/place_station_scenario_utility.lua
+++ b/scripts/place_station_scenario_utility.lua
@@ -96,6 +96,9 @@ function placeStation(x,y,name,faction,size,diagnostic)
 			station:setTemplate(szt())
 		end
 	end
+	if commsStation ~= nil then
+		station:setCommsScript(""):setCommsFunction(commsStation)
+	end
 	if diagnostic == nil then
 		diagnostic = false
 	else


### PR DESCRIPTION
In ECS, `setTemplate()` overwrites the entity's CommsReceiver component to use the default comms script.

In `place_station_scenario_utility.lua`, re-initialize `setCommsFunction` immediately after applying `setTemplate` in `placeStation`. On legacy this should be idempotent, on ECS this should restore the expected state.

Should fix #2796.