### PR TITLE
Ramp up HVLI damage over 1U

### DIFF
--- a/scripts/science_db.lua
+++ b/scripts/science_db.lua
@@ -230,7 +230,7 @@ item:addKeyValue(_('Sizes'), _('Small (S) / Medium (M) / Large (L)'))
 populateMissileStats(item, missile_stat_keys, hvli_stats)
 item:setLongDescription(_([[A high-velocity lead impactor (HVLI) fires a simple slug of lead at a high velocity. This weapon is usually found in simpler ships since it does not require guidance computers. This also means its projectiles fly in a straight line from its tube and can't pursue a target.
 
-Each shot from an HVLI fires a burst of 5 projectiles, which increases the chance to hit but requires precision aiming to be effective. It reaches its full damage potential at a range of 2u.]]))
+Each shot from an HVLI fires a burst of 5 projectiles, which increases the chance to hit but requires precision aiming to be effective. It reaches its full damage potential at a range of 1u.]]))
 
 local function angleDifference(angle_a, angle_b)
     local ret = (angle_b or 0) - (angle_a or 0)

--- a/src/components/lifetime.h
+++ b/src/components/lifetime.h
@@ -6,5 +6,6 @@ class LifeTime
 {
 public:
     float lifetime = 1.0;
+    float initial_lifetime = 1.0;
     sp::script::Callback on_expire;
 };

--- a/src/components/missile.h
+++ b/src/components/missile.h
@@ -31,6 +31,7 @@ public:
     sp::ecs::Entity owner;
     DamageType damage_type = DamageType::Kinetic;
     string explosion_sfx;
+    float full_damage_after = 0.0f;
 };
 class ExplodeOnTimeout
 {

--- a/src/script/components.cpp
+++ b/src/script/components.cpp
@@ -666,6 +666,7 @@ void initComponentScriptBindings()
     BIND_MEMBER(MoveTo, on_arrival);
     sp::script::ComponentHandler<LifeTime>::name("lifetime");
     BIND_MEMBER(LifeTime, lifetime);
+    BIND_MEMBER(LifeTime, initial_lifetime);
     BIND_MEMBER(LifeTime, on_expire);
 
     sp::script::ComponentHandler<Faction>::name("faction");

--- a/src/script/components.cpp
+++ b/src/script/components.cpp
@@ -310,6 +310,7 @@ void initComponentScriptBindings()
     BIND_MEMBER(ExplodeOnTouch, owner);
     BIND_MEMBER(ExplodeOnTouch, damage_type);
     BIND_MEMBER(ExplodeOnTouch, explosion_sfx);
+    BIND_MEMBER(ExplodeOnTouch, full_damage_after);
 
     sp::script::ComponentHandler<DelayedExplodeOnTouch>::name("delayed_explode_on_touch");
     BIND_MEMBER(DelayedExplodeOnTouch, delay);

--- a/src/systems/missilesystem.cpp
+++ b/src/systems/missilesystem.cpp
@@ -166,7 +166,17 @@ void MissileSystem::explode(sp::ecs::Entity source, sp::ecs::Entity target, Expl
     if (eot.blast_range > 100.0f || !target) {
         DamageSystem::damageArea(transform->getPosition(), eot.blast_range, eot.damage_at_edge, eot.damage_at_center, info, eot.blast_range / 2);
     } else {
-        DamageSystem::applyDamage(target, eot.damage_at_center, info);
+        if (eot.full_damage_after > 0.0f){
+            auto lifetime = source.getComponent<LifeTime>();
+            float alive_for = lifetime->initial_lifetime - lifetime->lifetime;
+            if (alive_for > eot.full_damage_after){
+                DamageSystem::applyDamage(target, eot.damage_at_center, info);
+            } else {
+                DamageSystem::applyDamage(target, eot.damage_at_center * (alive_for / eot.full_damage_after), info);
+            }
+        } else {
+            DamageSystem::applyDamage(target, eot.damage_at_center, info);
+        }
     }
 
     auto e = sp::ecs::Entity::create();
@@ -292,6 +302,7 @@ void MissileSystem::spawnProjectile(sp::ecs::Entity source, MissileTubes::MountP
             mc.damage_at_edge = 10.0f * category_modifier;
             mc.blast_range = 20.0f * category_modifier;
             mc.explosion_sfx = "sfx/explosion.wav";
+            mc.full_damage_after = 2000.0f / (mwd.speed / category_modifier); // Full damage after 2U
             missile.addComponent<RawRadarSignatureInfo>(0.1f, 0.0f, 0.0f);
         }
         break;
@@ -349,8 +360,11 @@ void MissileSystem::spawnProjectile(sp::ecs::Entity source, MissileTubes::MountP
             cpe.life_time = 10.0f;
         }
 
-        if (tube.type_loaded != MW_Mine)
-            missile.addComponent<LifeTime>().lifetime = mwd.lifetime * category_modifier;
+        if (tube.type_loaded != MW_Mine){
+            auto& lifetime = missile.addComponent<LifeTime>();
+            lifetime.lifetime = mwd.lifetime * category_modifier;
+            lifetime.initial_lifetime = mwd.lifetime * category_modifier;
+        }
 
         if (tube.type_loaded != MW_Mine) {
             auto& dbad = missile.addComponent<DestroyedByAreaDamage>();

--- a/src/systems/missilesystem.cpp
+++ b/src/systems/missilesystem.cpp
@@ -302,7 +302,7 @@ void MissileSystem::spawnProjectile(sp::ecs::Entity source, MissileTubes::MountP
             mc.damage_at_edge = 10.0f * category_modifier;
             mc.blast_range = 20.0f * category_modifier;
             mc.explosion_sfx = "sfx/explosion.wav";
-            mc.full_damage_after = 2000.0f / (mwd.speed / category_modifier); // Full damage after 2U
+            mc.full_damage_after = 1000.0f / (mwd.speed / category_modifier); // Full damage after 1U
             missile.addComponent<RawRadarSignatureInfo>(0.1f, 0.0f, 0.0f);
         }
         break;


### PR DESCRIPTION
For Legacy Compatibility, this PR restores the damage ramp-up for HVLI missiles in a way that I believe is extensible if missile type config gets pulled out of the C++ code.

This adds a `initial_lifetime` member to the LifeTime component to calculate how long an entity has existed.
This adds a 'full_damage_after` member to the ExplodeOnTouch component, which is used to calculate lifetime before full damage is applied.

For HVLI, the `full_damage_after` is calculated based on the time for the projectile to travel 1000 units (1U), based on tube size.