### PR TITLE
Bound replicated vector size before resize()

### DIFF
--- a/src/multiplayer/basic.h
+++ b/src/multiplayer/basic.h
@@ -6,8 +6,13 @@
 
 
 namespace sp::io {
+    // Upper bound on element counts announced by a replicated vector's size prefix.
+    // Without it, a corrupt or hostile packet can announce a size near UINT32_MAX and
+    // force a multi-gigabyte resize() before a single element is actually read.
+    constexpr size_t max_replicated_vector_size = 1'000'000;
+
     template<typename T> static inline DataBuffer& operator << (DataBuffer& packet, const std::vector<T>& v) { packet << uint32_t(v.size()); for(size_t n=0; n<v.size(); n++) packet << v[n]; return packet;} \
-    template<typename T> static inline DataBuffer& operator >> (DataBuffer& packet, std::vector<T>& v) { uint32_t size = 0; packet >> size; v.resize(size); for(size_t n=0; n<v.size(); n++) packet >> v[n]; return packet; }
+    template<typename T> static inline DataBuffer& operator >> (DataBuffer& packet, std::vector<T>& v) { uint32_t size = 0; packet >> size; if (size > max_replicated_vector_size) { LOG(Warning, "Replicated vector size", size, "exceeds maximum", max_replicated_vector_size, "- clamping"); size = uint32_t(max_replicated_vector_size); } v.resize(size); for(size_t n=0; n<v.size(); n++) packet >> v[n]; return packet; }
 }
 
 enum class BasicReplicationRequest {
@@ -83,7 +88,7 @@ enum class BasicReplicationRequest {
     switch(BRR) { \
     case BasicReplicationRequest::SendAll: flags |= flag; tmp << target.FIELD.size(); break; \
     case BasicReplicationRequest::Update: if (target.FIELD.size() != backup->FIELD.size()) { flags |= flag; tmp << target.FIELD.size(); backup->FIELD.resize(target.FIELD.size()); } break; \
-    case BasicReplicationRequest::Receive: if (flags & flag) { size_t size; packet >> size; target.FIELD.resize(size); } break; \
+    case BasicReplicationRequest::Receive: if (flags & flag) { size_t size; packet >> size; if (size > sp::io::max_replicated_vector_size) { LOG(Warning, "Replicated vector size", size, "exceeds maximum", sp::io::max_replicated_vector_size, "- clamping"); size = sp::io::max_replicated_vector_size; } target.FIELD.resize(size); } break; \
     } \
     flag <<= 1; \
     for(size_t idx=0; (BRR==BasicReplicationRequest::Receive) || idx<target.FIELD.size(); idx++) { \


### PR DESCRIPTION
## Problem

`std::vector<T>` replication reads a size prefix straight off the network and calls `resize()` with it before reading a single element — both the generic `sp::io::operator>>` for `std::vector<T>` in `src/multiplayer/basic.h` and the `BASIC_REPLICATION_VECTOR` macro's `Receive` case.

A corrupt packet, or a hostile client inside a multiplayer session, can announce a size near `UINT32_MAX`, forcing a multi-gigabyte allocation before any bounds/data-availability check happens — a memory-exhaustion DoS / crash for whoever processes the packet (client or server).

For contrast, the per-element index in `BASIC_REPLICATION_VECTOR`'s receive loop is already validated against the vector's current size before writing — this is specifically about the unbounded `resize()` call itself.

## Fix

Clamp the announced size to a fixed upper bound (`max_replicated_vector_size = 1'000'000`) before resizing, logging a warning when a packet exceeds it, in both places that resize from a wire-provided size.

## Testing

Built with `WARNING_IS_ERROR=1` against a sibling SeriousProton checkout — full clean build succeeds (539/539 targets), no warnings introduced.

I did not add an automated regression test for this — I'm not familiar enough with this codebase's network/replication test setup to know where a targeted test would fit; happy to add one if pointed at the right harness.