### PR TITLE
[#2877] Fix space station entry population in ScienceDatabase

### DIFF
--- a/scripts/api/entity/multiuse.lua
+++ b/scripts/api/entity/multiuse.lua
@@ -18,10 +18,12 @@ function Entity:setName(name)
     return self
 end
 
---- Sets this faction's longform description as shown in its Factions ScienceDatabase child entry.
+--- For factions, sets this faction's longform description as shown in its ScienceDatabase child entry.
 --- Wrap the string in the _() function to make it available for translation.
---- Example: faction:setDescription(_("The United Stellar Navy, or USN...")) -- sets a translatable description for this faction
---- As setDescriptions, but sets the same description for both unscanned and scanned states.
+--- For other entities, this works as setDescriptions, but sets the same description for both unscanned and scanned states.
+--- For ship templates, see ShipTemplate:setDescription().
+--- Examples:
+--- faction:setDescription(_("The United Stellar Navy, or USN...")) -- sets a translatable description for this faction
 --- Example: obj:setDescription("A refitted Atlantis X23 for more ...")
 function Entity:setDescription(description)
     if self.components.faction_info then

--- a/scripts/api/shipTemplate.lua
+++ b/scripts/api/shipTemplate.lua
@@ -101,7 +101,9 @@ function ShipTemplate:setClass(class, subclass)
     return self
 end
 --- Sets the description shown in the science database for entities created from this ShipTemplate.
---- Example: template:setDescription(_("The Phobos T3 is most any navy's workhorse frigate."))
+--- Wrap the string with the _() function to expose it for localization.
+--- For factions and other entity types, see Entity:setDescription().
+--- Example: template:setDescription(_([[The Phobos T3 is most any navy's workhorse frigate.]]))
 function ShipTemplate:setDescription(description)
     self.__description = description
     return self

--- a/scripts/science_db.lua
+++ b/scripts/science_db.lua
@@ -298,15 +298,17 @@ function __fillDefaultDatabaseData()
     local class_set = {}
 	local template_names = {}
 
-    -- Populate list of ship hull classes
+	-- Populate list of ship hull classes and collect all visible templates
 	for name, ship_template in pairs(__ship_templates) do
-        if not ship_template.__hidden and ship_template.__type ~= "station" then
-			local class_name = _("No class")
-			if ship_template.docking_port ~= nil then class_name = ship_template.docking_port.dock_class end
+		if not ship_template.__hidden then
+			if ship_template.__type ~= "station" then
+				local class_name = _("No class")
+				if ship_template.docking_port ~= nil then class_name = ship_template.docking_port.dock_class end
 
-			if class_set[class_name] == nil then
-				class_list[#class_list + 1] = class_name
-				class_set[class_name] = true
+				if class_set[class_name] == nil then
+					class_list[#class_list + 1] = class_name
+					class_set[class_name] = true
+				end
 			end
 			table.insert(template_names, name)
 		end
@@ -328,11 +330,15 @@ function __fillDefaultDatabaseData()
 			local class_name = _("No class")
 			local subclass_name = _("No sub-class")
 			if ship_template.docking_port ~= nil then class_name = ship_template.docking_port.dock_class subclass_name = ship_template.docking_port.dock_subclass end
-        	local entry = nil
+			local entry = nil
+			-- Add space stations to the Stations entry.
+			-- Otherwise, add them to ships by ship class.
 			if ship_template.__type == "station" then
 				entry = stations_database:addEntry(ship_template.typename.localized);
 			else
 				entry = class_database_entries[class_name]:addEntry(ship_template.typename.localized);
+				entry:addKeyValue(_("database", "Class"), class_name)
+				entry:addKeyValue(_("database", "Sub-class"), subclass_name)
 			end
 
 			if ship_template.__model_data_name then
@@ -342,8 +348,6 @@ function __fillDefaultDatabaseData()
 				entry:setImage(ship_template.radar_trace.icon)
 			end
 
-			entry:addKeyValue(_("database", "Class"), class_name)
-			entry:addKeyValue(_("database", "Sub-class"), subclass_name)
 			if ship_template.physics then
 				if type(ship_template.physics.size) == "table" then
 					entry:addKeyValue(_("database", "Size"), math.floor(ship_template.physics.size[1]))


### PR DESCRIPTION
Don't exclude space stations from ShipTemplate parsing for the ScienceDatabase. Don't display class/subclass for stations. More clearly document what setDescription() does differently for Factions, ShipTemplates, and other types of entities.

Fixes #2877.

Database view, Stations entry, before:

<img width="2512" height="1940" alt="Screenshot 2026-06-11 at 11 49 07 AM" src="https://github.com/user-attachments/assets/eed8016a-f6f3-45c4-9f05-8d3827c2a81e" />

After:

<img width="2512" height="1940" alt="Screenshot 2026-06-11 at 12 14 54 PM" src="https://github.com/user-attachments/assets/ba4ef943-2725-4319-b881-2d359c60b8af" />
