### PR TITLE
Replace multiplicative alert level overlay with background color change

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -255,6 +255,7 @@ set(MAIN_SOURCES
     src/screens/windowScreen.cpp
     src/screens/mainScreen.cpp
     src/screens/spectatorScreen.cpp
+    src/screens/baseShipScreen.cpp
     src/screens/crew4/operationsScreen.cpp
     src/screens/crew4/engineeringAdvancedScreen.cpp
     src/screens/crew4/tacticalScreen.cpp

--- a/resources/gui/default.theme.txt
+++ b/resources/gui/default.theme.txt
@@ -15,6 +15,12 @@
     # Background color and images
     [background] {
         color: #1F252D
+        [background.red_alert] {
+            color: #401216
+        }
+        [background.yellow_alert] {
+            color: #404016
+        }
         [background.crosses] {
             image: gui/background/crosses.png
         }
@@ -151,6 +157,12 @@
                 color: #FF0000
                 color.disabled: #A08080
             }
+            [button.yellow_alert.back] {
+                color: #FFFF00
+            }
+            [button.red_alert.back] {
+                color: #FF0000
+            }
             [button.toggle.off.back] {
             }
             [button.toggle.on.back] {
@@ -171,6 +183,12 @@
                 color: #FF0000
                 color.active: #120000
                 color.disabled: #FF00004D
+            }
+            [button.yellow_alert.front] {
+                color: #FFFF00
+            }
+            [button.red_alert.front] {
+                color: #FF0000
             }
             [button.toggle.off.front] {
             }

--- a/src/screenComponents/alertLevelButton.cpp
+++ b/src/screenComponents/alertLevelButton.cpp
@@ -4,31 +4,49 @@
 #include "playerInfo.h"
 #include "gui/gui2_togglebutton.h"
 
+string styleForLevel(AlertLevel level) {
+    switch (level) {
+    case AlertLevel::YellowAlert:
+        return "button.yellow_alert";
+    case AlertLevel::RedAlert:
+        return "button.red_alert";
+    default:
+        return "button";
+    }
+}
 
 GuiAlertLevelSelect::GuiAlertLevelSelect(GuiContainer* owner, string id)
-: GuiElement(owner, id)
+: GuiElement(owner, id), last_level(AlertLevel::Normal)
 {
     // Alert level buttons.
-    auto alert_level_button = new GuiToggleButton(this, "", tr("Alert level"), [this](bool value)
+    alert_level_button = new GuiToggleButton(this, "", tr("Alert level"), [this](bool value)
     {
         for(GuiButton* button : alert_level_buttons)
             button->setVisible(value);
     });
     alert_level_button->setValue(false);
+    alert_level_button->setStyle(styleForLevel(AlertLevel::Normal));
     alert_level_button->setSize(GuiElement::GuiSizeMax, 50);
 
     for(int level=int(AlertLevel::Normal); level < int(AlertLevel::MAX); level++)
     {
-        GuiButton* alert_button = new GuiButton(this, "", alertLevelToLocaleString(AlertLevel(level)), [this, level, alert_level_button]()
+        auto text = alertLevelToLocaleString(AlertLevel(level));
+        auto mainText = AlertLevel(level) == AlertLevel::Normal ? tr("Alert level") : text;
+        auto style = styleForLevel(AlertLevel(level));
+
+        GuiButton* alert_button = new GuiButton(this, "", text, [this, level, mainText, style]()
         {
             if (my_spaceship)
                 my_player_info->commandSetAlertLevel(AlertLevel(level));
             for(GuiButton* button : alert_level_buttons)
                 button->setVisible(false);
             alert_level_button->setValue(false);
+            alert_level_button->setText(mainText);
+            alert_level_button->setStyle(style);
         });
         alert_button->setVisible(false);
         alert_button->setSize(GuiElement::GuiSizeMax, 50);
+        alert_button->setStyle(style);
         alert_level_buttons.push_back(alert_button);
     }
 }
@@ -43,5 +61,18 @@ void GuiAlertLevelSelect::onUpdate()
             my_player_info->commandSetAlertLevel(AlertLevel::YellowAlert);
         if (keys.relay_alert_level_red.getDown())
             my_player_info->commandSetAlertLevel(AlertLevel::RedAlert);
+
+        if (auto pc = my_spaceship.getComponent<PlayerControl>()) {
+            if (last_level != pc->alert_level) {
+                last_level = pc->alert_level;
+
+                alert_level_button->setStyle(styleForLevel(pc->alert_level));
+                alert_level_button->setText(
+                    pc->alert_level == AlertLevel::Normal
+                        ? tr("Alert level")
+                        : alertLevelToLocaleString(pc->alert_level)
+                );
+            }
+        }
     }
 }

--- a/src/screenComponents/alertLevelButton.h
+++ b/src/screenComponents/alertLevelButton.h
@@ -2,6 +2,8 @@
 #define ALERT_LEVEL_BUTTON_H
 
 #include "gui/gui2_button.h"
+#include "gui/gui2_togglebutton.h"
+#include "components/player.h"
 
 class GuiAlertLevelSelect : public GuiElement
 {
@@ -12,6 +14,8 @@ public:
 
 private:
     std::vector<GuiButton*> alert_level_buttons;
+    GuiToggleButton* alert_level_button;
+    AlertLevel last_level;
 };
 
 #endif//ALERT_LEVEL_BUTTON_H

--- a/src/screenComponents/indicatorOverlays.cpp
+++ b/src/screenComponents/indicatorOverlays.cpp
@@ -57,8 +57,6 @@ void GuiIndicatorOverlays::onDraw(sp::RenderTarget& renderer)
 {
     if (my_spaceship)
     {
-        drawAlertLevel(renderer);
-
         float shield_hit = 0.0;
         bool low_shields = false;
         auto shields = my_spaceship.getComponent<Shields>();
@@ -165,27 +163,4 @@ bool GuiIndicatorOverlays::onMouseDown(sp::io::Pointer::Button button, glm::vec2
     if (pause_overlay->isVisible() || victory_overlay->isVisible())
         return true;
     return false;
-}
-
-void GuiIndicatorOverlays::drawAlertLevel(sp::RenderTarget& renderer)
-{
-    glm::u8vec4 multiply_color{255,255,255,255};
-
-    auto pc = my_spaceship.getComponent<PlayerControl>();
-    if (!pc) return;
-
-    switch(pc->alert_level)
-    {
-    case AlertLevel::RedAlert:
-        multiply_color = glm::u8vec4(255, 192, 192, 255);
-        break;
-    case AlertLevel::YellowAlert:
-        multiply_color = glm::u8vec4(255, 255, 192, 255);
-        break;
-    case AlertLevel::Normal:
-    default:
-        return;
-    }
-
-    renderer.drawRectColorMultiply(rect, multiply_color);
 }

--- a/src/screenComponents/indicatorOverlays.h
+++ b/src/screenComponents/indicatorOverlays.h
@@ -35,8 +35,6 @@ public:
     virtual bool onMouseDown(sp::io::Pointer::Button button, glm::vec2 position, sp::io::Pointer::ID id) override;
 
     void hasGlobalMessage() { has_global_message = true; }
-private:
-    void drawAlertLevel(sp::RenderTarget& renderer);
 };
 
 #endif//INDICATOR_OVERLAYS_H

--- a/src/screens/baseShipScreen.cpp
+++ b/src/screens/baseShipScreen.cpp
@@ -1,0 +1,37 @@
+#include "screens/baseShipScreen.h"
+#include "components/player.h"
+#include "gui/theme.h"
+#include "playerInfo.h"
+#include "screenComponents/alertOverlay.h"
+
+BaseShipScreen::BaseShipScreen(GuiContainer* owner, string id)
+: GuiOverlay(owner, id, GuiTheme::getColor("background")),
+	bg_default(GuiTheme::getColor("background")),
+	bg_yellow(GuiTheme::getColor("background.yellow_alert")),
+	bg_red(GuiTheme::getColor("background.red_alert"))
+{
+    background_crosses = new GuiOverlay(this, "BACKGROUND_CROSSES", glm::u8vec4{255,255,255,255});
+    background_crosses->setTextureTiledThemed("background.crosses");
+
+	new AlertLevelOverlay(this);
+}
+
+void BaseShipScreen::onUpdate() {
+	auto level = AlertLevel::Normal;
+
+	if (my_spaceship)
+		if (auto pc = my_spaceship.getComponent<PlayerControl>())
+			level = pc->alert_level;
+
+	switch (level) {
+	case AlertLevel::RedAlert:
+		setColor(bg_red);
+		break;
+	case AlertLevel::YellowAlert:
+		setColor(bg_yellow);
+		break;
+	default:
+		setColor(bg_default);
+		break;
+	}
+}

--- a/src/screens/baseShipScreen.h
+++ b/src/screens/baseShipScreen.h
@@ -1,0 +1,17 @@
+#pragma once
+
+#include "gui/gui2_overlay.h"
+
+class BaseShipScreen : public GuiOverlay
+{
+public:
+	glm::ivec4 bg_default;
+	glm::ivec4 bg_yellow;
+	glm::ivec4 bg_red;
+
+	GuiOverlay* background_crosses;
+
+	BaseShipScreen(GuiContainer* owner, string id);
+
+	virtual void onUpdate() override;
+};

--- a/src/screens/crew1/singlePilotScreen.cpp
+++ b/src/screens/crew1/singlePilotScreen.cpp
@@ -45,17 +45,11 @@
 #include "gui/gui2_label.h"
 
 SinglePilotScreen::SinglePilotScreen(GuiContainer* owner)
-: GuiOverlay(owner, "SINGLEPILOT_SCREEN", GuiTheme::getColor("background"))
+: BaseShipScreen(owner, "SINGLEPILOT_SCREEN")
 {
     // setColor(GuiTheme::getColor("background"));
     // Render the radar shadow and background decorations.
     (new GuiImage(this, "BACKGROUND_GRADIENT", ""))->setTextureThemed("background.gradient_single")->setPosition(glm::vec2(0, 0), sp::Alignment::Center)->setSize(1200, 900);
-
-    background_crosses = new GuiOverlay(this, "BACKGROUND_CROSSES", glm::u8vec4{255,255,255,255});
-    background_crosses->setTextureTiledThemed("background.crosses");
-
-    // Render the alert level color overlay.
-    (new AlertLevelOverlay(this));
 
     // 5U tactical radar with piloting features.
     radar = new GuiRadarView(this, "TACTICAL_RADAR", &targets);
@@ -157,11 +151,12 @@ void SinglePilotScreen::onDraw(sp::RenderTarget& renderer)
         else
             targets.set(sp::ecs::Entity{});
     }
-    GuiOverlay::onDraw(renderer);
+    BaseShipScreen::onDraw(renderer);
 }
 
 void SinglePilotScreen::onUpdate()
 {
+    BaseShipScreen::onUpdate();
     if (my_spaceship && isVisible())
     {
         auto angle = (keys.helms_turn_right.getValue() - keys.helms_turn_left.getValue()) * 5.0f;

--- a/src/screens/crew1/singlePilotScreen.h
+++ b/src/screens/crew1/singlePilotScreen.h
@@ -1,7 +1,7 @@
 #ifndef SINGLE_PILOT_SCREEN_H
 #define SINGLE_PILOT_SCREEN_H
 
-#include "gui/gui2_overlay.h"
+#include "screens/baseShipScreen.h"
 #include "screenComponents/targetsContainer.h"
 #include "gui/joystickConfig.h"
 
@@ -13,11 +13,9 @@ class GuiToggleButton;
 class GuiRotationDial;
 class GuiCombatManeuver;
 
-class SinglePilotScreen : public GuiOverlay
+class SinglePilotScreen : public BaseShipScreen
 {
 private:
-    GuiOverlay* background_crosses;
-
     GuiElement* warp_controls;
     GuiElement* jump_controls;
     GuiCombatManeuver* combat_maneuver;

--- a/src/screens/crew4/tacticalScreen.cpp
+++ b/src/screens/crew4/tacticalScreen.cpp
@@ -37,16 +37,10 @@
 #include "gui/gui2_rotationdial.h"
 
 TacticalScreen::TacticalScreen(GuiContainer* owner)
-: GuiOverlay(owner, "TACTICAL_SCREEN", GuiTheme::getColor("background"))
+: BaseShipScreen(owner, "TACTICAL_SCREEN")
 {
     // Render the radar shadow and background decorations.
     (new GuiImage(this, "BACKGROUND_GRADIENT", ""))->setTextureThemed("background.gradient_single")->setPosition(glm::vec2(0, 0), sp::Alignment::Center)->setSize(1200, 900);
-
-    background_crosses = new GuiOverlay(this, "BACKGROUND_CROSSES", glm::u8vec4{255,255,255,255});
-    background_crosses->setTextureTiledThemed("background.crosses");
-
-    // Render the alert level color overlay.
-    (new AlertLevelOverlay(this));
 
     // Short-range tactical radar with a 5U range.
     radar = new GuiRadarView(this, "TACTICAL_RADAR", &targets);
@@ -137,11 +131,12 @@ void TacticalScreen::onDraw(sp::RenderTarget& renderer)
         auto target = my_spaceship.getComponent<Target>();
         targets.set(target ? target->entity : sp::ecs::Entity{});
     }
-    GuiOverlay::onDraw(renderer);
+    BaseShipScreen::onDraw(renderer);
 }
 
 void TacticalScreen::onUpdate()
 {
+    BaseShipScreen::onUpdate();
     if (my_spaceship && isVisible())
     {
         auto angle = (keys.helms_turn_right.getValue() - keys.helms_turn_left.getValue()) * 5.0f;

--- a/src/screens/crew4/tacticalScreen.h
+++ b/src/screens/crew4/tacticalScreen.h
@@ -1,7 +1,7 @@
 #ifndef TACTICAL_SCREEN_H
 #define TACTICAL_SCREEN_H
 
-#include "gui/gui2_overlay.h"
+#include "screens/baseShipScreen.h"
 #include "screenComponents/targetsContainer.h"
 #include "gui/joystickConfig.h"
 
@@ -11,11 +11,9 @@ class GuiKeyValueDisplay;
 class GuiToggleButton;
 class GuiRotationDial;
 
-class TacticalScreen : public GuiOverlay
+class TacticalScreen : public BaseShipScreen
 {
 private:
-    GuiOverlay* background_crosses;
-
     GuiElement* warp_controls;
     GuiElement* jump_controls;
 

--- a/src/screens/crew6/engineeringScreen.cpp
+++ b/src/screens/crew6/engineeringScreen.cpp
@@ -31,17 +31,11 @@
 #include "gui/gui2_panel.h"
 
 EngineeringScreen::EngineeringScreen(GuiContainer* owner, CrewPosition crew_position)
-: GuiOverlay(owner, "ENGINEERING_SCREEN", GuiTheme::getColor("background"))
+: BaseShipScreen(owner, "ENGINEERING_SCREEN")
 {
     slider_tick_style = theme->getStyle("slider.tick");
     overlay_damaged_style = theme->getStyle("overlay.damaged");
     overlay_overheating_style = theme->getStyle("overlay.overheating");
-    // Render the background decorations.
-    background_crosses = new GuiOverlay(this, "BACKGROUND_CROSSES", glm::u8vec4{255,255,255,255});
-    background_crosses->setTextureTiledThemed("background.crosses");
-
-    // Render the alert level color overlay.
-    (new AlertLevelOverlay(this));
 
     auto stats = new GuiElement(this, "ENGINEER_STATS");
     stats->setPosition(20, 100, sp::Alignment::TopLeft)->setSize(240, 200)->setAttribute("layout", "vertical");
@@ -372,11 +366,12 @@ void EngineeringScreen::onDraw(sp::RenderTarget& renderer)
             }
         }
     }
-    GuiOverlay::onDraw(renderer);
+    BaseShipScreen::onDraw(renderer);
 }
 
 void EngineeringScreen::onUpdate()
 {
+    BaseShipScreen::onUpdate();
     if (my_spaceship && isVisible())
     {
         auto coolant = my_spaceship.getComponent<Coolant>();

--- a/src/screens/crew6/engineeringScreen.h
+++ b/src/screens/crew6/engineeringScreen.h
@@ -1,6 +1,6 @@
 #pragma once
 
-#include "gui/gui2_overlay.h"
+#include "screens/baseShipScreen.h"
 #include "playerInfo.h"
 
 class GuiSelfDestructButton;
@@ -14,14 +14,13 @@ class GuiProgressbar;
 class GuiProgressSlider;
 class GuiThemeStyle;
 
-class EngineeringScreen : public GuiOverlay
+class EngineeringScreen : public BaseShipScreen
 {
 private:
     const GuiThemeStyle* background_style;
     const GuiThemeStyle* slider_tick_style;
     const GuiThemeStyle* overlay_damaged_style;
     const GuiThemeStyle* overlay_overheating_style;
-    GuiOverlay* background_crosses;
 
     GuiSelfDestructButton* self_destruct_button;
     GuiLabel* power_label;

--- a/src/screens/crew6/helmsScreen.cpp
+++ b/src/screens/crew6/helmsScreen.cpp
@@ -28,16 +28,10 @@
 #include "gui/gui2_image.h"
 
 HelmsScreen::HelmsScreen(GuiContainer* owner)
-: GuiOverlay(owner, "HELMS_SCREEN", GuiTheme::getColor("background"))
+: BaseShipScreen(owner, "HELMS_SCREEN")
 {
     // Render the radar shadow and background decorations.
     (new GuiImage(this, "BACKGROUND_GRADIENT", ""))->setTextureThemed("background.gradient")->setPosition(glm::vec2(0, 0), sp::Alignment::Center)->setSize(1200, 900);
-
-    background_crosses = new GuiOverlay(this, "BACKGROUND_CROSSES", glm::u8vec4{255,255,255,255});
-    background_crosses->setTextureTiledThemed("background.crosses");
-
-    // Render the alert level color overlay.
-    (new AlertLevelOverlay(this));
 
     GuiRadarView* radar = new GuiRadarView(this, "HELMS_RADAR", nullptr);
 
@@ -125,11 +119,12 @@ HelmsScreen::HelmsScreen(GuiContainer* owner)
 
 void HelmsScreen::onDraw(sp::RenderTarget& renderer)
 {
-    GuiOverlay::onDraw(renderer);
+    BaseShipScreen::onDraw(renderer);
 }
 
 void HelmsScreen::onUpdate()
 {
+    BaseShipScreen::onUpdate();
     if (my_spaceship && isVisible())
     {
         auto angle = (keys.helms_turn_right.getValue() - keys.helms_turn_left.getValue()) * 5.0f;

--- a/src/screens/crew6/helmsScreen.h
+++ b/src/screens/crew6/helmsScreen.h
@@ -1,6 +1,6 @@
 #pragma once
 
-#include "gui/gui2_overlay.h"
+#include "screens/baseShipScreen.h"
 #include "gui/joystickConfig.h"
 
 class GuiKeyValueDisplay;
@@ -8,11 +8,9 @@ class GuiLabel;
 class GuiDockingButton;
 class GuiCombatManeuver;
 
-class HelmsScreen : public GuiOverlay
+class HelmsScreen : public BaseShipScreen
 {
 private:
-    GuiOverlay* background_crosses;
-
     GuiLabel* heading_hint;
     GuiCombatManeuver* combat_maneuver;
     GuiDockingButton* docking_button;

--- a/src/screens/crew6/scienceScreen.cpp
+++ b/src/screens/crew6/scienceScreen.cpp
@@ -22,7 +22,6 @@
 #include "screenComponents/frequencyCurve.h"
 #include "screenComponents/scanningDialog.h"
 #include "screenComponents/databaseView.h"
-#include "screenComponents/alertOverlay.h"
 #include "screenComponents/customShipFunctions.h"
 
 #include "gui/theme.h"
@@ -35,7 +34,7 @@
 #include "gui/gui2_image.h"
 
 ScienceScreen::ScienceScreen(GuiContainer* owner, CrewPosition crew_position)
-: GuiOverlay(owner, "SCIENCE_SCREEN", GuiTheme::getColor("background"))
+: BaseShipScreen(owner, "SCIENCE_SCREEN")
 {
     auto lrr = my_spaceship.getComponent<LongRangeRadar>();
     targets.setAllowWaypointSelection();
@@ -43,12 +42,6 @@ ScienceScreen::ScienceScreen(GuiContainer* owner, CrewPosition crew_position)
     // Render the radar shadow and background decorations.
     background_gradient = new GuiImage(this, "BACKGROUND_GRADIENT", "");
     background_gradient->setTextureThemed("background.gradient_offset")->setPosition(glm::vec2(105, 0), sp::Alignment::CenterLeft)->setSize(1200, 900);
-
-    background_crosses = new GuiOverlay(this, "BACKGROUND_CROSSES", glm::u8vec4{255,255,255,255});
-    background_crosses->setTextureTiledThemed("background.crosses");
-
-    // Render the alert level color overlay.
-    (new AlertLevelOverlay(this));
 
     // Draw the radar.
     radar_view = new GuiElement(this, "RADAR_VIEW");
@@ -248,7 +241,7 @@ ScienceScreen::ScienceScreen(GuiContainer* owner, CrewPosition crew_position)
 
 void ScienceScreen::onDraw(sp::RenderTarget& renderer)
 {
-    GuiOverlay::onDraw(renderer);
+    BaseShipScreen::onDraw(renderer);
     if (!isVisible())
         return;
 
@@ -532,6 +525,7 @@ void ScienceScreen::onDraw(sp::RenderTarget& renderer)
 
 void ScienceScreen::onUpdate()
 {
+    BaseShipScreen::onUpdate();
     if (my_spaceship)
     {
         // Initiate a scan on scannable objects.

--- a/src/screens/crew6/scienceScreen.h
+++ b/src/screens/crew6/scienceScreen.h
@@ -2,7 +2,7 @@
 #define SCIENCE_SCREEN_H
 
 #include "screenComponents/targetsContainer.h"
-#include "gui/gui2_overlay.h"
+#include "screens/baseShipScreen.h"
 #include "playerInfo.h"
 
 class GuiListbox;
@@ -20,11 +20,10 @@ class GuiImage;
 class DatabaseViewComponent;
 class GuiCustomShipFunctions;
 
-class ScienceScreen : public GuiOverlay
+class ScienceScreen : public BaseShipScreen
 {
 public:
     GuiImage* background_gradient;
-    GuiOverlay* background_crosses;
 
     GuiElement* radar_view;
     DatabaseViewComponent* database_view;

--- a/src/screens/crew6/weaponsScreen.cpp
+++ b/src/screens/crew6/weaponsScreen.cpp
@@ -28,16 +28,10 @@
 #include "gui/gui2_keyvaluedisplay.h"
 
 WeaponsScreen::WeaponsScreen(GuiContainer* owner)
-: GuiOverlay(owner, "WEAPONS_SCREEN", GuiTheme::getColor("background"))
+: BaseShipScreen(owner, "WEAPONS_SCREEN")
 {
-    // Render the radar shadow and background decorations.
+    // Render the radar shadow
     (new GuiImage(this, "BACKGROUND_GRADIENT", ""))->setTextureThemed("background.gradient")->setPosition(glm::vec2(0, 0), sp::Alignment::Center)->setSize(1200, 900);
-
-    background_crosses = new GuiOverlay(this, "BACKGROUND_CROSSES", glm::u8vec4{255,255,255,255});
-    background_crosses->setTextureTiledThemed("background.crosses");
-
-    // Render the alert level color overlay.
-    (new AlertLevelOverlay(this));
 
     radar = new GuiRadarView(this, "HELMS_RADAR", &targets);
     radar->setPosition(0, 0, sp::Alignment::Center)->setSize(GuiElement::GuiSizeMatchHeight, 800);
@@ -132,11 +126,12 @@ void WeaponsScreen::onDraw(sp::RenderTarget& renderer)
         if (beam_info_box)
             beam_info_box->setVisible(my_spaceship.hasComponent<BeamWeaponSys>());
     }
-    GuiOverlay::onDraw(renderer);
+    BaseShipScreen::onDraw(renderer);
 }
 
 void WeaponsScreen::onUpdate()
 {
+    BaseShipScreen::onUpdate();
     if (my_spaceship && isVisible())
     {
         if (keys.weapons_enemy_next_target.getDown())

--- a/src/screens/crew6/weaponsScreen.h
+++ b/src/screens/crew6/weaponsScreen.h
@@ -1,7 +1,7 @@
 #ifndef WEAPONS_SCREEN_H
 #define WEAPONS_SCREEN_H
 
-#include "gui/gui2_overlay.h"
+#include "screens/baseShipScreen.h"
 #include "screenComponents/radarView.h"
 #include "screenComponents/targetsContainer.h"
 #include "gui/joystickConfig.h"
@@ -11,11 +11,9 @@ class GuiKeyValueDisplay;
 class GuiToggleButton;
 class GuiRotationDial;
 
-class WeaponsScreen : public GuiOverlay
+class WeaponsScreen : public BaseShipScreen
 {
 private:
-    GuiOverlay* background_crosses;
-
     TargetsContainer targets;
     GuiKeyValueDisplay* energy_display;
     GuiKeyValueDisplay* front_shield_display;

--- a/src/screens/extra/commsScreen.cpp
+++ b/src/screens/extra/commsScreen.cpp
@@ -5,7 +5,7 @@
 #include "gui/theme.h"
 
 CommsScreen::CommsScreen(GuiContainer* owner)
-: GuiOverlay(owner, "COMMS_SCREEN", GuiTheme::getColor("background"))
+: BaseShipScreen(owner, "COMMS_SCREEN")
 {
     new ShipsLog(this);
     (new GuiCommsOverlay(this))->setSize(GuiElement::GuiSizeMax, GuiElement::GuiSizeMax);

--- a/src/screens/extra/commsScreen.h
+++ b/src/screens/extra/commsScreen.h
@@ -1,9 +1,9 @@
 #ifndef COMMS_SCREEN_H
 #define COMMS_SCREEN_H
 
-#include "gui/gui2_overlay.h"
+#include "screens/baseShipScreen.h"
 
-class CommsScreen : public GuiOverlay
+class CommsScreen : public BaseShipScreen
 {
 public:
     CommsScreen(GuiContainer* owner);

--- a/src/screens/extra/damcon.cpp
+++ b/src/screens/extra/damcon.cpp
@@ -12,7 +12,7 @@
 
 
 DamageControlScreen::DamageControlScreen(GuiContainer* owner)
-: GuiOverlay(owner, "DAMCON_SCREEN", GuiTheme::getColor("background"))
+: BaseShipScreen(owner, "DAMCON_SCREEN")
 {
     (new GuiShipInternalView(this, "SHIP_INTERNAL_VIEW", 48.0f * 1.5f))->setShip(my_spaceship)->setPosition(300, 0, sp::Alignment::TopLeft)->setSize(GuiElement::GuiSizeMax, GuiElement::GuiSizeMax);
 
@@ -33,7 +33,7 @@ DamageControlScreen::DamageControlScreen(GuiContainer* owner)
 
 void DamageControlScreen::onDraw(sp::RenderTarget& renderer)
 {
-    GuiOverlay::onDraw(renderer);
+    BaseShipScreen::onDraw(renderer);
 
     if (my_spaceship)
     {

--- a/src/screens/extra/damcon.h
+++ b/src/screens/extra/damcon.h
@@ -1,12 +1,12 @@
 #ifndef DAMCON_H
 #define DAMCON_H
 
-#include "gui/gui2_overlay.h"
+#include "screens/baseShipScreen.h"
 #include "components/shipsystem.h"
 
 class GuiKeyValueDisplay;
 
-class DamageControlScreen : public GuiOverlay
+class DamageControlScreen : public BaseShipScreen
 {
 private:
     GuiKeyValueDisplay* hull_display;

--- a/src/screens/extra/databaseScreen.cpp
+++ b/src/screens/extra/databaseScreen.cpp
@@ -6,12 +6,8 @@
 #include "gui/theme.h"
 
 DatabaseScreen::DatabaseScreen(GuiContainer* owner)
-: GuiOverlay(owner, "DATABASE_SCREEN", GuiTheme::getColor("background"))
+: BaseShipScreen(owner, "DATABASE_SCREEN")
 {
-    // Render background decorations.
-    (new GuiOverlay(this, "BACKGROUND_CROSSES", glm::u8vec4{255,255,255,255}))
-        ->setTextureTiled("gui/background/crosses.png");
-
     // Render database.
     DatabaseViewComponent* dvc = new DatabaseViewComponent(this);
     dvc->setPosition(0.0f, 0.0f, sp::Alignment::TopLeft)

--- a/src/screens/extra/databaseScreen.h
+++ b/src/screens/extra/databaseScreen.h
@@ -1,10 +1,10 @@
 #pragma once
 
-#include "gui/gui2_overlay.h"
+#include "screens/baseShipScreen.h"
 
 class DatabaseViewComponent;
 
-class DatabaseScreen : public GuiOverlay
+class DatabaseScreen : public BaseShipScreen
 {
 private:
 public:

--- a/src/screens/extra/powerManagement.cpp
+++ b/src/screens/extra/powerManagement.cpp
@@ -15,7 +15,7 @@
 #include "screenComponents/customShipFunctions.h"
 
 PowerManagementScreen::PowerManagementScreen(GuiContainer* owner)
-: GuiOverlay(owner, "POWER_MANAGEMENT_SCREEN", GuiTheme::getColor("background"))
+: BaseShipScreen(owner, "POWER_MANAGEMENT_SCREEN")
 {
     selected_system = ShipSystem::Type::None;
 
@@ -74,7 +74,7 @@ PowerManagementScreen::PowerManagementScreen(GuiContainer* owner)
 
 void PowerManagementScreen::onDraw(sp::RenderTarget& renderer)
 {
-    GuiOverlay::onDraw(renderer);
+    BaseShipScreen::onDraw(renderer);
     if (my_spaceship)
     {
         auto reactor = my_spaceship.getComponent<Reactor>();
@@ -128,6 +128,7 @@ void PowerManagementScreen::onDraw(sp::RenderTarget& renderer)
 
 void PowerManagementScreen::onUpdate()
 {
+    BaseShipScreen::onUpdate();
     if (my_spaceship && isVisible())
     {
         auto coolant = my_spaceship.getComponent<Coolant>();

--- a/src/screens/extra/powerManagement.h
+++ b/src/screens/extra/powerManagement.h
@@ -1,7 +1,7 @@
 #ifndef POWER_MANAGEMENT_H
 #define POWER_MANAGEMENT_H
 
-#include "gui/gui2_overlay.h"
+#include "screens/baseShipScreen.h"
 #include "components/shipsystem.h"
 
 class GuiPanel;
@@ -9,7 +9,7 @@ class GuiSlider;
 class GuiProgressbar;
 class GuiKeyValueDisplay;
 
-class PowerManagementScreen : public GuiOverlay
+class PowerManagementScreen : public BaseShipScreen
 {
 private:
     GuiKeyValueDisplay* energy_display;

--- a/src/screens/extra/shipLogScreen.cpp
+++ b/src/screens/extra/shipLogScreen.cpp
@@ -7,13 +7,12 @@
 #include "screenComponents/customShipFunctions.h"
 
 ShipLogScreen::ShipLogScreen(GuiContainer* owner)
-: GuiOverlay(owner, "SHIP_LOG_SCREEN", GuiTheme::getColor("background"))
+: BaseShipScreen(owner, "SHIP_LOG_SCREEN")
 {
     GuiElement* shiplog_layout = new GuiElement(this, "SHIPLOG_LAYOUT");
     shiplog_layout->setPosition(50, 120)->setSize(GuiElement::GuiSizeMax, GuiElement::GuiSizeMax)->setAttribute("layout", "horizontalright");
     custom_function_sidebar= new GuiCustomShipFunctions(shiplog_layout, CrewPosition::shipLog, "");
     custom_function_sidebar->setSize(270, GuiElement::GuiSizeMax);
-    (new GuiOverlay(this, "", glm::u8vec4{255,255,255,255}))->setTextureTiledThemed("background.crosses");
     log_text = new GuiAdvancedScrollText(shiplog_layout, "SHIP_LOG");
     log_text->enableAutoScrollDown();
     log_text->setSize(GuiElement::GuiSizeMax, GuiElement::GuiSizeMax);
@@ -21,7 +20,7 @@ ShipLogScreen::ShipLogScreen(GuiContainer* owner)
 
 void ShipLogScreen::onDraw(sp::RenderTarget& renderer)
 {
-    GuiOverlay::onDraw(renderer);
+    BaseShipScreen::onDraw(renderer);
 
     if (my_spaceship)
     {

--- a/src/screens/extra/shipLogScreen.h
+++ b/src/screens/extra/shipLogScreen.h
@@ -1,12 +1,12 @@
 #ifndef SHIP_LOG_SCREEN_H
 #define SHIP_LOG_SCREEN_H
 
-#include "gui/gui2_overlay.h"
+#include "screens/baseShipScreen.h"
 
 class GuiAdvancedScrollText;
 class GuiCustomShipFunctions;
 
-class ShipLogScreen : public GuiOverlay
+class ShipLogScreen : public BaseShipScreen
 {
 private:
     GuiAdvancedScrollText* log_text;


### PR DESCRIPTION
- Removed multiplicative alert-level overlay rect as it makes UI controls much harder to read & use.
- Most ship screens (all except Relay, Strategic Map, and mainscreen/windows) now derive from BaseShipScreen instead of GuiOverlay. BaseShipScreen handles:
  - Background crosses.
  - Background color changing by alert level of current ship.
- Relay & Strategic Map have their alert control upgraded:
  - Red/Yellow alert buttons have different style, so they can be red/yellow (or whatever color the theme says to make them)
  - The main button mirrors the Red/Yellow alert selection buttons' text & style when in red/yellow alert

<details>
<summary>Images of each station at each alert level, in default theme</summary>

AlertLevel::Normal (same as current except that some stations didn't have background crosses)
![](https://gn32.uk/i/2026-03-20_00-07-57.png)

AlertLevel::YellowAlert
![](https://gn32.uk/i/2026-03-20_00-08-59.png)

AlertLevel::RedAlert
![](https://gn32.uk/i/2026-03-20_00-09-48.png)
</details>

<details>
<summary>New Relay/Strategic Map alert control</summary>

![](https://gn32.uk/i/2026-03-20_00-26-48.png)
![](https://gn32.uk/i/2026-03-20_00-26-57.png)
![](https://gn32.uk/i/2026-03-20_00-27-03.png)
</details>