### PR TITLE
Hotkeys for custom buttons

### DIFF
--- a/src/gui/hotkeyConfig.cpp
+++ b/src/gui/hotkeyConfig.cpp
@@ -88,6 +88,24 @@ Keys::Keys() :
     debug_show_colliders("DEBUG_SHOW_COLLIDERS", "F12"),
 #endif
 
+    trigger_custom_button{{
+        {"TRIGGER_CUSTOM_BUTTON1"},
+        {"TRIGGER_CUSTOM_BUTTON2"},
+        {"TRIGGER_CUSTOM_BUTTON3"},
+        {"TRIGGER_CUSTOM_BUTTON4"},
+        {"TRIGGER_CUSTOM_BUTTON5"},
+        {"TRIGGER_CUSTOM_BUTTON6"},
+        {"TRIGGER_CUSTOM_BUTTON7"},
+        {"TRIGGER_CUSTOM_BUTTON8"},
+        {"TRIGGER_CUSTOM_BUTTON9"},
+        {"TRIGGER_CUSTOM_BUTTON10"},
+        {"TRIGGER_CUSTOM_BUTTON11"},
+        {"TRIGGER_CUSTOM_BUTTON12"},
+        {"TRIGGER_CUSTOM_BUTTON13"},
+        {"TRIGGER_CUSTOM_BUTTON14"},
+        {"TRIGGER_CUSTOM_BUTTON15"}
+    }},
+
     // Crew screen binds
     next_station("STATION_NEXT", "Tab"),
     prev_station("STATION_PREVIOUS"),
@@ -340,6 +358,11 @@ void Keys::init()
 #ifdef DEBUG
     debug_show_colliders.setLabel(tr("hotkey_menu", "General"), tr("hotkey_General", "Show debug colliders"));
 #endif
+
+    for (auto n = 0u; n < trigger_custom_button.size(); n++)
+    {
+        trigger_custom_button[n].setLabel(tr("hotkey_menu", "General"), tr("hotkey_General", "Custom button slot {number}").format({{"number", string(n + 1)}}));
+    }
 
     // Crew screens
     next_station.setLabel(tr("hotkey_menu", "Crew screens"), tr("hotkey_CrewScreen", "Switch to next crew screen"));

--- a/src/gui/hotkeyConfig.h
+++ b/src/gui/hotkeyConfig.h
@@ -27,6 +27,7 @@ public:
 #ifdef DEBUG
     sp::io::Keybinding debug_show_colliders;
 #endif
+    std::array<sp::io::Keybinding, 15> trigger_custom_button;
 
     // Crew screen binds
     sp::io::Keybinding next_station;

--- a/src/screenComponents/customShipFunctions.cpp
+++ b/src/screenComponents/customShipFunctions.cpp
@@ -21,6 +21,7 @@ void GuiCustomShipFunctions::onUpdate()
 void GuiCustomShipFunctions::checkEntries()
 {
     auto csf = my_spaceship.getComponent<CustomShipFunctions>();
+    int slot_count=0;
     if (!csf) return;
 
     if (csf->functions.size() != entries.size())
@@ -43,6 +44,10 @@ void GuiCustomShipFunctions::checkEntries()
         }
         else if (csf->functions[n].type == CustomShipFunctions::Function::Type::Button)
         {
+            if (keys.trigger_custom_button[slot_count].getDown()) {
+                my_player_info->commandCustomFunction(entries[n].name);
+            }
+            slot_count++;
             GuiButton* button = dynamic_cast<GuiButton*>(entries[n].element);
             if (!button)
             {
@@ -58,6 +63,7 @@ void GuiCustomShipFunctions::checkEntries()
         else if (csf->functions[n].type == CustomShipFunctions::Function::Type::Info)
         {
             GuiLabel* label = dynamic_cast<GuiLabel*>(entries[n].element);
+            slot_count++;
             if (!label)
             {
                 // ship data says this is a label but we have something else, rebuild the entries


### PR DESCRIPTION
This adds hotkeys for custom buttons.
Instead of numbering the buttons in order of their appearance(green), I used the position/slot (purple).
<img width="487" height="609" alt="buttonorder" src="https://github.com/user-attachments/assets/aceaf44d-cac2-4fc0-a3e1-3cffd3480c9c" />

Slot based hotkeys are pretty common in games, and this would also allow custom consoles with softkeys next to the screen. But if you prefer it the other way around, that would just be the removal of one line.
15 hotkeys, as that is the maximum that can be displayed (Engineering and most aux stations). 
I wasn't entirely sure whether or not I should make yet another config tab for the custom buttons, but had them placed in general for now.
