### PR TITLE
Log and return nullptr if fallback theme doesn't exist

### DIFF
--- a/src/gui/theme.cpp
+++ b/src/gui/theme.cpp
@@ -94,6 +94,13 @@ const GuiThemeStyle* GuiTheme::getStyle(const string& element)
     int n = element.rfind(".");
     if (n == -1)
     {
+        // Fallback is defined at style init, so this should never happen. We
+        // want to know if it somehow does.
+        if (element == "fallback")
+        {
+            LOG(Error, "Theme ", name, " is missing the 'fallback' style.");
+            return nullptr;
+        }
         LOG(Warning, "Can't find ", element, " in theme ", name, ". Falling back to 'fallback' style.");
         return getStyle("fallback");
     }


### PR DESCRIPTION
The GuiTheme initalizer defines a fallback style, but if for some reason that initialization fails or the fallback style is corrupted, theme application can enter an infinite loop when trying to apply the fallback style.

Check and return nullptr during GuiTheme::getStyle() if the fallback style isn't found.