### PR TITLE
Change Top-down 3D view button from toggle to regular button to match other buttons

### DIFF
--- a/src/menus/shipSelectionScreen.cpp
+++ b/src/menus/shipSelectionScreen.cpp
@@ -290,8 +290,8 @@ ShipSelectionScreen::ShipSelectionScreen()
     cinematic_button->setSize(GuiElement::GuiSizeMax, 50.0f);
 
     // Top-down 3D view button
-    auto topdown_button = new GuiToggleButton(right_panel, "TOP_DOWN_3D_BUTTON", tr("Top-down 3D view"),
-        [this](bool value)
+    auto topdown_button = new GuiButton(right_panel, "TOP_DOWN_3D_BUTTON", tr("Top-down 3D view"),
+        [this]()
         {
             if (gameGlobalInfo->gm_control_code.length() > 0)
             {


### PR DESCRIPTION
On the Ship Selection screen, the button for "Top-down 3D View" is a Toggle Button, as a remnant from before a refactor, and this changes it to a regular button, to match the other buttons in the list.