### PR TITLE
Move engine controls down on Single screen to make space for docking/overheat indicator

### DIFF
--- a/src/screens/crew1/singlePilotScreen.cpp
+++ b/src/screens/crew1/singlePilotScreen.cpp
@@ -119,7 +119,7 @@ SinglePilotScreen::SinglePilotScreen(GuiContainer* owner)
 
     // Engine layout in top left corner of left panel.
     auto engine_layout = new GuiElement(this, "ENGINE_LAYOUT");
-    engine_layout->setPosition(20, 80, sp::Alignment::TopLeft)->setSize(GuiElement::GuiSizeMax, 250)->setAttribute("layout", "horizontal");
+    engine_layout->setPosition(20, 110, sp::Alignment::TopLeft)->setSize(GuiElement::GuiSizeMax, 250)->setAttribute("layout", "horizontal");
     (new GuiImpulseControls(engine_layout, "IMPULSE"))->setSize(100, GuiElement::GuiSizeMax);
     warp_controls = (new GuiWarpControls(engine_layout, "WARP"))->setSize(100, GuiElement::GuiSizeMax);
     jump_controls = (new GuiJumpControls(engine_layout, "JUMP"))->setSize(100, GuiElement::GuiSizeMax);


### PR DESCRIPTION
Currently, the `engine_layout` block of the Single Pilot screen puts the docking/overheating indicators under the Request Dock button .  This moves it down to make room for the indcators.
Before:
<img width="2560" height="1440" alt="Screenshot 2026-03-31 at 11 12 14 AM" src="https://github.com/user-attachments/assets/4f653dc8-f3e5-4d34-9ec3-50733716ec66" />
<img width="2560" height="1440" alt="Screenshot 2026-03-31 at 11 12 17 AM" src="https://github.com/user-attachments/assets/3448b454-4536-4214-b593-8f764cecf63f" />

After:
<img width="2560" height="1440" alt="Screenshot 2026-03-31 at 11 14 49 AM" src="https://github.com/user-attachments/assets/6645ffaf-fac4-4412-9db3-5bcb55aeacb2" />
<img width="2560" height="1440" alt="Screenshot 2026-03-31 at 11 15 00 AM" src="https://github.com/user-attachments/assets/b0a12add-d129-4108-a412-ee2d780d7661" />
