### PR TITLE
[#2845] Replace fractional mouse_scroll_steps with per-element scroll speed calculations

### DIFF
--- a/src/gui/gui2_advancedscrolltext.cpp
+++ b/src/gui/gui2_advancedscrolltext.cpp
@@ -1,7 +1,7 @@
 #include "gui2_advancedscrolltext.h"
 
 GuiAdvancedScrollText::GuiAdvancedScrollText(GuiContainer* owner, string id)
-: GuiElement(owner, id), text_size(30.0f), rect_width(rect.size.x), max_prefix_width(0.0f), mouse_scroll_steps(25)
+: GuiElement(owner, id), text_size(30.0f), rect_width(rect.size.x), max_prefix_width(0.0f)
 {
     scrollbar = new GuiScrollbar(this, id + "_SCROLL", 0, 1, 0, nullptr);
     // Calculate scrolling a one-line entry by scrollbar arrow buttons.
@@ -146,7 +146,6 @@ void GuiAdvancedScrollText::onDraw(sp::RenderTarget& renderer)
 
 bool GuiAdvancedScrollText::onMouseWheelScroll(glm::vec2 position, float value)
 {
-    float range = scrollbar->getCorrectedMax() - scrollbar->getMin();
-    scrollbar->setValue((scrollbar->getValue() - value * range / mouse_scroll_steps) );
+    scrollbar->setValue(scrollbar->getValue() - value * text_size * 3.0f);
     return true;
 }

--- a/src/gui/gui2_advancedscrolltext.h
+++ b/src/gui/gui2_advancedscrolltext.h
@@ -26,7 +26,6 @@ protected:
     std::map<float, int> prefix_widths;
     bool auto_scroll_down;
     Entry prepEntry(Entry& e);
-    int mouse_scroll_steps;
 
 public:
     GuiAdvancedScrollText(GuiContainer* owner, string id);

--- a/src/gui/gui2_listbox.cpp
+++ b/src/gui/gui2_listbox.cpp
@@ -5,7 +5,7 @@
 #include "gui2_scrollbar.h"
 
 GuiListbox::GuiListbox(GuiContainer* owner, string id, func_t func)
-: GuiEntryList(owner, id, func), text_size(30), button_height(50), text_alignment(sp::Alignment::Center), mouse_scroll_steps(25)
+: GuiEntryList(owner, id, func), text_size(30), button_height(50), text_alignment(sp::Alignment::Center)
 {
     scroll = new GuiScrollbar(this, id + "_SCROLL", 0, 0, 0, [this](int value) {});
     scroll
@@ -136,7 +136,6 @@ void GuiListbox::onMouseUp(glm::vec2 position, sp::io::Pointer::ID id)
 
 bool GuiListbox::onMouseWheelScroll(glm::vec2 position, float value)
 {
-    float range = scroll->getCorrectedMax() - scroll->getMin();
-    scroll->setValue((scroll->getValue() - value * range / mouse_scroll_steps) );
+    scroll->setValue(scroll->getValue() - value * button_height);
     return true;
 }

--- a/src/gui/gui2_listbox.h
+++ b/src/gui/gui2_listbox.h
@@ -12,7 +12,6 @@ protected:
     sp::Alignment text_alignment;
     GuiScrollbar* scroll;
     sp::Rect last_rect;
-    int mouse_scroll_steps;
 
     const GuiThemeStyle* back_style;
     const GuiThemeStyle* front_style;

--- a/src/gui/gui2_scrolltext.cpp
+++ b/src/gui/gui2_scrolltext.cpp
@@ -64,8 +64,7 @@ void GuiScrollText::onDraw(sp::RenderTarget& renderer)
 
 bool GuiScrollText::onMouseWheelScroll(glm::vec2 position, float value)
 {
-    float range = scrollbar->getCorrectedMax() - scrollbar->getMin();
-    scrollbar->setValue((scrollbar->getValue() - value * range / mouse_scroll_steps) );
+    scrollbar->setValue(scrollbar->getValue() - value * text_size * 3.0f);
     return true;
 }
 

--- a/src/gui/gui2_scrolltext.h
+++ b/src/gui/gui2_scrolltext.h
@@ -13,7 +13,6 @@ protected:
     string text;
     float text_size = 30.0f;
     bool auto_scroll_down = false;
-    int mouse_scroll_steps = 25;
     const GuiThemeStyle* text_theme;
 
 public:


### PR DESCRIPTION
Remove `mouse_scroll_steps` member from scrolling elements, which defaulted scrolling to increments of 1/25 of the total height. For elements with very small overflows, this made scrolling very slow.

For scrolling text elements, replace that with `3 * text_size` (3 lines/increment). For listboxes, replace it with the button height (1 button/increment).

Fixes part of #2845 (slow scroll speeds).