### PR TITLE
Fix entity selection only checking physics entities

### DIFF
--- a/src/screenComponents/radarView.cpp
+++ b/src/screenComponents/radarView.cpp
@@ -714,7 +714,7 @@ void GuiRadarView::drawObjects(sp::RenderTarget& renderer)
 
             // For each of those objects, check if it is at least partially
             // inside the revealed radius. If so, reveal the object on the map.
-            for(auto entity2 : sp::CollisionSystem::queryArea(position - glm::vec2(r, r), position + glm::vec2(r, r)))
+            for(auto entity2 : sp::TransformQuery::queryArea(position - glm::vec2(r, r), position + glm::vec2(r, r)))
             {
                 //TODO: This isn't great, as not everything will collision attached...
                 auto trace = entity2.getComponent<RadarTrace>();

--- a/src/screenComponents/targetsContainer.cpp
+++ b/src/screenComponents/targetsContainer.cpp
@@ -65,7 +65,7 @@ void TargetsContainer::setToClosestTo(glm::vec2 position, float max_range, ESele
 {
     sp::ecs::Entity target;
     glm::vec2 target_position;
-    for(auto entity : sp::CollisionSystem::queryArea(position - glm::vec2(max_range, max_range), position + glm::vec2(max_range, max_range)))
+    for(auto entity : sp::TransformQuery::queryArea(position - glm::vec2(max_range, max_range), position + glm::vec2(max_range, max_range)))
     {
         auto transform = entity.getComponent<sp::Transform>();
         if (!transform) continue;

--- a/src/screenComponents/targetsContainer.cpp
+++ b/src/screenComponents/targetsContainer.cpp
@@ -204,6 +204,7 @@ bool TargetsContainer::isValidTarget(sp::ecs::Entity entity, ESelectionType sele
     case Selectable:
         if (entity.hasComponent<Hull>()) return true;
         if (entity.getComponent<ScanState>()) return true;
+        if (entity.getComponent<ScienceDescription>()) return true;
         if (entity.getComponent<ShareShortRangeRadar>()) return true;
         break;
     case Targetable:

--- a/src/screens/gm/gameMasterScreen.cpp
+++ b/src/screens/gm/gameMasterScreen.cpp
@@ -689,7 +689,7 @@ void GameMasterScreen::onMouseUp(glm::vec2 position)
             sp::ecs::Entity target;
             glm::vec2 target_position;
 
-            for (auto entity : sp::CollisionSystem::queryArea(position, position))
+            for (auto entity : sp::TransformQuery::queryArea(position, position))
             {
                 auto transform = entity.getComponent<sp::Transform>();
                 if (!transform) continue;

--- a/src/screens/spectatorScreen.cpp
+++ b/src/screens/spectatorScreen.cpp
@@ -345,7 +345,7 @@ void SpectatorScreen::onMouseUp(glm::vec2 position)
 
     glm::vec2 target_position;
 
-    for (auto entity : sp::CollisionSystem::queryArea(position - (glm::vec2{300.0f, 300.0f} * main_radar->getDistance() / LONG_RANGE_DISTANCE), position + (glm::vec2{300.0f, 300.0f} * main_radar->getDistance() / LONG_RANGE_DISTANCE)))
+    for (auto entity : sp::TransformQuery::queryArea(position - (glm::vec2{300.0f, 300.0f} * main_radar->getDistance() / LONG_RANGE_DISTANCE), position + (glm::vec2{300.0f, 300.0f} * main_radar->getDistance() / LONG_RANGE_DISTANCE)))
     {
         if (auto transform = entity.getComponent<sp::Transform>())
         {

--- a/src/script.cpp
+++ b/src/script.cpp
@@ -426,7 +426,7 @@ static int luaGetObjectsInRadius(lua_State* L)
     glm::vec2 position(x, y);
     lua_newtable(L);
     int idx = 1;
-    for(auto entity : sp::CollisionSystem::queryArea(position - glm::vec2(r, r), position + glm::vec2(r, r))) {
+    for(auto entity : sp::TransformQuery::queryArea(position - glm::vec2(r, r), position + glm::vec2(r, r))) {
         auto entity_transform = entity.getComponent<sp::Transform>();
         if (entity_transform) {
             if (glm::length2(entity_transform->getPosition() - position) < r*r) {
@@ -448,7 +448,7 @@ static int luaGetEnemiesInRadiusFor(lua_State* L)
     auto source_transform = source.getComponent<sp::Transform>();
     if (!source_transform) return 1;
     auto position = source_transform->getPosition();
-    for(auto entity : sp::CollisionSystem::queryArea(position - glm::vec2(r, r), position + glm::vec2(r, r))) {
+    for(auto entity : sp::TransformQuery::queryArea(position - glm::vec2(r, r), position + glm::vec2(r, r))) {
         auto entity_transform = entity.getComponent<sp::Transform>();
         if (entity_transform) {
             if (glm::length2(entity_transform->getPosition() - position) < r*r) {


### PR DESCRIPTION
Anything that previously used `sp::CollisionSystem::queryArea` to select entities for a purpose that did _not_ necessarily require them to be physical objects has been changed to use `sp::TransformQuery::queryArea` (https://github.com/daid/SeriousProton/pull/310):
- Radar object visibility
- Radar target selection
- GM selection
- Spectator selection
- Lua entities-in-radius queries

Science/Operations additionally consider `ScienceDescription` sufficient to allow selecting the entity.