### PR TITLE
Create indexed TubeFiredN and sum TubeFired hardware variables for mi…

### DIFF
--- a/src/components/missiletubes.h
+++ b/src/components/missiletubes.h
@@ -31,6 +31,7 @@ public:
         State state = State::Empty;
         float delay = 0.0f;
         int fire_count = 0;
+        int fired = 0;
 
         bool canLoad(EMissileWeapons type) {
             return (type_allowed_mask & (1 << type));

--- a/src/hardware/hardwareController.cpp
+++ b/src/hardware/hardwareController.cpp
@@ -29,6 +29,8 @@
 
 #include "hardwareMappingEffects.h"
 
+#include <numeric>
+
 HardwareController::~HardwareController()
 {
     for(HardwareOutputDevice* device : devices)
@@ -355,6 +357,14 @@ HardwareMappingEffect* HardwareController::createEffect(std::unordered_map<strin
     return nullptr;
 }
 
+namespace
+{
+    template <typename Container, typename Function> float SUM(Container items, Function func)
+    {
+        return static_cast<float>(std::transform_reduce(items.cbegin(), items.cend(), 0, std::plus{}, func));
+    }
+}
+
 #define SHIP_VARIABLE(name, COMP, formula) if (variable_name == name) { if (auto c = ship.getComponent<COMP>()) { value = (formula); return true; } return false; }
 #define SHIP_VARIABLE2(name, formula) if (variable_name == name) { if (c) { value = (formula); return true; } return false; }
 bool HardwareController::getVariableValue(string variable_name, float& value)
@@ -410,7 +420,9 @@ bool HardwareController::getVariableValue(string variable_name, float& value)
         SHIP_VARIABLE("TubeLoading" + string(n), MissileTubes, c->mounts.size() > n && c->mounts[n].state == MissileTubes::MountPoint::State::Loading ? 1.0f : 0.0f);
         SHIP_VARIABLE("TubeUnloading" + string(n), MissileTubes, c->mounts.size() > n && c->mounts[n].state == MissileTubes::MountPoint::State::Unloading ? 1.0f : 0.0f);
         SHIP_VARIABLE("TubeFiring" + string(n), MissileTubes, c->mounts.size() > n && c->mounts[n].state == MissileTubes::MountPoint::State::Firing ? 1.0f : 0.0f);
+        SHIP_VARIABLE("TubeFired" + string(n), MissileTubes, c->mounts.size() > n ? static_cast<float>(c->mounts[n].fired) : 0.0f);
     }
+    SHIP_VARIABLE("TubeFired", MissileTubes, SUM(c->mounts, [](const MissileTubes::MountPoint & tube){return tube.fired;}));
     for(int n=0; n<ShipSystem::COUNT; n++)
     {
         auto c = ShipSystem::get(ship, static_cast<ShipSystem::Type>(n));

--- a/src/systems/missilesystem.cpp
+++ b/src/systems/missilesystem.cpp
@@ -48,6 +48,7 @@ void MissileSystem::update(float delta)
                     if (game_server)
                     {
                         spawnProjectile(entity, tube, 0, {});
+                        tube.fired += 1;
 
                         tube.fire_count -= 1;
                         if (tube.fire_count > 0)
@@ -194,6 +195,7 @@ void MissileSystem::startLoad(sp::ecs::Entity source, MissileTubes::MountPoint& 
     if (tubes->storage[type] <= 0)
         return;
 
+    tube.fired = 0;
     tube.state = MissileTubes::MountPoint::State::Loading;
     tube.delay = tube.load_time;
     tube.type_loaded = type;
@@ -227,6 +229,7 @@ void MissileSystem::fire(sp::ecs::Entity source, MissileTubes::MountPoint& tube,
         tube.delay = 0.0;
     }else{
         spawnProjectile(source, tube, target_angle, target);
+        tube.fired += 1;
         tube.state = MissileTubes::MountPoint::State::Empty;
         tube.type_loaded = MW_None;
     }


### PR DESCRIPTION
…ssile events

Facilitated by introducing a simple fire counter per-tube:
* Increments when a missile projectile is spawned
* Resets when Weapons starts loading (successfully) something else into the tube

The TubeFiredN variables give float versions of each tube counter.
The TubeFired variable gives a sum of all tube counters for convenient setup of one DMX light.
These provide rising edges for triggering hardware events.

Example of hardware.ini suggested usage:

[event]
trigger = >TubeFired
target = MissileLight
runtime = 0.2
value = 1.0
