### PR TITLE
Convert "Request dock" button to a menu

### DIFF
--- a/src/screenComponents/dockingButton.cpp
+++ b/src/screenComponents/dockingButton.cpp
@@ -3,6 +3,7 @@
 #include "dockingButton.h"
 #include "gui/gui2_button.h"
 #include "gui/gui2_listbox.h"
+#include "gui/gui2_panel.h"
 #include "systems/collision.h"
 #include "systems/docking.h"
 #include "components/collision.h"
@@ -12,8 +13,14 @@
 #include "ecs/query.h"
 
 GuiDockingButton::GuiDockingButton(GuiContainer* owner, string id)
-: GuiPanel(owner, id)
+: GuiElement(owner, id)
 {
+    background_panel = new GuiPanel(this, id + "_BG");
+    background_panel
+        ->setSize(GuiElement::GuiSizeMax, GuiElement::GuiSizeMax)
+        ->setPosition(0.0f, 0.0f, sp::Alignment::TopLeft)
+        ->hide();
+
     action_button = new GuiButton(this, id + "_BTN", tr("Request dock"),
         [this]()
         {
@@ -42,9 +49,8 @@ GuiDockingButton::GuiDockingButton(GuiContainer* owner, string id)
     );
     action_button
         ->setIcon("gui/icons/docking")
+        ->setSize(GuiElement::GuiSizeMax, GuiElement::GuiSizeMax)
         ->setPosition(0.0f, 0.0f, sp::Alignment::TopLeft);
-    action_button->setAttribute("fill_width", "true");
-    action_button->setAttribute("fill_height", "true");
 
     target_list = new GuiListbox(this, id + "_LIST",
         [this](int index, string value)
@@ -60,14 +66,17 @@ GuiDockingButton::GuiDockingButton(GuiContainer* owner, string id)
     );
     target_list
         ->setPosition(0.0f, 0.0f, sp::Alignment::TopLeft)
+        ->setSize(GuiElement::GuiSizeMax, GuiElement::GuiSizeMax)
         ->hide();
-    target_list->setAttribute("fill_width", "true");
-    target_list->setAttribute("fill_height", "true");
 }
 
 void GuiDockingButton::onUpdate()
 {
-    if (!my_spaceship) { hide(); return; }
+    if (!my_spaceship)
+    {
+        hide();
+        return;
+    }
     auto port = my_spaceship.getComponent<DockingPort>();
     setVisible(port != nullptr);
     if (!port) return;
@@ -129,6 +138,7 @@ void GuiDockingButton::onUpdate()
 
             // Expand height to fit all entries.
             layout.size.y = (dock_targets.size() + 1) * item_height;
+            background_panel->show();
             action_button->hide();
             target_list->show();
             return;
@@ -137,6 +147,7 @@ void GuiDockingButton::onUpdate()
 
     // If collapsed, just show the action button.
     layout.size.y = item_height;
+    background_panel->hide();
     target_list->hide();
     action_button->show();
 

--- a/src/screenComponents/dockingButton.cpp
+++ b/src/screenComponents/dockingButton.cpp
@@ -1,38 +1,68 @@
 #include <i18n.h>
 #include "playerInfo.h"
 #include "dockingButton.h"
+#include "gui/gui2_button.h"
+#include "gui/gui2_listbox.h"
 #include "systems/collision.h"
 #include "systems/docking.h"
 #include "components/collision.h"
 #include "components/docking.h"
 #include "components/faction.h"
+#include "components/name.h"
 #include "ecs/query.h"
 
-
 GuiDockingButton::GuiDockingButton(GuiContainer* owner, string id)
-: GuiButton(owner, id, "", [this]() { click(); })
+: GuiPanel(owner, id)
 {
-    setIcon("gui/icons/docking");
-}
+    action_button = new GuiButton(this, id + "_BTN", tr("Request dock"),
+        [this]()
+        {
+            if (!my_spaceship || !my_player_info) return;
+            auto port = my_spaceship.getComponent<DockingPort>();
+            if (!port) return;
 
-void GuiDockingButton::click()
-{
-    if (!my_spaceship) { return; }
-    auto port = my_spaceship.getComponent<DockingPort>();
-    if (!port) { return; }
+            switch (port->state)
+            {
+            case DockingPort::State::NotDocking:
+                dock_targets = findDockingTargets();
+                // Expand list if it has more than one entry.
+                // Otherwise, just dock.
+                if (dock_targets.size() == 1)
+                    my_player_info->commandDock(dock_targets[0]);
+                else if (dock_targets.size() > 1) expanded = true;
+                break;
+            case DockingPort::State::Docking:
+                my_player_info->commandAbortDock();
+                break;
+            case DockingPort::State::Docked:
+                my_player_info->commandUndock();
+                break;
+            }
+        }
+    );
+    action_button
+        ->setIcon("gui/icons/docking")
+        ->setPosition(0.0f, 0.0f, sp::Alignment::TopLeft);
+    action_button->setAttribute("fill_width", "true");
+    action_button->setAttribute("fill_height", "true");
 
-    switch(port->state)
-    {
-    case DockingPort::State::NotDocking:
-        my_player_info->commandDock(findDockingTarget());
-        break;
-    case DockingPort::State::Docking:
-        my_player_info->commandAbortDock();
-        break;
-    case DockingPort::State::Docked:
-        my_player_info->commandUndock();
-        break;
-    }
+    target_list = new GuiListbox(this, id + "_LIST",
+        [this](int index, string value)
+        {
+            if (!my_player_info) return;
+            expanded = false;
+            if (value == "cancel") return;
+            int idx = value.toInt();
+            if (idx >= 0 && idx < static_cast<int>(dock_targets.size()))
+                my_player_info->commandDock(dock_targets[idx]);
+
+        }
+    );
+    target_list
+        ->setPosition(0.0f, 0.0f, sp::Alignment::TopLeft)
+        ->hide();
+    target_list->setAttribute("fill_width", "true");
+    target_list->setAttribute("fill_height", "true");
 }
 
 void GuiDockingButton::onUpdate()
@@ -40,7 +70,9 @@ void GuiDockingButton::onUpdate()
     if (!my_spaceship) { hide(); return; }
     auto port = my_spaceship.getComponent<DockingPort>();
     setVisible(port != nullptr);
+    if (!port) return;
 
+    // Keyboard shortcuts dock to the nearest.
     if (isVisible())
     {
         if (keys.helms_dock_action.getDown())
@@ -48,7 +80,11 @@ void GuiDockingButton::onUpdate()
             switch(port->state)
             {
             case DockingPort::State::NotDocking:
-                my_player_info->commandDock(findDockingTarget());
+                {
+                    auto targets = findDockingTargets();
+                    if (!targets.empty())
+                        my_player_info->commandDock(targets[0]);
+                }
                 break;
             case DockingPort::State::Docking:
                 my_player_info->commandAbortDock();
@@ -59,62 +95,89 @@ void GuiDockingButton::onUpdate()
             }
         }
         else if (keys.helms_dock_request.getDown())
-            my_player_info->commandDock(findDockingTarget());
+        {
+            auto targets = findDockingTargets();
+            if (!targets.empty())
+                my_player_info->commandDock(targets[0]);
+        }
         else if (keys.helms_dock_abort.getDown())
             my_player_info->commandAbortDock();
         else if (keys.helms_undock.getDown())
             my_player_info->commandUndock();
     }
-}
 
-void GuiDockingButton::onDraw(sp::RenderTarget& renderer)
-{
-    if (!my_spaceship) { return; }
-    auto port = my_spaceship.getComponent<DockingPort>();
-    if (!port) { return; }
+    // Collapse the listbox when docking state changes away from NotDocking.
+    if (port->state != DockingPort::State::NotDocking) expanded = false;
 
-    switch(port->state)
+    // Update the docking list if it's expanded.
+    if (expanded)
     {
-    case DockingPort::State::NotDocking:
-        setText(tr("Request Dock"));
-        if (DockingSystem::canStartDocking(my_spaceship) && findDockingTarget())
+        dock_targets = findDockingTargets();
+        if (dock_targets.empty()) expanded = false;
+        else
         {
-            enable();
-        }else{
-            disable();
+            target_list->clear();
+            for (int i = 0; i < static_cast<int>(dock_targets.size()); i++)
+            {
+                // Use the callsign if available for the entry name.
+                string name = tr("Unknown");
+                if (auto cs = dock_targets[i].getComponent<CallSign>())
+                    name = cs->callsign;
+                target_list->addEntry(name, string(i));
+            }
+            target_list->addEntry(tr("Cancel"), "cancel");
+
+            // Expand height to fit all entries.
+            layout.size.y = (dock_targets.size() + 1) * item_height;
+            action_button->hide();
+            target_list->show();
+            return;
         }
-        break;
-    case DockingPort::State::Docking:
-        setText(tr("Cancel Docking"));
-        enable();
-        break;
-    case DockingPort::State::Docked:
-        setText(tr("Undock"));
-        enable();
-        break;
     }
 
-    GuiButton::onDraw(renderer);
+    // If collapsed, just show the action button.
+    layout.size.y = item_height;
+    target_list->hide();
+    action_button->show();
+
+    switch (port->state)
+    {
+    case DockingPort::State::NotDocking:
+        dock_targets = findDockingTargets();
+        action_button
+            ->setText(tr("Request dock"))
+            ->setEnable(DockingSystem::canStartDocking(my_spaceship) && !dock_targets.empty());
+        break;
+    case DockingPort::State::Docking:
+        action_button
+            ->setText(tr("Cancel docking"))
+            ->enable();
+        break;
+    case DockingPort::State::Docked:
+        action_button
+            ->setText(tr("Undock"))
+            ->enable();
+        break;
+    }
 }
 
-sp::ecs::Entity GuiDockingButton::findDockingTarget()
+std::vector<sp::ecs::Entity> GuiDockingButton::findDockingTargets()
 {
-    if (!my_spaceship) { return {}; }
+    std::vector<sp::ecs::Entity> targets;
+    if (!my_spaceship) return targets;
     auto port = my_spaceship.getComponent<DockingPort>();
-    if (!port) { return {}; }
+    if (!port) return targets;
     auto my_transform = my_spaceship.getComponent<sp::Transform>();
-    if (!my_transform) { return {}; }
+    if (!my_transform) return targets;
 
-    sp::ecs::Entity dock_object;
-    for(auto [entity, bay, transform, physics] : sp::ecs::Query<DockingBay, sp::Transform, sp::Physics>())
+    for (auto [entity, bay, transform, physics] : sp::ecs::Query<DockingBay, sp::Transform, sp::Physics>())
     {
         if (entity == my_spaceship) continue;
         if (Faction::getRelation(my_spaceship, entity) == FactionRelation::Enemy) continue;
         if (port->canDockOn(bay) == DockingStyle::None) continue;
-        if (glm::length(transform.getPosition() - my_transform->getPosition()) > 1000.0f + physics.getSize().x) continue;
-
-        dock_object = entity;
-        break;
+        if (glm::length(transform.getPosition() - my_transform->getPosition()) > 1000.0f + std::max(physics.getSize().x, physics.getSize().y)) continue;
+        targets.push_back(entity);
     }
-    return dock_object;
+
+    return targets;
 }

--- a/src/screenComponents/dockingButton.h
+++ b/src/screenComponents/dockingButton.h
@@ -1,13 +1,14 @@
 #pragma once
 
-#include "gui/gui2_panel.h"
+#include "gui/gui2_element.h"
 #include "ecs/entity.h"
 
 class GuiButton;
 class GuiListbox;
+class GuiPanel;
 
 // Button/listbox combo to manage docking state and select a docking target.
-class GuiDockingButton : public GuiPanel
+class GuiDockingButton : public GuiElement
 {
 public:
     GuiDockingButton(GuiContainer* owner, string id);
@@ -16,6 +17,7 @@ public:
 private:
     static constexpr float item_height = 50.0f;
 
+    GuiPanel* background_panel;
     GuiButton* action_button;
     GuiListbox* target_list;
     std::vector<sp::ecs::Entity> dock_targets;

--- a/src/screenComponents/dockingButton.h
+++ b/src/screenComponents/dockingButton.h
@@ -1,19 +1,25 @@
-#ifndef DOCKING_BUTTON_H
-#define DOCKING_BUTTON_H
+#pragma once
 
-#include "gui/gui2_button.h"
+#include "gui/gui2_panel.h"
+#include "ecs/entity.h"
 
-class GuiDockingButton : public GuiButton
+class GuiButton;
+class GuiListbox;
+
+// Button/listbox combo to manage docking state and select a docking target.
+class GuiDockingButton : public GuiPanel
 {
 public:
     GuiDockingButton(GuiContainer* owner, string id);
 
     virtual void onUpdate() override;
-    virtual void onDraw(sp::RenderTarget& target) override;
 private:
-    void click();
+    static constexpr float item_height = 50.0f;
 
-    sp::ecs::Entity findDockingTarget();
+    GuiButton* action_button;
+    GuiListbox* target_list;
+    std::vector<sp::ecs::Entity> dock_targets;
+    bool expanded = false;
+
+    std::vector<sp::ecs::Entity> findDockingTargets();
 };
-
-#endif//DOCKING_BUTTON_H


### PR DESCRIPTION
When multiple compatible DockingBay entities are within range, list them on the "Request dock" button and let the player select which entity to dock with instead of automatically choosing the nearest entity.

This converts DockingBay to subclass GuiPanel instead of GuiButton, and uses separate GuiButton and GuiListbox components in order to handle different docking states and dynamically update list contents.

This does NOT CHANGE keyboard shortcut behavior, which continues to dock with the nearest eligible target. It also does NOT CHANGE any existing interactions when only one eligible target is within range.

https://github.com/user-attachments/assets/088782cb-acbf-40e6-a90a-3f25da7e0aa4

