### PR TITLE
Fix invalid lang attribute and minor CSS issues in www UI

### DIFF
--- a/script_docs/template.html
+++ b/script_docs/template.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<html lang="us">
+<html lang="en">
 <head>
 <!-- Font faces -->
 <link rel="preconnect" href="https://fonts.googleapis.com" />

--- a/www/index.html
+++ b/www/index.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="us">
+<html lang="en">
 
   <head>
     <meta charset="utf-8">
@@ -157,7 +157,6 @@
       }
 
       .ui-tabs-vertical .ui-tabs-panel {
-        padding: 1em;
         float: right;
         border-left-width: 0;
         height: 100%;
@@ -436,7 +435,7 @@
       }
 
       a.icon span.icon::before {
-        font-family: "empty-epsilon";
+        font-family: "empty-epsilon", sans-serif;
         font-weight: normal;
         width: 40px;
         height: 40px;
@@ -502,7 +501,7 @@
 
       h2.station::before, 
       h2.station::after {
-        font-family: empty-epsilon;
+        font-family: empty-epsilon, sans-serif;
       }
 
       h2.station::before {


### PR DESCRIPTION
Small accessibility/CSS cleanup found while running static analysis on our fork (espaciokooplagunak):

- `lang="us"` is not a valid language code (`us` is a country, not a language), so screen readers fall back to guessing. Changed to `lang="en"` in `www/index.html` and `script_docs/template.html`.
- Removed a duplicate `padding` declaration in `.ui-tabs-vertical .ui-tabs-panel` — it was dead code, always overridden by the `!important` declaration a few lines below, so there is no visual change.
- Added a `sans-serif` fallback after the `empty-epsilon` icon font.

4 insertions, 5 deletions, static HTML/CSS only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)