### PR TITLE
Fix setAttribute("position", ...)

### DIFF
--- a/src/gui/gui2_container.cpp
+++ b/src/gui/gui2_container.cpp
@@ -155,7 +155,7 @@ void GuiContainer::setAttribute(const string& key, const string& value)
     {
         auto p = value.partition(",");
         layout.position.x = p.first.strip().toFloat();
-        layout.position.y = p.first.strip().toFloat();
+        layout.position.y = p.second.strip().toFloat();
     }
     else if (key == "margin")
     {


### PR DESCRIPTION
If using `setAttribute("position", ...)`, the first value sets both the x- and y-coordinate values.

Use the second value for the y coordinate.