### PR TITLE
Don't hide entities from GM screen radar

### DIFF
--- a/src/systems/missilesystem.cpp
+++ b/src/systems/missilesystem.cpp
@@ -361,7 +361,7 @@ void MissileSystem::spawnProjectile(sp::ecs::Entity source, MissileTubes::MountP
         trace.icon = mwd.radar_trace;
         trace.radius = 32.0f;
         trace.max_size = trace.min_size = 32 * (0.25f + 0.25f * category_modifier);
-        trace.flags = RadarTrace::Rotate;
+        trace.flags = RadarTrace::Rotate; // LongRange intentionally omitted for gameplay
         trace.color = mwd.color;
 
         auto& sfx = missile.addComponent<Sfx>();

--- a/src/systems/radar.cpp
+++ b/src/systems/radar.cpp
@@ -15,7 +15,11 @@ std::vector<RadarRenderSystem::Handler> RadarRenderSystem::handlers;
 
 void BasicRadarRendering::renderOnRadar(sp::RenderTarget& renderer, sp::ecs::Entity entity, glm::vec2 screen_position, float scale, float rotation, RadarTrace& trace)
 {
-    if ((RadarRenderSystem::current_flags & RadarRenderSystem::FlagLongRange) && !(trace.flags & RadarTrace::LongRange))
+    // Exit early if the trace is flagged for LongRange and this is non-GM
+    // LongRange radar.
+    if ((RadarRenderSystem::current_flags & RadarRenderSystem::FlagLongRange)
+        && !(RadarRenderSystem::current_flags & RadarRenderSystem::FlagGM)
+        && !(trace.flags & RadarTrace::LongRange))
         return;
 
     auto scanstate = entity.getComponent<ScanState>();


### PR DESCRIPTION
Bypass the early exit in `BasicRadarRendering::renderOnRadar()` for LongRange-only traces if the radar system is flagged as GM (GM screen, Spectate).

This fixes the regression of LongRange traces not rendering on the GM screen, where those entities are still selectable but invisible. This also doesn't change the behavior of not rendering them on Science radar, Probe View radar, or Relay's shared short-range radar, which is intentional per #2821.

GM screen before: LongRange-flagged traces aren't visible, but the entities are still selectable

https://github.com/user-attachments/assets/59d052b5-327d-4d00-bb64-6ff4027a7a3f

GM screen after: LongRange-flagged traces are visible

https://github.com/user-attachments/assets/8d1aa2c3-e453-46cd-ad93-998fd22b3523

