### PR TITLE
Treat touch input the same as left button click for minesweeper

### DIFF
--- a/src/screenComponents/mineSweeper.cpp
+++ b/src/screenComponents/mineSweeper.cpp
@@ -245,7 +245,7 @@ void MineSweeper::FieldItem::onMouseUp(glm::vec2 position, sp::io::Pointer::ID i
 {
     if (!rect.contains(position)) return;
 
-    if (last_button == sp::io::Pointer::Button::Left && left_click_func)
+    if ((last_button == sp::io::Pointer::Button::Left || last_button == sp::io::Pointer::Button::Touch ) && left_click_func)
     {
         func_t f = left_click_func;
         f(getValue());


### PR DESCRIPTION
Pull #2626 added functionality for left and right clicks, but did not handle touch inputs.  This PR treats touch inputs the same as left clicks for the minesweeper hacking game, restoring missing functionality.