### PR TITLE
Refactor mousewheel behavior on GuiRadarView

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -297,6 +297,7 @@ set(MAIN_SOURCES
     src/screenComponents/shipInternalView.cpp
     src/screenComponents/beamFrequencySelector.cpp
     src/screenComponents/radarView.cpp
+    src/screenComponents/radarZoomSlider.cpp
     src/screenComponents/rawScannerDataRadarOverlay.cpp
     src/screenComponents/scanTargetButton.cpp
     src/screenComponents/snapSlider.cpp
@@ -595,6 +596,7 @@ set(MAIN_SOURCES
     src/screenComponents/openCommsButton.h
     src/screenComponents/powerDamageIndicator.h
     src/screenComponents/radarView.h
+    src/screenComponents/radarZoomSlider.h
     src/screenComponents/rawScannerDataRadarOverlay.h
     src/screenComponents/rotatingModelView.h
     src/screenComponents/scanningDialog.h

--- a/src/gui/hotkeyConfig.cpp
+++ b/src/gui/hotkeyConfig.cpp
@@ -78,7 +78,7 @@ Keys::Keys() :
     pause("PAUSE", "P"),
     help("HELP", "F1"),
     escape("ESCAPE", {"Escape", "Home", "Keypad 7", "AC Back"}),
-    zoom_in("ZOOM_IN", {"wheel:y"}),
+    zoom_in("ZOOM_IN"),
     zoom_out("ZOOM_OUT"),
     voice_all("VOICE_ALL", "Backspace"),
     voice_ship("VOICE_SHIP"),

--- a/src/screenComponents/radarView.cpp
+++ b/src/screenComponents/radarView.cpp
@@ -886,3 +886,14 @@ void GuiRadarView::onMouseUp(glm::vec2 position, sp::io::Pointer::ID id)
     if (mouse_up_func)
         mouse_up_func(screenToWorld(position));
 }
+
+bool GuiRadarView::onMouseWheelScroll(glm::vec2 position, float value)
+{
+    if (mouse_wheel_func)
+    {
+        mouse_wheel_func(value, position);
+        return true;
+    }
+
+    return false;
+}

--- a/src/screenComponents/radarView.h
+++ b/src/screenComponents/radarView.h
@@ -25,7 +25,7 @@ public:
 
     typedef std::function<void(sp::io::Pointer::Button button, glm::vec2 position)> bpfunc_t;
     typedef std::function<void(glm::vec2 position)> pfunc_t;
-    typedef std::function<void(float position)>     ffunc_t;
+    typedef std::function<void(float value, glm::vec2 position)> fpfunc_t;
 private:
     class GhostDot
     {
@@ -65,6 +65,7 @@ private:
     bpfunc_t mouse_down_func;
     pfunc_t mouse_drag_func;
     pfunc_t mouse_up_func;
+    fpfunc_t mouse_wheel_func;
     // Overlay callback
     std::function<void(sp::RenderTarget&)> overlay_func;
 
@@ -110,7 +111,7 @@ public:
     GuiRadarView* setAutoCenterTarget(sp::ecs::Entity target) { this->auto_center_target = target; return this; }
     bool getAutoRotating() { return auto_rotate_on_ship; }
     GuiRadarView* setAutoRotating(bool value) { this->auto_rotate_on_ship = value; return this; }
-    GuiRadarView* setCallbacks(bpfunc_t mouse_down_func, pfunc_t mouse_drag_func, pfunc_t mouse_up_func) { this->mouse_down_func = mouse_down_func; this->mouse_drag_func = mouse_drag_func; this->mouse_up_func = mouse_up_func; return this; }
+    GuiRadarView* setCallbacks(bpfunc_t mouse_down_func, pfunc_t mouse_drag_func, pfunc_t mouse_up_func, fpfunc_t mouse_wheel_func) { this->mouse_down_func = mouse_down_func; this->mouse_drag_func = mouse_drag_func; this->mouse_up_func = mouse_up_func; this->mouse_wheel_func = mouse_wheel_func; return this; }
     // Define the overlay callback function. This passes the onDraw()
     // RenderTarget and runs near the end of the frame.
     GuiRadarView* setOverlayCallback(std::function<void(sp::RenderTarget&)> f) { overlay_func = f; return this; }
@@ -126,6 +127,7 @@ public:
     virtual bool onMouseDown(sp::io::Pointer::Button button, glm::vec2 position, sp::io::Pointer::ID id) override;
     virtual void onMouseDrag(glm::vec2 position, sp::io::Pointer::ID id) override;
     virtual void onMouseUp(glm::vec2 position, sp::io::Pointer::ID id) override;
+    virtual bool onMouseWheelScroll(glm::vec2 position, float value) override;
 private:
     void updateGhostDots();
 

--- a/src/screenComponents/radarZoomSlider.cpp
+++ b/src/screenComponents/radarZoomSlider.cpp
@@ -1,0 +1,70 @@
+#include "radarZoomSlider.h"
+#include <i18n.h>
+
+#include "gui/gui2_label.h"
+#include "gui/gui2_slider.h"
+
+GuiRadarZoomSlider::GuiRadarZoomSlider(GuiContainer* owner, string id, float min_distance, float max_distance, float start_value, GuiRadarView* radar)
+: GuiElement(owner, id), radar(radar), min_distance(min_distance), max_distance(max_distance), zoom_ref(max_distance)
+{
+    slider = new GuiSlider(this, "", max_distance, min_distance, start_value,
+        [this](float value)
+        {
+            this->radar->setDistance(value);
+            label->setText(tr("Zoom: {zoom}x").format({{"zoom", string(zoom_ref / value, label_precision)}}));
+        }
+    );
+    slider->setSize(GuiElement::GuiSizeMax, GuiElement::GuiSizeMax);
+
+    label = new GuiLabel(slider, "", tr("Zoom: {zoom}x").format({{"zoom", string(1.0f, label_precision)}}), 30.0f);
+    label->setSize(GuiElement::GuiSizeMax, GuiElement::GuiSizeMax);
+}
+
+void GuiRadarZoomSlider::applyDistance(float view_distance)
+{
+    if (min_distance > max_distance) min_distance = max_distance;
+    view_distance = std::clamp(view_distance, min_distance, max_distance);
+    radar->setDistance(view_distance);
+    slider->setValue(view_distance);
+    label->setText(tr("Zoom: {zoom}x").format({{"zoom", string(zoom_ref / view_distance, label_precision)}}));
+}
+
+GuiRadarZoomSlider* GuiRadarZoomSlider::setRange(float new_max, float new_min)
+{
+    max_distance = new_max;
+    min_distance = new_min;
+    if (!custom_zoom_ref) zoom_ref = new_max;
+    slider->setRange(new_max, new_min);
+    return this;
+}
+
+GuiRadarZoomSlider* GuiRadarZoomSlider::setZoomReference(float ref)
+{
+    zoom_ref = ref;
+    custom_zoom_ref = true;
+    return this;
+}
+
+GuiRadarZoomSlider* GuiRadarZoomSlider::setLabelPrecision(int precision)
+{
+    label_precision = precision;
+    applyDistance(slider->getValue());
+    return this;
+}
+
+GuiRadarZoomSlider* GuiRadarZoomSlider::setValue(float value)
+{
+    applyDistance(value);
+    return this;
+}
+
+float GuiRadarZoomSlider::getValue()
+{
+    return slider->getValue();
+}
+
+bool GuiRadarZoomSlider::onMouseWheelScroll(glm::vec2 position, float value)
+{
+    applyDistance(radar->getDistance() * (1.0f - value * 0.1f));
+    return true;
+}

--- a/src/screenComponents/radarZoomSlider.h
+++ b/src/screenComponents/radarZoomSlider.h
@@ -1,0 +1,40 @@
+#pragma once
+
+#include "gui/gui2_element.h"
+#include "screenComponents/radarView.h"
+
+class GuiLabel;
+class GuiSlider;
+
+// RadarView zoom slider with mousewheel handling.
+class GuiRadarZoomSlider : public GuiElement
+{
+private:
+    GuiSlider* slider;
+    GuiLabel* label;
+    GuiRadarView* radar;
+    float min_distance;
+    float max_distance;
+    float zoom_ref;
+    bool custom_zoom_ref = false;
+    int label_precision = 1;
+
+    void applyDistance(float view_distance);
+
+public:
+    GuiRadarZoomSlider(GuiContainer* owner, string id, float min_distance, float max_distance, float start_value, GuiRadarView* radar);
+
+    // Update the view distance range.
+    GuiRadarZoomSlider* setRange(float new_max, float new_min);
+    // Override the view distance of 1x zoom as used in the label.
+    GuiRadarZoomSlider* setZoomReference(float ref);
+    // Set the number of decimal places shown in the zoom multiplier label.
+    GuiRadarZoomSlider* setLabelPrecision(int precision);
+    // Set the slider value by view distance.
+    GuiRadarZoomSlider* setValue(float value);
+    // Return the slider value in view distance.
+    float getValue();
+
+    // Handle mousewheel zoom when hovering over the slider.
+    virtual bool onMouseWheelScroll(glm::vec2 position, float value) override;
+};

--- a/src/screens/crew1/singlePilotScreen.cpp
+++ b/src/screens/crew1/singlePilotScreen.cpp
@@ -81,7 +81,7 @@ SinglePilotScreen::SinglePilotScreen(GuiContainer* owner)
         },
         [this](glm::vec2 position) {
            drag_rotate=false;
-        }
+        }, nullptr
     );
     radar->setAutoRotating(PreferencesManager::get("single_pilot_radar_lock","0")=="1");
 

--- a/src/screens/crew4/operationsScreen.cpp
+++ b/src/screens/crew4/operationsScreen.cpp
@@ -70,6 +70,15 @@ OperationScreen::OperationScreen(GuiContainer* owner)
                 science->targets.setWaypointIndex(drag_waypoint_index);
                 break;
             }
+        },
+        [this](float value, glm::vec2 position) { // Wheel
+            float view_distance = std::clamp(
+                science->science_radar->getDistance() * (1.0f - value * 0.1f),
+                science->DEFAULT_MIN_ZOOM_DISTANCE,
+                science->DEFAULT_MAX_ZOOM_DISTANCE
+            );
+            science->science_radar->setDistance(view_distance);
+            // zoom_slider->setValue(view_distance);
         }
     );
     science->science_radar->setAutoRotating(PreferencesManager::get("operations_radar_lock","0")=="1");

--- a/src/screens/crew4/tacticalScreen.cpp
+++ b/src/screens/crew4/tacticalScreen.cpp
@@ -74,7 +74,7 @@ TacticalScreen::TacticalScreen(GuiContainer* owner)
         },
         [this](glm::vec2 position) {
             drag_rotate=false;
-        }
+        }, nullptr
     );
     radar->setAutoRotating(PreferencesManager::get("tactical_radar_lock","0")=="1");
 

--- a/src/screens/crew6/helmsScreen.cpp
+++ b/src/screens/crew6/helmsScreen.cpp
@@ -48,7 +48,7 @@ HelmsScreen::HelmsScreen(GuiContainer* owner)
     radar->setRangeIndicatorStepSize(1000.0)->shortRange()->enableGhostDots()->enableWaypoints()->enableCallsigns()->enableHeadingIndicators()->setStyle(GuiRadarView::Circular);
     radar->enableMissileTubeIndicators();
     radar->setCallbacks(
-        [radar, this](sp::io::Pointer::Button button, glm::vec2 position) {
+        [radar, this](sp::io::Pointer::Button button, glm::vec2 position) { // down
             if (auto transform = my_spaceship.getComponent<sp::Transform>())
             {
                 auto r = radar->getRect();
@@ -71,7 +71,7 @@ HelmsScreen::HelmsScreen(GuiContainer* owner)
                 my_player_info->commandTargetRotation(angle);
             }
         },
-        [radar, this](glm::vec2 position) {
+        [radar, this](glm::vec2 position) { // drag
             if (auto transform = my_spaceship.getComponent<sp::Transform>())
             {
                 auto r = radar->getRect();
@@ -93,11 +93,11 @@ HelmsScreen::HelmsScreen(GuiContainer* owner)
                 my_player_info->commandTargetRotation(angle);
             }
         },
-        [this](glm::vec2 position) {
+        [this](glm::vec2 position) { // up
             if (auto transform = my_spaceship.getComponent<sp::Transform>())
                 my_player_info->commandTargetRotation(vec2ToAngle(position - transform->getPosition()));
             heading_hint->hide();
-        }
+        }, nullptr
     );
     radar->setAutoRotating(PreferencesManager::get("helms_radar_lock","0")=="1");
 

--- a/src/screens/crew6/relayScreen.cpp
+++ b/src/screens/crew6/relayScreen.cpp
@@ -12,6 +12,7 @@
 #include "components/name.h"
 
 #include "screenComponents/radarView.h"
+#include "screenComponents/radarZoomSlider.h"
 #include "screenComponents/openCommsButton.h"
 #include "screenComponents/commsOverlay.h"
 #include "screenComponents/shipsLogControl.h"
@@ -22,9 +23,9 @@
 #include "gui/mouseRenderer.h"
 #include "gui/theme.h"
 #include "gui/gui2_keyvaluedisplay.h"
+#include "gui/gui2_label.h"
 #include "gui/gui2_selector.h"
 #include "gui/gui2_slider.h"
-#include "gui/gui2_label.h"
 #include "gui/gui2_togglebutton.h"
 
 //TODO: This function does not belong here.
@@ -41,7 +42,7 @@ RelayScreen::RelayScreen(GuiContainer* owner, bool allow_comms)
 : GuiOverlay(owner, "RELAY_SCREEN", GuiTheme::getColor("background")), mode(TargetSelection)
 {
     targets.setAllowWaypointSelection();
-    radar = new GuiRadarView(this, "RELAY_RADAR", 50000.0f, &targets);
+    radar = new GuiRadarView(this, "RELAY_RADAR", MAX_ZOOM_DISTANCE, &targets);
     radar->longRange()->enableWaypoints()->enableCallsigns()->setStyle(GuiRadarView::Rectangular)->setFogOfWarStyle(GuiRadarView::FriendlysShortRangeFogOfWar);
     radar->setAutoCentering(false);
     radar->setPosition(0, 0, sp::Alignment::TopLeft)->setSize(GuiElement::GuiSizeMax, GuiElement::GuiSizeMax);
@@ -90,6 +91,25 @@ RelayScreen::RelayScreen(GuiContainer* owner, bool allow_comms)
                 cancel_button->hide();
                 break;
             }
+        },
+        [this](float value, glm::vec2 position) { // wheel
+            // Calculate the new zoom level.
+            const float view_distance = std::clamp(
+                radar->getDistance() * (1.0f - value * 0.1f),
+                MIN_ZOOM_DISTANCE,
+                MAX_ZOOM_DISTANCE
+            );
+
+            // Get the world coordinates under the pointer before zooming.
+            const glm::vec2 world_position_before_zoom = radar->screenToWorld(position);
+
+            // Set the new zoom level.
+            radar->setDistance(view_distance);
+            zoom_slider->setValue(view_distance);
+
+            // Adjust the radar's view position to keep the world coordinates
+            // under the pointer consistent.
+            radar->setViewPosition(radar->getViewPosition() + world_position_before_zoom - radar->screenToWorld(position));
         }
     );
 
@@ -105,13 +125,10 @@ RelayScreen::RelayScreen(GuiContainer* owner, bool allow_comms)
     info_faction = new GuiKeyValueDisplay(sidebar, "SCIENCE_FACTION", 0.4, tr("Faction"), "");
     info_faction->setSize(GuiElement::GuiSizeMax, 30);
 
-    zoom_slider = new GuiSlider(this, "ZOOM_SLIDER", 50000.0f, 6250.0f, 50000.0f, [this](float value) {
-        zoom_label->setText(tr("Zoom: {zoom}x").format({{"zoom", string(50000.0f / value, 1.0f)}}));
-        radar->setDistance(value);
-    });
-    zoom_slider->setPosition(20, -70, sp::Alignment::BottomLeft)->setSize(250, 50);
-    zoom_label = new GuiLabel(zoom_slider, "", "Zoom: 1.0x", 30);
-    zoom_label->setSize(GuiElement::GuiSizeMax, GuiElement::GuiSizeMax);
+    zoom_slider = new GuiRadarZoomSlider(this, "", MIN_ZOOM_DISTANCE, MAX_ZOOM_DISTANCE, MAX_ZOOM_DISTANCE, radar);
+    zoom_slider
+        ->setPosition(20.0f, -70.0f, sp::Alignment::BottomLeft)
+        ->setSize(250.0f, 50.0f);
 
     // Option buttons for comms, waypoints, and probes.
     option_buttons = new GuiElement(this, "BUTTONS");
@@ -207,21 +224,17 @@ RelayScreen::RelayScreen(GuiContainer* owner, bool allow_comms)
 
 void RelayScreen::onDraw(sp::RenderTarget& renderer)
 {
-    ///Handle mouse wheel
-    float mouse_wheel_delta = keys.zoom_in.getValue() - keys.zoom_out.getValue();
-    if (mouse_wheel_delta != 0.0f)
+    float key_zoom_delta = keys.zoom_in.getValue() - keys.zoom_out.getValue();
+    if (key_zoom_delta != 0.0f)
     {
-        float view_distance = radar->getDistance() * (1.0f - (mouse_wheel_delta * 0.1f));
-        if (view_distance > 50000.0f)
-            view_distance = 50000.0f;
-        if (view_distance < 6250.0f)
-            view_distance = 6250.0f;
+        float view_distance = std::clamp(
+            radar->getDistance() * (1.0f - (key_zoom_delta * 0.1f)),
+            MIN_ZOOM_DISTANCE,
+            MAX_ZOOM_DISTANCE
+        );
         radar->setDistance(view_distance);
-        // Keep the zoom slider in sync.
         zoom_slider->setValue(view_distance);
-        zoom_label->setText("Zoom: " + string(50000.0f / view_distance, 1.0f) + "x");
     }
-    ///!
 
     GuiOverlay::onDraw(renderer);
 

--- a/src/screens/crew6/relayScreen.h
+++ b/src/screens/crew6/relayScreen.h
@@ -3,13 +3,14 @@
 #include "screenComponents/targetsContainer.h"
 #include "gui/gui2_overlay.h"
 
-class GuiRadarView;
-class GuiKeyValueDisplay;
 class GuiButton;
-class GuiToggleButton;
-class GuiSlider;
-class GuiLabel;
 class GuiHackingDialog;
+class GuiKeyValueDisplay;
+class GuiLabel;
+class GuiRadarView;
+class GuiRadarZoomSlider;
+class GuiSlider;
+class GuiToggleButton;
 
 class RelayScreen : public GuiOverlay
 {
@@ -21,6 +22,9 @@ private:
         LaunchProbe,
         MoveWaypoint
     } mode = TargetSelection;
+
+    const float MIN_ZOOM_DISTANCE = 6250.0f;
+    const float MAX_ZOOM_DISTANCE = 50000.0f;
 
     TargetsContainer targets;
     int drag_waypoint_index;
@@ -39,7 +43,7 @@ private:
     GuiButton* launch_probe_button;
     GuiToggleButton* center_button;
 
-    GuiSlider* zoom_slider;
+    GuiRadarZoomSlider* zoom_slider;
     GuiLabel* zoom_label;
 
     GuiHackingDialog* hacking_dialog;

--- a/src/screens/crew6/scienceScreen.cpp
+++ b/src/screens/crew6/scienceScreen.cpp
@@ -17,6 +17,7 @@
 #include "systems/radarblock.h"
 
 #include "screenComponents/radarView.h"
+#include "screenComponents/radarZoomSlider.h"
 #include "screenComponents/rawScannerDataRadarOverlay.h"
 #include "screenComponents/scanTargetButton.h"
 #include "screenComponents/frequencyCurve.h"
@@ -55,23 +56,32 @@ ScienceScreen::ScienceScreen(GuiContainer* owner, CrewPosition crew_position)
     radar_view->setSize(GuiElement::GuiSizeMax, GuiElement::GuiSizeMax);
 
     // Draw the science radar.
-    science_radar = new GuiRadarView(radar_view, "SCIENCE_RADAR", lrr ? lrr->long_range : 30000.0f, &targets);
+    science_radar = new GuiRadarView(radar_view, "SCIENCE_RADAR", lrr ? lrr->long_range : DEFAULT_MAX_ZOOM_DISTANCE, &targets);
     science_radar->setPosition(120, 0, sp::Alignment::CenterLeft)->setSize(900,GuiElement::GuiSizeMax);
-    science_radar->setRangeIndicatorStepSize(5000.0)->longRange()->enableWaypoints()->enableCallsigns()->enableHeadingIndicators()->setStyle(GuiRadarView::Circular)->setFogOfWarStyle(GuiRadarView::NebulaFogOfWar);
+    science_radar->setRangeIndicatorStepSize(DEFAULT_MIN_ZOOM_DISTANCE)->longRange()->enableWaypoints()->enableCallsigns()->enableHeadingIndicators()->setStyle(GuiRadarView::Circular)->setFogOfWarStyle(GuiRadarView::NebulaFogOfWar);
     science_radar->setCallbacks(
-        [this](sp::io::Pointer::Button button, glm::vec2 position) {
+        [this](sp::io::Pointer::Button button, glm::vec2 position) { // down
             if (auto scanner = my_spaceship.getComponent<ScienceScanner>())
                 if (scanner->delay > 0.0f)
                     return;
 
             targets.setToClosestTo(position, 1000, TargetsContainer::Selectable);
-        }, nullptr, nullptr
+        }, nullptr, nullptr,
+        [this](float value, glm::vec2 position) { // wheel
+            float view_distance = std::clamp(
+                science_radar->getDistance() * (1.0f - value * 0.1f),
+                DEFAULT_MIN_ZOOM_DISTANCE,
+                DEFAULT_MAX_ZOOM_DISTANCE
+            );
+            science_radar->setDistance(view_distance);
+            zoom_slider->setValue(view_distance);
+        }
     );
     science_radar->setAutoRotating(PreferencesManager::get("science_radar_lock","0")=="1");
     new RawScannerDataRadarOverlay(science_radar, "");
 
     // Draw and hide the probe radar.
-    probe_radar = new GuiRadarView(radar_view, "PROBE_RADAR", 5000, &targets);
+    probe_radar = new GuiRadarView(radar_view, "PROBE_RADAR", PROBE_ZOOM_DISTANCE, &targets);
     probe_radar->setPosition(120, 0, sp::Alignment::CenterLeft)->setSize(900,GuiElement::GuiSizeMax)->hide();
     probe_radar->setAutoCentering(false)->longRange()->enableWaypoints()->enableCallsigns()->enableHeadingIndicators()->setStyle(GuiRadarView::Circular)->setFogOfWarStyle(GuiRadarView::NoFogOfWar);
     probe_radar->setCallbacks(
@@ -81,7 +91,7 @@ ScienceScreen::ScienceScreen(GuiContainer* owner, CrewPosition crew_position)
                     return;
 
             targets.setToClosestTo(position, 1000, TargetsContainer::Selectable);
-        }, nullptr, nullptr
+        }, nullptr, nullptr, nullptr
     );
     new RawScannerDataRadarOverlay(probe_radar, "");
 
@@ -224,15 +234,12 @@ ScienceScreen::ScienceScreen(GuiContainer* owner, CrewPosition crew_position)
     probe_view_button->setPosition(20, -120, sp::Alignment::BottomLeft)->setSize(200, 50)->disable();
 
     // Draw the zoom slider.
-    zoom_slider = new GuiSlider(radar_view, "", lrr ? lrr->long_range : 30000.0f, lrr ? lrr->short_range : 5000.0f, lrr ? lrr->long_range : 30000.0f, [this](float value)
-    {
-        if (auto lrr = my_spaceship.getComponent<LongRangeRadar>())
-            zoom_label->setText(tr("scienceButton", "Zoom: {zoom}x").format({{"zoom", string(lrr->long_range / value, 1)}}));
-        science_radar->setDistance(value);
-    });
-    zoom_slider->setPosition(-20, -20, sp::Alignment::BottomRight)->setSize(250, 50);
-    zoom_label = new GuiLabel(zoom_slider, "", "Zoom: 1.0x", 30);
-    zoom_label->setSize(GuiElement::GuiSizeMax, GuiElement::GuiSizeMax);
+    float lrr_long = lrr ? lrr->long_range : DEFAULT_MAX_ZOOM_DISTANCE;
+    float lrr_short = lrr ? lrr->short_range : DEFAULT_MIN_ZOOM_DISTANCE;
+    zoom_slider = new GuiRadarZoomSlider(radar_view, "RADAR_ZOOM", lrr_short, lrr_long, lrr_long, science_radar);
+    zoom_slider
+        ->setPosition(-20.0f, -20.0f, sp::Alignment::BottomRight)
+        ->setSize(250.0f, 50.0f);
 
     // Radar/database view toggle.
     view_mode_selection = new GuiListbox(this, "VIEW_SELECTION", [this](int index, string value) {
@@ -259,21 +266,17 @@ void ScienceScreen::onDraw(sp::RenderTarget& renderer)
     auto rl = my_spaceship.getComponent<RadarLink>();
 
     float view_distance = science_radar->getDistance();
-    float mouse_wheel_delta = keys.zoom_in.getValue() - keys.zoom_out.getValue();
-    if (mouse_wheel_delta!=0)
-    {
-        view_distance *= (1.0f - (mouse_wheel_delta * 0.1f));
-    }
+    float key_zoom_delta = keys.zoom_in.getValue() - keys.zoom_out.getValue();
+    if (key_zoom_delta != 0)
+        view_distance *= (1.0f - (key_zoom_delta * 0.1f));
+
     view_distance = std::min(view_distance, lrr->long_range);
     view_distance = std::max(view_distance, lrr->short_range);
     if (view_distance!=science_radar->getDistance() || previous_long_range_radar != lrr->long_range || previous_short_range_radar != lrr->short_range)
     {
         previous_short_range_radar = lrr->long_range;
         previous_long_range_radar = lrr->short_range;
-        science_radar->setDistance(view_distance);
-        // Keep the zoom slider in sync.
-        zoom_slider->setValue(view_distance)->setRange(lrr->long_range, lrr->short_range);
-        zoom_label->setText(tr("scienceButton", "Zoom: {zoom}x").format({{"zoom", string(lrr->long_range / view_distance, 1)}}));
+        zoom_slider->setRange(lrr->long_range, lrr->short_range)->setValue(view_distance);
     }
 
     if (probe_view_button->getValue() && rl && rl->linked_entity)
@@ -558,7 +561,7 @@ void ScienceScreen::onUpdate()
         {
             if (auto transform = my_spaceship.getComponent<sp::Transform>()) {
                 auto lrr = my_spaceship.getComponent<LongRangeRadar>();
-                targets.setNext(transform->getPosition(), lrr ? lrr->long_range : 25000.0f, TargetsContainer::ESelectionType::Scannable);
+                targets.setNext(transform->getPosition(), lrr ? lrr->long_range : DEFAULT_MAX_ZOOM_DISTANCE, TargetsContainer::ESelectionType::Scannable);
             }
         }
     }

--- a/src/screens/crew6/scienceScreen.h
+++ b/src/screens/crew6/scienceScreen.h
@@ -1,5 +1,4 @@
-#ifndef SCIENCE_SCREEN_H
-#define SCIENCE_SCREEN_H
+#pragma once
 
 #include "screenComponents/targetsContainer.h"
 #include "gui/gui2_overlay.h"
@@ -14,8 +13,7 @@ class GuiButton;
 class GuiScanTargetButton;
 class GuiToggleButton;
 class GuiSelector;
-class GuiSlider;
-class GuiLabel;
+class GuiRadarZoomSlider;
 class GuiImage;
 class DatabaseViewComponent;
 class GuiCustomShipFunctions;
@@ -23,6 +21,10 @@ class GuiCustomShipFunctions;
 class ScienceScreen : public GuiOverlay
 {
 public:
+    const float PROBE_ZOOM_DISTANCE = 5000.0f;
+    const float DEFAULT_MIN_ZOOM_DISTANCE = 5000.0f;
+    const float DEFAULT_MAX_ZOOM_DISTANCE = 30000.0f;
+
     GuiImage* background_gradient;
     GuiOverlay* background_crosses;
 
@@ -32,8 +34,7 @@ public:
     TargetsContainer targets;
     GuiRadarView* science_radar;
     GuiRadarView* probe_radar;
-    GuiSlider* zoom_slider;
-    GuiLabel* zoom_label;
+    GuiRadarZoomSlider* zoom_slider;
 
     GuiSelector* sidebar_selector;
     GuiElement* info_sidebar;
@@ -58,15 +59,13 @@ public:
     GuiToggleButton* probe_view_button;
     sp::ecs::Entity observation_point;
     GuiListbox* view_mode_selection;
-public:
+
     ScienceScreen(GuiContainer* owner, CrewPosition crew_position=CrewPosition::scienceOfficer);
 
     virtual void onDraw(sp::RenderTarget& target) override;
     virtual void onUpdate() override;
 private:
-    //used to judge when to update the UI label and zoom
-    float previous_long_range_radar=0;
-    float previous_short_range_radar=0;
+    // Used to judge when to update the UI label and zoom
+    float previous_long_range_radar = 0.0f;
+    float previous_short_range_radar = 0.0f;
 };
-
-#endif//SCIENCE_SCREEN_H

--- a/src/screens/crew6/weaponsScreen.cpp
+++ b/src/screens/crew6/weaponsScreen.cpp
@@ -43,13 +43,13 @@ WeaponsScreen::WeaponsScreen(GuiContainer* owner)
     radar->setPosition(0, 0, sp::Alignment::Center)->setSize(GuiElement::GuiSizeMatchHeight, 800);
     radar->setRangeIndicatorStepSize(1000.0)->shortRange()->enableCallsigns()->enableHeadingIndicators()->setStyle(GuiRadarView::Circular);
     radar->setCallbacks(
-        [this](sp::io::Pointer::Button button, glm::vec2 position) {
+        [this](sp::io::Pointer::Button button, glm::vec2 position) { // down
             targets.setToClosestTo(position, 250, TargetsContainer::Targetable);
             if (my_spaceship && targets.get())
                 my_player_info->commandSetTarget(targets.get());
             else if (my_spaceship)
                 my_player_info->commandSetTarget({});
-        }, nullptr, nullptr
+        }, nullptr, nullptr, nullptr
     );
     radar->setAutoRotating(PreferencesManager::get("weapons_radar_lock","0")=="1");
 

--- a/src/screens/gm/gameMasterScreen.cpp
+++ b/src/screens/gm/gameMasterScreen.cpp
@@ -23,6 +23,7 @@
 #include "systems/collision.h"
 
 #include "screenComponents/radarView.h"
+#include "screenComponents/radarZoomSlider.h"
 #include "screenComponents/helpOverlay.h"
 
 #include "gui/mouseRenderer.h"
@@ -69,7 +70,7 @@ static std::unordered_map<string, string> getGMInfo(sp::ecs::Entity entity)
 GameMasterScreen::GameMasterScreen(RenderLayer* render_layer)
 : GuiCanvas(render_layer)
 {
-    main_radar = new GuiRadarView(this, "MAIN_RADAR", 50000.0f, &targets);
+    main_radar = new GuiRadarView(this, "MAIN_RADAR", LONG_RANGE_DISTANCE, &targets);
     main_radar
         ->setStyle(GuiRadarView::Rectangular)
         ->longRange()
@@ -79,7 +80,8 @@ GameMasterScreen::GameMasterScreen(RenderLayer* render_layer)
         ->setCallbacks(
             [this](sp::io::Pointer::Button button, glm::vec2 position) { this->onMouseDown(button, position); },
             [this](glm::vec2 position) { this->onMouseDrag(position); },
-            [this](glm::vec2 position) { this->onMouseUp(position); }
+            [this](glm::vec2 position) { this->onMouseUp(position); },
+            [this](float value, glm::vec2 position) { this->onMouseWheel(value, position); }
         )
         ->setOverlayCallback(
             [this](sp::RenderTarget& renderer)
@@ -172,15 +174,28 @@ GameMasterScreen::GameMasterScreen(RenderLayer* render_layer)
     });
     create_button->setPosition(20, -70, sp::Alignment::BottomLeft)->setSize(250, 50);
 
+    zoom_slider = new GuiRadarZoomSlider(this, "ZOOM_SLIDER", MIN_ZOOM_DISTANCE, MAX_ZOOM_DISTANCE, LONG_RANGE_DISTANCE, main_radar);
+    zoom_slider
+        ->setZoomReference(LONG_RANGE_DISTANCE)
+        ->setLabelPrecision(3)
+        ->setPosition(-20.0f, -20.0f, sp::Alignment::BottomRight)
+        ->setSize(250.0f, 50.0f);
+
     copy_scenario_button = new GuiButton(this, "COPY_SCENARIO_BUTTON", tr("button", "Copy scenario"), [this]() {
         Clipboard::setClipboard(getScriptExport(false));
     });
-    copy_scenario_button->setTextSize(20)->setPosition(-20, -20, sp::Alignment::BottomRight)->setSize(125, 25);
+    copy_scenario_button
+        ->setTextSize(20.0f)
+        ->setPosition(-20.0f, -70.0f, sp::Alignment::BottomRight)
+        ->setSize(125.0f, 25.0f);
 
     copy_selected_button = new GuiButton(this, "COPY_SELECTED_BUTTON", tr("button", "Copy selected"), [this]() {
         Clipboard::setClipboard(getScriptExport(true));
     });
-    copy_selected_button->setTextSize(20)->setPosition(-20, -45, sp::Alignment::BottomRight)->setSize(125, 25);
+    copy_selected_button
+        ->setTextSize(20.0f)
+        ->setPosition(-20.0f, -95.0f, sp::Alignment::BottomRight)
+        ->setSize(125.0f, 25.0f);
 
     cancel_action_button = new GuiButton(this, "CANCEL_CREATE_BUTTON", tr("button", "Cancel"), []() {
         gameGlobalInfo->on_gm_click = nullptr;
@@ -321,12 +336,12 @@ GameMasterScreen::~GameMasterScreen()
 
 void GameMasterScreen::update(float delta)
 {
-    float mouse_wheel_delta = keys.zoom_in.getValue() - keys.zoom_out.getValue();
-    if (mouse_wheel_delta != 0.0f)
+    float key_zoom_delta = keys.zoom_in.getValue() - keys.zoom_out.getValue();
+    if (key_zoom_delta != 0.0f)
     {
-        float view_distance = std::clamp(main_radar->getDistance() * (1.0f - (mouse_wheel_delta * 0.1f)), 5000.0f, 1000000.0f);
+        float view_distance = std::clamp(main_radar->getDistance() * (1.0f - (key_zoom_delta * 0.1f)), MIN_ZOOM_DISTANCE, MAX_ZOOM_DISTANCE);
         main_radar->setDistance(view_distance);
-        if (view_distance < 10000) main_radar->shortRange();
+        if (view_distance < SHORT_RANGE_DISTANCE) main_radar->shortRange();
         else main_radar->longRange();
     }
 
@@ -845,6 +860,27 @@ void GameMasterScreen::onMouseUp(glm::vec2 position)
     // the box.
     click_and_drag_state = ClickAndDragState::None;
     box_selection_overlay->hide();
+}
+
+void GameMasterScreen::onMouseWheel(float value, glm::vec2 position)
+{
+    // Calculate the new zoom level.
+    const float view_distance = std::clamp(
+        main_radar->getDistance() * (1.0f - value * 0.1f),
+        MIN_ZOOM_DISTANCE,
+        MAX_ZOOM_DISTANCE
+    );
+
+    // Get the world coordinates under the pointer before zooming.
+    const glm::vec2 world_position_before_zoom = main_radar->screenToWorld(position);
+
+    // Set the new zoom level.
+    main_radar->setDistance(view_distance);
+    zoom_slider->setValue(view_distance);
+
+    // Adjust the radar's view position to keep the world coordinates
+    // under the pointer consistent.
+    main_radar->setViewPosition(main_radar->getViewPosition() + world_position_before_zoom - main_radar->screenToWorld(position));
 }
 
 std::vector<sp::ecs::Entity> GameMasterScreen::getSelection()

--- a/src/screens/gm/gameMasterScreen.h
+++ b/src/screens/gm/gameMasterScreen.h
@@ -11,6 +11,7 @@ class GuiGlobalMessageEntry;
 class GuiObjectCreationScreen;
 class GuiEntityTweak;
 class GuiRadarView;
+class GuiRadarZoomSlider;
 class GuiOverlay;
 class GuiSelector;
 class GuiKeyValueDisplay;
@@ -27,6 +28,11 @@ class GuiPanel;
 class GameMasterScreen : public GuiCanvas, public Updatable
 {
 private:
+    const float MIN_ZOOM_DISTANCE = 5000.0f;
+    const float MAX_ZOOM_DISTANCE = 1000000.0f;
+    const float LONG_RANGE_DISTANCE = 50000.0f;
+    const float SHORT_RANGE_DISTANCE = 10000.0f;
+
     TargetsContainer targets;
     sp::ecs::Entity target;
     GuiRadarView* main_radar;
@@ -49,6 +55,7 @@ private:
     GuiToggleButton* pause_button;
     GuiToggleButton* intercept_comms_button;
     GuiButton* tweak_button;
+    GuiRadarZoomSlider* zoom_slider;
     GuiButton* copy_scenario_button;
     GuiButton* copy_selected_button;
     GuiSelector* player_ship_selector;
@@ -114,6 +121,7 @@ public:
     void onMouseDown(sp::io::Pointer::Button button, glm::vec2 position);
     void onMouseDrag(glm::vec2 position);
     void onMouseUp(glm::vec2 position);
+    void onMouseWheel(float value, glm::vec2 position);
 
     std::vector<sp::ecs::Entity> getSelection();
 

--- a/src/screens/spectatorScreen.cpp
+++ b/src/screens/spectatorScreen.cpp
@@ -13,7 +13,9 @@
 
 #include "screenComponents/indicatorOverlays.h"
 #include "screenComponents/radarView.h"
+#include "screenComponents/radarZoomSlider.h"
 #include "screenComponents/helpOverlay.h"
+
 #include "gui/gui2_keyvaluedisplay.h"
 #include "gui/gui2_label.h"
 #include "gui/gui2_panel.h"
@@ -24,13 +26,14 @@
 SpectatorScreen::SpectatorScreen(RenderLayer* render_layer)
 : GuiCanvas(render_layer)
 {
-    main_radar = new GuiRadarView(this, "MAIN_RADAR", 50000.0f, nullptr);
+    main_radar = new GuiRadarView(this, "MAIN_RADAR", LONG_RANGE_DISTANCE, nullptr);
     main_radar->setStyle(GuiRadarView::Rectangular)->longRange()->gameMaster()->enableTargetProjections(nullptr)->setAutoCentering(false)->enableCallsigns();
     main_radar->setPosition(0, 0, sp::Alignment::TopLeft)->setSize(GuiElement::GuiSizeMax, GuiElement::GuiSizeMax);
     main_radar->setCallbacks(
         [this](sp::io::Pointer::Button button, glm::vec2 position) { this->onMouseDown(position); },
         [this](glm::vec2 position) { this->onMouseDrag(position); },
-        [this](glm::vec2 position) { this->onMouseUp(position); }
+        [this](glm::vec2 position) { this->onMouseUp(position); },
+        [this](float value, glm::vec2 position) { this->onMouseWheel(value, position); }
     );
 
     ui_toggle = new GuiToggleButton(this, "UI_TOGGLE", "", [this](bool value) {
@@ -89,14 +92,14 @@ SpectatorScreen::SpectatorScreen(RenderLayer* render_layer)
     });
     info_position_lock->setTextSize(16)->setSize(50, 27)->setPosition(0, 0, sp::Alignment::CenterRight);
 
-    zoom_slider = new GuiSlider(this, "ZOOM_SLIDER", 100000.0f, 5000.0f, 50000.0f, [this](float value) {
-        zoom_label->setText(tr("Zoom: {zoom}x").format({{"zoom", string(50000.0f / value, 2.0f)}}));
-        main_radar->setDistance(value);
-    });
-    zoom_slider->setPosition(0, 0, sp::Alignment::BottomRight)->setSize(350, 50)->hide();
-    zoom_slider->setAttribute("margin", "20");
-    zoom_label = new GuiLabel(zoom_slider, "ZOOM_SLIDER_LABEL", "Zoom: 1.0x", 30);
-    zoom_label->setSize(GuiElement::GuiSizeMax, GuiElement::GuiSizeMax);
+    zoom_slider = new GuiRadarZoomSlider(this, "ZOOM_SLIDER", MIN_ZOOM_DISTANCE, MAX_ZOOM_DISTANCE, LONG_RANGE_DISTANCE, main_radar);
+    zoom_slider
+        ->setZoomReference(LONG_RANGE_DISTANCE)
+        ->setLabelPrecision(3)
+        ->setPosition(0.0f, 0.0f, sp::Alignment::BottomRight)
+        ->setSize(350.0f, 50.0f)
+        ->hide()
+        ->setAttribute("margin", "20");
 
     new GuiIndicatorOverlays(this);
 
@@ -135,22 +138,18 @@ void SpectatorScreen::toggleUI()
 void SpectatorScreen::update(float delta)
 {
     auto view_position = main_radar->getViewPosition();
-    float mouse_wheel_delta = keys.zoom_in.getValue() - keys.zoom_out.getValue();
-    if (mouse_wheel_delta != 0.0f)
+    float key_zoom_delta = keys.zoom_in.getValue() - keys.zoom_out.getValue();
+    if (key_zoom_delta != 0.0f)
     {
-        float view_distance = main_radar->getDistance() * (1.0f - (mouse_wheel_delta * 0.1f));
-        if (view_distance > 1000000)
-            view_distance = 1000000;
-        if (view_distance < 5000)
-            view_distance = 5000;
+        float view_distance = std::clamp(
+            main_radar->getDistance() * (1.0f - (key_zoom_delta * 0.1f)),
+            MIN_ZOOM_DISTANCE,
+            MAX_ZOOM_DISTANCE
+        );
         main_radar->setDistance(view_distance);
-        if (view_distance < 10000)
-            main_radar->shortRange();
-        else
-            main_radar->longRange();
-        // Keep the zoom slider in sync.
+        if (view_distance < SHORT_RANGE_DISTANCE) main_radar->shortRange();
+        else main_radar->longRange();
         zoom_slider->setValue(view_distance);
-        zoom_label->setText(tr("Zoom: {zoom}x").format({{"zoom", string(50000.0f / view_distance, 2.0f)}}));
     }
 
     if (keys.help.getDown())
@@ -346,7 +345,7 @@ void SpectatorScreen::onMouseUp(glm::vec2 position)
 
     glm::vec2 target_position;
 
-    for (auto entity : sp::CollisionSystem::queryArea(position - (glm::vec2{300.0f, 300.0f} * main_radar->getDistance() / 50000.0f), position + (glm::vec2{300.0f, 300.0f} * main_radar->getDistance() / 50000.0f)))
+    for (auto entity : sp::CollisionSystem::queryArea(position - (glm::vec2{300.0f, 300.0f} * main_radar->getDistance() / LONG_RANGE_DISTANCE), position + (glm::vec2{300.0f, 300.0f} * main_radar->getDistance() / LONG_RANGE_DISTANCE)))
     {
         if (auto transform = entity.getComponent<sp::Transform>())
         {
@@ -367,4 +366,25 @@ void SpectatorScreen::onMouseUp(glm::vec2 position)
         main_radar->setAutoCentering(false);
         info_position_lock->setValue(false);
     }
+}
+
+void SpectatorScreen::onMouseWheel(float value, glm::vec2 position)
+{
+    // Calculate the new zoom level.
+    const float view_distance = std::clamp(
+        main_radar->getDistance() * (1.0f - value * 0.1f),
+        MIN_ZOOM_DISTANCE,
+        MAX_ZOOM_DISTANCE
+    );
+
+    // Get the world coordinates under the pointer before zooming.
+    const glm::vec2 world_position_before_zoom = main_radar->screenToWorld(position);
+
+    // Set the new zoom level.
+    main_radar->setDistance(view_distance);
+    zoom_slider->setValue(view_distance);
+
+    // Adjust the radar's view position to keep the world coordinates
+    // under the pointer consistent.
+    main_radar->setViewPosition(main_radar->getViewPosition() + world_position_before_zoom - main_radar->screenToWorld(position));
 }

--- a/src/screens/spectatorScreen.h
+++ b/src/screens/spectatorScreen.h
@@ -1,5 +1,4 @@
-#ifndef SPECTATOR_SCREEN_H
-#define SPECTATOR_SCREEN_H
+#pragma once
 
 #include "engine.h"
 #include "gui/gui2_canvas.h"
@@ -9,6 +8,7 @@
 class GuiKeyValueDisplay;
 class GuiRadarView;
 class GuiLabel;
+class GuiRadarZoomSlider;
 class GuiSelector;
 class GuiSlider;
 class GuiToggleButton;
@@ -17,6 +17,10 @@ class GuiHelpOverlay;
 class SpectatorScreen : public GuiCanvas, public Updatable
 {
 private:
+    const float MIN_ZOOM_DISTANCE = 5000.0f;
+    const float MAX_ZOOM_DISTANCE = 1000000.0f;
+    const float LONG_RANGE_DISTANCE = 50000.0f;
+    const float SHORT_RANGE_DISTANCE = 10000.0f;
     bool dragging = false;
 
     GuiRadarView* main_radar;
@@ -33,7 +37,7 @@ public:
     GuiToggleButton* ui_toggle;
     GuiElement* info_layout;
     GuiElement* info_coordinates;
-    GuiSlider* zoom_slider;
+    GuiRadarZoomSlider* zoom_slider;
     GuiLabel* zoom_label;
     GuiKeyValueDisplay* info_coordinates_x;
     GuiKeyValueDisplay* info_coordinates_y;
@@ -51,7 +55,5 @@ public:
     void onMouseDown(glm::vec2 position);
     void onMouseDrag(glm::vec2 position);
     void onMouseUp(glm::vec2 position);
+    void onMouseWheel(float value, glm::vec2 position);
 };
-
-
-#endif//SPECTATOR_SCREEN_H

--- a/src/screens/topDownScreen.cpp
+++ b/src/screens/topDownScreen.cpp
@@ -60,6 +60,12 @@ TopDownScreen::TopDownScreen(RenderLayer* render_layer)
     }
 }
 
+void TopDownScreen::onMouseWheelScroll(glm::vec2 position, float value)
+{
+    if (!executeScrollOnElement(position, value))
+        pending_zoom += value;
+}
+
 void TopDownScreen::update(float delta)
 {
     // If this is a client and it is disconnected, exit.
@@ -71,15 +77,13 @@ void TopDownScreen::update(float delta)
         return;
     }
 
-    // Enable mouse wheel zoom.
-    float mouse_wheel_delta = keys.zoom_in.getValue() - keys.zoom_out.getValue();
-    if (mouse_wheel_delta != 0.0f)
+    float zoom_delta = keys.zoom_in.getValue() - keys.zoom_out.getValue() + pending_zoom;
+    pending_zoom = 0.0f;
+    if (zoom_delta != 0.0f)
     {
-        camera_position.z = camera_position.z * (1.0f - (mouse_wheel_delta) * 4 * delta);
-        if (camera_position.z > 10000)
-            camera_position.z = 10000;
-        if (camera_position.z < 1000)
-            camera_position.z = 1000;
+        camera_position.z *= (1.0f - zoom_delta * 0.1f);
+        if (camera_position.z > 10000) camera_position.z = 10000;
+        if (camera_position.z < 1000) camera_position.z = 1000;
     }
 
     if (keys.help.getDown())

--- a/src/screens/topDownScreen.h
+++ b/src/screens/topDownScreen.h
@@ -17,8 +17,10 @@ private:
     GuiSelector* camera_lock_selector;
     GuiToggleButton* camera_lock_toggle;
     GuiHelpOverlay* keyboard_help;
+    float pending_zoom = 0.0f;
 public:
     TopDownScreen(RenderLayer* render_layer);
 
     virtual void update(float delta) override;
+    virtual void onMouseWheelScroll(glm::vec2 position, float value) override;
 };


### PR DESCRIPTION
Limit mousewheel radar zoom behavior to when the pointer is over either the radar or the zoom slider. Change mousewheel zoom behavior to use pointer coordinates as an anchor while zooming.

- Add a mousewheel callback to `GuiRadarView::setCallbacks()`.
  - Move radar mousewheel zoom behavior from `onUpdate()` to the mousewheel callback, which limits mousewheel zoom on radar to events captured by the element.
  - Move the radar view position to keep the pointer's world coordinates under the pointer position while using mousewheel zoom.

     [Screencast_20260324_131739.webm](https://github.com/user-attachments/assets/6c230c29-ea3f-4df4-aa30-d766f58843bf)
- Consolidate each screen's radar zoom slider behavior into a `GuiRadarZoomSlider` screenComponent.
  - Implement similar mousewheel callback behavior on the slider.
- Add a zoom slider to the GM screen.

Fixes the mousewheel hover behavior part of #2721.