### PR TITLE
Show launched missiles on long-range radars

### DIFF
--- a/src/systems/missilesystem.cpp
+++ b/src/systems/missilesystem.cpp
@@ -361,7 +361,7 @@ void MissileSystem::spawnProjectile(sp::ecs::Entity source, MissileTubes::MountP
         trace.icon = mwd.radar_trace;
         trace.radius = 32.0f;
         trace.max_size = trace.min_size = 32 * (0.25f + 0.25f * category_modifier);
-        trace.flags = RadarTrace::Rotate;
+        trace.flags = RadarTrace::Rotate | RadarTrace::LongRange;
         trace.color = mwd.color;
 
         auto& sfx = missile.addComponent<Sfx>();


### PR DESCRIPTION
Add `LongRange` to the radar trace flags for MissileSystem-spawned projectiles. This change causes such missiles to appear on long-range radars (Science, Relay, GM).

Launched missile visibility is a change from legacy behavior on Science and Relay, and a restoration of legacy behavior on the GM screen.

Before: missiles are visible on Helms/Weapons (short-range) but not Science, Relay, or GM

[Screencast_20260329_235022.webm](https://github.com/user-attachments/assets/5d5464b2-c80d-4c10-992a-cbe4ee48762e)

After: missiles are visible on all of those views

[Screencast_20260329_235131.webm](https://github.com/user-attachments/assets/4a342d4a-85f4-43e3-b567-b6474e8bef96)
