### PR TITLE
fix off-by-one issue with autoconnect

### DIFF
--- a/src/menus/autoConnectScreen.cpp
+++ b/src/menus/autoConnectScreen.cpp
@@ -271,6 +271,7 @@ AutoConnectPosition::AutoConnectPosition(string value)
                 continue;
             }
 
+            pos -= 1;  // Shift for legacy compatibility
             if (pos < 0) pos = 0;
             if (pos > static_cast<int>(CrewPosition::MAX)) pos = static_cast<int>(CrewPosition::MAX);
             crew_position = CrewPosition(pos);


### PR DESCRIPTION
In master, the positions are 0-indexed, which means that Helms is value 0, which also translates to not autoconnect.  by shifting the position value down by 1, position ids are maintained properly from legacy (Helms=1, Weapons=2, etc)