### PR TITLE
[#2776] Fix AvoidObject range edge cases

### DIFF
--- a/src/components/avoidobject.h
+++ b/src/components/avoidobject.h
@@ -2,12 +2,12 @@
 
 #include <stdint.h>
 
-
 // Component to indicate that this entity should be avoided by path planning.
 class AvoidObject
 {
 public:
-    float range = 100.0f;
+    AvoidObject() = default;
+    AvoidObject(float range) : range(std::max(0.0f, range)) {}
 
     // Internal state used by the pathfinding system.
     enum class InternalState {
@@ -16,11 +16,23 @@ public:
         SmallEntity,
     } state = InternalState::New;
     uint32_t position_hash = 0;
+
+    void setRange(float range) { this->range = std::max(0.0f, range); }
+    float getRange() const { return this->range; }
+private:
+    float range = 100.0f;
 };
 
 class DelayedAvoidObject
 {
 public:
+    DelayedAvoidObject() = default;
+    DelayedAvoidObject(float delay, float range) : delay(delay), range(std::max(0.0f, range)) {}
+
     float delay = 10.0f;
+
+    void setRange(float range) { this->range = std::max(0.0f, range); }
+    float getRange() const { return this->range; }
+private:
     float range = 100.0f;
 };

--- a/src/script/components.cpp
+++ b/src/script/components.cpp
@@ -297,11 +297,11 @@ void initComponentScriptBindings()
     BIND_MEMBER(Orbit, time);
 
     sp::script::ComponentHandler<AvoidObject>::name("avoid_object");
-    BIND_MEMBER(AvoidObject, range);
+    BIND_MEMBER_GS(AvoidObject, "range", getRange, setRange);
 
     sp::script::ComponentHandler<DelayedAvoidObject>::name("delayed_avoid_object");
     BIND_MEMBER(DelayedAvoidObject, delay);
-    BIND_MEMBER(DelayedAvoidObject, range);
+    BIND_MEMBER_GS(DelayedAvoidObject, "range", getRange, setRange);
 
     sp::script::ComponentHandler<ExplodeOnTouch>::name("explode_on_touch");
     BIND_MEMBER(ExplodeOnTouch, damage_at_center);

--- a/src/systems/pathfinding.cpp
+++ b/src/systems/pathfinding.cpp
@@ -32,7 +32,7 @@ void PathFindingSystem::update(float delta)
     for(auto [entity, dao] : sp::ecs::Query<DelayedAvoidObject>()) {
         dao.delay -= delta;
         if (dao.delay <= 0.0f) {
-            entity.addComponent<AvoidObject>().range = dao.range;
+            entity.addComponent<AvoidObject>().setRange(dao.getRange());
             entity.removeComponent<DelayedAvoidObject>();
         }
     }
@@ -41,7 +41,7 @@ void PathFindingSystem::update(float delta)
     for(auto [entity, ao, transform] : sp::ecs::Query<AvoidObject, sp::Transform>()) {
         switch(ao.state) {
         case AvoidObject::InternalState::New:
-            if (ao.range > small_object_max_size) {
+            if (ao.getRange() > small_object_max_size) {
                 big_entities.push_back(entity);
                 ao.state = AvoidObject::InternalState::BigEntity;
             } else {
@@ -167,7 +167,7 @@ bool PathPlanner::checkToAvoid(glm::vec2 start, glm::vec2 end, glm::vec2& new_po
         if (ao && transform)
         {
             auto position = transform->getPosition();
-            float range = std::max(0.0f, ao->range);
+            const float range = ao->getRange();
             float f = glm::dot(startEndDiff, position - start) / startEndLength;
             if (f > 0 && f < startEndLength)
             {
@@ -231,7 +231,7 @@ bool PathPlanner::checkToAvoid(glm::vec2 start, glm::vec2 end, glm::vec2& new_po
                 if (ao && transform)
                 {
                     glm::vec2 position = transform->getPosition();
-                    float range = std::max(0.0f, ao->range);
+                    const float range = ao->getRange();
                     float f = glm::dot(startEndDiff, position - start) / startEndLength;
                     if (f > 0 && f < startEndLength)
                     {
@@ -264,7 +264,7 @@ bool PathPlanner::checkToAvoid(glm::vec2 start, glm::vec2 end, glm::vec2& new_po
         auto transform = avoidObject.getComponent<sp::Transform>();
 
         glm::vec2 position = transform->getPosition();
-        float range = std::max(0.0f, ao->range);
+        const float range = ao->getRange();
         if (firstAvoidQ.x == position.x && firstAvoidQ.y == position.y)
             firstAvoidQ.x += 0.1f;
         new_point = position + glm::normalize(firstAvoidQ - position) * (range * 1.1f + my_size);


### PR DESCRIPTION
- Use getter/setter to validate AvoidObject component `range` values are non-negative. Prevents #2776.
- Remove subtraction of AvoidObject `range` from `startEndLength` comparisons, which caused checks to ignore avoidance and plot paths through entities with avoidance when `range` was greater than `startEndLength` * 1.1 (i.e. black holes with `ranges` > 13k).