### PR TITLE
Rebuild script docs when generator or Lua API changes

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -752,10 +752,14 @@ endif()
 find_package(Python3 COMPONENTS Interpreter)
 if(Python3_Interpreter_FOUND)
     set(SCRIPT_REFERENCE_HTML "${PROJECT_BINARY_DIR}/script_reference.html")
+    file(GLOB_RECURSE SCRIPT_REFERENCE_SOURCES
+        "${CMAKE_SOURCE_DIR}/scripts/api/*.lua"
+        "${CMAKE_SOURCE_DIR}/script_docs/*.py")
     add_custom_command(
         OUTPUT "${SCRIPT_REFERENCE_HTML}"
         COMMAND ${Python3_EXECUTABLE} ${CMAKE_SOURCE_DIR}/script_docs/main.py "${SCRIPT_REFERENCE_HTML}"
         WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}
+        DEPENDS ${SCRIPT_REFERENCE_SOURCES}
         COMMENT "Building script reference documentation.")
     add_custom_target(script_reference ALL DEPENDS "${SCRIPT_REFERENCE_HTML}")
   

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -754,7 +754,8 @@ if(Python3_Interpreter_FOUND)
     set(SCRIPT_REFERENCE_HTML "${PROJECT_BINARY_DIR}/script_reference.html")
     file(GLOB_RECURSE SCRIPT_REFERENCE_SOURCES
         "${CMAKE_SOURCE_DIR}/scripts/api/*.lua"
-        "${CMAKE_SOURCE_DIR}/script_docs/*.py")
+        "${CMAKE_SOURCE_DIR}/script_docs/*.py"
+        "${CMAKE_SOURCE_DIR}/script_docs/template.html")
     add_custom_command(
         OUTPUT "${SCRIPT_REFERENCE_HTML}"
         COMMAND ${Python3_EXECUTABLE} ${CMAKE_SOURCE_DIR}/script_docs/main.py "${SCRIPT_REFERENCE_HTML}"

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -753,6 +753,8 @@ find_package(Python3 COMPONENTS Interpreter)
 if(Python3_Interpreter_FOUND)
     set(SCRIPT_REFERENCE_HTML "${PROJECT_BINARY_DIR}/script_reference.html")
     file(GLOB_RECURSE SCRIPT_REFERENCE_SOURCES
+        "${CMAKE_SOURCE_DIR}/src/script.cpp"
+        "${CMAKE_SOURCE_DIR}/src/script/*.cpp"
         "${CMAKE_SOURCE_DIR}/scripts/api/*.lua"
         "${CMAKE_SOURCE_DIR}/script_docs/*.py"
         "${CMAKE_SOURCE_DIR}/script_docs/template.html")


### PR DESCRIPTION
Add the Lua-language Lua API sources and the script_docs generator scripts as dependencies to script reference generation in CMakeLists.txt. This should regenerate the script docs file in the build directory when either the Lua-defined APIs or the generator itself are changed.

As it stands now, the script reference is regenerated only if it's deleted from the build directory.