### PR TITLE
Apply #2507 bounds checks to RandomGenerator():random() and :irandom()

### DIFF
--- a/src/script/scriptRandom.cpp
+++ b/src/script/scriptRandom.cpp
@@ -26,7 +26,7 @@ static int lua_rngIRandom(lua_State* L)
     auto imin = luaL_checkinteger(L, 2);
     auto imax = luaL_checkinteger(L, 3);
     if (imin > imax)
-        return luaL_error(L, "bad call irandom(%f, %f): lower bound is greater than upper bound", imin, imax);
+        return luaL_error(L, "bad call irandom(%d, %d): lower bound is greater than upper bound", imin, imax);
     lua_pushinteger(L, std::uniform_int_distribution<>(imin, imax)(*rng));
     return 1;
 }

--- a/src/script/scriptRandom.cpp
+++ b/src/script/scriptRandom.cpp
@@ -14,6 +14,8 @@ static int lua_rngRandom(lua_State* L)
     std::mt19937_64* rng = reinterpret_cast<std::mt19937_64*>(luaL_checkudata(L, 1, "RandomGenerator"));
     auto fmin = luaL_checknumber(L, 2);
     auto fmax = luaL_checknumber(L, 3);
+    if (fmin > fmax)
+        return luaL_error(L, "bad call random(%f, %f): lower bound is greater than upper bound", fmin, fmax);
     lua_pushnumber(L, static_cast<lua_Number>(std::uniform_real_distribution<float>(fmin, fmax)(*rng)));
     return 1;
 }
@@ -23,6 +25,8 @@ static int lua_rngIRandom(lua_State* L)
     std::mt19937_64* rng = reinterpret_cast<std::mt19937_64*>(luaL_checkudata(L, 1, "RandomGenerator"));
     auto imin = luaL_checkinteger(L, 2);
     auto imax = luaL_checkinteger(L, 3);
+    if (imin > imax)
+        return luaL_error(L, "bad call irandom(%f, %f): lower bound is greater than upper bound", imin, imax);
     lua_pushinteger(L, std::uniform_int_distribution<>(imin, imax)(*rng));
     return 1;
 }


### PR DESCRIPTION
PR #2507 added standalone `random()` and `irandom()` Lua global functions with bounds checks, but didn't add bounds checks to `RandomGenerator():random()` and `RandomGenerator():irandom()`.

Align `RandomGenerator()` behavior to the standalone functions'.

Not sure if there was a reason for this omission, cc @GinjaNinja32 