### PR TITLE
trying to fix probe view next scannable object

### DIFF
--- a/src/screens/crew6/scienceScreen.cpp
+++ b/src/screens/crew6/scienceScreen.cpp
@@ -559,7 +559,11 @@ void ScienceScreen::onUpdate()
             my_spaceship.hasComponent<ScienceScanner>() &&
             my_spaceship.getComponent<ScienceScanner>()->delay == 0.0f)
         {
-            if (auto transform = my_spaceship.getComponent<sp::Transform>()) {
+            auto rl = my_spaceship.getComponent<RadarLink>();
+            if (probe_view_button->getValue() && rl && rl->linked_entity) {
+                if (auto probe_transform = rl->linked_entity.getComponent<sp::Transform>())
+                    targets.setNext(probe_transform->getPosition(), PROBE_ZOOM_DISTANCE, TargetsContainer::ESelectionType::Scannable);
+            } else if (auto transform = my_spaceship.getComponent<sp::Transform>()) {
                 auto lrr = my_spaceship.getComponent<LongRangeRadar>();
                 targets.setNext(transform->getPosition(), lrr ? lrr->long_range : DEFAULT_MAX_ZOOM_DISTANCE, TargetsContainer::ESelectionType::Scannable);
             }


### PR DESCRIPTION
I found that if you're in probe view the next scanable target wasn't working.  This was the quick solution I came up with. 
It checks to see if the probeview is active and if so it will use the probe_transform instead of the ship's transform as the closest target. 

This was tested in my rig. 