### PR TITLE
Add room_container nil check to GuiShipInternalView::onDraw

### DIFF
--- a/src/screenComponents/shipInternalView.cpp
+++ b/src/screenComponents/shipInternalView.cpp
@@ -80,7 +80,7 @@ void GuiShipInternalView::onDraw(sp::RenderTarget& target)
                     break;
                 }
             }
-            if (!found) {
+            if (!found && room_container) {
                 crew_list.push_back(new GuiShipCrew(room_container, "CREW", entity, selected_crew_member, [this](sp::ecs::Entity crew_member){
                     selected_crew_member = crew_member;
                 }));


### PR DESCRIPTION
gn32: 

> `PlayerSpaceship():setTemplate("MP52 Hornet").components.internal_rooms = nil` immediately segfaults any Engineering or Engineering+ consoles connected to that ship

This also removes any already drawn internal rooms if `internal_rooms = nil` is set on a ship that already exists/has connected clients