### PR TITLE
Provide an entity:onTakingShieldDamage() callback

### DIFF
--- a/scripts/api/entity/shiptemplatebasedobject.lua
+++ b/scripts/api/entity/shiptemplatebasedobject.lua
@@ -346,6 +346,13 @@ function Entity:onTakingDamage(callback)
     if self.components.hull then self.components.hull.on_taking_damage = callback end
     return self
 end
+--- Defines a function to call when this entity takes damage to its shields.
+--- Passes the object taking damage to its shields and the instigator entity (or nil) to the function.
+--- Example: stbo:onTakingShieldDamage(function(this_stbo,instigator) print(this_stbo:getCallSign() .. " had shields damaged by " .. instigator:getCallSign()) end)
+function Entity:onTakingShieldDamage(callback)
+    if self.components.shields then self.components.shields.on_taking_damage = callback end
+    return self
+end
 --- Defines a function to call when this entity is destroyed by taking damage.
 --- Passes the object taking damage and the instigator entity that delivered the destroying damage (or nil) to the function.
 --- Example: stbo:onDestruction(function(this_stbo,instigator) print(this_stbo:getCallSign() .. " was destroyed by " .. instigator:getCallSign()) end)

--- a/src/components/shields.h
+++ b/src/components/shields.h
@@ -2,7 +2,7 @@
 
 #include "ecs/entity.h"
 #include "shipsystem.h"
-
+#include "script/callback.h"
 
 class Shields {
 public:
@@ -28,4 +28,6 @@ public:
 
     ShipSystem& getSystemForIndex(int index);
     float getDamageFactor(int index);
+
+     sp::script::Callback on_taking_damage;
 };

--- a/src/script/components.cpp
+++ b/src/script/components.cpp
@@ -424,6 +424,7 @@ void initComponentScriptBindings()
     BIND_MEMBER(Shields, calibration_delay);
     BIND_MEMBER(Shields, frequency);
     BIND_MEMBER(Shields, energy_use_per_second);
+    BIND_MEMBER(Shields, on_taking_damage);
     BIND_ARRAY(Shields, entries);
     BIND_ARRAY_MEMBER(Shields, entries, level);
     BIND_ARRAY_MEMBER(Shields, entries, max);

--- a/src/systems/damage.cpp
+++ b/src/systems/damage.cpp
@@ -78,6 +78,16 @@ void DamageSystem::applyDamage(sp::ecs::Entity entity, float amount, const Damag
         {
             amount = 0.0;
         }
+
+        if (shields->on_taking_damage)
+        {
+            if (info.instigator)
+            {
+                LuaConsole::checkResult(shields->on_taking_damage.call<void>(entity, info.instigator));
+            } else {
+                LuaConsole::checkResult(shields->on_taking_damage.call<void>(entity));
+            }
+        }
     }
 
     if (amount > 0.0f)


### PR DESCRIPTION
This PR adds a `entity:onTakingShieldDamage()` callback which works the same as `entity:onTakingDamage()` but for damage to Shields instead of damage to Hull.

This allows for lua scripts to trigger on shield damage instead of just hull damage.