### PR TITLE
Only run scan completed callback if it exists

### DIFF
--- a/src/systems/scanning.cpp
+++ b/src/systems/scanning.cpp
@@ -53,8 +53,8 @@ void ScanningSystem::scanningFinished(sp::ecs::Entity command_source)
         case ScanState::State::FullScan:
             break;
         }
-
-        LuaConsole::checkResult(ss->on_scan_completed.call<void>(scanner->target, command_source, scanner->source));
+        if (ss->on_scan_completed)
+            LuaConsole::checkResult(ss->on_scan_completed.call<void>(scanner->target, command_source, scanner->source));
     }
 
     scanner->target = {};


### PR DESCRIPTION
This fixes a issue from #2675 by checking if the `on_scan_completed` callback exists before calling it.
Without this, every scan that doesn't have a callback generates a Lua error.