### PR TITLE
Fix control visibility on component removal

### DIFF
--- a/src/screenComponents/combatManeuver.cpp
+++ b/src/screenComponents/combatManeuver.cpp
@@ -34,8 +34,18 @@ void GuiCombatManeuver::onUpdate()
 {
     if (!my_spaceship) return;
 
-    setVisible(my_spaceship.hasComponent<CombatManeuveringThrusters>());
-    if (!isVisible()) return;
+    setVisible(my_spaceship.hasComponent<CombatManeuveringThrusters>() && my_spaceship.hasComponent<ManeuveringThrusters>());
+    if (!isVisible())
+    {
+        if (hotkey_boost_active || hotkey_strafe_active || slider->getValue() != glm::vec2(0.0f, 0.0f))
+        {
+            setBoostValue(0.0f);
+            setStrafeValue(0.0f);
+            hotkey_boost_active = false;
+            hotkey_strafe_active = false;
+        }
+        return;
+    }
 
     if (auto docking_port = my_spaceship.getComponent<DockingPort>())
     slider->setEnable(!docking_port || docking_port->state == DockingPort::State::NotDocking);

--- a/src/screenComponents/combatManeuver.cpp
+++ b/src/screenComponents/combatManeuver.cpp
@@ -7,6 +7,7 @@
 #include "gui/gui2_progressbar.h"
 
 #include "components/docking.h"
+#include "components/impulse.h"
 #include "components/maneuveringthrusters.h"
 
 GuiCombatManeuver::GuiCombatManeuver(GuiContainer* owner, string id)
@@ -34,7 +35,12 @@ void GuiCombatManeuver::onUpdate()
 {
     if (!my_spaceship) return;
 
-    setVisible(my_spaceship.hasComponent<CombatManeuveringThrusters>() && my_spaceship.hasComponent<ManeuveringThrusters>());
+    setVisible(
+        my_spaceship.hasComponent<CombatManeuveringThrusters>()
+        && (my_spaceship.hasComponent<ManeuveringThrusters>() || my_spaceship.hasComponent<ImpulseEngine>())
+    );
+
+    // Reset boost, strafe if not visible.
     if (!isVisible())
     {
         if (hotkey_boost_active || hotkey_strafe_active || slider->getValue() != glm::vec2(0.0f, 0.0f))

--- a/src/screenComponents/infoDisplay.cpp
+++ b/src/screenComponents/infoDisplay.cpp
@@ -97,7 +97,9 @@ HullInfoDisplay::HullInfoDisplay(GuiContainer* owner, const string& id, float di
 
 void HullInfoDisplay::onUpdate()
 {
-    if (auto hull = my_spaceship.getComponent<Hull>())
+    auto hull = my_spaceship.getComponent<Hull>();
+    setVisible(hull);
+    if (hull)
     {
         setValue(toNearbyIntString(100.0f * hull->current / hull->max) + "%");
         if (hull->current < hull->max / 4.0f)

--- a/src/screens/crew1/singlePilotScreen.cpp
+++ b/src/screens/crew1/singlePilotScreen.cpp
@@ -11,6 +11,7 @@
 #include "components/jumpdrive.h"
 #include "components/collision.h"
 #include "components/maneuveringthrusters.h"
+#include "components/beamweapon.h"
 #include "components/missiletubes.h"
 #include "components/shields.h"
 #include "components/target.h"

--- a/src/screens/crew1/singlePilotScreen.cpp
+++ b/src/screens/crew1/singlePilotScreen.cpp
@@ -11,6 +11,7 @@
 #include "components/jumpdrive.h"
 #include "components/collision.h"
 #include "components/maneuveringthrusters.h"
+#include "components/missiletubes.h"
 #include "components/shields.h"
 #include "components/target.h"
 #include "components/radar.h"
@@ -106,11 +107,16 @@ SinglePilotScreen::SinglePilotScreen(GuiContainer* owner)
     tube_controls->setPosition(20, -20, sp::Alignment::BottomLeft);
     radar->enableTargetProjections(tube_controls);
 
+    beam_info_box = new GuiElement(this, "BEAM_INFO_BOX");
+    beam_info_box
+        ->setPosition(0.0f, -20.0f, sp::Alignment::BottomCenter)
+        ->setSize(500.0f, 50.0f)
+        ->hide();
+
     // Beam controls beneath the radar.
     if (gameGlobalInfo->use_beam_shield_frequencies || gameGlobalInfo->use_system_damage)
     {
-        GuiElement* beam_info_box = new GuiElement(this, "BEAM_INFO_BOX");
-        beam_info_box->setPosition(0, -20, sp::Alignment::BottomCenter)->setSize(500, 50);
+        beam_info_box->show();
         (new GuiLabel(beam_info_box, "BEAM_INFO_LABEL", tr("Beams"), 30))->addBackground()->setPosition(0, 0, sp::Alignment::BottomLeft)->setSize(80, 50);
         (new GuiBeamFrequencySelector(beam_info_box, "BEAM_FREQUENCY_SELECTOR"))->setPosition(80, 0, sp::Alignment::BottomLeft)->setSize(132, 50);
         (new GuiPowerDamageIndicator(beam_info_box, "", ShipSystem::Type::BeamWeapons, sp::Alignment::CenterLeft))->setPosition(0, 0, sp::Alignment::BottomLeft)->setSize(212, 50);
@@ -143,14 +149,14 @@ void SinglePilotScreen::onDraw(sp::RenderTarget& renderer)
     {
         warp_controls->setVisible(my_spaceship.hasComponent<WarpDrive>());
         jump_controls->setVisible(my_spaceship.hasComponent<JumpDrive>());
+        beam_info_box->setVisible(my_spaceship.hasComponent<BeamWeaponSys>() && (gameGlobalInfo->use_beam_shield_frequencies || gameGlobalInfo->use_system_damage));
 
-        missile_aim->setVisible(tube_controls->getManualAim());
+        const bool has_tubes = my_spaceship.hasComponent<MissileTubes>();
+        lock_aim->setVisible(has_tubes);
+        missile_aim->setVisible(has_tubes && tube_controls->getManualAim());
 
         auto target = my_spaceship.getComponent<Target>();
-        if (target)
-            targets.set(target->entity);
-        else
-            targets.set(sp::ecs::Entity{});
+        targets.set(target ? target->entity : sp::ecs::Entity{});
     }
     GuiOverlay::onDraw(renderer);
 }

--- a/src/screens/crew1/singlePilotScreen.h
+++ b/src/screens/crew1/singlePilotScreen.h
@@ -24,6 +24,7 @@ private:
     AimLock* missile_aim;
     AimLockButton* lock_aim;
     GuiMissileTubeControls* tube_controls;
+    GuiElement* beam_info_box;
     bool drag_rotate;
 public:
     SinglePilotScreen(GuiContainer* owner);

--- a/src/screens/crew4/tacticalScreen.cpp
+++ b/src/screens/crew4/tacticalScreen.cpp
@@ -12,6 +12,8 @@
 #include "components/shields.h"
 #include "components/target.h"
 #include "components/radar.h"
+#include "components/beamweapon.h"
+#include "components/missiletubes.h"
 
 #include "screenComponents/aimLock.h"
 #include "screenComponents/alertOverlay.h"
@@ -94,11 +96,16 @@ TacticalScreen::TacticalScreen(GuiContainer* owner)
     tube_controls->setPosition(20, -20, sp::Alignment::BottomLeft);
     radar->enableTargetProjections(tube_controls);
 
+    beam_info_box = new GuiElement(this, "BEAM_INFO_BOX");
+    beam_info_box
+        ->setPosition(0.0f, -20.0f, sp::Alignment::BottomCenter)
+        ->setSize(500.0f, 50.0f)
+        ->hide();
+
     // Beam controls beneath the radar.
     if (gameGlobalInfo->use_beam_shield_frequencies || gameGlobalInfo->use_system_damage)
     {
-        GuiElement* beam_info_box = new GuiElement(this, "BEAM_INFO_BOX");
-        beam_info_box->setPosition(0, -20, sp::Alignment::BottomCenter)->setSize(500, 50);
+        beam_info_box->show();
         (new GuiLabel(beam_info_box, "BEAM_INFO_LABEL", tr("Beams"), 30))->addBackground()->setPosition(0, 0, sp::Alignment::BottomLeft)->setSize(80, 50);
         (new GuiBeamFrequencySelector(beam_info_box, "BEAM_FREQUENCY_SELECTOR"))->setPosition(80, 0, sp::Alignment::BottomLeft)->setSize(132, 50);
         (new GuiPowerDamageIndicator(beam_info_box, "", ShipSystem::Type::BeamWeapons, sp::Alignment::CenterLeft))->setPosition(0, 0, sp::Alignment::BottomLeft)->setSize(212, 50);
@@ -131,6 +138,11 @@ void TacticalScreen::onDraw(sp::RenderTarget& renderer)
     {
         warp_controls->setVisible(my_spaceship.hasComponent<WarpDrive>());
         jump_controls->setVisible(my_spaceship.hasComponent<JumpDrive>());
+        beam_info_box->setVisible(my_spaceship.hasComponent<BeamWeaponSys>() && (gameGlobalInfo->use_beam_shield_frequencies || gameGlobalInfo->use_system_damage));
+
+        const bool has_tubes = my_spaceship.hasComponent<MissileTubes>();
+        lock_aim->setVisible(has_tubes);
+        missile_aim->setVisible(has_tubes && tube_controls->getManualAim());
 
         auto target = my_spaceship.getComponent<Target>();
         targets.set(target ? target->entity : sp::ecs::Entity{});

--- a/src/screens/crew4/tacticalScreen.h
+++ b/src/screens/crew4/tacticalScreen.h
@@ -22,6 +22,7 @@ private:
     AimLock* missile_aim;
     AimLockButton* lock_aim;
     GuiMissileTubeControls* tube_controls;
+    GuiElement* beam_info_box;
     bool drag_rotate;
 public:
     TacticalScreen(GuiContainer* owner);

--- a/src/screens/crew6/relayScreen.cpp
+++ b/src/screens/crew6/relayScreen.cpp
@@ -168,7 +168,7 @@ RelayScreen::RelayScreen(GuiContainer* owner, bool allow_comms)
             my_player_info->commandClearScienceLink();
         }
     });
-    link_to_science_button->setSize(GuiElement::GuiSizeMax, 50)->setVisible(my_spaceship.hasComponent<LongRangeRadar>() && my_spaceship.hasComponent<ScanProbeLauncher>());
+    link_to_science_button->setSize(GuiElement::GuiSizeMax, 50)->setVisible(my_spaceship.hasComponent<LongRangeRadar>() && my_spaceship.hasComponent<ScanProbeLauncher>() && my_spaceship.hasComponent<RadarLink>());
 
     // Manage waypoints.
     (new GuiButton(option_buttons, "WAYPOINT_PLACE_BUTTON", tr("Place waypoint"), [this]() {
@@ -328,7 +328,7 @@ void RelayScreen::onDraw(sp::RenderTarget& renderer)
         auto spl = my_spaceship.getComponent<ScanProbeLauncher>();
         launch_probe_button->setVisible(spl);
         launch_probe_button->setEnable(spl ? spl->stock > 0 : false);
-        link_to_science_button->setVisible(my_spaceship.hasComponent<LongRangeRadar>() && spl);
+        link_to_science_button->setVisible(my_spaceship.hasComponent<LongRangeRadar>() && spl && my_spaceship.hasComponent<RadarLink>());
         hack_target_button->setVisible(my_spaceship.hasComponent<HackingDevice>());
 
         info_reputation->setValue(string(Faction::getInfo(my_spaceship).reputation_points, 0));

--- a/src/screens/crew6/scienceScreen.cpp
+++ b/src/screens/crew6/scienceScreen.cpp
@@ -329,6 +329,7 @@ void ScienceScreen::onDraw(sp::RenderTarget& renderer)
     for(int n = 0; n < ShipSystem::COUNT; n++)
         info_system[n]->setValue("-")->hide();
 
+    probe_view_button->setVisible(rl);
     if (rl && rl->linked_entity)
     {
         probe_view_button->enable();

--- a/src/screens/crew6/weaponsScreen.cpp
+++ b/src/screens/crew6/weaponsScreen.cpp
@@ -10,6 +10,7 @@
 #include "components/radar.h"
 #include "components/beamweapon.h"
 #include "components/collision.h"
+#include "components/missiletubes.h"
 
 #include "screenComponents/aimLock.h"
 #include "screenComponents/alertOverlay.h"
@@ -65,20 +66,25 @@ WeaponsScreen::WeaponsScreen(GuiContainer* owner)
     lock_aim = new AimLockButton(this, "LOCK_AIM", tube_controls, missile_aim);
     lock_aim->setPosition(250, 20, sp::Alignment::TopCenter)->setSize(130, 50);
 
+    beam_info_box = new GuiElement(this, "BEAM_INFO_BOX");
+    beam_info_box
+        ->setPosition(-20.0f, -120.0f, sp::Alignment::BottomRight)
+        ->setSize(280.0f, 150.0f)
+        ->hide();
+
     if (gameGlobalInfo->use_beam_shield_frequencies || gameGlobalInfo->use_system_damage)
     {
-        beam_info_box = new GuiElement(this, "BEAM_INFO_BOX");
-        beam_info_box->setPosition(-20, -120, sp::Alignment::BottomRight)->setSize(280, 150);
+        beam_info_box->show();
         (new GuiLabel(beam_info_box, "BEAM_INFO_LABEL", tr("Beam info"), 30))->addBackground()->setSize(GuiElement::GuiSizeMax, 50);
         (new GuiPowerDamageIndicator(beam_info_box, "", ShipSystem::Type::BeamWeapons, sp::Alignment::CenterLeft))->setSize(GuiElement::GuiSizeMax, 50);
         (new GuiBeamFrequencySelector(beam_info_box, "BEAM_FREQUENCY_SELECTOR"))->setPosition(0, 0, sp::Alignment::BottomRight)->setSize(GuiElement::GuiSizeMax, 50);
         (new GuiBeamTargetSelector(beam_info_box, "BEAM_TARGET_SELECTOR"))->setPosition(0, -50, sp::Alignment::BottomRight)->setSize(GuiElement::GuiSizeMax, 50);
 
+        // If system damage is enabled but shield frequencies are not, the
+        // shield button partially overlaps this control. So move the beam
+        // configuration a bit down.
         if (!gameGlobalInfo->use_beam_shield_frequencies)
-        {   //If we do have system damage, but no shield frequencies, we can partially overlap this with the shield button.
-            //So move the beam configuration a bit down.
-            beam_info_box->setPosition(-20, -50, sp::Alignment::BottomRight);
-        }
+            beam_info_box->setPosition(-20.0f, -50.0f, sp::Alignment::BottomRight);
     }
 
     auto stats = new GuiElement(this, "WEAPONS_STATS");
@@ -91,13 +97,11 @@ WeaponsScreen::WeaponsScreen(GuiContainer* owner)
     rear_shield_display = new GuiKeyValueDisplay(stats, "REAR_SHIELD_DISPLAY", 0.45, tr("shields", "Rear"), "");
     rear_shield_display->setIcon("gui/icons/shields-aft")->setTextSize(20)->setSize(240, 40);
 
+    // Shield frequency selection includes a shield enable button.
     if (gameGlobalInfo->use_beam_shield_frequencies)
-    {
-        //The shield frequency selection includes a shield enable button.
         (new GuiShieldFrequencySelect(this, "SHIELD_FREQ"))->setPosition(-20, -20, sp::Alignment::BottomRight)->setSize(280, 100);
-    }else{
+    else
         (new GuiShieldsEnableButton(this, "SHIELDS_ENABLE"))->setPosition(-20, -20, sp::Alignment::BottomRight)->setSize(280, 50);
-    }
 
     (new GuiCustomShipFunctions(this, CrewPosition::weaponsOfficer, ""))->setPosition(-20, 120, sp::Alignment::TopRight)->setSize(250, GuiElement::GuiSizeMax);
 }
@@ -128,9 +132,10 @@ void WeaponsScreen::onDraw(sp::RenderTarget& renderer)
         else
             targets.set(sp::ecs::Entity{});
 
-        missile_aim->setVisible(tube_controls->getManualAim());
-        if (beam_info_box)
-            beam_info_box->setVisible(my_spaceship.hasComponent<BeamWeaponSys>());
+        beam_info_box->setVisible(my_spaceship.hasComponent<BeamWeaponSys>() && (gameGlobalInfo->use_beam_shield_frequencies || gameGlobalInfo->use_system_damage));
+        const bool has_tubes = my_spaceship.hasComponent<MissileTubes>();
+        lock_aim->setVisible(has_tubes);
+        missile_aim->setVisible(has_tubes && tube_controls->getManualAim());
     }
     GuiOverlay::onDraw(renderer);
 }


### PR DESCRIPTION
- Don't show combat maneuver controls if both ManeuveringThrusters and ImpulseEngine components are removed.
- Reset boost/strafe behaviors to 0 if combat maneuver controls aren't visible.
- Don't show beam info box if BeamWeapons component is removed.
- Don't show manual missile aiming controls if MissileTubes component is removed.
- Don't show Hull info displays if the Hull component is removed.
- Don't show probe link-related buttons on Science, Ops, Relay if RadarLink component is removed.