### PR TITLE
Fix various bugs with science/operations zoom

### DIFF
--- a/src/screens/crew4/operationsScreen.cpp
+++ b/src/screens/crew4/operationsScreen.cpp
@@ -14,6 +14,7 @@
 
 #include "gui/theme.h"
 #include "screenComponents/radarView.h"
+#include "screenComponents/radarZoomSlider.h"
 #include "screenComponents/openCommsButton.h"
 #include "screenComponents/commsOverlay.h"
 #include "screenComponents/shipsLogControl.h"
@@ -72,13 +73,7 @@ OperationScreen::OperationScreen(GuiContainer* owner)
             }
         },
         [this](float value, glm::vec2 position) { // Wheel
-            float view_distance = std::clamp(
-                science->science_radar->getDistance() * (1.0f - value * 0.1f),
-                science->DEFAULT_MIN_ZOOM_DISTANCE,
-                science->DEFAULT_MAX_ZOOM_DISTANCE
-            );
-            science->science_radar->setDistance(view_distance);
-            // zoom_slider->setValue(view_distance);
+            science->doRadarZoom(value);
         }
     );
     science->science_radar->setAutoRotating(PreferencesManager::get("operations_radar_lock","0")=="1");

--- a/src/screens/crew6/scienceScreen.cpp
+++ b/src/screens/crew6/scienceScreen.cpp
@@ -68,13 +68,7 @@ ScienceScreen::ScienceScreen(GuiContainer* owner, CrewPosition crew_position)
             targets.setToClosestTo(position, 1000, TargetsContainer::Selectable);
         }, nullptr, nullptr,
         [this](float value, glm::vec2 position) { // wheel
-            float view_distance = std::clamp(
-                science_radar->getDistance() * (1.0f - value * 0.1f),
-                DEFAULT_MIN_ZOOM_DISTANCE,
-                DEFAULT_MAX_ZOOM_DISTANCE
-            );
-            science_radar->setDistance(view_distance);
-            zoom_slider->setValue(view_distance);
+            doRadarZoom(value);
         }
     );
     science_radar->setAutoRotating(PreferencesManager::get("science_radar_lock","0")=="1");
@@ -253,6 +247,17 @@ ScienceScreen::ScienceScreen(GuiContainer* owner, CrewPosition crew_position)
     new GuiScanningDialog(this, "SCANNING_DIALOG");
 }
 
+void ScienceScreen::doRadarZoom(float value)
+{
+    float view_distance = std::clamp(
+        science_radar->getDistance() * (1.0f - value * 0.1f),
+        previous_short_range_radar,
+        previous_long_range_radar
+    );
+    science_radar->setDistance(view_distance);
+    zoom_slider->setValue(view_distance);
+}
+
 void ScienceScreen::onDraw(sp::RenderTarget& renderer)
 {
     GuiOverlay::onDraw(renderer);
@@ -274,8 +279,8 @@ void ScienceScreen::onDraw(sp::RenderTarget& renderer)
     view_distance = std::max(view_distance, lrr->short_range);
     if (view_distance!=science_radar->getDistance() || previous_long_range_radar != lrr->long_range || previous_short_range_radar != lrr->short_range)
     {
-        previous_short_range_radar = lrr->long_range;
-        previous_long_range_radar = lrr->short_range;
+        previous_short_range_radar = lrr->short_range;
+        previous_long_range_radar = lrr->long_range;
         zoom_slider->setRange(lrr->long_range, lrr->short_range)->setValue(view_distance);
     }
 

--- a/src/screens/crew6/scienceScreen.h
+++ b/src/screens/crew6/scienceScreen.h
@@ -64,6 +64,7 @@ public:
 
     virtual void onDraw(sp::RenderTarget& target) override;
     virtual void onUpdate() override;
+    void doRadarZoom(float value);
 private:
     // Used to judge when to update the UI label and zoom
     float previous_long_range_radar = 0.0f;


### PR DESCRIPTION
- Operations screen did not update zoom slider if mouse-scroll zooming was used rather than hotkey.
- Both science and operations clamped zoom to {5U, 30U} rather than using the playership's radar ranges.
- The science screen reset its zoom slider range every tick due to swapping the long & short ranges.