### PR TITLE
Add CXX_STANDARD to force C++17 on legacy

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -11,6 +11,9 @@ endif()
 
 cmake_minimum_required(VERSION 3.8 FATAL_ERROR)
 
+# Force C++17 across all compilers
+set(CMAKE_CXX_STANDARD 17)
+
 set(CMAKE_MODULE_PATH "${CMAKE_SOURCE_DIR}/cmake" ${CMAKE_MODULE_PATH})
 
 # Set a default version.


### PR DESCRIPTION
Explicitly define [CXX_STANDARD 17](https://cmake.org/cmake/help/latest/prop_tgt/CXX_STANDARD.html) in EmptyEpsilon's CMakeLists.txt for the legacy branch, which fixes legacy builds on GCC 16. SeriousProton's legacy branch already does this.