### PR TITLE
[#2866] Add CXX_STANDARD to force C++17

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -11,6 +11,9 @@ endif()
 
 cmake_minimum_required(VERSION 3.12 FATAL_ERROR)
 
+# Force C++17 across all compilers
+set(CMAKE_CXX_STANDARD 17)
+
 set(CMAKE_MODULE_PATH "${CMAKE_SOURCE_DIR}/cmake" ${CMAKE_MODULE_PATH})
 
 # Set a default version.


### PR DESCRIPTION
Mitigate #2866 by explicitly defining [`CXX_STANDARD 17`](https://cmake.org/cmake/help/latest/prop_tgt/CXX_STANDARD.html) in EmptyEpsilon's `CMakeLists.txt`. SeriousProton [already does this](https://github.com/daid/SeriousProton/blob/9a3958ea2dcec8ab714cab706c977ed6b07c59b5/CMakeLists.txt#L26).