### PR TITLE
PlayerInfo: don't reset crew positions on reset

### DIFF
--- a/src/playerInfo.cpp
+++ b/src/playerInfo.cpp
@@ -139,7 +139,6 @@ void PlayerInfo::reset()
     ship = {};
     main_screen_control = 0;
     last_ship_password = "";
-    crew_positions.clear();
 }
 
 bool PlayerInfo::hasPosition(CrewPosition cp)


### PR DESCRIPTION
This keep the selected crew position on scenario chance. This should be the default for crews who don't like to rotate stations each scenario.