### PR TITLE
Tweak script docs

### DIFF
--- a/script_docs/main.py
+++ b/script_docs/main.py
@@ -12,6 +12,17 @@ class ReferenceBuilder:
         self.db.read("api/all.lua")
         self.output_file = open(output_filename, "wt")
 
+    def _write_func(self, data, func):
+        if not func.doc and not func.example:
+            print(f"WARNING: {func.name} has no description or example")
+        out = data
+        out = out.replace("{{name}}", html.escape(func.name))
+        out = out.replace("{{doc}}", html.escape("\n".join(func.doc)))
+        out = out.replace("{{docs}}", html.escape("\n".join(func.doc)))
+        out = out.replace("{{example}}", html.escape("\n".join(func.example)))
+        out = out.replace("{{params}}", html.escape(", ".join(func.params)))
+        self.output_file.write(out)
+
     def process_block(self, data, tag, params):
         if tag == "foreach":
             funcs = list(self.db.filter(params))
@@ -34,24 +45,12 @@ class ReferenceBuilder:
                 for cat in sorted(groups.keys(), key=lambda s: s.lower()):
                     self.output_file.write(f"<h2 id='category_{html.escape(cat)}'><a href='#entity'>{html.escape(cat)} functions</a></h2><ul>\n")
                     for func in groups[cat]:
-                        out = data
-                        out = out.replace("{{name}}", html.escape(func.name))
-                        out = out.replace("{{doc}}", html.escape("\n".join(func.doc)))
-                        out = out.replace("{{docs}}", html.escape("\n".join(func.doc)))
-                        out = out.replace("{{example}}", html.escape("\n".join(func.example)))
-                        out = out.replace("{{params}}", html.escape(", ".join(func.params)))
-                        self.output_file.write(out)
+                        self._write_func(data, func)
                     self.output_file.write("</ul>\n")
                 return
             # Fallback to all functions ungrouped without ToC
             for func in funcs:
-                out = data
-                out = out.replace("{{name}}", html.escape(func.name))
-                out = out.replace("{{doc}}", html.escape("\n".join(func.doc)))
-                out = out.replace("{{docs}}", html.escape("\n".join(func.doc)))
-                out = out.replace("{{example}}", html.escape("\n".join(func.example)))
-                out = out.replace("{{params}}", html.escape(", ".join(func.params)))
-                self.output_file.write(out)
+                self._write_func(data, func)
         else:
             print(tag, params)
 

--- a/script_docs/template.html
+++ b/script_docs/template.html
@@ -67,6 +67,7 @@ rel="stylesheet"
     font-weight: bold;
     background: rgba(36, 40, 44, 0.8);
     padding-left: 1rem;
+    margin-top: 1rem;
     border-top: 1px solid rgba(255, 255, 255, 0.1);
   }
 

--- a/scripts/api/entity/shiptemplatebasedobject.lua
+++ b/scripts/api/entity/shiptemplatebasedobject.lua
@@ -1,9 +1,9 @@
 local Entity = getLuaEntityFunctionTable()
 
------ Template-based entity functions -----
+-- Template-based entity functions --
 
---- These functions apply to entities created from a ShipTemplate, such as those created by CpuShip(), PlayerSpaceship(), and SpaceStation().
---- Use setTemplate() to apply a ShipTemplate's properties to an entity.
+-- These functions apply to entities created from a ShipTemplate, such as those created by CpuShip(), PlayerSpaceship(), and SpaceStation().
+-- Use setTemplate() to apply a ShipTemplate's properties to an entity.
 
 --- Sets this ShipTemplate that defines this entity's traits, and then applies them to this entity.
 --- ShipTemplates define the entity's class, weapons, hull and shield strength, 3D appearance, and more.


### PR DESCRIPTION
- Consolidate script_docs function writer logic to a function
- Emit a warning for each function that lacks both a description and an example
- Add 1rem margin between function blocks in the script reference output
- Use two dashes instead of 3+ for file organization lines in shiptemplatebasedobject.lua to prevent them from bleeding into the `Entity:setTemplate()` function docs